### PR TITLE
Change SP_RDDATA to be the GPIO pin that is connected to the Disk II.

### DIFF
--- a/.github/workflows/platformio.release-MASTERIES-REVA-SPIFIX.ini
+++ b/.github/workflows/platformio.release-MASTERIES-REVA-SPIFIX.ini
@@ -16,4 +16,4 @@ build_type = debug
 build_flags =
     ${env.build_flags}
     -D PINMAP_A2_REV0
-    -D MASTERIES_SPI_FIX
+    -D MASTERIES_REV0

--- a/include/pinmap/a2_rev0.h
+++ b/include/pinmap/a2_rev0.h
@@ -6,11 +6,11 @@
 #define PIN_CARD_DETECT_FIX     GPIO_NUM_15 // fnSystem.h
 #define PIN_SD_HOST_CS          GPIO_NUM_5 //fnFsSD.cpp
 #define PIN_SD_HOST_MISO        GPIO_NUM_19
-#ifdef MASTERIES_SPI_FIX
+#ifdef MASTERIES_REV0
 #define PIN_SD_HOST_MOSI        GPIO_NUM_14
 #else
 #define PIN_SD_HOST_MOSI        GPIO_NUM_23
-#endif
+#endif // MASTERIES_REV0
 #define PIN_SD_HOST_SCK         GPIO_NUM_18
 
 /* UART */
@@ -35,14 +35,16 @@
 #define PIN_DAC1                GPIO_NUM_25 // samlib.h
 
 /* IWM Bus Pins */
-#define SP_REQ                  GPIO_NUM_32
 #define SP_PHI0                 GPIO_NUM_32
 #define SP_PHI1                 GPIO_NUM_33
 #define SP_PHI2                 GPIO_NUM_34
 #define SP_PHI3                 GPIO_NUM_35
 #define SP_WRPROT               GPIO_NUM_27
-#define SP_ACK                  GPIO_NUM_27
-#define SP_RDDATA               GPIO_NUM_4 // tri-state gate enable line
+#ifdef MASTERIES_REV0
+#define SP_RDDATA               GPIO_NUM_23 // Pin to use for SmartPort SPI hardware mod Masteries edition
+#else
+#define SP_RDDATA               GPIO_NUM_14 // Pin to use for SmartPort SPI hardware mod FujiApple Rev0
+#endif // MASTERIES_REV0
 #define SP_WRDATA               GPIO_NUM_22
 // TODO: go through each line and make sure the code is OK for each one before moving to next
 #define SP_WREQ                 GPIO_NUM_26
@@ -51,11 +53,11 @@
 #define SP_EN35                 GPIO_NUM_39
 #define SP_HDSEL                GPIO_NUM_13
 
-#ifdef MASTERIES_SPI_FIX
-#define SP_SPI_FIX_PIN          GPIO_NUM_23 // Pin to use for SmartPort SPI hardware mod Masteries edition
-#else
-#define SP_SPI_FIX_PIN          GPIO_NUM_14 // Pin to use for SmartPort SPI hardware mod FujiApple Rev0
-#endif // MASTERIES_SPI_FIX
+/* Aliases of other pins */
+#define SP_REQ                  SP_PHI0
+#define SP_ACK                  SP_WRPROT
+
+#define SP_RD_BUFFER            GPIO_NUM_4 // tri-state gate enable line
 
 #define SP_EXTRA                SP_DRIVE2 // For extra debugging with logic analyzer
 #endif /* PINMAP_A2_REV0 */

--- a/lib/bus/mac/mac_ll.cpp
+++ b/lib/bus/mac/mac_ll.cpp
@@ -519,8 +519,8 @@
 
 //   spi_buffer = (uint8_t *)heap_caps_malloc(SPI_SP_LEN, MALLOC_CAP_DMA);
 
-//   if(fnSystem.spifix())
-//     spirx_mosi_pin = SP_SPI_FIX_PIN;
+//   if(fnSystem.hasbuffer())
+//     spirx_mosi_pin = SP_RDDATA;
 
 //   // SPI for receiving packets - sprirx
 //   bus_cfg = {
@@ -564,13 +564,13 @@
 //     .queue_size = 2                    // We want to be able to queue 7 transactions at a time
 //   };
 
-//   if(fnSystem.spifix())
+//   if(fnSystem.hasbuffer())
 //   {
 //     // use different SPI than SDCARD
 //     ret = spi_bus_add_device(VSPI_HOST, &devcfg, &spi);
 //     assert(ret == ESP_OK);
 //     // connect peripheral to GPIO because RMT screwed it up
