### PR TITLE
[dw][foenix] - fixed board, not inverting tx-rx

### DIFF
--- a/data/webui/config/fujinet-foenix-lolin-d32-dw.yaml
+++ b/data/webui/config/fujinet-foenix-lolin-d32-dw.yaml
@@ -7,12 +7,21 @@ components:
   hardware: true
   hosts_list: true
   mount_list: true
+<<<<<<< HEAD
   printer_settings: true
   modem_settings: true
   hsio_settings: true
   timezone: true
   udp_stream: true
   program_recorder: true
+=======
+  printer_settings: false
+  modem_settings: false
+  hsio_settings: false
+  timezone: true
+  udp_stream: true
+  program_recorder: false
+>>>>>>> acd-foenix1
   disk_swap: true
   boot_settings: true
   apetime: false

--- a/lib/hardware/fnUART.cpp
+++ b/lib/hardware/fnUART.cpp
@@ -113,10 +113,13 @@ void UARTManager::begin(int baud)
 #endif /* BUILD_ADAM */
 
 #ifdef BUILD_COCO
-#ifndef PINMAP_COCO_CART
+    Debug_printv("SKIPPING TX-RX INVERT FOR FOENIX");
+#ifndef PINMAP_COCO_CART     // do not invert for coco cart
+#ifndef FOENIX_BUILD        // do not invert for Foenix with real D32 lolin
     if (_uart_num == 2)
         uart_set_line_inverse(_uart_num, UART_SIGNAL_TXD_INV | UART_SIGNAL_RXD_INV);
-#endif
+#endif /* FOENIX_BUILD */
+#endif /* PINMAP_COCO_CART */
 #endif /* BUILD_COCO */
 
 

--- a/platformio-sample.ini
+++ b/platformio-sample.ini
@@ -309,10 +309,8 @@ build_type = debug
 build_flags =
     ${env.build_flags}
     -D PINMAP_FOENIX_OS9_D32PRO
-    -D FORCE_UART_BAUD=230400  ; Set baud rate for Foenix F256
-    ;-D INVERT_SERIAL           ; Invert the RX/TX serial pins (e.g. Foenix F256)
-    ;-D DEBUG_TIMING
-    ;-D DATA_STREAM
+    -D FORCE_UART_BAUD=230400    ; Set baud rate for Foenix F256 and OS9
+    -D FOENIX_BUILD              ; ensure you do not reverse tx-rx like some coco builds require
 
 
 ; Color Computer Becker Port Drivewire (ESP32-DEVKITC-VE WROVER 8MB Flash, 8MB PSRAM)


### PR DESCRIPTION
Fixed D32 not working with foenix had to set a new define BUILD_FOENIX that will disable the tx rx inverting and make this board work with the F256k.
