### PR TITLE
webui: make webui mobile-friendly (responsive)

### DIFF
--- a/data/webui/template/www/css/core.tmpl.css
+++ b/data/webui/template/www/css/core.tmpl.css
@@ -3,7 +3,16 @@ body {
     margin: 1rem 1.5rem 1rem 1.5rem;
 }
 
-#logowob {
+* { box-sizing: border-box; }
+
+@media screen and (max-width: 600px) {
+    body {
+        margin: 1rem 0.5rem 1rem 0.5rem;
+        font-size: 13px;
+    }
+}
+
+.logowob {
     content: url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTAwJSIgaGVpZ2h0PSIxMDAlIiB2aWV3Qm94PSIwIDAgMTkzIDE4OSIgdmVyc2lvbj0iMS4xIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB4bWw6c3BhY2U9InByZXNlcnZlIiB4bWxuczpzZXJpZj0iaHR0cDovL3d3dy5zZXJpZi5jb20vIiBzdHlsZT0iZmlsbC1ydWxlOmV2ZW5vZGQ7Y2xpcC1ydWxlOmV2ZW5vZGQ7c3Ryb2tlLWxpbmVqb2luOnJvdW5kO3N0cm9rZS1taXRlcmxpbWl0OjI7Ij4KICAgIDxnPgogICAgICAgIDxjaXJjbGUgY3g9IjEzMS4zOTUiIGN5PSIxMjYuMjY4IiByPSIyMS41MTEiIHN0eWxlPSJzdHJva2U6I2ZmZjtzdHJva2Utd2lkdGg6Mi41OHB4OyIvPgogICAgICAgIDxjaXJjbGUgY3g9IjEzMS4zOTUiIGN5PSI4My4yNDUiIHI9IjIxLjUxMSIgc3R5bGU9InN0cm9rZTojZmZmO3N0cm9rZS13aWR0aDoyLjU4cHg7Ii8+CiAgICAgICAgPGNpcmNsZSBjeD0iODguMzcyIiBjeT0iODMuMjQ1IiByPSIyMS41MTEiIHN0eWxlPSJmaWxsOiNmZmY7c3Ryb2tlOiNmZmY7c3Ryb2tlLXdpZHRoOjIuNThweDsiLz4KICAgICAgICA8Y2lyY2xlIGN4PSI0NS4zNDkiIGN5PSI4My4yNDUiIHI9IjIxLjUxMSIgc3R5bGU9InN0cm9rZTojZmZmO3N0cm9rZS13aWR0aDoyLjU4cHg7Ii8+CiAgICAgICAgPGNpcmNsZSBjeD0iODguMzcyIiBjeT0iNDAuMjIzIiByPSIyMS41MTEiIHN0eWxlPSJzdHJva2U6I2ZmZjtzdHJva2Utd2lkdGg6Mi41OHB4OyIvPgogICAgICAgIDxwYXRoIGQ9Ik00NS4zNDksMTA0Ljc1N2wwLDQzLjAyMiIgc3R5bGU9ImZpbGw6bm9uZTtzdHJva2U6I2ZmZjtzdHJva2Utd2lkdGg6Mi4xOXB4O3N0cm9rZS1saW5lY2FwOnNxdWFyZTtzdHJva2UtbGluZWpvaW46bWl0ZXI7c3Ryb2tlLW1pdGVybGltaXQ6MS41OyIvPgogICAgICAgIDxwYXRoIGQ9Ik00NS4zNDksNjEuNzM0bDAsLTMxLjM2NSIgc3R5bGU9ImZpbGw6bm9uZTtzdHJva2U6I2ZmZjtzdHJva2Utd2lkdGg6Mi4wM3B4O3N0cm9rZS1saW5lY2FwOnNxdWFyZTtzdHJva2UtbGluZWpvaW46bWl0ZXI7c3Ryb2tlLW1pdGVybGltaXQ6MS41OyIvPgogICAgICAgIDxwYXRoIGQ9Ik04OC4zNzIsMS43NjhsMCwxNi45NDMiIHN0eWxlPSJmaWxsOm5vbmU7c3Ryb2tlOiNmZmY7c3Ryb2tlLXdpZHRoOjEuOTZweDtzdHJva2UtbGluZWNhcDpzcXVhcmU7c3Ryb2tlLWxpbmVqb2luOm1pdGVyO3N0cm9rZS1taXRlcmxpbWl0OjEuNTsiLz4KICAgICAgICA8cGF0aCBkPSJNMTA5Ljg4Myw0MC4yMjNsMzYuNzMsLTAiIHN0eWxlPSJmaWxsOm5vbmU7c3Ryb2tlOiNmZmY7c3Ryb2tlLXdpZHRoOjIuMXB4O3N0cm9rZS1saW5lY2FwOnNxdWFyZTtzdHJva2UtbGluZWpvaW46bWl0ZXI7c3Ryb2tlLW1pdGVybGltaXQ6MS41OyIvPgogICAgICAgIDxwYXRoIGQ9Ik02Ni44NjEsNDAuMjIzbC0zNi43MywtMCIgc3R5bGU9ImZpbGw6bm9uZTtzdHJva2U6I2ZmZjtzdHJva2Utd2lkdGg6Mi40cHg7c3Ryb2tlLWxpbmVjYXA6c3F1YXJlO3N0cm9rZS1saW5lam9pbjptaXRlcjtzdHJva2UtbWl0ZXJsaW1pdDoxLjU7Ii8+CiAgICAgICAgPHBhdGggZD0iTTIzLjgzOCw4My4yNDVsLTIxLjUxMSwwLjY2NSIgc3R5bGU9ImZpbGw6bm9uZTtzdHJva2U6I2ZmZjtzdHJva2Utd2lkdGg6Mi41OHB4O3N0cm9rZS1saW5lY2FwOnNxdWFyZTtzdHJva2UtbGluZWpvaW46bWl0ZXI7c3Ryb2tlLW1pdGVybGltaXQ6MS41OyIvPgogICAgICAgIDxwYXRoIGQ9Ik0xNTIuOTA2LDgzLjI0NWw2Ljk5NiwwIiBzdHlsZT0iZmlsbDpub25lO3N0cm9rZTojZmZmO3N0cm9rZS13aWR0aDoxLjkycHg7c3Ryb2tlLWxpbmVjYXA6c3F1YXJlO3N0cm9rZS1saW5lam9pbjptaXRlcjtzdHJva2UtbWl0ZXJsaW1pdDoxLjU7Ii8+CiAgICAgICAgPHBhdGggZD0iTTM0LjA3OCwxMjYuMjY4bDc1LjgwNSwwIiBzdHlsZT0iZmlsbDpub25lO3N0cm9rZTojZmZmO3N0cm9rZS13aWR0aDoyLjQzcHg7c3Ryb2tlLWxpbmVjYXA6c3F1YXJlO3N0cm9rZS1saW5lam9pbjptaXRlcjtzdHJva2UtbWl0ZXJsaW1pdDoxLjU7Ii8+CiAgICAgICAgPHBhdGggZD0iTTYuMTE0LDczLjEyN2wwLDI1Ljc0NyIgc3R5bGU9ImZpbGw6bm9uZTtzdHJva2U6I2ZmZjtzdHJva2Utd2lkdGg6Mi40OXB4O3N0cm9rZS1saW5lY2FwOnNxdWFyZTtzdHJva2UtbGluZWpvaW46bWl0ZXI7c3Ryb2tlLW1pdGVybGltaXQ6MS41OyIvPgogICAgICAgIDxwYXRoIGQ9Ik04OC4zNzIsMTA0Ljc1N2wwLDcyLjMwNSIgc3R5bGU9ImZpbGw6bm9uZTtzdHJva2U6I2ZmZjtzdHJva2Utd2lkdGg6Mi4zOHB4O3N0cm9rZS1saW5lY2FwOnNxdWFyZTtzdHJva2UtbGluZWpvaW46bWl0ZXI7c3Ryb2tlLW1pdGVybGltaXQ6MS41OyIvPgogICAgICAgIDxwYXRoIGQ9Ik0xMzEuMzk1LDE0Ny43NzlsLTAsMzkuMjY4IiBzdHlsZT0iZmlsbDpub25lO3N0cm9rZTojZmZmO3N0cm9rZS13aWR0aDoyLjE0cHg7c3Ryb2tlLWxpbmVjYXA6c3F1YXJlO3N0cm9rZS1saW5lam9pbjptaXRlcjtzdHJva2UtbWl0ZXJsaW1pdDoxLjU7Ii8+CiAgICAgICAgPHBhdGggZD0iTTE1Mi45MDYsMTI2LjI2OGwxNC4xNTgsMCIgc3R5bGU9ImZpbGw6bm9uZTtzdHJva2U6I2ZmZjtzdHJva2Utd2lkdGg6Mi4xOXB4O3N0cm9rZS1saW5lY2FwOnNxdWFyZTtzdHJva2UtbGluZWpvaW46bWl0ZXI7c3Ryb2tlLW1pdGVybGltaXQ6MS41OyIvPgogICAgICAgIDxwYXRoIGQ9Ik03OS4zODcsMTY5LjI5MWwxMTAuNzY3LC0wIiBzdHlsZT0iZmlsbDpub25lO3N0cm9rZTojZmZmO3N0cm9rZS13aWR0aDoyLjYycHg7c3Ryb2tlLWxpbmVjYXA6c3F1YXJlO3N0cm9rZS1saW5lam9pbjptaXRlcjtzdHJva2UtbWl0ZXJsaW1pdDoxLjU7Ii8+CiAgICAgICAgPHBhdGggZD0iTTE3NC40MTcsMTQyLjA4MWwwLDM5LjI2OCIgc3R5bGU9ImZpbGw6bm9uZTtzdHJva2U6I2ZmZjtzdHJva2Utd2lkdGg6Mi4yNnB4O3N0cm9rZS1saW5lY2FwOnNxdWFyZTtzdHJva2UtbGluZWpvaW46bWl0ZXI7c3Ryb2tlLW1pdGVybGltaXQ6MS41OyIvPgogICAgICAgIDxwYXRoIGQ9Ik0xMzEuMzk1LDMwLjM2OWwtMCwzMS4zNjUiIHN0eWxlPSJmaWxsOm5vbmU7c3Ryb2tlOiNmZmY7c3Ryb2tlLXdpZHRoOjIuMjZweDtzdHJva2UtbGluZWNhcDpzcXVhcmU7c3Ryb2tlLWxpbmVqb2luOm1pdGVyO3N0cm9rZS1taXRlcmxpbWl0OjEuNTsiLz4KICAgIDwvZz4KPC9zdmc+);
     width: 2.2rem;
     height: 2rem;
