### PR TITLE
Fix printer emulator form feed

### DIFF
--- a/lib/printer-emulator/atari_1025.cpp
+++ b/lib/printer-emulator/atari_1025.cpp
@@ -172,6 +172,11 @@ void atari1025::pdf_handle_char(uint16_t c, uint8_t aux1, uint8_t aux2)
     }
     else if (c == 27)
         escMode = true;
+    else if (c == 12) // form feed.
+    {
+        pdf_end_page();
+        pdf_new_page();
+    }
     else
     { // maybe printable character
         print_char(c);

--- a/lib/printer-emulator/atari_1027.cpp
+++ b/lib/printer-emulator/atari_1027.cpp
@@ -39,6 +39,11 @@ void atari1027::pdf_handle_char(uint16_t c, uint8_t aux1, uint8_t aux2)
         uscoreFlag = false;
     else if (c == 27)
         escMode = true;
+    else if (c == 12)
+    {
+        pdf_end_page();
+        pdf_new_page();
+    }
     else
     { // maybe printable character
         //printable characters for 1027 Standard Set + a few more >123 -- see mapping atari on ATASCII

--- a/lib/printer-emulator/atari_1029.cpp
+++ b/lib/printer-emulator/atari_1029.cpp
@@ -221,6 +221,11 @@ void atari1029::pdf_handle_char(uint16_t c, uint8_t aux1, uint8_t aux2)
                     pdf_X += charWidth; // update x position
                 }
             }
+            else if (c == 12)
+            {
+                pdf_end_page();
+                pdf_new_page();
+            }
             else if (c > 31 && c < 127)
             {
                 if (c == '\\' || c == '(' || c == ')')

--- a/lib/printer-emulator/atari_820.cpp
+++ b/lib/printer-emulator/atari_820.cpp
@@ -41,6 +41,12 @@ void atari820::pdf_handle_char(uint16_t c, uint8_t aux1, uint8_t aux2)
         // could increase charWidth, but not necessary to make this work. I force EOL.
     }
 
+    if (c == 12)
+    {
+        pdf_end_page();
+        pdf_new_page();
+    }
+
     // maybe printable character
     if (c > 31 && c < 127)
     {

--- a/lib/printer-emulator/atari_822.cpp
+++ b/lib/printer-emulator/atari_822.cpp
@@ -82,6 +82,12 @@ void atari822::pdf_handle_char(uint16_t c, uint8_t aux1, uint8_t aux2)
 
     // TODO: looks like auto wrapped lines are 1 dot apart and EOL lines are 3 dots apart
 
+    if (textMode && c == 12)
+    {
+        pdf_end_page();
+        pdf_new_page();
+    }
+
     // simple ASCII printer
     if (textMode && c > 31 && c < 127)
     {

--- a/lib/printer-emulator/atari_825.cpp
+++ b/lib/printer-emulator/atari_825.cpp
@@ -185,6 +185,10 @@ void atari825::pdf_handle_char(uint16_t c, uint8_t aux1, uint8_t aux2)
             pdf_dY -= lineHeight; // set pdf_dY and rise to N1/216.
             pdf_set_rise();
             break;
+        case 12: // Form feed
+            pdf_end_page();
+            pdf_new_page();
+            break;
         case 13: // Carriage Return.
             // Prints buffer contents and resets buffer character count to zero
             // Implemented outside in pdf_printer()

--- a/lib/printer-emulator/atari_xdm121.cpp
+++ b/lib/printer-emulator/atari_xdm121.cpp
@@ -220,6 +220,7 @@ void xdm121::pdf_handle_char(uint16_t c, uint8_t aux1, uint8_t aux2)
                 break;
             case 12: // XDM Advances paper to next logical TOF (top of form)
                 pdf_end_page();
+                pdf_new_page();
                 // XMM
                 break;
             case 13: // XDM Carriage Return.

--- a/lib/printer-emulator/atari_xmm801.cpp
+++ b/lib/printer-emulator/atari_xmm801.cpp
@@ -448,6 +448,7 @@ void xmm801::pdf_handle_char(uint16_t c, uint8_t aux1, uint8_t aux2)
             if (intlFlag)
                 break;
             pdf_end_page();
+            pdf_new_page();
             // XMM
             break;
         case 13: // Carriage Return.

--- a/lib/printer-emulator/epson_80.cpp
+++ b/lib/printer-emulator/epson_80.cpp
@@ -439,6 +439,7 @@ void epson80::pdf_handle_char(uint16_t c, uint8_t aux1, uint8_t aux2)
             break;
         case 12: // Advances paper to next logical TOF (top of form)
             pdf_end_page();
+            pdf_new_page();
             break;
         case 13: // Carriage Return.
             // Prints buffer contents and resets buffer character count to zero


### PR DESCRIPTION
For PDF printers that support form feed, eject the current page, create the next one.