### PR TITLE
Added SmartPort STATUS and CONTROL commands to monitor Disk II

### DIFF
--- a/lib/bus/iwm/iwm.cpp
+++ b/lib/bus/iwm/iwm.cpp
@@ -579,6 +579,7 @@ bool IRAM_ATTR iwmBus::serviceDiskII()
     break;
 
   case iwm_enable_state_t::on:
+    diskii_xface.d2_enable_seen |= diskii_xface.iwm_enable_states();
 #ifdef DEBUG
     new_track = IWM_ACTIVE_DISK2->get_track_pos();
     if (old_track != new_track)

--- a/lib/bus/iwm/iwm.h
+++ b/lib/bus/iwm/iwm.h
@@ -107,12 +107,14 @@ enum {
 #define IWM_CTRL_RUN_ROUTINE 0x05
 #define IWM_CTRL_DWNLD_ADDRESS 0x06
 #define IWM_CTRL_DOWNLOAD 0x07
+#define IWM_CTRL_CLEAR_ENSEEN 0x08
 
 #define IWM_STATUS_STATUS 0x00
 #define IWM_STATUS_DCB 0x01
 #define IWM_STATUS_NEWLINE 0x02
 #define IWM_STATUS_DIB 0x03
 #define IWM_STATUS_UNI35 0x05
+#define IWM_STATUS_ENSEEN 0x08
 
 // class def'ns
 class iwmFuji;     // declare here so can reference it, but define in fuji.h

--- a/lib/bus/iwm/iwm_ll.h
+++ b/lib/bus/iwm/iwm_ll.h
@@ -293,6 +293,7 @@ private:
 
 public:
   QueueHandle_t iwm_write_queue;
+  uint8_t d2_enable_seen = 0;
 
   // Phase lines and ACK handshaking
   uint8_t iwm_phase_vector() { return (uint8_t)(GPIO.in1.val & (uint32_t)0b1111); };

--- a/lib/device/iwm/fuji.cpp
+++ b/lib/device/iwm/fuji.cpp
@@ -80,6 +80,7 @@ iwmFuji::iwmFuji()
 
         { FUJICMD_RESET,  [this]()                     { this->send_reply_packet(err_result); this->iwm_ctrl_reset_fujinet(); }},   // 0xFF
         { IWM_CTRL_RESET, [this]()                     { this->send_reply_packet(err_result); this->iwm_ctrl_reset_fujinet(); }},   // 0x00
+	{ IWM_CTRL_CLEAR_ENSEEN, [this]()	       { diskii_xface.d2_enable_seen = 0; err_result = SP_ERR_NOERROR; }},
 
         { FUJICMD_MOUNT_ALL, [&]()                     { err_result = (mount_all() ? SP_ERR_IOERROR : SP_ERR_NOERROR); }},          // 0xD7
         { FUJICMD_MOUNT_IMAGE, [&]()                   { err_result = iwm_ctrl_disk_image_mount(); }},  // 0xF8
@@ -91,6 +92,7 @@ iwmFuji::iwmFuji()
         
         { IWM_STATUS_DIB, [this]()                     { this->send_status_dib_reply_packet(); status_completed = true; }},     // 0x03
         { IWM_STATUS_STATUS, [this]()                  { this->send_status_reply_packet(); status_completed = true; }},         // 0x00
+	{ IWM_STATUS_ENSEEN, [this]()		       { data_len = 1; data_buffer[0] = diskii_xface.d2_enable_seen; }},
         
         { FUJICMD_DEVICE_ENABLE_STATUS, [this]()       { this->send_stat_get_enable(); }},                      // 0xD1
         { FUJICMD_GET_ADAPTERCONFIG_EXTENDED, [this]() { this->iwm_stat_get_adapter_config_extended(); }},      // 0xC4


### PR DESCRIPTION
Added a SmartPort STATUS and CONTROL command which allows CONFIG to see which /DRIVEn lines are connected to the FujiNet.

New `IWM_CTRL_CLEAR_ENSEEN` and `IWM_STATUS_ENSEEN` are both defined as `0x08` since it was available. Not sure if it should be a different value, but seems like both should be identical.

CLEAR will reset the "sticky" variable `d2_enable_seen` to 0x00. After that whenever a Disk II enable is seen the appropriate bit will be set in `d2_enable_seen` (bit 0 is drive 1, bit 1 is drive 2). STATUS will fetch the current value so that CONFIG can determine if FujiNet saw the drive access.

This change is for use with the change on CONFIG, see the diskii_drive_detect PR there. https://github.com/FujiNetWIFI/fujinet-config/pull/101