-//     esp_rom_gpio_connect_out_signal(SP_SPI_FIX_PIN, spi_periph_signal[VSPI_HOST].spid_out, false, false);
+//     esp_rom_gpio_connect_out_signal(SP_RDDATA, spi_periph_signal[VSPI_HOST].spid_out, false, false);
 //   }
 //   else
 //   {
@@ -598,8 +598,8 @@ void mac_ll::setup_gpio()
   // if (fnSystem.no3state())
   // {
   //   // set up the output pin as IO (like SPI does) and set to low, then to hi-z
-  //   fnSystem.set_pin_mode(SP_SPI_FIX_PIN, gpio_mode_t::GPIO_MODE_INPUT_OUTPUT);
-  //   fnSystem.digital_write(SP_SPI_FIX_PIN, DIGI_LOW);
+  //   fnSystem.set_pin_mode(SP_RDDATA, gpio_mode_t::GPIO_MODE_INPUT_OUTPUT);
+  //   fnSystem.digital_write(SP_RDDATA, DIGI_LOW);
   //   disable_output();
   // }
 
@@ -616,8 +616,8 @@ void mac_ll::setup_gpio()
 
   if (!fnSystem.no3state())
   {
-    fnSystem.set_pin_mode(SP_RDDATA, gpio_mode_t::GPIO_MODE_OUTPUT); // tri-state buffer control
-    fnSystem.digital_write(SP_RDDATA, DIGI_LOW); // Turn tristate buffer ON by default
+    fnSystem.set_pin_mode(SP_RD_BUFFER, gpio_mode_t::GPIO_MODE_OUTPUT); // tri-state buffer control
+    fnSystem.digital_write(SP_RD_BUFFER, DIGI_LOW); // Turn tristate buffer ON by default
   }
 
 #ifdef EXTRA
@@ -775,9 +775,9 @@ void mac_ll::setup_gpio()
 
 // void iwm_sp_ll::set_output_to_spi()
 // {
-//   if(fnSystem.spifix())
+//   if(fnSystem.hasbuffer())
 //   {
-//     esp_rom_gpio_connect_out_signal(SP_SPI_FIX_PIN, spi_periph_signal[VSPI_HOST].spid_out, false, false);
+//     esp_rom_gpio_connect_out_signal(SP_RDDATA, spi_periph_signal[VSPI_HOST].spid_out, false, false);
 //   }
 //   else
 //   {
@@ -787,10 +787,10 @@ void mac_ll::setup_gpio()
 
 // void iwm_diskii_ll::set_output_to_low()
 // {
-//   if(fnSystem.spifix())
+//   if(fnSystem.hasbuffer())
 //   {
-//     fnSystem.digital_write(SP_SPI_FIX_PIN, DIGI_LOW);
-//     esp_rom_gpio_connect_out_signal(SP_SPI_FIX_PIN, SIG_GPIO_OUT_IDX, false, false);
+//     fnSystem.digital_write(SP_RDDATA, DIGI_LOW);
+//     esp_rom_gpio_connect_out_signal(SP_RDDATA, SIG_GPIO_OUT_IDX, false, false);
 //     enable_output();
 //   }
 // }
@@ -824,13 +824,13 @@ void mac_floppy_ll::stop()
 // void iwm_diskii_ll::set_output_to_rmt()
 // {
 // #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0)
-//   if(fnSystem.spifix())
-//     esp_rom_gpio_connect_out_signal(SP_SPI_FIX_PIN, rmt_periph_signals.groups[0].channels[0].tx_sig, false, false);
+//   if(fnSystem.hasbuffer())
+//     esp_rom_gpio_connect_out_signal(SP_RDDATA, rmt_periph_signals.groups[0].channels[0].tx_sig, false, false);
 //   else
 //     esp_rom_gpio_connect_out_signal(PIN_SD_HOST_MOSI, rmt_periph_signals.groups[0].channels[0].tx_sig, false, false);
 // #else
-//   if(fnSystem.spifix())
-//     esp_rom_gpio_connect_out_signal(SP_SPI_FIX_PIN, rmt_periph_signals.channels[0].tx_sig, false, false);
+//   if(fnSystem.hasbuffer())
+//     esp_rom_gpio_connect_out_signal(SP_RDDATA, rmt_periph_signals.channels[0].tx_sig, false, false);
 //   else
 //     esp_rom_gpio_connect_out_signal(PIN_SD_HOST_MOSI, rmt_periph_signals.channels[0].tx_sig, false, false);
 // #endif
