### PR TITLE
fix typos in documentation markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A multi-function peripheral built on ESP32 hardware being developed for the multiple 8-bit systems
 
-### Please see the [GitHub wiki](https://github.com/FujiNetWIFI/fujinet-platformio/wiki) for documenation and additional details.
+### Please see the [GitHub wiki](https://github.com/FujiNetWIFI/fujinet-platformio/wiki) for documentation and additional details.
 
 ### A dedicated web site is also available at https://fujinet.online/
 

--- a/README_wifi.md
+++ b/README_wifi.md
@@ -2,7 +2,7 @@
 
 This is disabled by default, and will reset to disabled on CONFIG reset (Power ON + B button)
 
-In the WiFi UI configuration is an option to enable wifi passphrase encryptiong.
+In the WiFi UI configuration is an option to enable wifi passphrase encryption.
 
 The option will enable/disable wifi passphrase encryption with a key unique to the FUJINET device and offers protection from observation of passphrases in INI files.
 

--- a/build-sh.md
+++ b/build-sh.md
@@ -66,7 +66,7 @@ You can specify the local file that will be used (in both reading and generating
 ./build.sh -s fujinet-atari-v1 -l platformio.local-atari.ini
 ```
 The above will generate a new local file, but name it `platformio.local-atari.ini` instead
-of the default `platforio.local.ini`
+of the default `platformio.local.ini`
 
 You can then use this file in building the application, instead of the default file. This is
 useful if you have several devices, e.g. if you generate `platformio.local-apple.ini` and `platformio.local-atari.ini`, then you can build with them:


### PR DESCRIPTION
I spotted a few typos in the markdown files (readme, build-sh, readme_wifi), so I corrected them :)