### PR TITLE
Canonical path resolution fixes

### DIFF
--- a/lib/network-protocol/FS.cpp
+++ b/lib/network-protocol/FS.cpp
@@ -129,7 +129,7 @@ void NetworkProtocolFS::update_dir_filename(PeoplesUrlParser *url)
 {
     size_t found = url->path.find_last_of("/");
 
-    dir = url->path.substr(0, found + 1);
+    dir = util_get_canonical_path(url->path.substr(0, found + 1));
     filename = url->path.substr(found + 1);
 
     // transform the possible everything wildcards

--- a/lib/utils/utils.cpp
+++ b/lib/utils/utils.cpp
@@ -845,7 +845,7 @@ std::string util_get_canonical_path(std::string prefix)
     }
 
     // kludge
-    if (res[res.length() - 1] != '/')
+    if ((res[res.length() - 1] != '/') && (res.length() > 0))
         res.append("/");
 
     return res;


### PR DESCRIPTION
Corrected two issues found when using NOS:

1. Unable to open files (such as binary load) from relative path that includes traversing through a parent directory. The logs would show a file open request such as:
Before: `TNFS://my_path/my_sub1/../my_sub2/file.ext`
After: `TNFS://my_path/my_sub2/file.ext`

2. `NCD Nn:` is supposed to clear the mount point. However, sending a null path through the util function to return a canonical path was incorrectly resolving to "/".  A null path now resolves to null.