### PR TITLE
Remove direct access to _fnDisk2s

### DIFF
--- a/lib/bus/iwm/iwm.cpp
+++ b/lib/bus/iwm/iwm.cpp
@@ -546,12 +546,12 @@ void IRAM_ATTR iwmBus::service()
     break;
   case iwm_enable_state_t::off2on:
     // need to start a counter and wait to turn on enable output after 1 ms only iff enable state is on
-    if (theFuji._fnDisk2s[diskii_xface.iwm_enable_states() - 1].device_active)
+    if (IWM_ACTIVE_DISK2->device_active)
     {
       fnSystem.delay(1); // need a better way to figure out persistence
       if (iwm_drive_enabled() == iwm_enable_state_t::on)
       {
-        theFuji._fnDisk2s[diskii_xface.iwm_enable_states() - 1].change_track(0); // copy current track in for this drive
+        IWM_ACTIVE_DISK2->change_track(0); // copy current track in for this drive
         diskii_xface.start(diskii_xface.iwm_enable_states() - 1); // start it up
       }
     } // make a call to start the RMT stream
@@ -564,7 +564,7 @@ void IRAM_ATTR iwmBus::service()
     return; // return so the SP code doesn't get checked
   case iwm_enable_state_t::on:
 #ifdef DEBUG
-    new_track = theFuji._fnDisk2s[diskii_xface.iwm_enable_states() - 1].get_track_pos();
+    new_track = IWM_ACTIVE_DISK2->get_track_pos();
     if (old_track != new_track)
     {
       Debug_printf("\ntrk pos %03d on d%d", new_track, diskii_xface.iwm_enable_states());

--- a/lib/bus/iwm/iwm.h
+++ b/lib/bus/iwm/iwm.h
@@ -340,5 +340,6 @@ public:
 
 extern iwmBus IWM;
 
+#define IWM_ACTIVE_DISK2 ((iwmDisk2 *) theFuji.get_disk_dev(MAX_SP_DEVICES + diskii_xface.iwm_enable_states() - 1))
 #endif // guard
 #endif /* BUILD_APPLE */

--- a/lib/bus/iwm/iwm_ll.cpp
+++ b/lib/bus/iwm/iwm_ll.cpp
@@ -122,10 +122,10 @@ void IRAM_ATTR phi_isr_handler(void *arg)
   // and then PH1 = 0 (going low) and PH3 = 1 (still high)
   else if ((diskii_xface.iwm_enable_states() & 0b11) && !((int_gpio_num == SP_PHI1 && _phases == 0b1000)))
   {
-    if (theFuji._fnDisk2s[diskii_xface.iwm_enable_states() - 1].move_head())
+    if (IWM_ACTIVE_DISK2->move_head())
     {
       isrctr = isrctr + 1;
-      theFuji._fnDisk2s[diskii_xface.iwm_enable_states() - 1].change_track(isrctr);
+      IWM_ACTIVE_DISK2->change_track(isrctr);
     }
   }
 }

--- a/lib/device/iwm/disk.cpp
+++ b/lib/device/iwm/disk.cpp
@@ -445,7 +445,7 @@ mediatype_t iwmDisk::mount(fnFile *f, const char *filename, uint32_t disksize, m
       mt = MediaType::discover_dsk_mediatype(f, disksize);
   }
 
