### PR TITLE
add nightly builds GHA

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -74,8 +74,8 @@ jobs:
     - name: Deploy ${{ matrix.target-platform }} Firmware
       uses: WebFreak001/deploy-nightly@v3.1.0
       with: 
-        upload_url: https://uploads.github.com/repos/benjamink/fujinet-firmware/releases/156601928/assets{?name,label}
-        release_id: 156601928 
+        upload_url: https://uploads.github.com/repos/FujiNetWIFI/fujinet-firmware/releases/156608864/assets{?name,label}
+        release_id: 156608864 
         asset_path: ./firmware/fujinet-${{ matrix.target-platform }}-${{ steps.version.outputs.VERSION }}-${{ github.ref_name }}.zip 
         asset_name: fujinet-${{ matrix.target-platform }}-${{ steps.version.outputs.VERSION }}-$$.zip
         asset_content_type: application/zip
@@ -84,8 +84,8 @@ jobs:
     - name: Deploy ${{ matrix.target-platform }} release.json
       uses: WebFreak001/deploy-nightly@v3.1.0
       with: 
-        upload_url: https://uploads.github.com/repos/benjamink/fujinet-firmware/releases/156601928/assets{?name,label}
-        release_id: 156601928 
+        upload_url: https://uploads.github.com/repos/FujiNetWIFI/fujinet-firmware/releases/156608864/assets{?name,label}
+        release_id: 156608864 
         asset_path: ./firmware/release.json
         asset_name: release-${{ matrix.target-platform }}-${{ steps.version.outputs.VERSION }}-$$.json
         asset_content_type: application/json

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,92 @@
+name: "FujiNet Nightly Builds"
+
+on:
+  schedule:
+    - cron: '0 4 * * *'
+  workflow_dispatch:
+    
+jobs:
+  nightly-release:
+    name: "PlatformIO CI"
+    runs-on: "ubuntu-latest"
+    strategy:
+      matrix:
+        target-platform: [ATARI, ADAM, APPLE, IEC-LOLIN-D32]
+
+    steps:
+    - name: Checkout Source
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Cache pip
+      uses: actions/cache@v2
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
+
+    - name: Cache PlatformIO
+      uses: actions/cache@v2
+      with:
+        path: ~/.platformio
+        key: ${{ runner.os }}-${{ hashFiles('**/lockfiles') }}
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.12.1'
+
+    - name: Install PlatformIO
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools
+        pip install --upgrade platformio
+        pip install Jinja2
+        pip install pyyaml
+
+    - name: Show python version
+      run: python --version
+
+    - name: Show pio system info
+      run: pio system info
+
+    - name: Show pio location
+      run: pip show platformio
+
+    - name: Create PlatformIO INI for Build
+      run: cd /home/runner/work/fujinet-firmware/fujinet-firmware && /usr/bin/bash ./build.sh -l /home/runner/work/fujinet-firmware/fujinet-firmware/.github/workflows/platformio.release-${{ matrix.target-platform }}.ini -i /home/runner/work/fujinet-firmware/fujinet-firmware/platformio-generated.ini
+
+    - name: Show platformio.ini
+      run: cat /home/runner/work/fujinet-firmware/fujinet-firmware/platformio-generated.ini
+
+    - name: Build release
+      run: cd /home/runner/work/fujinet-firmware/fujinet-firmware && /usr/bin/bash ./build.sh -z -l /home/runner/work/fujinet-firmware/fujinet-firmware/.github/workflows/platformio.release-${{ matrix.target-platform }}.ini -i /home/runner/work/fujinet-firmware/fujinet-firmware/platformio-generated.ini
+    
+    - name: Get Version
+      id: version
+      run: echo "VERSION=$(jq -r '.version' firmware/release.json)" >> $GITHUB_OUTPUT
+
+    - name: Fix firmware name
+      run: mv firmware/fujinet*.zip firmware/fujinet-${{ matrix.target-platform }}-${{ steps.version.outputs.VERSION }}-${{ github.ref_name }}.zip
+    
+    - name: Deploy ${{ matrix.target-platform }} Firmware
+      uses: WebFreak001/deploy-nightly@v3.1.0
+      with: 
+        upload_url: https://uploads.github.com/repos/benjamink/fujinet-firmware/releases/156601928/assets{?name,label}
+        release_id: 156601928 
+        asset_path: ./firmware/fujinet-${{ matrix.target-platform }}-${{ steps.version.outputs.VERSION }}-${{ github.ref_name }}.zip 
+        asset_name: fujinet-${{ matrix.target-platform }}-${{ steps.version.outputs.VERSION }}-$$.zip
+        asset_content_type: application/zip
+        max_releases: 1
+
+    - name: Deploy ${{ matrix.target-platform }} release.json
+      uses: WebFreak001/deploy-nightly@v3.1.0
+      with: 
+        upload_url: https://uploads.github.com/repos/benjamink/fujinet-firmware/releases/156601928/assets{?name,label}
+        release_id: 156601928 
+        asset_path: ./firmware/release.json
+        asset_name: release-${{ matrix.target-platform }}-${{ steps.version.outputs.VERSION }}-$$.json
+        asset_content_type: application/json
+        max_releases: 1


### PR DESCRIPTION
GitHub Action that will build nightly firmware builds & attach them to a pre-existing static Release.

# NOTE

The URL in this PR in lines 77-78 & 87-88 need to be updated for the pre-created Release setup in the `FujiNetWiFi/fujinet-firmware` repo.

Find the URL for the new release at this URL: https://api.github.com/repos/fujinetwifi/fujinet-firmware/releases

Also this permission setting in `Settings -> Actions -> General` will need to be set to allow the Action to upload the assets: 

![Actions_settings_·_benjamink_fujinet-firmware](https://github.com/FujiNetWIFI/fujinet-firmware/assets/1457764/744e4e7f-d6d1-406a-abdc-9f171fca94ba)
