### PR TITLE
Added directory filtering when filter pattern ends with `/`

### DIFF
--- a/lib/FileSystem/fnFsTNFS.cpp
+++ b/lib/FileSystem/fnFsTNFS.cpp
@@ -264,13 +264,26 @@ bool FileSystemTNFS::dir_open(const char * path, const char *pattern, uint16_t d
 
     uint8_t d_opt = 0;
     uint8_t s_opt = 0;
+	char realpat[TNFS_MAX_FILELEN];
+	char *thepat = 0;
 
+	if (!!pattern) {
+		thepat = realpat;
+		strlcpy (realpat, pattern, sizeof (realpat));
+		if (realpat[strlen(realpat)-1] == '/') {
+			Debug_print (
+				"FileSystemTNFS::dir_open applying pattern to directories\n"
+			);
+			realpat[strlen(realpat)-1] = '\0';
+			d_opt |= TNFS_DIROPT_DIR_PATTERN;
+		}
+	}
     if(diropts & DIR_OPTION_DESCENDING)
         s_opt |= TNFS_DIRSORT_DESCENDING;
     if(diropts & DIR_OPTION_FILEDATE)
         s_opt |= TNFS_DIRSORT_MODIFIED;
 
-    if(TNFS_RESULT_SUCCESS == tnfs_opendirx(&_mountinfo, path, s_opt, d_opt, pattern, 0))
+    if(TNFS_RESULT_SUCCESS == tnfs_opendirx(&_mountinfo, path, s_opt, d_opt, thepat, 0))
     {
         // Save the directory for later use, making sure it starts and ends with '/''
         if(path[0] != '/')


### PR DESCRIPTION
The CoCo repository is replete with directories for each application/game/whatever, and as such being able to filter the directory names as well is helpful.  This commit adds this functionality by adding a trailing `/` to the filter string.
