### PR TITLE
Add build platforms and pin maps for Foenix comptuer using D32

### DIFF
--- a/build-platforms/platformio-fujinet-foenix-lolin-d32-dw.ini
+++ b/build-platforms/platformio-fujinet-foenix-lolin-d32-dw.ini
@@ -1,0 +1,15 @@
+[fujinet]
+build_platform = BUILD_COCO
+build_bus      = DRIVEWIRE
+build_board    = fujinet-foenix-lolin-d32-dw
+
+[env:fujinet-foenix-lolin-d32-dw]
+platform = espressif32@${fujinet.esp32_platform_version}
+platform_packages = ${fujinet.esp32_platform_packages}
+board = fujinet-v1
+build_type = debug
+build_flags =
+    ${env.build_flags}
+    -D PINMAP_FOENIX_OS9_D32PRO
+    -D FORCE_UART_BAUD=230400  ; Set baud rate for Foenix F256
+    ;-D INVERT_SERIAL           ; Invert the RX/TX serial pins (e.g. Foenix F256)

--- a/data/webui/config/fujinet-foenix-lolin-d32-dw.yaml
+++ b/data/webui/config/fujinet-foenix-lolin-d32-dw.yaml
@@ -1,0 +1,20 @@
+paths:
+  font_path: /file?
+  css_path: /file?css
+  js_path: /file?js
+components:
+  network: true
+  hardware: true
+  hosts_list: true
+  mount_list: true
+  printer_settings: true
+  modem_settings: true
+  hsio_settings: true
+  timezone: true
+  udp_stream: true
+  program_recorder: true
+  disk_swap: true
+  boot_settings: true
+  apetime: false
+tweaks:
+  # webui tweaks, if any

--- a/include/pinmap.h
+++ b/include/pinmap.h
@@ -14,6 +14,7 @@
 #include "pinmap/coco_devkitc.h"
 #include "pinmap/coco_cart.h"
 #include "pinmap/coco_s3.h"
+#include "pinmap/foenix_os9_d32pro.h"
 #include "pinmap/iec-nugget.h"
 #include "pinmap/fujiloaf-rev0.h"
 #include "pinmap/fujiapple-iec.h"

--- a/include/pinmap/foenix_os9_d32pro.h
+++ b/include/pinmap/foenix_os9_d32pro.h
@@ -1,0 +1,47 @@
+/* FujiNet Hardware Pin Mapping */
+#ifdef PINMAP_FOENIX_OS9_D32PRO
+
+
+/* SD Card */
+// pins 12-15 are used to interface with the JTAG debugger
+// so leave them alone if we're using JTAG
+#ifndef JTAG
+#define PIN_CARD_DETECT         GPIO_NUM_12 // fnSystem.h
+#define PIN_CARD_DETECT_FIX     GPIO_NUM_15 // fnSystem.h
+#endif
+
+#define PIN_SD_HOST_CS          GPIO_NUM_4  // LOLIN D32 Pro
+#define PIN_SD_HOST_MISO        GPIO_NUM_19
+#define PIN_SD_HOST_MOSI        GPIO_NUM_23
+#define PIN_SD_HOST_SCK         GPIO_NUM_18
+
+
+/* UART - fnuart.cpp */
+#define PIN_UART0_RX            GPIO_NUM_3  // USB Serial
+#define PIN_UART0_TX            GPIO_NUM_1  // USB Serial
+#define PIN_UART1_RX            GPIO_NUM_13 // RS232
+#define PIN_UART1_TX            GPIO_NUM_21 // RS232
+#define PIN_UART2_RX          GPIO_NUM_33
+#define PIN_UART2_TX          GPIO_NUM_21
+
+/* Buttons - keys.cpp */
+#define PIN_BUTTON_A            GPIO_NUM_0  // Button 0 on DEVKITC-VE
+#define PIN_BUTTON_B            GPIO_NUM_NC // No Button B
+#define PIN_BUTTON_C            GPIO_NUM_14 // Safe reset
+
+/* LEDs - leds.cpp */
+#define PIN_LED_WIFI            GPIO_NUM_2
+#define PIN_LED_BUS             GPIO_NUM_4
+#define PIN_LED_BT              GPIO_NUM_NC // No BT LED
+
+/* Audio Output - samlib.h */
+#define PIN_DAC1                GPIO_NUM_25 // not connected
+
+/* Coco */
+#define PIN_CASS_MOTOR          GPIO_NUM_34 // Second motor pin is tied to +3V
+#define PIN_CASS_DATA_IN        GPIO_NUM_33
+#define PIN_CASS_DATA_OUT       GPIO_NUM_26
+#define PIN_CD                  GPIO_NUM_22 // same as atari PROC
+#define PIN_EPROM_A14           GPIO_NUM_36 // Used to set the serial baud rate
+#define PIN_EPROM_A15           GPIO_NUM_39 // based on the HDB-DOS image selected
+#endif /* PINMAP_FOENIX_OS9_D32PRO */

