### PR TITLE
Update fnHardwareTimer to use driver/gptimer.h

### DIFF
--- a/lib/hardware/fnHardwareTimer.cpp
+++ b/lib/hardware/fnHardwareTimer.cpp
@@ -77,33 +77,17 @@ void HardwareTimer::config()
   //     uint32_t divider;               /*!< Counter clock divider */
   // } timer_config_t;
 
-#if defined(CONFIG_IDF_TARGET_ESP32S3)
-
 fn_config.direction = GPTIMER_COUNT_UP,
 fn_config.clk_src = GPTIMER_CLK_SRC_APB;
+#if defined(CONFIG_IDF_TARGET_ESP32)
+fn_config.resolution_hz = APB_CLK_FREQ / TIMER_DIVIDER;
+#else
 fn_config.resolution_hz = 10000000;
+#endif
 
 gptimer_new_timer(&fn_config, &gptimer);
 gptimer_enable(gptimer);
 gptimer_start(gptimer);
-
-#else
-
-fn_config.alarm_en = TIMER_ALARM_DIS;
-fn_config.counter_en = TIMER_PAUSE;
-fn_config.intr_type = TIMER_INTR_LEVEL;
-fn_config.counter_dir = TIMER_COUNT_UP;
-fn_config.auto_reload = TIMER_AUTORELOAD_DIS;
-#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0)
-fn_config.clk_src = TIMER_SRC_CLK_APB;
-#endif
-fn_config.divider = TIMER_DIVIDER; // default clock source is APB
-
-timer_init(TIMER_GROUP_1, TIMER_1, &fn_config);
-timer_set_counter_value(TIMER_GROUP_1, TIMER_1, 0);
-timer_start(TIMER_GROUP_1, TIMER_1);
-
-#endif
 
 }
 

--- a/lib/hardware/fnHardwareTimer.h
+++ b/lib/hardware/fnHardwareTimer.h
@@ -4,9 +4,7 @@
 #include "esp_idf_version.h"
 #include "sdkconfig.h"
 
-#if defined(CONFIG_IDF_TARGET_ESP32)
-#include "driver/timer.h"
-#elif defined(CONFIG_IDF_TARGET_ESP32S3)
+#if defined(CONFIG_IDF_TARGET_ESP32) || defined(CONFIG_IDF_TARGET_ESP32S3)
 #include "driver/gptimer.h"
 #else
 #error "neither esp32 or s3"
@@ -42,19 +40,12 @@ private:
   } fn_timer;
 
 
-#if defined(CONFIG_IDF_TARGET_ESP32S3)
 gptimer_handle_t gptimer;
 gptimer_config_t fn_config;
 //gptimer_alarm_config_t alarm_config;
-#else
-timer_config_t fn_config;
-#endif
 
 public:
   void config();
-
-#if defined(CONFIG_IDF_TARGET_ESP32S3)
-
   void reset() { gptimer_set_raw_count(gptimer, 0); };
   void latch() {};
   void read() { 
@@ -62,20 +53,6 @@ public:
     gptimer_get_raw_count(gptimer, &count);
     fn_timer.t0 = count & 0xFFFFFFFF;
   };
-
-#else
-
-#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0)
-  void reset() { TIMERG1.hw_timer[TIMER_1].loadlo.val = 0; TIMERG1.hw_timer[TIMER_1].load.val = 0; };
-  void latch() { TIMERG1.hw_timer[TIMER_1].update.val = 0; };
-  void read() { fn_timer.t0 = TIMERG1.hw_timer[TIMER_1].lo.val; };
-#else
-  void reset() { TIMERG1.hw_timer[TIMER_1].load_low = 0; TIMERG1.hw_timer[TIMER_1].reload = 0; };
-  void latch() { TIMERG1.hw_timer[TIMER_1].update = 0; };
-  void read() { fn_timer.t0 = TIMERG1.hw_timer[TIMER_1].cnt_low; };
-#endif
-
-#endif
 
   bool timeout() { return (fn_timer.t0 > fn_timer.tn); };
   void wait() { do{latch(); read();} while (!timeout()); };


### PR DESCRIPTION
Enables use of driver/gptimer.h on CONFIG_IDF_TARGET_ESP32. Eliminates the warning about using legacy driver/timer.h.