### PR TITLE
Wait a little longer before deciding there are no more 1 bits.

### DIFF
--- a/lib/bus/iwm/iwm_ll.cpp
+++ b/lib/bus/iwm/iwm_ll.cpp
@@ -445,7 +445,7 @@ int IRAM_ATTR iwm_sp_ll::iwm_read_packet_spi(uint8_t* buffer, int packet_len)
       fnTimer.alarm_snooze( (samples * 10 * 1000 * 1000) / f_spirx); // samples * 10 /2 ); // snooze the timer based on the previous number of samples
     }
 
-    rxbyte = iwm_decode_byte(spi_buffer, SPI_SP_LEN, f_spirx, 19, &spirx_bit_ctr, &more_data);
+    rxbyte = iwm_decode_byte(spi_buffer, SPI_SP_LEN, f_spirx, 23, &spirx_bit_ctr, &more_data);
 
     if ((rxbyte == 0xc3) && (!synced))
     {


### PR DESCRIPTION
Spent some time in the logic analyzer going over what's going on when SmartPort is being initialized. I turned on a debug signal to go high just after the call to `spi_device_polling_start()` and go low when `iwm_read_packet_spi()` finished the while loop. For the most part† the `spi_device_polling_start()` is getting called within the first sync byte, so it seemed like the delay between calling `iwm_read_packet_spi()` and when the SPI capture started might be a red herring.

Looking at when the while loop ended I was seeing that whenever I kept getting 

```12:34:40.291 > SendPacket timeout waiting for REQ
12:34:40.321 > SendPacket timeout waiting for REQ
12:34:40.351 > SendPacket timeout waiting for REQ
12:34:40.381 > SendPacket timeout waiting for REQ
```

the while loop was dropping out early. Checking the state of more_data I could see that it was false even though there was definitely more SPI data captured. It seems that it is timing out looking for more `1` bits. Changing the timeout to 23 seems to make the timeout problem go away, I've tried several dozen times and I can't get it to repeat. (I can get the init to fail, but now it's from the occasional checksum error.)

† Sometimes I see the spi capture doesn't start until 2 sync bytes in. This is probably the same problem I was having with the delay starting SPI when capturing the write signal and had to go to using continuous SPI.

Logic analyzer capture with timeout failure:

![image](https://github.com/user-attachments/assets/92b6982e-8b13-4e5f-8a53-41d42051f466)

