### PR TITLE
Adjusted malloc for PC build for ATARI

### DIFF
--- a/lib/device/sio/fuji.cpp
+++ b/lib/device/sio/fuji.cpp
@@ -17,7 +17,9 @@
 #include "compat_string.h"
 
 #include "../../../include/debug.h"
+#ifdef ESP_PLATFORM
 #include "../../../include/PSRAMAllocator.h"
+#endif
 
 #include "fnSystem.h"
 #include "fnConfig.h"
@@ -131,7 +133,11 @@ sioFuji::sioFuji()
 
     for (int i = 0; i < MAX_NETWORK_DEVICES; i++)
     {
+#ifdef ESP_PLATFORM
         void *p = heap_caps_malloc(sizeof(sioNetwork), MALLOC_CAP_DEFAULT);
+#else
+        void *p = malloc(sizeof(sioNetwork));
+#endif
         sioNetDevs[i] = new(p) sioNetwork();
     }
 }

--- a/lib/device/sio/fuji.h
+++ b/lib/device/sio/fuji.h
@@ -225,7 +225,7 @@ public:
 #endif
 
     sioFuji();
-    virtual ~sioFuji();
+    ~sioFuji();
 };
 
 extern sioFuji theFuji;


### PR DESCRIPTION
Modified following files to _**not**_ use PSRAM functions to allocate memory when building for the fujinet-pc for ATARI.
- `lib/device/sio/fuji.cpp`
- `lib/device/sio/fuji.h`