### PR TITLE
fix uint32 compile errors

### DIFF
--- a/lib/device/rs232/disk.cpp
+++ b/lib/device/rs232/disk.cpp
@@ -39,9 +39,9 @@ rs232Disk::rs232Disk()
 // Read disk data and send to computer
 void rs232Disk::rs232_read()
 {
-    Debug_printf("disk READ %u\n", cmdFrame.aux);
+	Debug_printf("disk READ %lu\n", cmdFrame.aux);
 
-    if (_disk == nullptr)
+	if (_disk == nullptr)
     {
         rs232_error();
         return;

--- a/lib/device/rs232/fuji.cpp
+++ b/lib/device/rs232/fuji.cpp
@@ -104,7 +104,7 @@ void rs232Fuji::rs232_status()
     {
 	char ret[4] = {0};
 
-        Debug_printf("Status for what? %08x\n", cmdFrame.aux);
+	Debug_printf("Status for what? %08lx\n", cmdFrame.aux);
 	bus_to_computer((uint8_t *)ret, sizeof(ret), false);
     }
     return;


### PR DESCRIPTION
Fix compile time errors due to mis-matched formats in debug output functions.

![image](https://github.com/user-attachments/assets/01740283-f09c-4e28-9114-c9375d6a5e8c)
