### PR TITLE
Swap conditions, will guard against index out-of-bounds

### DIFF
--- a/lib/utils/utils.cpp
+++ b/lib/utils/utils.cpp
@@ -844,8 +844,8 @@ std::string util_get_canonical_path(std::string prefix)
         st1.pop();
     }
 
-    // kludge
-    if ((res[res.length() - 1] != '/') && (res.length() > 0))
+    // Append trailing slash if not already there
+    if ((res.length() > 0) && (res[res.length() - 1] != '/'))
         res.append("/");
 
     return res;


### PR DESCRIPTION
length > 0 condition is needed to return a null string if a null string was provided as input. But by putting that condition first, it will block the second condition from deriving -1 as an array index.