### PR TITLE
[dw][foenix] fix board by not inverting tx rx in fnuart2

### DIFF
--- a/data/webui/config/fujinet-foenix-lolin-d32-dw.yaml
+++ b/data/webui/config/fujinet-foenix-lolin-d32-dw.yaml
@@ -7,12 +7,12 @@ components:
   hardware: true
   hosts_list: true
   mount_list: true
-  printer_settings: true
-  modem_settings: true
-  hsio_settings: true
+  printer_settings: false
+  modem_settings: false
+  hsio_settings: false
   timezone: true
   udp_stream: true
-  program_recorder: true
+  program_recorder: false
   disk_swap: true
   boot_settings: true
   apetime: false

--- a/lib/hardware/fnUART.cpp
+++ b/lib/hardware/fnUART.cpp
@@ -112,11 +112,13 @@ void UARTManager::begin(int baud)
         uart_set_line_inverse(_uart_num, UART_SIGNAL_TXD_INV | UART_SIGNAL_RXD_INV);
 #endif /* BUILD_ADAM */
 
-#ifdef BUILD_COCO
-#ifndef PINMAP_COCO_CART
+#ifdef BUILD_COCO                   // do invert for coco builds
+#ifndef PINMAP_COCO_CART           // do not invert for coco carts
+#ifndef PINMAP_FOENIX_OS9_D32PRO  // do not invert for Foenix
     if (_uart_num == 2)
         uart_set_line_inverse(_uart_num, UART_SIGNAL_TXD_INV | UART_SIGNAL_RXD_INV);
-#endif
+#endif /* PINMAP_FOENIX_OS9_D32PRO */
+#endif /* PINMAP_COCO_CART */
 #endif /* BUILD_COCO */
 
 

--- a/platformio-sample.ini
+++ b/platformio-sample.ini
@@ -310,10 +310,7 @@ build_flags =
     ${env.build_flags}
     -D PINMAP_FOENIX_OS9_D32PRO
     -D FORCE_UART_BAUD=230400  ; Set baud rate for Foenix F256
-    ;-D INVERT_SERIAL           ; Invert the RX/TX serial pins (e.g. Foenix F256)
-    ;-D DEBUG_TIMING
-    ;-D DATA_STREAM
-
+ 
 
 ; Color Computer Becker Port Drivewire (ESP32-DEVKITC-VE WROVER 8MB Flash, 8MB PSRAM)
 [env:fujinet-coco-becker]


### PR DESCRIPTION
following advice of team members i'm using the PINMAP definition of the D32 on the Foenix hardware to stop fnuart.cpp from inverting the tx and rx lines for the FN. This works and now the devices are communicating with logs. It's not completely mounting and reading the disk yet but on it's way.