### PR TITLE
stop attaching the release.json files

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -80,13 +80,3 @@ jobs:
         asset_name: fujinet-${{ matrix.target-platform }}-${{ steps.version.outputs.VERSION }}-$$.zip
         asset_content_type: application/zip
         max_releases: 1
-
-    - name: Deploy ${{ matrix.target-platform }} release.json
-      uses: WebFreak001/deploy-nightly@v3.1.0
-      with: 
-        upload_url: https://uploads.github.com/repos/FujiNetWIFI/fujinet-firmware/releases/156608864/assets{?name,label}
-        release_id: 156608864 
-        asset_path: ./firmware/release.json
-        asset_name: release-${{ matrix.target-platform }}-${{ steps.version.outputs.VERSION }}-$$.json
-        asset_content_type: application/json
-        max_releases: 1


### PR DESCRIPTION
Remove the step that attaches the `release*.json` files to the nightly release assets since they aren't useful. 