### PR TITLE
URL shortener

### DIFF
--- a/lib/http/httpService.cpp
+++ b/lib/http/httpService.cpp
@@ -1,4 +1,5 @@
 
+#include "fnHttpClient.h"
 #pragma GCC diagnostic ignored "-Wmissing-field-initializers"
 
 #include "httpService.h"
@@ -1183,6 +1184,44 @@ esp_err_t fnHttpService::get_handler_slot(httpd_req_t *req)
     return ESP_OK;
 }
 
+std::string fnHttpService::shorten_url(std::string url)
+{
+    int id = shortURLs.size();
+    shortURLs.push_back(url);
+
+    // Ideally would use hostname, but it doesn't include .local needed for mDNS devices
+    std::string shortened = "http://" + fnSystem.Net.get_ip4_address_str() + "/url/" + std::to_string(id);
+    Debug_printf("Short URL /url/%d registered for URL: %s\n", id, url.c_str());
+    return shortened;
+}
+
+esp_err_t fnHttpService::get_handler_shorturl(httpd_req_t *req)
+{
+    // Strip the /url/ from the path
+    std::string id_str = std::string(req->uri).substr(5);
+    Debug_printf("Short URL handler: %s\n", id_str.c_str());
+
+    if (!std::all_of(id_str.begin(), id_str.end(), ::isdigit)) {
+        httpd_resp_set_status(req, "400 Bad Request");
+        httpd_resp_send(req, NULL, 0);
+        return ESP_FAIL;
+    }
+
+    int id = std::stoi(id_str);
+    if (id > fnHTTPD.shortURLs.size())
+    {
+        httpd_resp_set_status(req, "404 Not Found");
+        httpd_resp_send(req, NULL, 0);
+    }
+    else
+    {
+        httpd_resp_set_status(req, "303 See Other");
+        httpd_resp_set_hdr(req, "Location", fnHTTPD.shortURLs[id].c_str());
+        httpd_resp_send(req, NULL, 0);
+    }
+    return ESP_OK;
+}
+
 esp_err_t fnHttpService::post_handler_config(httpd_req_t *req)
 {
 #ifdef VERBOSE_HTTP
@@ -1441,6 +1480,13 @@ httpd_handle_t fnHttpService::start_server(serverstate &state)
          .is_websocket = false,
          .handle_ws_control_frames = false,
          .supported_subprotocol = nullptr},
