### PR TITLE
clearly output firmware file location

### DIFF
--- a/build_firmwarezip.py
+++ b/build_firmwarezip.py
@@ -170,13 +170,23 @@ def makezip(source, target, env):
             f.write(json_contents)
 
         # Create the ZIP File
-        with ZipFile(firmwarezip, 'w') as zip_object:
-            zip_object.write(env.subst("$BUILD_DIR/bootloader.bin"), "bootloader.bin")
-            zip_object.write(env.subst("$BUILD_DIR/partitions.bin"), "partitions.bin")
-            zip_object.write(env.subst("$BUILD_DIR/firmware.bin"), "firmware.bin")
-            zip_object.write(env.subst("$BUILD_DIR/littlefs.bin"), "littlefs.bin")
-            zip_object.write("firmware/release.json", "release.json")
+        try:
+            with ZipFile(firmwarezip, 'w') as zip_object:
+                zip_object.write(env.subst("$BUILD_DIR/bootloader.bin"), "bootloader.bin")
+                zip_object.write(env.subst("$BUILD_DIR/partitions.bin"), "partitions.bin")
+                zip_object.write(env.subst("$BUILD_DIR/firmware.bin"), "firmware.bin")
+                zip_object.write(env.subst("$BUILD_DIR/littlefs.bin"), "littlefs.bin")
+                zip_object.write("firmware/release.json", "release.json")
+        finally: 
+            print("*" * 80)
+            print("*")
+            print("*   FIRMWARE ZIP CREATED AT: " + firmwarezip)
+            print("*")
+            print("*" * 80)
+ 
+	
     else:
         print("Skipping making firmware ZIP due to error")
 
 env.AddPostAction("$BUILD_DIR/${PROGNAME}.bin", makezip)
+   


### PR DESCRIPTION
Clearly outputs firmware zip file location at the end of a `build.sh -z` run.

Example: 

```
...

makezip([".pio/build/fujiapple-rev0/firmware.bin"], [".pio/build/fujiapple-rev0/firmware.elf"])
Creating firmware zip for FujiNet ESP32 Board: fujinet-v1-8mb
********************************************************************************
*
*   FIRMWARE ZIP CREATED AT: firmware/fujinet-APPLE-v1.3.zip
*
********************************************************************************
```