### PR TITLE
Connect to TCP by default and fallback to UDP.

### DIFF
--- a/lib/FileSystem/fnFsTNFS.cpp
+++ b/lib/FileSystem/fnFsTNFS.cpp
@@ -48,7 +48,7 @@ bool FileSystemTNFS::start(const char *host, uint16_t port, const char * mountpa
         {
             return false;
         }
-        _mountinfo.use_tcp = true;
+        _mountinfo.protocol = TNFS_PROTOCOL_TCP;
         strlcpy(_mountinfo.hostname, host_no_prefix, sizeof(_mountinfo.hostname));
     }
     else

--- a/lib/TNFSlib/tnfslibMountInfo.h
+++ b/lib/TNFSlib/tnfslibMountInfo.h
@@ -22,6 +22,10 @@
 
 #define TNFS_MAX_DIRCACHE_ENTRIES 32 // Max number of directory cache entries we'll store
 
+#define TNFS_PROTOCOL_UNKNOWN 0
+#define TNFS_PROTOCOL_TCP 1
+#define TNFS_PROTOCOL_UDP 2
+
 // Some things we need to keep track of for every file we open
 struct tnfsFileHandleInfo
 {
@@ -81,7 +85,7 @@ public:
     void set_dircache_eof() { _dir_cache_eof = true; };
     bool get_dircache_eof() { return _dir_cache_eof; };
 
-    bool use_tcp = false;
+    uint8_t protocol = TNFS_PROTOCOL_UNKNOWN;
     fnTcpClient tcp_client;
 
     // These char[] sizes are abitrary...


### PR DESCRIPTION
With this PR, the firmware will first try to connect to tnfsd using TCP protocol. If the connection is not possible (tcp/16384 doesn't respond) or the connection is accepted but server doesn't respond to the MOUNT command (because it's an old server version that doesn't handle TCP commands), the client will fallback to UDP.

My suggestion is to wait with merging this PR until these two servers support TCP:

* fujinet.atari8bit.net
* fujinet.pl

I already contacted owners.