@@ -29,12 +38,13 @@ hr {
     margin: 0.5rem 0.5rem;
 }
 
-.header {
+.wrapper {
     width: 100%;
 }
 
 .headerlogo {
     width: 20rem;
+    max-width: 65%;
     margin: 0 auto;
 }
 
@@ -43,7 +53,7 @@ hr {
     text-align: center;
 }
 
-.flexparent {
+.module-container {
     display: flex;
     flex-wrap: wrap;
     flex-direction: column;
@@ -52,13 +62,13 @@ hr {
     align-content: stretch;
 }
 
-.flexchild {
+.module {
     border: 0.25rem solid #000;
     width: 100%;
-    margin: 0.5rem;
+    margin: 0.5rem 0;
 }
 
-.flexchild .child-header {
+.module .module-header {
     color: #fff;
     border: 0.25rem solid #000;
     background-color: #000;
@@ -66,7 +76,7 @@ hr {
     font-size: 1.5rem;
 }
 
-.flexchild .child-header button {
+.module .module-header button {
     border: 1px solid rgba(0, 0, 0, 0.2);
     height: 2rem;
     line-height: 1.9rem;
@@ -141,7 +151,7 @@ hr {
 
 .radio-container .r-yes-no {
     width: 3rem;
-    font-size: medium;
+    font-size: small;
 }
 
 .radio-container .r-pr-activate {
@@ -202,9 +212,67 @@ hr {
     padding: 1rem 0;
 }
 
+.settings .settings-content .action-link {
+    display: none;
+}
+
 .settings .settings-footer {
     grid-area: f;
     text-align: center;
+}
+
+@media only screen and (max-width: 500px) {
+    .settings {
+        display: grid;
+        width: 100%;
+        grid-template-areas: "i h" "c c" "f f";
+        grid-template-columns: 3rem 1fr;
+        grid-template-rows: 3rem 1fr 3rem;
+    }
+
+    .settings .settings-left {
+        grid-area: i;
+        min-height: unset;
+        border-right: none;
+        border-bottom: 4px black solid;
+    }
+
+    .settings .settings-left .svgicon {
+        margin-top: 17.5%;
+    }
+
+    .settings .settings-left .action-link {
+        display: none;
+    }
+
+    .settings .settings-header {
+        grid-area: h;
+        font-size: 1.2rem;
+    }
+
+    .settings .settings-header .logowob {
+        width: 1.5rem;
+    }
+
+    .settings .settings-content {
+        grid-area: c;
+        padding: 1rem 0;
+    }
+
+    .settings .settings-content .action-link {
+        display: inline-block;
+        margin-left: 1rem;
+        margin-bottom: 1rem;
+    }
+
+    .settings .settings-footer {
+        grid-area: f;
+        text-align: center;
+    }
+
+    label.r-yes-no {
+        font-size: 1rem;
+    }
 }
 
 .settings .settings-footer button {
@@ -440,6 +508,11 @@ select:focus+.focus {
     font-weight: bolder;
 }
 
+.action-link {
+    color: #000;
+    font-weight: bolder;
+}
+
 @media only screen and (min-width: 500px) {
     .radio-container .r-pr-activate {
         width: 4rem;
@@ -453,7 +526,7 @@ select:focus+.focus {
 
     .radio-container .r-config-boot-mode {
         width: 2.5rem;
-        font-size: xx-small;
+        font-size: x-small;
     }
 }
 
@@ -470,9 +543,17 @@ select:focus+.focus {
 }
 
 @media only screen and (min-width: 600px) {
+    .module {
+        margin: 0.5rem;
+    }
+
     .radio-container .r-pr-activate {
         width: 5rem;
         font-size: small;
+    }
+
+    .radio-container .r-yes-no {
+        font-size: medium;
     }
 
     .radio-container .r-config-boot-mode {
@@ -494,11 +575,11 @@ select:focus+.focus {
 }
 
 @media only screen and (min-width: 1024px) {
-    .flexparent {
+    .module-container {
         flex-direction: row;
     }
 
-    .flexchild {
+    .module {
         width: 47.5%;
     }
 
@@ -514,7 +595,7 @@ select:focus+.focus {
 }
 
 @media only screen and (min-width: 1280px) {
-    .flexparent {
+    .module-container {
         flex-direction: row;
     }
 

--- a/data/webui/template/www/header.tmpl.html
+++ b/data/webui/template/www/header.tmpl.html
@@ -3,9 +3,10 @@
     <head>
         <title>Directory</title>
         <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <script type="text/javascript" src="{{ paths.js_path }}/utils.js"></script>
         <style>
-            #logowob {
+            .logowob {
                 content: url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTAwJSIgaGVpZ2h0PSIxMDAlIiB2aWV3Qm94PSIwIDAgMTkzIDE4OSIgdmVyc2lvbj0iMS4xIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB4bWw6c3BhY2U9InByZXNlcnZlIiB4bWxuczpzZXJpZj0iaHR0cDovL3d3dy5zZXJpZi5jb20vIiBzdHlsZT0iZmlsbC1ydWxlOmV2ZW5vZGQ7Y2xpcC1ydWxlOmV2ZW5vZGQ7c3Ryb2tlLWxpbmVqb2luOnJvdW5kO3N0cm9rZS1taXRlcmxpbWl0OjI7Ij4KICAgIDxnPgogICAgICAgIDxjaXJjbGUgY3g9IjEzMS4zOTUiIGN5PSIxMjYuMjY4IiByPSIyMS41MTEiIHN0eWxlPSJzdHJva2U6I2ZmZjtzdHJva2Utd2lkdGg6Mi41OHB4OyIvPgogICAgICAgIDxjaXJjbGUgY3g9IjEzMS4zOTUiIGN5PSI4My4yNDUiIHI9IjIxLjUxMSIgc3R5bGU9InN0cm9rZTojZmZmO3N0cm9rZS13aWR0aDoyLjU4cHg7Ii8+CiAgICAgICAgPGNpcmNsZSBjeD0iODguMzcyIiBjeT0iODMuMjQ1IiByPSIyMS41MTEiIHN0eWxlPSJmaWxsOiNmZmY7c3Ryb2tlOiNmZmY7c3Ryb2tlLXdpZHRoOjIuNThweDsiLz4KICAgICAgICA8Y2lyY2xlIGN4PSI0NS4zNDkiIGN5PSI4My4yNDUiIHI9IjIxLjUxMSIgc3R5bGU9InN0cm9rZTojZmZmO3N0cm9rZS13aWR0aDoyLjU4cHg7Ii8+CiAgICAgICAgPGNpcmNsZSBjeD0iODguMzcyIiBjeT0iNDAuMjIzIiByPSIyMS41MTEiIHN0eWxlPSJzdHJva2U6I2ZmZjtzdHJva2Utd2lkdGg6Mi41OHB4OyIvPgogICAgICAgIDxwYXRoIGQ9Ik00NS4zNDksMTA0Ljc1N2wwLDQzLjAyMiIgc3R5bGU9ImZpbGw6bm9uZTtzdHJva2U6I2ZmZjtzdHJva2Utd2lkdGg6Mi4xOXB4O3N0cm9rZS1saW5lY2FwOnNxdWFyZTtzdHJva2UtbGluZWpvaW46bWl0ZXI7c3Ryb2tlLW1pdGVybGltaXQ6MS41OyIvPgogICAgICAgIDxwYXRoIGQ9Ik00NS4zNDksNjEuNzM0bDAsLTMxLjM2NSIgc3R5bGU9ImZpbGw6bm9uZTtzdHJva2U6I2ZmZjtzdHJva2Utd2lkdGg6Mi4wM3B4O3N0cm9rZS1saW5lY2FwOnNxdWFyZTtzdHJva2UtbGluZWpvaW46bWl0ZXI7c3Ryb2tlLW1pdGVybGltaXQ6MS41OyIvPgogICAgICAgIDxwYXRoIGQ9Ik04OC4zNzIsMS43NjhsMCwxNi45NDMiIHN0eWxlPSJmaWxsOm5vbmU7c3Ryb2tlOiNmZmY7c3Ryb2tlLXdpZHRoOjEuOTZweDtzdHJva2UtbGluZWNhcDpzcXVhcmU7c3Ryb2tlLWxpbmVqb2luOm1pdGVyO3N0cm9rZS1taXRlcmxpbWl0OjEuNTsiLz4KICAgICAgICA8cGF0aCBkPSJNMTA5Ljg4Myw0MC4yMjNsMzYuNzMsLTAiIHN0eWxlPSJmaWxsOm5vbmU7c3Ryb2tlOiNmZmY7c3Ryb2tlLXdpZHRoOjIuMXB4O3N0cm9rZS1saW5lY2FwOnNxdWFyZTtzdHJva2UtbGluZWpvaW46bWl0ZXI7c3Ryb2tlLW1pdGVybGltaXQ6MS41OyIvPgogICAgICAgIDxwYXRoIGQ9Ik02Ni44NjEsNDAuMjIzbC0zNi43MywtMCIgc3R5bGU9ImZpbGw6bm9uZTtzdHJva2U6I2ZmZjtzdHJva2Utd2lkdGg6Mi40cHg7c3Ryb2tlLWxpbmVjYXA6c3F1YXJlO3N0cm9rZS1saW5lam9pbjptaXRlcjtzdHJva2UtbWl0ZXJsaW1pdDoxLjU7Ii8+CiAgICAgICAgPHBhdGggZD0iTTIzLjgzOCw4My4yNDVsLTIxLjUxMSwwLjY2NSIgc3R5bGU9ImZpbGw6bm9uZTtzdHJva2U6I2ZmZjtzdHJva2Utd2lkdGg6Mi41OHB4O3N0cm9rZS1saW5lY2FwOnNxdWFyZTtzdHJva2UtbGluZWpvaW46bWl0ZXI7c3Ryb2tlLW1pdGVybGltaXQ6MS41OyIvPgogICAgICAgIDxwYXRoIGQ9Ik0xNTIuOTA2LDgzLjI0NWw2Ljk5NiwwIiBzdHlsZT0iZmlsbDpub25lO3N0cm9rZTojZmZmO3N0cm9rZS13aWR0aDoxLjkycHg7c3Ryb2tlLWxpbmVjYXA6c3F1YXJlO3N0cm9rZS1saW5lam9pbjptaXRlcjtzdHJva2UtbWl0ZXJsaW1pdDoxLjU7Ii8+CiAgICAgICAgPHBhdGggZD0iTTM0LjA3OCwxMjYuMjY4bDc1LjgwNSwwIiBzdHlsZT0iZmlsbDpub25lO3N0cm9rZTojZmZmO3N0cm9rZS13aWR0aDoyLjQzcHg7c3Ryb2tlLWxpbmVjYXA6c3F1YXJlO3N0cm9rZS1saW5lam9pbjptaXRlcjtzdHJva2UtbWl0ZXJsaW1pdDoxLjU7Ii8+CiAgICAgICAgPHBhdGggZD0iTTYuMTE0LDczLjEyN2wwLDI1Ljc0NyIgc3R5bGU9ImZpbGw6bm9uZTtzdHJva2U6I2ZmZjtzdHJva2Utd2lkdGg6Mi40OXB4O3N0cm9rZS1saW5lY2FwOnNxdWFyZTtzdHJva2UtbGluZWpvaW46bWl0ZXI7c3Ryb2tlLW1pdGVybGltaXQ6MS41OyIvPgogICAgICAgIDxwYXRoIGQ9Ik04OC4zNzIsMTA0Ljc1N2wwLDcyLjMwNSIgc3R5bGU9ImZpbGw6bm9uZTtzdHJva2U6I2ZmZjtzdHJva2Utd2lkdGg6Mi4zOHB4O3N0cm9rZS1saW5lY2FwOnNxdWFyZTtzdHJva2UtbGluZWpvaW46bWl0ZXI7c3Ryb2tlLW1pdGVybGltaXQ6MS41OyIvPgogICAgICAgIDxwYXRoIGQ9Ik0xMzEuMzk1LDE0Ny43NzlsLTAsMzkuMjY4IiBzdHlsZT0iZmlsbDpub25lO3N0cm9rZTojZmZmO3N0cm9rZS13aWR0aDoyLjE0cHg7c3Ryb2tlLWxpbmVjYXA6c3F1YXJlO3N0cm9rZS1saW5lam9pbjptaXRlcjtzdHJva2UtbWl0ZXJsaW1pdDoxLjU7Ii8+CiAgICAgICAgPHBhdGggZD0iTTE1Mi45MDYsMTI2LjI2OGwxNC4xNTgsMCIgc3R5bGU9ImZpbGw6bm9uZTtzdHJva2U6I2ZmZjtzdHJva2Utd2lkdGg6Mi4xOXB4O3N0cm9rZS1saW5lY2FwOnNxdWFyZTtzdHJva2UtbGluZWpvaW46bWl0ZXI7c3Ryb2tlLW1pdGVybGltaXQ6MS41OyIvPgogICAgICAgIDxwYXRoIGQ9Ik03OS4zODcsMTY5LjI5MWwxMTAuNzY3LC0wIiBzdHlsZT0iZmlsbDpub25lO3N0cm9rZTojZmZmO3N0cm9rZS13aWR0aDoyLjYycHg7c3Ryb2tlLWxpbmVjYXA6c3F1YXJlO3N0cm9rZS1saW5lam9pbjptaXRlcjtzdHJva2UtbWl0ZXJsaW1pdDoxLjU7Ii8+CiAgICAgICAgPHBhdGggZD0iTTE3NC40MTcsMTQyLjA4MWwwLDM5LjI2OCIgc3R5bGU9ImZpbGw6bm9uZTtzdHJva2U6I2ZmZjtzdHJva2Utd2lkdGg6Mi4yNnB4O3N0cm9rZS1saW5lY2FwOnNxdWFyZTtzdHJva2UtbGluZWpvaW46bWl0ZXI7c3Ryb2tlLW1pdGVybGltaXQ6MS41OyIvPgogICAgICAgIDxwYXRoIGQ9Ik0xMzEuMzk1LDMwLjM2OWwtMCwzMS4zNjUiIHN0eWxlPSJmaWxsOm5vbmU7c3Ryb2tlOiNmZmY7c3Ryb2tlLXdpZHRoOjIuMjZweDtzdHJva2UtbGluZWNhcDpzcXVhcmU7c3Ryb2tlLWxpbmVqb2luOm1pdGVyO3N0cm9rZS1taXRlcmxpbWl0OjEuNTsiLz4KICAgIDwvZz4KPC9zdmc+);
                 width: 2.2rem;
                 height: 2rem;
@@ -37,6 +38,7 @@
 
             .headerlogo {
                 width: 20rem;
+                max-width: 65%;
                 margin: 0 auto;
             }
 
@@ -45,7 +47,7 @@
                 text-align: center;
             }
 
-            .flexparent {
+            .module-container {
                 display: flex;
                 flex-wrap: wrap;
                 flex-direction: column;
@@ -54,13 +56,13 @@
                 align-content: stretch;
             }
 
-            .flexchild {
+            .module {
                 border: 0.2rem solid #000;
                 width: 99%;
                 margin: 0.5rem;
             }
 
-            .flexchild header {
+            .module header {
                 color: #fff;
                 border: 0.2rem solid #000;
                 background-color: #000;
@@ -201,11 +203,11 @@
                 optgroup {
                     /* font-size: 130%; */
                 }
-                .flexparent {
+                .module-container {
                     flex-direction: row;
                 }
 
-                .flexchild {
+                .module {
                     width: 47.5%;
                 }
 
@@ -219,11 +221,11 @@
                     /* font-size: 120%; */
                 }
 
-                .flexparent {
+                .module-container {
                     flex-direction: row;
                 }
 
-                .flexchild {
+                .module {
                     width: 47.5%;
                 }
 

--- a/data/webui/template/www/index.tmpl.html
+++ b/data/webui/template/www/index.tmpl.html
@@ -4,12 +4,13 @@
 <head>
 	<title>FujiNet - {% if tweaks.fujinet_pc %}<%FN_LABEL%>{% else %}<%FN_HOSTNAME%>{% endif %}</title>
 	<meta charset="utf-8" />
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<script type="text/javascript" src="{{ paths.js_path }}/utils.js"></script>
 	<link rel="stylesheet" href="{{ paths.css_path }}/core.css">
 </head>
 
 <body>
-	<div class="header">
+	<div class="wrapper">
 		<div class="headerlogo">
 			<a href="https://fujinet.online/">
 				<svg width="100%" height="100%" viewBox="0 0 594 189" version="1.1" xmlns="http://www.w3.org/2000/svg"
@@ -76,15 +77,17 @@
 				</svg>
 			</a>
 		</div>
-		<div class="flexparent">
-			<div class="flexchild">
-				<h2 style="text-align: center;">Need help? Go to the <a href="https://github.com/FujiNetWIFI/fujinet-platformio/wiki">FujiNet Wiki!</a></h2>
+
+		<div class="module-container">
+			<div class="module">
+				<h3 style="text-align: center;">Need help? Go to the <a href="https://github.com/FujiNetWIFI/fujinet-platformio/wiki">FujiNet Wiki!</a></h3>
 			</div>
 		</div>
-		<div class="flexparent">
+
+		<div class="module-container">
 			{% if components.network %}
-			<div class="flexchild">
-				<header class="child-header">NET<span id="logowob"></span>WORK</header>
+			<div class="module">
+				<header class="module-header">NET<span class="logowob"></span>WORK</header>
 				<div class="detline">
 					<div class="deth detlinecol">FujiNet version</div>
 					<div class="det detlinecol"><%FN_VERSION%></div>
@@ -159,9 +162,9 @@
 			</div>
 			{% endif %}
 			{% if components.hardware %}
-			<div class="flexchild">
-				<header class="child-header">
-					HARD<span id="logowob"></span>WARE
+			<div class="module">
+				<header class="module-header">
+					HARD<span class="logowob"></span>WARE
 					<span style="float: right">
 						{% if tweaks.fujinet_pc %}
 						<input type="button" id="restartButton" value="Restart..." onclick="restartButton()" style="width: 7em">
@@ -274,8 +277,8 @@
 			</div>
 			{% endif %}
 			{% if components.hosts_list %}
-			<div class="flexchild">
-				<header class="child-header">HOSTS<span id="logowob"></span>LIST</header>
+			<div class="module">
+				<header class="module-header">HOSTS<span class="logowob"></span>LIST</header>
 				{% for hs in range(1, 9) %}
 				<div class="{{ loop.cycle('detline', 'detline alt') }}">
 					<div class="deth detlinecol">Host {{ hs }}</div>
@@ -289,8 +292,8 @@
 			</div>
 			{% endif %}
 			{% if components.mount_list %}
-			<div class="flexchild">
-				<header class="child-header">MOUNT<span id="logowob"></span>LIST</header>
+			<div class="module">
+				<header class="module-header">MOUNT<span class="logowob"></span>LIST</header>
 				{% if not tweaks.fujinet_pc %}
 				<div class="detline alt">
 					<div class="deth detlinecol"><a href="/mount?mountall=1"> MOUNT ALL DISKS</a></div>
@@ -336,10 +339,10 @@
 			</div>
 			{% endif %}
 			{% if components.printer_settings %}
-			<div class="flexchild">
+			<div class="module">
 				<form action="/config" method="post">
 				<div class="settings">
-					<div class="settings-header">Printer<span id="logowob"></span>Settings</div>
+					<div class="settings-header">Printer<span class="logowob"></span>Settings</div>
 					<div class="settings-left">
 						<div class="svgicon">
 						<a href="/print">
@@ -397,11 +400,12 @@
 									</g>
 								</g>
 							</svg>
-							<span class="important">Click to download your current print-out</span>
+							<span class="action-link">Click to download your current print-out</span>
 						</a>
 						</div>
 					</div>
 					<div class="settings-content settings-45-55">
+						<a href="/print" class="action-link">Download your current print-out</a>
 						<div class="set">
 							<div class="settings-label">
 								<label>Use as virtual printer</label>
@@ -460,11 +464,11 @@
 			</div>
 			{% endif %}
 			{% if components.modem_settings %}
-			<div class="flexchild">
+			<div class="module">
 				<form action="/config" method="post">
 				<div class="settings">
 					<div class="settings-header">
-						Modem<span id="logowob"></span>Settings
+						Modem<span class="logowob"></span>Settings
 					</div>
 					<div class="settings-left">
 						<a href="/modem-sniffer.txt">
@@ -493,11 +497,12 @@
 										</g>
 									</g>
 								</svg>
-								<span class="important">Click to download modem sniffer log</span>
+								<span class="action-link">Click to download modem sniffer log</span>
 							</div>
 						</a>
 					</div>
 					<div class="settings-content settings-55-45">
+						<a href="/modem-sniffer.txt" class="action-link">Download modem sniffer log</a>
 						<div class="set">
 							<div class="settings-label">
 								<label>Use as virtual modem</label>
@@ -539,11 +544,11 @@
 			</div>
 			{% endif %}
 			{% if components.hsio_settings %}
-			<div class="flexchild">
+			<div class="module">
 				<form action="/config" method="post">
 				<div class="settings">
 					<div class="settings-header">
-						HSIO<span id="logowob"></span>Settings
+						HSIO<span class="logowob"></span>Settings
 					</div>
 					<div class="settings-left">
 						<div class="svgicon">
@@ -640,11 +645,11 @@
 			</div>
 			{% endif %}
 			{% if components.timezone %}
-			<div class="flexchild">
+			<div class="module">
 				<form action="/config" method="post">
 				<div class="settings">
 					<div class="settings-header">
-						Time<span id="logowob"></span>{% if tweaks.fujinet_pc %}Settings{% else %}Zone{% endif %}
+						Time<span class="logowob"></span>{% if tweaks.fujinet_pc %}Settings{% else %}Zone{% endif %}
 					</div>
 					<script>
 						{% if components.apetime %}
@@ -739,10 +744,10 @@
 			</div>
 			{% endif %}
 			{% if components.udp_stream %}
-			<div class="flexchild">
+			<div class="module">
 				<div class="settings">
 					<div class="settings-header">
-						UDP<span id="logowob"></span>Stream
+						UDP<span class="logowob"></span>Stream
 					</div>
 					<div class="settings-left">
 						<div class="svgicon">
@@ -800,10 +805,10 @@
 			</div>
 			{% endif %}
 			{% if components.program_recorder %}
-			<div class="flexchild">
+			<div class="module">
 				<div class="settings">
 					<div class="settings-header">
-						Program<span id="logowob"></span>Recorder
+						Program<span class="logowob"></span>Recorder
 					</div>
 					<script>
 						var current_cassette_enabled = "<%FN_CASSETTE_ENABLED%>";
@@ -908,15 +913,15 @@
 			</div>
 			{% endif %}
 			{% if components.cpm_settings %}
-			<div class="flexchild">
+			<div class="module">
 				<form action="/config" method="post">
 				<div class="settings">
 					<div class="settings-header">
-						CP/M<span id="logowob"></span>Settings
+						CP/M<span class="logowob"></span>Settings
 					</div>
 					<div class="settings-left">
 							<div class="svgicon">
-								<svg width="53.317mm" height="46.17mm" version="1.1" viewBox="0 0 53.317 46.17" xmlns="http://www.w3.org/2000/svg">
+								<svg width="100%" height="100%" version="1.1" viewBox="0 0 53.317 46.17" xmlns="http://www.w3.org/2000/svg">
 								 <g transform="translate(-7.5798 -24.586)">
 								  <rect x="9.7771" y="26.784" width="48.922" height="41.775" ry="8.4013" fill="#454545" stroke="#000" stroke-width="3.9947"/>
 								  <g fill="#0f0">
@@ -981,11 +986,11 @@
 			</div>
 			{% endif %}
 			{% if components.pclink %}
-			<div class="flexchild">
+			<div class="module">
 				<form action="/config" method="post">
 				<div class="settings">
 					<div class="settings-header">
-						PC<span id="logowob"></span>Link
+						PC<span class="logowob"></span>Link
 					</div>
 					<script>
 						var current_pclink = "<%FN_PCLINK_ENABLED%>";
@@ -1023,11 +1028,11 @@
 			</div>
 			{% endif %}
 			{% if components.disk_swap %}
-			<div class="flexchild">
+			<div class="module">
 				<form action="/config" method="post">
 				<div class="settings">
 					<div class="settings-header">
-						Disk<span id="logowob"></span>Swap
+						Disk<span class="logowob"></span>Swap
 					</div>
 					<script>
 						var current_rotation_sounds = "<%FN_ROTATION_SOUNDS%>";
@@ -1123,10 +1128,10 @@
 			</div>
 			{% endif %}
 			{% if components.serial_port %}
-			<div class="flexchild">
+			<div class="module">
 				<form action="/config" method="post">
 				<div class="settings">
-					<div class="settings-header">Serial<span id="logowob"></span>Port</div>
+					<div class="settings-header">Serial<span class="logowob"></span>Port</div>
 					<div class="settings-left">
 						<div class="svgicon">
 							<svg width="100%" height="100%" viewBox="0 0 140 140" version="1.1" xmlns="http://www.w3.org/2000/svg"
@@ -1209,10 +1214,10 @@
 			</div>
 			{% endif %}
 			{% if components.emulator_settings %}
-			<div class="flexchild">
+			<div class="module">
 				<form action="/config" method="post">
 				<div class="settings">
-					<div class="settings-header">Emulator<span id="logowob"></span>Settings</div>
+					<div class="settings-header">Emulator<span class="logowob"></span>Settings</div>
 					<div class="settings-left">
 						<div class="svgicon">
 						</div>
@@ -1261,11 +1266,11 @@
 			</div>
 			{% endif %}
 			{% if components.boot_settings %}
-			<div class="flexchild">
+			<div class="module">
 				<form action="/config" method="post">
 				<div class="settings">
 					<div class="settings-header">
-						Boot<span id="logowob"></span>Settings
+						Boot<span class="logowob"></span>Settings
 					</div>
 					<script>
 						var current_boot_mode = "<%FN_BOOT_MODE%>";

--- a/data/webui/template/www/restart.html
+++ b/data/webui/template/www/restart.html
@@ -4,8 +4,9 @@
 <head>
 	<title>FujiNet - <%FN_LABEL%> : Restarting ...</title>
 	<meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<style>
-		#logowob {
+		.logowob {
 			content: url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTAwJSIgaGVpZ2h0PSIxMDAlIiB2aWV3Qm94PSIwIDAgMTkzIDE4OSIgdmVyc2lvbj0iMS4xIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB4bWw6c3BhY2U9InByZXNlcnZlIiB4bWxuczpzZXJpZj0iaHR0cDovL3d3dy5zZXJpZi5jb20vIiBzdHlsZT0iZmlsbC1ydWxlOmV2ZW5vZGQ7Y2xpcC1ydWxlOmV2ZW5vZGQ7c3Ryb2tlLWxpbmVqb2luOnJvdW5kO3N0cm9rZS1taXRlcmxpbWl0OjI7Ij4KICAgIDxnPgogICAgICAgIDxjaXJjbGUgY3g9IjEzMS4zOTUiIGN5PSIxMjYuMjY4IiByPSIyMS41MTEiIHN0eWxlPSJzdHJva2U6I2ZmZjtzdHJva2Utd2lkdGg6Mi41OHB4OyIvPgogICAgICAgIDxjaXJjbGUgY3g9IjEzMS4zOTUiIGN5PSI4My4yNDUiIHI9IjIxLjUxMSIgc3R5bGU9InN0cm9rZTojZmZmO3N0cm9rZS13aWR0aDoyLjU4cHg7Ii8+CiAgICAgICAgPGNpcmNsZSBjeD0iODguMzcyIiBjeT0iODMuMjQ1IiByPSIyMS41MTEiIHN0eWxlPSJmaWxsOiNmZmY7c3Ryb2tlOiNmZmY7c3Ryb2tlLXdpZHRoOjIuNThweDsiLz4KICAgICAgICA8Y2lyY2xlIGN4PSI0NS4zNDkiIGN5PSI4My4yNDUiIHI9IjIxLjUxMSIgc3R5bGU9InN0cm9rZTojZmZmO3N0cm9rZS13aWR0aDoyLjU4cHg7Ii8+CiAgICAgICAgPGNpcmNsZSBjeD0iODguMzcyIiBjeT0iNDAuMjIzIiByPSIyMS41MTEiIHN0eWxlPSJzdHJva2U6I2ZmZjtzdHJva2Utd2lkdGg6Mi41OHB4OyIvPgogICAgICAgIDxwYXRoIGQ9Ik00NS4zNDksMTA0Ljc1N2wwLDQzLjAyMiIgc3R5bGU9ImZpbGw6bm9uZTtzdHJva2U6I2ZmZjtzdHJva2Utd2lkdGg6Mi4xOXB4O3N0cm9rZS1saW5lY2FwOnNxdWFyZTtzdHJva2UtbGluZWpvaW46bWl0ZXI7c3Ryb2tlLW1pdGVybGltaXQ6MS41OyIvPgogICAgICAgIDxwYXRoIGQ9Ik00NS4zNDksNjEuNzM0bDAsLTMxLjM2NSIgc3R5bGU9ImZpbGw6bm9uZTtzdHJva2U6I2ZmZjtzdHJva2Utd2lkdGg6Mi4wM3B4O3N0cm9rZS1saW5lY2FwOnNxdWFyZTtzdHJva2UtbGluZWpvaW46bWl0ZXI7c3Ryb2tlLW1pdGVybGltaXQ6MS41OyIvPgogICAgICAgIDxwYXRoIGQ9Ik04OC4zNzIsMS43NjhsMCwxNi45NDMiIHN0eWxlPSJmaWxsOm5vbmU7c3Ryb2tlOiNmZmY7c3Ryb2tlLXdpZHRoOjEuOTZweDtzdHJva2UtbGluZWNhcDpzcXVhcmU7c3Ryb2tlLWxpbmVqb2luOm1pdGVyO3N0cm9rZS1taXRlcmxpbWl0OjEuNTsiLz4KICAgICAgICA8cGF0aCBkPSJNMTA5Ljg4Myw0MC4yMjNsMzYuNzMsLTAiIHN0eWxlPSJmaWxsOm5vbmU7c3Ryb2tlOiNmZmY7c3Ryb2tlLXdpZHRoOjIuMXB4O3N0cm9rZS1saW5lY2FwOnNxdWFyZTtzdHJva2UtbGluZWpvaW46bWl0ZXI7c3Ryb2tlLW1pdGVybGltaXQ6MS41OyIvPgogICAgICAgIDxwYXRoIGQ9Ik02Ni44NjEsNDAuMjIzbC0zNi43MywtMCIgc3R5bGU9ImZpbGw6bm9uZTtzdHJva2U6I2ZmZjtzdHJva2Utd2lkdGg6Mi40cHg7c3Ryb2tlLWxpbmVjYXA6c3F1YXJlO3N0cm9rZS1saW5lam9pbjptaXRlcjtzdHJva2UtbWl0ZXJsaW1pdDoxLjU7Ii8+CiAgICAgICAgPHBhdGggZD0iTTIzLjgzOCw4My4yNDVsLTIxLjUxMSwwLjY2NSIgc3R5bGU9ImZpbGw6bm9uZTtzdHJva2U6I2ZmZjtzdHJva2Utd2lkdGg6Mi41OHB4O3N0cm9rZS1saW5lY2FwOnNxdWFyZTtzdHJva2UtbGluZWpvaW46bWl0ZXI7c3Ryb2tlLW1pdGVybGltaXQ6MS41OyIvPgogICAgICAgIDxwYXRoIGQ9Ik0xNTIuOTA2LDgzLjI0NWw2Ljk5NiwwIiBzdHlsZT0iZmlsbDpub25lO3N0cm9rZTojZmZmO3N0cm9rZS13aWR0aDoxLjkycHg7c3Ryb2tlLWxpbmVjYXA6c3F1YXJlO3N0cm9rZS1saW5lam9pbjptaXRlcjtzdHJva2UtbWl0ZXJsaW1pdDoxLjU7Ii8+CiAgICAgICAgPHBhdGggZD0iTTM0LjA3OCwxMjYuMjY4bDc1LjgwNSwwIiBzdHlsZT0iZmlsbDpub25lO3N0cm9rZTojZmZmO3N0cm9rZS13aWR0aDoyLjQzcHg7c3Ryb2tlLWxpbmVjYXA6c3F1YXJlO3N0cm9rZS1saW5lam9pbjptaXRlcjtzdHJva2UtbWl0ZXJsaW1pdDoxLjU7Ii8+CiAgICAgICAgPHBhdGggZD0iTTYuMTE0LDczLjEyN2wwLDI1Ljc0NyIgc3R5bGU9ImZpbGw6bm9uZTtzdHJva2U6I2ZmZjtzdHJva2Utd2lkdGg6Mi40OXB4O3N0cm9rZS1saW5lY2FwOnNxdWFyZTtzdHJva2UtbGluZWpvaW46bWl0ZXI7c3Ryb2tlLW1pdGVybGltaXQ6MS41OyIvPgogICAgICAgIDxwYXRoIGQ9Ik04OC4zNzIsMTA0Ljc1N2wwLDcyLjMwNSIgc3R5bGU9ImZpbGw6bm9uZTtzdHJva2U6I2ZmZjtzdHJva2Utd2lkdGg6Mi4zOHB4O3N0cm9rZS1saW5lY2FwOnNxdWFyZTtzdHJva2UtbGluZWpvaW46bWl0ZXI7c3Ryb2tlLW1pdGVybGltaXQ6MS41OyIvPgogICAgICAgIDxwYXRoIGQ9Ik0xMzEuMzk1LDE0Ny43NzlsLTAsMzkuMjY4IiBzdHlsZT0iZmlsbDpub25lO3N0cm9rZTojZmZmO3N0cm9rZS13aWR0aDoyLjE0cHg7c3Ryb2tlLWxpbmVjYXA6c3F1YXJlO3N0cm9rZS1saW5lam9pbjptaXRlcjtzdHJva2UtbWl0ZXJsaW1pdDoxLjU7Ii8+CiAgICAgICAgPHBhdGggZD0iTTE1Mi45MDYsMTI2LjI2OGwxNC4xNTgsMCIgc3R5bGU9ImZpbGw6bm9uZTtzdHJva2U6I2ZmZjtzdHJva2Utd2lkdGg6Mi4xOXB4O3N0cm9rZS1saW5lY2FwOnNxdWFyZTtzdHJva2UtbGluZWpvaW46bWl0ZXI7c3Ryb2tlLW1pdGVybGltaXQ6MS41OyIvPgogICAgICAgIDxwYXRoIGQ9Ik03OS4zODcsMTY5LjI5MWwxMTAuNzY3LC0wIiBzdHlsZT0iZmlsbDpub25lO3N0cm9rZTojZmZmO3N0cm9rZS13aWR0aDoyLjYycHg7c3Ryb2tlLWxpbmVjYXA6c3F1YXJlO3N0cm9rZS1saW5lam9pbjptaXRlcjtzdHJva2UtbWl0ZXJsaW1pdDoxLjU7Ii8+CiAgICAgICAgPHBhdGggZD0iTTE3NC40MTcsMTQyLjA4MWwwLDM5LjI2OCIgc3R5bGU9ImZpbGw6bm9uZTtzdHJva2U6I2ZmZjtzdHJva2Utd2lkdGg6Mi4yNnB4O3N0cm9rZS1saW5lY2FwOnNxdWFyZTtzdHJva2UtbGluZWpvaW46bWl0ZXI7c3Ryb2tlLW1pdGVybGltaXQ6MS41OyIvPgogICAgICAgIDxwYXRoIGQ9Ik0xMzEuMzk1LDMwLjM2OWwtMCwzMS4zNjUiIHN0eWxlPSJmaWxsOm5vbmU7c3Ryb2tlOiNmZmY7c3Ryb2tlLXdpZHRoOjIuMjZweDtzdHJva2UtbGluZWNhcDpzcXVhcmU7c3Ryb2tlLWxpbmVqb2luOm1pdGVyO3N0cm9rZS1taXRlcmxpbWl0OjEuNTsiLz4KICAgIDwvZz4KPC9zdmc+);
 			width: 2.2rem;
 			height: 2rem;
@@ -42,6 +43,7 @@
 
 		.headerlogo {
 			width: 20rem;
+			max-width: 65%;
 			margin: 0 auto;
 		}
 
@@ -50,7 +52,7 @@
 			text-align: center;
 		}
 
-		.flexparent {
+		.module-container {
 			display: flex;
 			flex-wrap: wrap;
 			flex-direction: column;
@@ -59,13 +61,13 @@
 			align-content: stretch;
 		}
 
-		.flexchild {
+		.module {
 			border: 0.2rem solid #000;
 			width: 99%;
 			margin: 0.5rem;
 		}
 
-		.flexchild header {
+		.module header {
 			color: #fff;
 			border: 0.2rem solid #000;
 			background-color: #000;
@@ -174,11 +176,11 @@
 			optgroup {
 				/* font-size: 130%; */
 			}
-			.flexparent {
+			.module-container {
 				flex-direction: row;
 			}
 
-			.flexchild {
+			.module {
 				width: 47.5%;
 			}
 
@@ -192,11 +194,11 @@
 				/* font-size: 120%; */
 			}
 
-			.flexparent {
+			.module-container {
 				flex-direction: row;
 			}
 
-			.flexchild {
+			.module {
 				width: 47.5%;
 			}
 
@@ -277,8 +279,8 @@
 				</svg>
 			</a>
 		</div>
-		<div class="flexparent">
-			<div class="flexchild">
+		<div class="module-container">
+			<div class="module">
 				<h2 id="restartMsg" style="text-align: center;">Restarting
                                         <span id="progressDots" style="display: inline-block; text-align: left; width: 3em;">.</span></h2>
 			</div>

--- a/lib/http/httpService.cpp
+++ b/lib/http/httpService.cpp
@@ -913,7 +913,7 @@ esp_err_t fnHttpService::get_handler_dir(httpd_req_t *req)
     chunk +=
         "        <div class=\"fileflex\">\n"
         "            <div class=\"filechild\">\n"
-        "               <header>SELECT DISK TO MOUNT<span id=\"logowob\"></span>" +
+        "               <header>SELECT DISK TO MOUNT<span class=\"logowob\"></span>" +
         string(theFuji.get_hosts(hs)->get_hostname()) +
         qp.query_parsed["path"] +
         "</header>\n"
@@ -1090,7 +1090,7 @@ esp_err_t fnHttpService::get_handler_slot(httpd_req_t *req)
     chunk +=
         "        <div class=\"fileflex\">\n"
         "            <div class=\"filechild\">\n"
-        "               <header>SELECT DRIVE SLOT<span id=\"logowob\"></span>" +
+        "               <header>SELECT DRIVE SLOT<span class=\"logowob\"></span>" +
         string(theFuji.get_hosts(hs)->get_hostname()) + " :: " + qp.query_parsed["filename"] +
         "</header>\n"
         "               <div class=\"abortline\"><a href=\"/\">ABORT</a></div>\n"


### PR DESCRIPTION
A few responsive updates to CSS and HTML for web UI. The text should now be legible, and buttons and links clickable, without having to zoom in on mobile devices.

- add `<meta name="viewport" content="width=device-width, initial-scale=1.0">` to enable responsive sizing
- move large icons into section headers on small screen sizes
- clean up markup/naming (e.g. change invalid repetition of `id="logowob"` to `class="logowob"`)

### Before
This is actual size on an iPhone 12 pro
![fn-webui-0](https://github.com/FujiNetWIFI/fujinet-firmware/assets/132390/7c02aedb-f7cf-4629-9e52-7ec004879690)

### After
![fn-webui-2](https://github.com/FujiNetWIFI/fujinet-firmware/assets/132390/db42a5a2-e665-4154-bb23-8834755f4faa)
