### PR TITLE
Adjusted sio_set_prefix() to comply with NCD documentation

### DIFF
--- a/lib/device/sio/network.cpp
+++ b/lib/device/sio/network.cpp
@@ -548,67 +548,54 @@ void sioNetwork::sio_set_prefix()
     prefixSpec_str = prefixSpec_str.substr(prefixSpec_str.find_first_of(":") + 1);
     Debug_printf("sioNetwork::sio_set_prefix(%s)\n", prefixSpec_str.c_str());
 
+    // If "NCD Nn:" then prefix is cleared completely
     if (prefixSpec_str.empty())
     {
         prefix.clear();
     }
-    else if (prefixSpec_str == ".." || prefixSpec_str == "<") // Devance path N:..
+    else 
     {
-        std::vector<int> pathLocations;
-        for (int i = 0; i < prefix.size(); i++)
+        // For the remaining cases, append trailing slash if not found
+        if (prefix[prefix.size()-1] != '/')
         {
-            if (prefix[i] == '/')
-            {
-                pathLocations.push_back(i);
-            }
-        }
-
-        if (prefix[prefix.size() - 1] == '/')
-        {
-            // Get rid of last path segment.
-            pathLocations.pop_back();
-        }
-
-        // truncate to that location.
-        prefix = prefix.substr(0, pathLocations.back() + 1);
-    }
-    else if ((prefixSpec_str == "/") || (prefixSpec_str == ">")) // Go back to hostname.
-    {
-        // TNFS://foo.com/path
-        size_t pos = prefix.find("/");
-        
-        if (pos == string::npos)
-            prefix.clear();
-        
-        pos = prefix.find("/",++pos);
-
-        if (pos == string::npos)
-            prefix.clear();
-
-        pos = prefix.find("/",++pos);
-
-        if (pos == string::npos)
             prefix += "/";
+        }
 
+        // Find pos of 3rd "/" in prefix
+        size_t pos = prefix.find("/");
+        pos = prefix.find("/",++pos);
         pos = prefix.find("/",++pos);
 
-        prefix = prefix.substr(0,pos);
-    }
-    else if (prefixSpec_str[0] == '/') // N:/DIR
-    {
-        prefix = prefixSpec_str;
-    }
-    else if (prefixSpec_str.find_first_of(":") != string::npos)
-    {
-        prefix = prefixSpec_str;
-    }
-    else // append to path.
-    {
-        prefix += prefixSpec_str;
+        // If "NCD Nn:.."" or "NCD .." then devance prefix
+        if (prefixSpec_str == ".." || prefixSpec_str == "<")
+        {
+            prefix += ".."; // call to canonical path later will resolve
+        }
+        // If "NCD Nn:/" or "NCD /" then truncate to hostname (e.g. TNFS://hostname/)
+        else if (prefixSpec_str == "/" || prefixSpec_str == ">")
+        {
+            // truncate at pos of 3rd slash
+            prefix = prefix.substr(0,pos+1);
+        }
+        // If "NCD Nn:/path/to/dir/" then concatenate hostname and prefix
+        else if (prefixSpec_str[0] == '/') // N:/DIR
+        {
+            // append at pos of 3rd slash
+            prefix = prefix.substr(0,pos);
+            prefix += prefixSpec_str;
+        }
+        // If "NCD TNFS://foo.com/" then reset entire prefix
+        else if (prefixSpec_str.find_first_of(":") != string::npos)
+        {
+            prefix = prefixSpec_str;
+        }
+        else // append to path.
+        {
+            prefix += prefixSpec_str;
+        }
     }
 
     prefix = util_get_canonical_path(prefix);
-
     Debug_printf("Prefix now: %s\n", prefix.c_str());
 
     // We are okay, signal complete.


### PR DESCRIPTION
Tested with both NOS and N-enabled DOS XL. Assumption is other versions use same N-tools wand will behave the same.