### PR TITLE
[network-protocol] do not emit EOF on write.

### DIFF
--- a/lib/network-protocol/FS.cpp
+++ b/lib/network-protocol/FS.cpp
@@ -58,6 +58,8 @@ bool NetworkProtocolFS::open_file()
 
     if (aux1_open == 4 || aux1_open == 8)
         resolve();
+    else
+        stat();
 
     update_dir_filename(opened_url);
 
@@ -182,6 +184,8 @@ bool NetworkProtocolFS::read(unsigned short len)
 {
     bool ret;
 
+    is_write = false;
+    
     switch (openMode)
     {
     case FILE:
@@ -245,6 +249,7 @@ bool NetworkProtocolFS::read_dir(unsigned short len)
 
 bool NetworkProtocolFS::write(unsigned short len)
 {
+    is_write = true;
     len = translate_transmit_buffer();
     return write_file(len); // Do more here? not sure.
 }
@@ -285,7 +290,10 @@ bool NetworkProtocolFS::status_file(NetworkStatus *status)
 #endif
 
     status->connected = fileSize > 0 ? 1 : 0;
-    status->error = fileSize > 0 ? error : NETWORK_ERROR_END_OF_FILE;
+    if (is_write)
+        status->error = 1;
+    else
+        status->error = fileSize > 0 ? error : NETWORK_ERROR_END_OF_FILE;
 
     NetworkProtocol::status(status);
 

--- a/lib/network-protocol/Protocol.cpp
+++ b/lib/network-protocol/Protocol.cpp
@@ -181,7 +181,7 @@ bool NetworkProtocol::write(unsigned short len)
  */
 bool NetworkProtocol::status(NetworkStatus *status)
 {
-    if (receiveBuffer->length() == 0 && status->rxBytesWaiting > 0)
+    if (!is_write && receiveBuffer->length() == 0 && status->rxBytesWaiting > 0)
         read(status->rxBytesWaiting);
 
     status->rxBytesWaiting = receiveBuffer->length();

--- a/lib/network-protocol/Protocol.h
+++ b/lib/network-protocol/Protocol.h
@@ -11,7 +11,11 @@ class NetworkProtocol
 {
 public:
     std::string name = "UNKNOWN";
-
+    /**
+     * Was the last command a write?
+     */
+    bool is_write = false;
+    
     /**
      * Pointer to the receive buffer
      */


### PR DESCRIPTION
Mode 0x0c (12) read/write was returning EOF when writing to the end of file.

Code was added to flag this, and to return a successful error if the write is successful.

Mode 0x0c (12) was also returning 0 bytes available for any file that had existing data. This was because the file was not stat() and filesize() had not been adjusted. 

There is still a potential for reading and writing within the same file to cause a file size change, however, this will not come into play until seeking and telling (NOTE/POINT) are actually implemented in FS.
