### PR TITLE
[PC] fix: include <algorithm> header

### DIFF
--- a/lib/http/mgHttpService.cpp
+++ b/lib/http/mgHttpService.cpp
@@ -6,6 +6,7 @@
 #include <sstream>
 #include <vector>
 #include <map>
+#include <algorithm>
 
 #include "fnSystem.h"
 #include "fnConfig.h"


### PR DESCRIPTION
Fixes issue with building FujiNet-PC on Ubuntu/Windows due to omitting include