### PR TITLE
Fix ATARI set_prefix like TNFS://localhost -> TNFS:/localhost/

### DIFF
--- a/lib/device/sio/network.cpp
+++ b/lib/device/sio/network.cpp
@@ -572,6 +572,11 @@ void sioNetwork::sio_set_prefix()
         else if (prefixSpec_str.find_first_of(":") != string::npos)
         {
             prefix = prefixSpec_str;
+            // Check for trailing slash. Append if missing.
+            if (prefix[prefix.size()-1] != '/')
+            {
+                prefix += "/";
+            }
         }
         else // append to path.
         {


### PR DESCRIPTION
Before:
`NCD N1:TNFS://localhost` resolves to `TNFS:/localhost/` (losing the `//` after the protocol)

After
`NCD N1:TNFS://localhost` resolves to `TNFS://localhost/`

As reported in Discord https://discord.com/channels/655893677146636301/925136532959002684/1251354402241904733