### PR TITLE
Use recursive mutex for the transactions.

### DIFF
--- a/lib/TNFSlib/tnfslib.cpp
+++ b/lib/TNFSlib/tnfslib.cpp
@@ -1323,7 +1323,7 @@ int _tnfs_recv(fnUDP *udp, tnfsMountInfo *m_info, tnfsPacket &pkt)
  */
 bool _tnfs_transaction(tnfsMountInfo *m_info, tnfsPacket &pkt, uint16_t payload_size)
 {
-    std::lock_guard<std::mutex> lock(m_info->transaction_mutex);
+    std::lock_guard<std::recursive_mutex> lock(m_info->transaction_mutex);
 
     fnUDP udp;
 

--- a/lib/TNFSlib/tnfslibMountInfo.h
+++ b/lib/TNFSlib/tnfslibMountInfo.h
@@ -106,7 +106,7 @@ public:
 
     int16_t dir_handle = TNFS_INVALID_HANDLE; // Stored from server's response to TNFS_OPENDIR
     uint16_t dir_entries = 0; // Stored from server's response to TNFS_OPENDIRX
-    std::mutex transaction_mutex;
+    std::recursive_mutex transaction_mutex;
 };
 
 #endif // _TNFSLIB_MOUNTINFO_H


### PR DESCRIPTION
The standard mutex is not reentrant and we use recursive calls to _tnfs_transaction in the session recovery (which will block with std::mutex).