@@ -839,20 +839,20 @@ void mac_floppy_ll::stop()
 // void iwm_ll::enable_output()
 // {
 //   if(fnSystem.no3state())
-//     GPIO.enable_w1ts = ((uint32_t)0x01 << SP_SPI_FIX_PIN); // enable output
+//     GPIO.enable_w1ts = ((uint32_t)0x01 << SP_RDDATA); // enable output
 //   else
-//     GPIO.out_w1tc = ((uint32_t)1 << SP_RDDATA); //  enable the tri-state buffer activating RDDATA
+//     GPIO.out_w1tc = ((uint32_t)1 << SP_RD_BUFFER); //  enable the tri-state buffer activating RDDATA
 // }
 
 // void iwm_ll::disable_output()
 // {
 //   if(fnSystem.no3state())
 //   {
-//     GPIO.func_out_sel_cfg[SP_SPI_FIX_PIN].oen_sel = 1;     // let me control the enable register
-//     GPIO.enable_w1tc = ((uint32_t)0x01 << SP_SPI_FIX_PIN); // go hi-z with disabled output
+//     GPIO.func_out_sel_cfg[SP_RDDATA].oen_sel = 1;     // let me control the enable register
+//     GPIO.enable_w1tc = ((uint32_t)0x01 << SP_RDDATA); // go hi-z with disabled output
 //   }
 //   else
-//     GPIO.out_w1ts = ((uint32_t)1 << SP_RDDATA); // make RDDATA go hi-z through the tri-state
+//     GPIO.out_w1ts = ((uint32_t)1 << SP_RD_BUFFER); // make RDDATA go hi-z through the tri-state
 // }
 
 //Convert track data to rmt format data.
@@ -926,8 +926,8 @@ void mac_floppy_ll::setup_rmt()
 // #ifdef RMTTEST
 //   config.gpio_num = (gpio_num_t)SP_EXTRA;
 // #else
-//   if(fnSystem.spifix())
-//     config.gpio_num = (gpio_num_t)SP_SPI_FIX_PIN; 
+//   if(fnSystem.hasbuffer())
+//     config.gpio_num = (gpio_num_t)SP_RDDATA; 
 //   else
 //     config.gpio_num = (gpio_num_t)PIN_SD_HOST_MOSI; 
 // #endif

--- a/lib/device/iwm/cpm.cpp
+++ b/lib/device/iwm/cpm.cpp
@@ -97,10 +97,10 @@ void iwmCPM::iwm_open(iwm_decoded_cmd_t cmd)
 
     Debug_printf("\r\nCP/M: Open\n");
 #ifdef ESP_PLATFORM // OS