--- a/platformio-sample.ini
+++ b/platformio-sample.ini
@@ -89,6 +89,8 @@ flash_filesystem = FLASH_LITTLEFS
 ;build_bus      = DRIVEWIRE
 ;build_board    = fujinet-coco-devkitc      ; Color Computer Drivewire using ESP32-DEVKITC-VE
 ;build_board    = fujinet-coco-lolin-d32-dw ; Color Computer Drivewire using Lolin D32 Pro
+;build_board    = fujinet-foenix-lolin-d32-dw ; Foenix 256jr and 256k with OS-9
+
 
 [platformio]
 description = FujiNet retro computer to ESP32 WiFi Multifunction Firmware
@@ -297,6 +299,20 @@ build_flags =
     -D PINMAP_COCO_DEVKITC
     ;-D DEBUG_TIMING        ; IEC Timing
     ;-D DATA_STREAM
+
+; Foenix 6809 OS9 Drivewire using Lolin D32 Pro (ESP32-WROVER 16MB Flash, 8MB PSRAM)
+[env:fujinet-foenix-lolin-d32-dw]
+platform = espressif32@${fujinet.esp32_platform_version}
+platform_packages = ${fujinet.esp32_platform_packages}
+board = fujinet-v1
+build_type = debug
+build_flags =
+    ${env.build_flags}
+    -D PINMAP_FOENIX_OS9-D32PRO
+    -D FORCE_UART_BAUD=1000000
+    ;-D DEBUG_TIMING
+    ;-D DATA_STREAM
+
 
 ; Color Computer Becker Port Drivewire (ESP32-DEVKITC-VE WROVER 8MB Flash, 8MB PSRAM)
 [env:fujinet-coco-becker]

--- a/platformio-sample.ini
+++ b/platformio-sample.ini
@@ -87,8 +87,8 @@ flash_filesystem = FLASH_LITTLEFS
 
 ;build_platform = BUILD_COCO
 ;build_bus      = DRIVEWIRE
-;build_board    = fujinet-coco-devkitc      ; Color Computer Drivewire using ESP32-DEVKITC-VE
-;build_board    = fujinet-coco-lolin-d32-dw ; Color Computer Drivewire using Lolin D32 Pro
+;build_board    = fujinet-coco-devkitc        ; Color Computer Drivewire using ESP32-DEVKITC-VE
+;build_board    = fujinet-coco-lolin-d32-dw   ; Color Computer Drivewire using Lolin D32 Pro
 ;build_board    = fujinet-foenix-lolin-d32-dw ; Foenix 256jr and 256k with OS-9
 
 
@@ -308,8 +308,9 @@ board = fujinet-v1
 build_type = debug
 build_flags =
     ${env.build_flags}
-    -D PINMAP_FOENIX_OS9-D32PRO
-    -D FORCE_UART_BAUD=1000000
+    -D PINMAP_FOENIX_OS9_D32PRO
+    -D FORCE_UART_BAUD=230400  ; Set baud rate for Foenix F256
+    ;-D INVERT_SERIAL           ; Invert the RX/TX serial pins (e.g. Foenix F256)
     ;-D DEBUG_TIMING
     ;-D DATA_STREAM
 


### PR DESCRIPTION
Adding in some platform and pinmap configs in the builds for Foenix retro computer using the D32 Lolin.

Build board remains COCO w/ drivewire.

SD card reading works again, so reading wifi config works.