### PR TITLE
Split up service() into sub services

### DIFF
--- a/lib/bus/iwm/iwm.h
+++ b/lib/bus/iwm/iwm.h
@@ -320,6 +320,8 @@ public:
   // these things stay for the most part
   void setup();
   void service();
+  bool serviceSmartPort();
+  bool serviceDiskII();
   void shutdown();
 
   int numDevices();


### PR DESCRIPTION
Split up service() into sub services to make it easier to add more services (such as Disk II write).