-    if (!fnSystem.spifix())
+    if (!fnSystem.hasbuffer())
     {
         err_result = SP_ERR_OFFLINE;
-    Debug_printf("FujiApple SPI Fix Missing, not starting CP/M\n");
+    Debug_printf("FujiApple HASBUFFER Missing, not starting CP/M\n");
     }
     else
     {
@@ -256,10 +256,10 @@ void iwmCPM::iwm_ctrl(iwm_decoded_cmd_t cmd)
         {
         case 'B': // Boot
 #ifdef ESP_PLATFORM // OS
-            if (!fnSystem.spifix())
+            if (!fnSystem.hasbuffer())
             {
                 err_result = SP_ERR_OFFLINE;
-                Debug_printf("FujiApple SPI Fix Missing, not starting CP/M\n");
+                Debug_printf("FujiApple HASBUFFER Missing, not starting CP/M\n");
             }
             else
 #endif

--- a/lib/hardware/fnSystem.cpp
+++ b/lib/hardware/fnSystem.cpp
@@ -1095,7 +1095,7 @@ void SystemManager::check_hardware_ver()
     /*  Apple II
         Check all the madness :zany_face:
     */
-#   if defined(MASTERIES_SPI_FIX)
+#   if defined(MASTERIES_REV0)
     Debug_printf("Masteries RevA SPI fix ENABLED\r\nNO3STATE Disabled\r\n");
     #ifdef PIN_SD_HOST_MOSI
     #undef PIN_SD_HOST_MOSI
@@ -1103,30 +1103,30 @@ void SystemManager::check_hardware_ver()
     #define PIN_SD_HOST_MOSI GPIO_NUM_14
     safe_reset_gpio = PIN_BUTTON_C;
     a2no3state = false;
-    a2spifix = true;
+    a2hasbuffer = true;
     _hardware_version = 5;
 #   elif defined(MASTERIES_REVAB)
     /* All Masteries boards have Tristate buffer. Check for pullup on IO14 to 
         determine if it's RevB
     */
-    int spifixupcheck, spifixdowncheck;
+    int hasbufferupcheck, hasbufferdowncheck;
 
     fnSystem.set_pin_mode(PIN_BUTTON_C, gpio_mode_t::GPIO_MODE_INPUT, SystemManager::pull_updown_t::PULL_UP);
-    spifixupcheck = fnSystem.digital_read(PIN_BUTTON_C);
+    hasbufferupcheck = fnSystem.digital_read(PIN_BUTTON_C);
     fnSystem.set_pin_mode(PIN_BUTTON_C, gpio_mode_t::GPIO_MODE_INPUT, SystemManager::pull_updown_t::PULL_DOWN);
-    spifixdowncheck = fnSystem.digital_read(PIN_BUTTON_C);
+    hasbufferdowncheck = fnSystem.digital_read(PIN_BUTTON_C);
 
-    if(spifixdowncheck == spifixupcheck)
+    if(hasbufferdowncheck == hasbufferupcheck)
     {
-        a2spifix = true;
-        Debug_printf("Masteries RevB Hardware Detected\r\nNO3STATE Disabled\r\nSPIFIX Enabled\r\n");
+        a2hasbuffer = true;
+        Debug_printf("Masteries RevB Hardware Detected\r\nNO3STATE Disabled\r\nHASBUFFER Enabled\r\n");
         _hardware_version = 6;
         safe_reset_gpio = GPIO_NUM_NC; // RevB has a Hard Reset button instead of GPIO connected button
     }
     else
     {
-        a2spifix = false;
-        Debug_printf("Masteries RevA Hardware Detected\r\nNO3STATE Disabled\r\nSPIFIX Disabled\r\n");
+        a2hasbuffer = false;
+        Debug_printf("Masteries RevA Hardware Detected\r\nNO3STATE Disabled\r\nHASBUFFER Disabled\r\n");
         _hardware_version = 4;
         safe_reset_gpio = PIN_BUTTON_C;
     }
@@ -1135,13 +1135,13 @@ void SystemManager::check_hardware_ver()
     /* For the 3 people on earth who got Rev1 hardware before the proper pullup
     used for hardware detection was added.
     */
-    a2spifix = true;
+    a2hasbuffer = true;
     a2no3state = true;
-    Debug_printf("Rev1 Hardware Defined\r\nFujiApple NO3STATE & SPIFIX Enabled\r\n");
+    Debug_printf("Rev1 Hardware Defined\r\nFujiApple NO3STATE & HASBUFFER Enabled\r\n");
     safe_reset_gpio = GPIO_NUM_4; /* Change Safe Reset GPIO for Rev 1 */
     _hardware_version = 3;
 #   else
-    int spifixupcheck, spifixdowncheck, rev1upcheck, rev1downcheck, bufupcheck, bufdowncheck;
+    int hasbufferupcheck, hasbufferdowncheck, rev1upcheck, rev1downcheck, bufupcheck, bufdowncheck;
 
     /* Apple 2 Rev 1 Latest has pulldown on IO25 for buffer/bus enable line
     If found, enable the buffer chips, spi fix, no tristate and safe reset on GPIO4
@@ -1154,7 +1154,7 @@ void SystemManager::check_hardware_ver()
     if (bufupcheck == bufdowncheck && bufupcheck == DIGI_LOW)
     {
         Debug_printf("FujiApple Rev1 Buffered Bus\r\nFujiApple NO3STATE Enabled\r\n");
-        a2spifix = true;
+        a2hasbuffer = true;
         a2no3state = true;
         safe_reset_gpio = GPIO_NUM_4; /* Change Safe Reset GPIO for Rev 1 */
         /* Enabled the buffer */
@@ -1174,7 +1174,7 @@ void SystemManager::check_hardware_ver()
 
         if (rev1upcheck == rev1downcheck && rev1downcheck == DIGI_HIGH)
         {
-            a2spifix = true;
+            a2hasbuffer = true;
             a2no3state = true;
             Debug_printf("FujiApple NO3STATE Enabled\r\n");
             safe_reset_gpio = GPIO_NUM_4; /* Change Safe Reset GPIO for Rev 1 */
@@ -1187,13 +1187,13 @@ void SystemManager::check_hardware_ver()
     Check for pullup and determine if safe reset button or SPI fix
     */
     fnSystem.set_pin_mode(PIN_BUTTON_C, gpio_mode_t::GPIO_MODE_INPUT, SystemManager::pull_updown_t::PULL_UP);
-    spifixupcheck = fnSystem.digital_read(PIN_BUTTON_C);
+    hasbufferupcheck = fnSystem.digital_read(PIN_BUTTON_C);
     fnSystem.set_pin_mode(PIN_BUTTON_C, gpio_mode_t::GPIO_MODE_INPUT, SystemManager::pull_updown_t::PULL_DOWN);
-    spifixdowncheck = fnSystem.digital_read(PIN_BUTTON_C);
+    hasbufferdowncheck = fnSystem.digital_read(PIN_BUTTON_C);
 
-    if(spifixdowncheck == spifixupcheck)
+    if(hasbufferdowncheck == hasbufferupcheck)
     {
-        a2spifix = true;
+        a2hasbuffer = true;
         Debug_println("FujiApple SPI fix Enabled");
         /* If hardware version has not been set yet, it's not a Rev1. Make it Rev00 With SPI fix */
         if (_hardware_version == 0)
@@ -1201,7 +1201,7 @@ void SystemManager::check_hardware_ver()
     }
     else
     {
-        a2spifix = false;
+        a2hasbuffer = false;
         Debug_println("FujiApple SPI fix not found");
         safe_reset_gpio = PIN_BUTTON_C;
         fnSystem.set_pin_mode(safe_reset_gpio, gpio_mode_t::GPIO_MODE_INPUT, SystemManager::pull_updown_t::PULL_UP);

--- a/lib/hardware/fnSystem.h
+++ b/lib/hardware/fnSystem.h
@@ -34,7 +34,7 @@ private:
     char _uptime_string[24];
     char _currenttime_string[40];
     int _hardware_version = 0; // unknown
-    bool a2spifix = false;
+    bool a2hasbuffer = false;
     bool a2no3state = false;
     bool ledstrip_found = false;
 #ifdef ESP_PLATFORM
@@ -164,7 +164,7 @@ public:
     const char *get_hardware_ver_str();
     const char *get_target_platform_str();
 
-    bool spifix() { return a2spifix; };
+    bool hasbuffer() { return a2hasbuffer; };
     bool no3state() { return a2no3state; };
     bool ledstrip() { return ledstrip_found; };
     bool has_button_c();

--- a/platformio-sample.ini
+++ b/platformio-sample.ini
@@ -166,7 +166,7 @@ build_flags =
     -D PINMAP_A2_REV0
     ;-D DBUG2 ; enable monitor messages for a release build
     ;-D EXTRA ; enable DRIVE2 pin as extra debugging signal for logic analyzer
-    ;-D MASTERIES_SPI_FIX ; Hardware mod fix for Masteries RevA
+    ;-D MASTERIES_REV0 ; Hardware mod fix for Masteries RevA
     ;-D MASTERIES_REVAB ; Masteries RevA (no SPI fix) and RevB
     ;-D NO3STATE ; no external tri-state on FN data out to A2, done internally
     ;-D REV1DETECT ; Only 3 people on earth need this enabled. You know who you are :P
@@ -183,7 +183,7 @@ build_flags =
     -D PINMAP_MAC_REV0
     ;-D DBUG2 ; enable monitor messages for a release build
     ;-D EXTRA ; enable DRIVE2 pin as extra debugging signal for logic analyzer
-    ;-D MASTERIES_SPI_FIX ; Hardware mod for Masteries Rev0
+    ;-D MASTERIES_REV0 ; Hardware mod for Masteries Rev0
     ;-D NO3STATE ; no external tri-state on FN data out to A2, done internally
 
 ; FujiNet for Atari Lynx (ESP32-WROVER 16MB Flash, 8MB PSRAM)


### PR DESCRIPTION
This renames a couple of pin constants so they better reflect what they represent. SP_RDDATA is now the pin that will be controlled by SPI & RMT and SP_RD_BUFFER is the pin that is used to enable/disable the buffer chip on older FujiNet Apple II revisions.