### PR TITLE
Fixes a few minor warnings

### DIFF
--- a/components/libsmb2/lib/init.c
+++ b/components/libsmb2/lib/init.c
@@ -507,6 +507,7 @@ static void smb2_set_password_from_file(struct smb2_context *smb2)
                         switch (buf[strlen(buf) - 1]) {
                         case '\n':
                                 buf[strlen(buf) - 1] = 0;
+                                [[fallthrough]];
                         default:
                                 finished = 1;
                         }

--- a/components/libsmb2/lib/libsmb2.c
+++ b/components/libsmb2/lib/libsmb2.c
@@ -1169,6 +1169,7 @@ smb2_open_async(struct smb2_context *smb2, const char *path, int flags,
                                 SMB2_FILE_WRITE_ATTRIBUTES;
                         if ((flags & O_ACCMODE) == O_WRONLY)
                                 break;
+                        [[fallthrough]];
                 case O_RDONLY:
                         desired_access |= SMB2_FILE_READ_DATA |
                                 SMB2_FILE_READ_EA |

--- a/lib/hardware/fnRMTstream.cpp
+++ b/lib/hardware/fnRMTstream.cpp
@@ -34,7 +34,6 @@
 #include "soc/rmt_struct.h"
 #include "hal/rmt_types.h"
 #include "driver/periph_ctrl.h"
-#include "driver/rmt.h"
 #include "rom/gpio.h"
 #include "fnRMTstream.h"
 
@@ -352,14 +351,14 @@ rmt_data_mode_t rmtStream::rmt_get_data_mode()
 void rmtStream::rmt_set_intr_enable_mask(uint32_t mask)
 {
     portENTER_CRITICAL(&rmt_spinlock);
-    RMT.int_ena.val |= mask;
+    RMT.int_ena.val = RMT.int_ena.val | mask;
     portEXIT_CRITICAL(&rmt_spinlock);
 }
 
 void rmtStream::rmt_clr_intr_enable_mask(uint32_t mask)
 {
     portENTER_CRITICAL(&rmt_spinlock);
-    RMT.int_ena.val &= (~mask);
+    RMT.int_ena.val = RMT.int_ena.val & (~mask);
     portEXIT_CRITICAL(&rmt_spinlock);
 }
 
@@ -645,7 +644,7 @@ esp_err_t rmtStream::rmt_isr_deregister(rmt_isr_handle_t handle)
                     case 2:
                         ESP_EARLY_LOGE(RMT_TAG, "RMT[%d] ERR", channel);
                         ESP_EARLY_LOGE(RMT_TAG, "status: 0x%08x", RMT.status_ch[channel]);
-                        RMT.int_ena.val &= (~(BIT(i)));
+                        RMT.int_ena.val = RMT.int_ena.val & (~(BIT(i)));
                         break;
                     default:
                         break;

--- a/lib/runcpm/cpu.h
+++ b/lib/runcpm/cpu.h
@@ -3144,6 +3144,7 @@ static inline void Z80run(void) {
 
 			case 0x94:      /* SUB IXH */
 				SETFLAG(C, 0);/* fall through, a bit less efficient but smaller code */
+				[[fallthrough]];
 
 			case 0x9c:      /* SBC A,IXH */
 				temp = HIGH_REGISTER(IX);
@@ -3154,6 +3155,7 @@ static inline void Z80run(void) {
 
 			case 0x95:      /* SUB IXL */
 				SETFLAG(C, 0);/* fall through, a bit less efficient but smaller code */
+				[[fallthrough]];
 
 			case 0x9d:      /* SBC A,IXL */
 				temp = LOW_REGISTER(IX);
@@ -4391,6 +4393,7 @@ static inline void Z80run(void) {
 
 			case 0x94:      /* SUB IYH */
 				SETFLAG(C, 0);/* fall through, a bit less efficient but smaller code */
+				[[fallthrough]];
 
 			case 0x9c:      /* SBC A,IYH */
 				temp = HIGH_REGISTER(IY);
@@ -4401,6 +4404,7 @@ static inline void Z80run(void) {
 
 			case 0x95:      /* SUB IYL */
 				SETFLAG(C, 0);/* fall through, a bit less efficient but smaller code */
+				[[fallthrough]];
 
 			case 0x9d:      /* SBC A,IYL */
 				temp = LOW_REGISTER(IY);


### PR DESCRIPTION
Fixes a few minor warnings to make it easier to find where the real errors are.

* Declare fallthrough is expected
* Add missing fields to struct init in iwm_ll.cpp
* Resolve volatile warnings