### PR TITLE
Put the TNFS transaction in a mutex.

### DIFF
--- a/lib/TNFSlib/tnfslib.cpp
+++ b/lib/TNFSlib/tnfslib.cpp
@@ -3,6 +3,7 @@
 
 #include <sys/stat.h>
 #include <errno.h>
+#include <mutex>
 #include "compat_string.h"
 
 #include "../../include/debug.h"
@@ -1322,6 +1323,8 @@ int _tnfs_recv(fnUDP *udp, tnfsMountInfo *m_info, tnfsPacket &pkt)
  */
 bool _tnfs_transaction(tnfsMountInfo *m_info, tnfsPacket &pkt, uint16_t payload_size)
 {
+    std::lock_guard<std::mutex> lock(m_info->transaction_mutex);
+
     fnUDP udp;
 
     // Keep copy of 1st payload byte

--- a/lib/TNFSlib/tnfslibMountInfo.h
+++ b/lib/TNFSlib/tnfslibMountInfo.h
@@ -2,6 +2,7 @@
 #define _TNFSLIB_MOUNTINFO_H
 
 #include <cstdint>
+#include <mutex>
 
 #include "fnDNS.h"
 #include "fnTcpClient.h"
@@ -105,6 +106,7 @@ public:
 
     int16_t dir_handle = TNFS_INVALID_HANDLE; // Stored from server's response to TNFS_OPENDIR
     uint16_t dir_entries = 0; // Stored from server's response to TNFS_OPENDIRX
+    std::mutex transaction_mutex;
 };
 
 #endif // _TNFSLIB_MOUNTINFO_H


### PR DESCRIPTION
This is required, because the keep-alive timer can interrupt a running transaction and cause unexpected recv() results, which usually breaks the whole session, as in https://github.com/FujiNetWIFI/fujinet-firmware/issues/741.