### PR TITLE
unused vars and undefined structure fields

### DIFF
--- a/components/libsmb2/lib/dcerpc.c
+++ b/components/libsmb2/lib/dcerpc.c
@@ -15,6 +15,9 @@
    You should have received a copy of the GNU Lesser General Public License
    along with this program; if not, see <http://www.gnu.org/licenses/>.
 */
+
+#pragma GCC diagnostic ignored "-Wmissing-field-initializers"
+
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif

--- a/components/libsmb2/lib/init.c
+++ b/components/libsmb2/lib/init.c
@@ -272,9 +272,8 @@ struct smb2_context *smb2_init_context(void)
         struct smb2_context *smb2;
         char buf[1024];
         int i, ret;
-        static int ctr;
 
-        srandom(time(NULL) ^ getpid() ^ ctr++);
+        srandom(time(NULL) ^ getpid());
 
         smb2 = calloc(1, sizeof(struct smb2_context));
         if (smb2 == NULL) {

--- a/lib/FileSystem/fnDirCache.cpp
+++ b/lib/FileSystem/fnDirCache.cpp
@@ -59,14 +59,14 @@ fsdir_entry &DirCache::new_entry()
 void DirCache::apply_filter(const char *pattern, uint16_t diropts)
 {
 	char realpat[MAX_PATHLEN];
-	char *thepat = nullptr;
+	//char *thepat = nullptr;
     bool have_pattern = pattern != nullptr && pattern[0] != '\0';
 	bool filter_dirs = have_pattern && pattern[strlen(pattern)-1] == '/';
 	if (filter_dirs) {
 		strlcpy (realpat, pattern, sizeof (realpat));
 		realpat[strlen(realpat)-1] = '\0';
 	}
-	thepat = filter_dirs ? realpat : (char *)pattern;
+	//thepat = filter_dirs ? realpat : (char *)pattern;
     fsdir_entry entry;
 
     // Filter directory entries

--- a/lib/FileSystem/fnFsLittleFS.cpp
+++ b/lib/FileSystem/fnFsLittleFS.cpp
@@ -1,5 +1,7 @@
 #ifdef FLASH_LITTLEFS
 
+#pragma GCC diagnostic ignored "-Wmissing-field-initializers"
+
 #include "fnFsLittleFS.h"
 #include "fnFileLocal.h"
 

--- a/lib/FileSystem/fnFsSD.cpp
+++ b/lib/FileSystem/fnFsSD.cpp
@@ -1,6 +1,8 @@
 /* TODO: Check why using the SD/FAT routines takes up a large amount of the stack (around 4.5K)
 */
 
+#pragma GCC diagnostic ignored "-Wmissing-field-initializers"
+
 #include "fnFsSD.h"
 #include "fnFileLocal.h"
 

--- a/lib/hardware/fnWiFi.cpp
+++ b/lib/hardware/fnWiFi.cpp
@@ -764,7 +764,7 @@ int32_t WiFiManager::localIP()
 {
     std::string result;
     esp_netif_ip_info_t ip_info;
-    esp_err_t e = esp_netif_get_ip_info(get_adapter_handle(), &ip_info);
+    esp_netif_get_ip_info(get_adapter_handle(), &ip_info);
     return ip_info.ip.addr;
 }
 

--- a/lib/http/httpService.cpp
+++ b/lib/http/httpService.cpp
@@ -1,4 +1,6 @@
 
+#pragma GCC diagnostic ignored "-Wmissing-field-initializers"
+
 #include "httpService.h"
 
 #include <sstream>

--- a/lib/libssh/src/misc.c
+++ b/lib/libssh/src/misc.c
@@ -306,7 +306,7 @@ char *ssh_get_local_username(void)
     int rc;
 
     rc = getpwuid_r(getuid(), &pwd, buf, NSS_BUFLEN_PASSWD, &pwdbuf);
-    if (rc != 0 || pwdbuf == NULL) {
+    if (rc != 0 || pwdbuf == NULL || strlen(buf) == 0) {
         return NULL;
     }
 


### PR DESCRIPTION
Hi,
due to some misleading warnings during build I propose to remove unused variables and disable warning related to uninitialized structure fields for some source files using  #pragma compiler feature;