-  if (deviceSlot < 4) // SP drive
+  if (deviceSlot < MAX_SP_DEVICES) // SP drive
   {    
     switch (mt)
     {
@@ -487,8 +487,11 @@ mediatype_t iwmDisk::mount(fnFile *f, const char *filename, uint32_t disksize, m
       case MEDIATYPE_DO:
       case MEDIATYPE_PO:
       case MEDIATYPE_WOZ:
-          theFuji._fnDisk2s[deviceSlot - 4].init();
-          mt = theFuji._fnDisk2s[deviceSlot - 4].mount(f, disksize, mt);
+	{
+          iwmDisk2 *dev = (iwmDisk2 *) theFuji.get_disk_dev(deviceSlot);
+          dev->init();
+          mt = dev->mount(f, disksize, mt);
+	}
       break;
     default:
         Debug_printf("\r\nUnsupported Media Type for DiskII");

--- a/lib/device/iwm/disk2.h
+++ b/lib/device/iwm/disk2.h
@@ -2,10 +2,10 @@
 #ifndef DISK2_H
 #define DISK2_H
 
-#include "bus.h"
+#include "disk.h"
 #include "../media/media.h"
 
-class iwmDisk2 : public iwmDevice
+class iwmDisk2 : public iwmDisk
 {
 
 protected:
@@ -52,7 +52,6 @@ public:
     bool isDrive2Enabled() { return enabledD2; };
     // void set_disk_number(char c) { disk_num = c; }
     // char get_disk_number() { return disk_num; };
-    mediatype_t disktype() { return _disk == nullptr ? MEDIATYPE_UNKNOWN : _disk->_mediatype; };
 
     ~iwmDisk2();
 };

--- a/lib/device/iwm/fuji.h
+++ b/lib/device/iwm/fuji.h
@@ -26,6 +26,7 @@
 #define MAX_DISK_DEVICES 6 // 4 SP devices + 2 DiskII devices
 #define MAX_DISK2_DEVICES 2 // for now until we add 3.5" disks
 #define MAX_NETWORK_DEVICES 4
+#define MAX_SP_DEVICES (MAX_DISK_DEVICES - MAX_DISK2_DEVICES)
 
 #define MAX_SSID_LEN 32
 #define MAX_WIFI_PASS_LEN 64
@@ -113,6 +114,9 @@ private:
     fujiHost _fnHosts[MAX_HOSTS];
 
     fujiDisk _fnDisks[MAX_DISK_DEVICES];
+#ifndef DEV_RELAY_SLIP
+    iwmDisk2 _fnDisk2s[MAX_DISK2_DEVICES];
+#endif
 
     iwmNetwork *theNetwork;
 
@@ -253,9 +257,11 @@ public:
 
     fujiHost *get_hosts(int i) { return &_fnHosts[i]; }
     fujiDisk *get_disks(int i) { return &_fnDisks[i]; }
-#ifndef DEV_RELAY_SLIP
-    iwmDisk2 _fnDisk2s[MAX_DISK2_DEVICES];
-#endif
+    DEVICE_TYPE *get_disk_dev(int i) {
+      return i < MAX_SP_DEVICES
+	? (DEVICE_TYPE *) &_fnDisks[i].disk_dev
+	: (DEVICE_TYPE *) &_fnDisk2s[i - MAX_SP_DEVICES];
+    }
 
     void _populate_slots_from_config();
     void _populate_config_from_slots();

--- a/lib/http/httpService.cpp
+++ b/lib/http/httpService.cpp
@@ -661,6 +661,11 @@ esp_err_t fnHttpService::get_handler_mount(httpd_req_t *req)
         {
             fujiDisk *disk = theFuji.get_disks(ds);
             fujiHost *host = theFuji.get_hosts(hs);
+#ifdef BUILD_APPLE
+            DEVICE_TYPE *disk_dev = theFuji.get_disk_dev(ds);
+#else
+	    DEVICE_TYPE *disk_dev = &disk->disk_dev;
+#endif
 
             disk->fileh = host->fnfile_open(qp.query_parsed["filename"].c_str(), (char *)qp.query_parsed["filename"].c_str(), qp.query_parsed["filename"].length() + 1, flag);
 
@@ -677,14 +682,14 @@ esp_err_t fnHttpService::get_handler_mount(httpd_req_t *req)
 #endif
                 strcpy(disk->filename,qp.query_parsed["filename"].c_str());
                 disk->disk_size = host->file_size(disk->fileh);
-                disk->disk_type = disk->disk_dev.mount(disk->fileh, disk->filename, disk->disk_size);
+                disk->disk_type = disk_dev->mount(disk->fileh, disk->filename, disk->disk_size);
                 #ifdef BUILD_APPLE
-                if(mode == fnConfig::mount_modes::MOUNTMODE_WRITE) {disk->disk_dev.readonly = false;}
+                if(mode == fnConfig::mount_modes::MOUNTMODE_WRITE) {disk_dev->readonly = false;}
                 #endif
                 Config.store_mount(ds, hs, qp.query_parsed["filename"].c_str(), mode);
                 Config.save();
                 theFuji._populate_slots_from_config(); // otherwise they don't show up in config.
-                disk->disk_dev.device_active = true;
+                disk_dev->device_active = true;
             }
         }
         else
@@ -728,11 +733,14 @@ esp_err_t fnHttpService::get_handler_eject(httpd_req_t *req)
     {
         fnHTTPD.addToErrMsg("<li>deviceslot should be between 0 and 7</li>");
     }
-    #ifdef BUILD_APPLE
-    if(theFuji.get_disks(ds)->disk_dev.device_active) //set disk switched only if device was previosly mounted. 
-        theFuji.get_disks(ds)->disk_dev.switched = true;
-    #endif
-    theFuji.get_disks(ds)->disk_dev.unmount();
+#ifdef BUILD_APPLE
+    DEVICE_TYPE *disk_dev = theFuji.get_disk_dev(ds);
+    if(disk_dev->device_active) //set disk switched only if device was previosly mounted.
+        disk_dev->switched = true;
+#else
+    DEVICE_TYPE *disk_dev = &theFuji.get_disks(ds)->disk_dev;
+#endif
+    disk_dev->unmount();
 #ifdef BUILD_ATARI
     if (theFuji.get_disks(ds)->disk_type == MEDIATYPE_CAS || theFuji.get_disks(ds)->disk_type == MEDIATYPE_WAV)
     {
@@ -744,7 +752,7 @@ esp_err_t fnHttpService::get_handler_eject(httpd_req_t *req)
     Config.clear_mount(ds);
     Config.save();
     theFuji._populate_slots_from_config(); // otherwise they don't show up in config.
-    theFuji.get_disks(ds)->disk_dev.device_active = false;
+    disk_dev->device_active = false;
 
     // Finally, scan all device slots, if all empty, and config enabled, enable the config device.
     if (Config.get_general_config_enabled())


### PR DESCRIPTION
Remove direct access to `_fnDisk2s` to eliminate shadowing issues with `_fnDisks.disk_dev` and ensure more consistent access. This is necessary to allow config settings (such as write enabled) to pass through to the object that is actually being used to contain the disk image.

Changing `DEVICE_TYPE` to be a pointer seems like a "more correct" change but that would have required changing far too many things.