### PR TITLE
Improve relative path resolution (retry)

### DIFF
--- a/lib/utils/peoples_url_parser.cpp
+++ b/lib/utils/peoples_url_parser.cpp
@@ -26,6 +26,7 @@
 #include <vector>
 
 #include "../../include/debug.h"
+#include "utils.h"
 
 #include "string_utils.h"
 
@@ -92,7 +93,7 @@ void PeoplesUrlParser::cleanPath() {
     // while(mstr::endsWith(path,"/")) {
     //     path=mstr::dropLast(path, 1);
     // }
-    mstr::replaceAll(path, "//", "/");
+    path = util_get_canonical_path(path);
 }
 
 void PeoplesUrlParser::processPath() {


### PR DESCRIPTION
These changes were inspired by issues found in ATARI NOS when trying to open, launch, copy files using relative paths.

- Fixed a bug in function `util_get_canonical_path`
  - Previous logic always exited with trailing slash, not good if input ends with a filename. If trailing slash found in input, then it will exist in output. If not then no slash in output.
  - Corrected mistake with condition involving C++ string length.
  - Renamed input arg from `prefix` to `path` throughout.
- In peoples_url_parser, added call to `util_get_canonical_path` in place of an existing string replace function that substituted '//' with '/'. This should resolve relative paths in general for all protocols.