+        {.uri = "/url/*",
+        .method = HTTP_GET,
+        .handler = get_handler_shorturl,
+        .user_ctx = NULL,
+        .is_websocket = false,
+        .handle_ws_control_frames = false,
+        .supported_subprotocol = nullptr},
 #ifdef BUILD_ADAM
         {.uri = "/term",
          .method = HTTP_GET,

--- a/lib/http/httpService.h
+++ b/lib/http/httpService.h
@@ -21,7 +21,7 @@ If a file has an extention pre-determined to support parsing (see/update
 
     * The entire file contents are loaded into an in-memory string.
     * Anything with the pattern <%PARSE_TAG%> is replaced with an
-    * appropriate value as determined by the 
+    * appropriate value as determined by the
     *       string substitute_tag(const string &tag)
     * function.
 */
@@ -31,7 +31,6 @@ If a file has an extention pre-determined to support parsing (see/update
 
 #include <map>
 #include <string>
-
 
 #include "fnFS.h"
 
@@ -60,7 +59,7 @@ If a file has an extention pre-determined to support parsing (see/update
 
 #define PRINTER_BUSY_TIME 2000 // milliseconds to wait until printer is done
 
-class fnHttpService 
+class fnHttpService
 {
     struct serverstate {
 #ifdef ESP_PLATFORM
@@ -79,12 +78,14 @@ class fnHttpService
         fnwserr_post_fail
     };
 
+    std::vector<std::string> shortURLs;
+
 #ifdef ESP_PLATFORM
     struct queryparts {
         std::string full_uri;
         std::string path;
         std::string query;
-        std::map<std::string, std::string> query_parsed; 
+        std::map<std::string, std::string> query_parsed;
     };
 
     static void custom_global_ctx_free(void * ctx);
@@ -120,7 +121,7 @@ class fnHttpService
 
 public:
 
-    std::string errMsg; 
+    std::string errMsg;
 
     std::string getErrMsg() { return errMsg; }
     void clearErrMsg() { errMsg.clear(); }
@@ -138,6 +139,7 @@ public:
     static esp_err_t get_handler_eject(httpd_req_t *req);
     static esp_err_t get_handler_dir(httpd_req_t *req);
     static esp_err_t get_handler_slot(httpd_req_t *req);
+    static esp_err_t get_handler_shorturl(httpd_req_t *req);
 
 #ifdef BUILD_ADAM
     static esp_err_t get_handler_term(httpd_req_t *req);
@@ -156,10 +158,13 @@ public:
     static int post_handler_config(struct mg_connection *c, struct mg_http_message *hm);
 
     static int get_handler_browse(mg_connection *c, mg_http_message *hm);
+    static int get_handler_shorturl(mg_connection *c, mg_http_message *hm);
 
     void service();
 // !ESP_PLATFORM
 #endif
+
+    std::string shorten_url(std::string url);
 
     void start();
     void stop();

--- a/lib/http/mgHttpService.cpp
+++ b/lib/http/mgHttpService.cpp
@@ -3,11 +3,9 @@
  */
 
 #ifndef ESP_PLATFORM
-
 #include <sstream>
 #include <vector>
 #include <map>
-
 
 #include "fnSystem.h"
 #include "fnConfig.h"
@@ -17,6 +15,7 @@
 #include "printer.h"
 #include "fuji.h"
 
+#include "mongoose.h"
 #include "httpService.h"
 #include "httpServiceConfigurator.h"
 #include "httpServiceParser.h"
@@ -391,7 +390,7 @@ int fnHttpService::get_handler_browse(mg_connection *c, mg_http_message *hm)
     {
         mg_http_reply(c, 403, "", "Bad browse request\n");
     }
-    
+
     return 0;
 }
 
@@ -411,7 +410,7 @@ int fnHttpService::get_handler_mount(mg_connection *c, mg_http_message *hm)
     {
         // Mount all the things
         Debug_printf("Mount all from webui\n");
-#ifdef BUILD_ATARI        
+#ifdef BUILD_ATARI
         theFuji.mount_all(false);
 #else
         theFuji.mount_all();
@@ -436,7 +435,7 @@ int fnHttpService::get_handler_eject(mg_connection *c, mg_http_message *hm)
     else
     {
 #ifdef BUILD_APPLE
-        if(theFuji.get_disks(ds)->disk_dev.device_active) //set disk switched only if device was previosly mounted. 
+        if(theFuji.get_disks(ds)->disk_dev.device_active) //set disk switched only if device was previosly mounted.
             theFuji.get_disks(ds)->disk_dev.switched = true;
 #endif
         theFuji.get_disks(ds)->disk_dev.unmount();
@@ -480,6 +479,39 @@ int fnHttpService::get_handler_eject(mg_connection *c, mg_http_message *hm)
     else
     {
         send_file(c, "redirect_to_index.html");
+    }
+    return 0;
+}
+
+std::string fnHttpService::shorten_url(std::string url)
+{
+    int id = shortURLs.size();
+    shortURLs.push_back(url);
+
+    std::string shortened = "http://" + fnSystem.Net.get_hostname() + ":8000/url/" + std::to_string(id);
+    Debug_printf("Short URL /url/%d registered for URL: %s\n", id, url.c_str());
+    return shortened;
+}
+
+int fnHttpService::get_handler_shorturl(mg_connection *c, mg_http_message *hm)
+{
+    // Strip the /url/ from the path
+    std::string id_str = std::string(hm->uri.ptr).substr(5, hm->uri.len-5);
+    Debug_printf("Short URL handler: %s\n", id_str.c_str());
+
+    if (!std::all_of(id_str.begin(), id_str.end(), ::isdigit)) {
+        mg_http_reply(c, 400, "", "Bad Request");
+        return 0;
+    }
+
+    int id = std::stoi(id_str);
+    if (id > fnHTTPD.shortURLs.size())
+    {
+        mg_http_reply(c, 404, "", "Not Found");
+    }
+    else
+    {
+        mg_printf(c, "HTTP/1.1 303 See Other\r\nLocation: %s\r\nContent-Length: 0\r\n\r\n", fnHTTPD.shortURLs[id].c_str());
     }
     return 0;
 }
@@ -558,7 +590,7 @@ void fnHttpService::cb(struct mg_connection *c, int ev, void *ev_data)
             // get "exit" query variable
             char exit[10] = "";
             mg_http_get_var(&hm->query, "exit", exit, sizeof(exit));
-            if (atoi(exit)) 
+            if (atoi(exit))
             {
                 mg_http_reply(c, 200, "", "{\"result\": %d}\n", 1); // send reply
                 fnSystem.reboot(500, false); // deferred exit with code 0
@@ -570,6 +602,10 @@ void fnHttpService::cb(struct mg_connection *c, int ev, void *ev_data)
                 // keep running for a while to transfer restart.html page
                 fnSystem.reboot(500, true); // deferred exit with code 75 -> should be started again
             }
+        }
+        else if (mg_http_match_uri(hm, "/url/*"))
+        {
+            get_handler_shorturl(c, hm);
         }
         else
         // default handler, serve static content of www firectory


### PR DESCRIPTION
Adds a simple URL shortener to the webserver, primarily for use with the new QR code encoding feature.

You are pretty limited in the amount of data you can encode in a QR code if it can only be 21x21, and this may be too short for many URLs. This URL shortener allows you to take an arbitrarily long URL and shorten to `http://{fujinet_ip}/url/{id}`.

For Atari, you can tell the QR encoder to shorten the supplied URL first by setting bit 4 on AUX2 (i.e. adding 16 to the desired error correction level).