### PR TITLE
Validate the path in Fujinet "hosts list" browser in the web UI.

### DIFF
--- a/lib/http/httpServiceBrowser.h
+++ b/lib/http/httpServiceBrowser.h
@@ -9,6 +9,7 @@ class fnHttpServiceBrowser
 {
     static int browse_url_encode(const char *src, size_t src_len, char *dst, size_t dst_len);
     static int browse_html_escape(const char *src, size_t src_len, char *dst, size_t dst_len);
+    static int validate_path(const char *path, size_t path_len);
 
     static int browse_listdir(mg_connection *c, mg_http_message *hm, FileSystem *pFS, int slot, const char *host_path, unsigned pathlen);
     static int browse_listdrives(mg_connection *c, int slot, const char *esc_path, const char *enc_path);


### PR DESCRIPTION
Before this commit it's possible to escape the configured root by specifying `..` between the URL-encoded slash: `%2F`:

```
http://localhost:8000/browse/host/1/%2F..%2F..%2F..%2F
```