### PR TITLE
[webui] add /hosts endpoint for view/updating host slots 

### DIFF
--- a/lib/device/sio/fuji.cpp
+++ b/lib/device/sio/fuji.cpp
@@ -2778,4 +2778,10 @@ std::string sioFuji::get_host_prefix(int host_slot)
     return _fnHosts[host_slot].get_prefix();
 }
 
+fujiHost *sioFuji::set_slot_hostname(int host_slot, char *hostname)
+{
+    _fnHosts[host_slot].set_hostname(hostname);
+    return &_fnHosts[host_slot];
+}
+
 #endif /* BUILD_ATARI */

--- a/lib/device/sio/fuji.h
+++ b/lib/device/sio/fuji.h
@@ -219,6 +219,7 @@ public:
 
     fujiHost *get_hosts(int i) { return &_fnHosts[i]; }
     fujiDisk *get_disks(int i) { return &_fnDisks[i]; }
+    fujiHost *set_slot_hostname(int host_slot, char *hostname);
 
     void _populate_slots_from_config();
     void _populate_config_from_slots();

--- a/lib/http/httpService.cpp
+++ b/lib/http/httpService.cpp
@@ -1184,6 +1184,34 @@ esp_err_t fnHttpService::get_handler_slot(httpd_req_t *req)
     return ESP_OK;
 }
 
+esp_err_t fnHttpService::get_handler_hosts(httpd_req_t *req)
+{
+    std::string response = "";
+    for (int hs = 0; hs < 8; hs++) {
+        response += std::string(theFuji.get_hosts(hs)->get_hostname()) + "\n";
+    }
+    httpd_resp_send(req, response.c_str(), response.length());
+    return ESP_OK;
+}
+
+esp_err_t fnHttpService::post_handler_hosts(httpd_req_t *req)
+{
+    queryparts qp;
+    parse_query(req, &qp);
+
+    int hostslot = atoi(qp.query_parsed["hostslot"].c_str());
+    char *hostname = (char *)qp.query_parsed["hostname"].c_str();
+
+    theFuji.set_slot_hostname(hostslot, hostname);
+
+    std::string response = "";
+    for (int hs = 0; hs < 8; hs++) {
+        response += std::string(theFuji.get_hosts(hs)->get_hostname()) + "\n";
+    }
+    httpd_resp_send(req, response.c_str(), response.length());
+    return ESP_OK;
+}
+
 std::string fnHttpService::shorten_url(std::string url)
 {
     int id = shortURLs.size();
@@ -1480,13 +1508,27 @@ httpd_handle_t fnHttpService::start_server(serverstate &state)
          .is_websocket = false,
          .handle_ws_control_frames = false,
          .supported_subprotocol = nullptr},
+        {.uri = "/hosts",
+         .method = HTTP_GET,
+         .handler = get_handler_hosts,
+         .user_ctx = NULL,
+         .is_websocket = false,
+         .handle_ws_control_frames = false,
+         .supported_subprotocol = nullptr},
+        {.uri = "/hosts",
+         .method = HTTP_POST,
+         .handler = post_handler_hosts,
+         .user_ctx = NULL,
+         .is_websocket = false,
+         .handle_ws_control_frames = false,
+         .supported_subprotocol = nullptr},
         {.uri = "/url/*",
-        .method = HTTP_GET,
-        .handler = get_handler_shorturl,
-        .user_ctx = NULL,
-        .is_websocket = false,
-        .handle_ws_control_frames = false,
-        .supported_subprotocol = nullptr},
+         .method = HTTP_GET,
+         .handler = get_handler_shorturl,
+         .user_ctx = NULL,
+         .is_websocket = false,
+         .handle_ws_control_frames = false,
+         .supported_subprotocol = nullptr},
 #ifdef BUILD_ADAM
         {.uri = "/term",
          .method = HTTP_GET,

--- a/lib/http/httpService.cpp
+++ b/lib/http/httpService.cpp
@@ -1184,6 +1184,7 @@ esp_err_t fnHttpService::get_handler_slot(httpd_req_t *req)
     return ESP_OK;
 }
 
+#ifdef BUILD_ATARI
 esp_err_t fnHttpService::get_handler_hosts(httpd_req_t *req)
 {
     std::string response = "";
@@ -1211,6 +1212,7 @@ esp_err_t fnHttpService::post_handler_hosts(httpd_req_t *req)
     httpd_resp_send(req, response.c_str(), response.length());
     return ESP_OK;
 }
+#endif
 
 std::string fnHttpService::shorten_url(std::string url)
 {
@@ -1508,6 +1510,7 @@ httpd_handle_t fnHttpService::start_server(serverstate &state)
          .is_websocket = false,
          .handle_ws_control_frames = false,
          .supported_subprotocol = nullptr},
+#ifdef BUILD_ATARI
         {.uri = "/hosts",
          .method = HTTP_GET,
          .handler = get_handler_hosts,
@@ -1522,6 +1525,7 @@ httpd_handle_t fnHttpService::start_server(serverstate &state)
          .is_websocket = false,
          .handle_ws_control_frames = false,
          .supported_subprotocol = nullptr},
+#endif
         {.uri = "/url/*",
          .method = HTTP_GET,
          .handler = get_handler_shorturl,

--- a/lib/http/httpService.h
+++ b/lib/http/httpService.h
@@ -141,6 +141,8 @@ public:
     static esp_err_t get_handler_eject(httpd_req_t *req);
     static esp_err_t get_handler_dir(httpd_req_t *req);
     static esp_err_t get_handler_slot(httpd_req_t *req);
+    static esp_err_t get_handler_hosts(httpd_req_t *req);
+    static esp_err_t post_handler_hosts(httpd_req_t *req);
     static esp_err_t get_handler_shorturl(httpd_req_t *req);
 
 #ifdef BUILD_ADAM
@@ -155,6 +157,8 @@ public:
     // static esp_err_t get_handler_modem_sniffer(httpd_req_t *req);
     static int get_handler_swap(struct mg_connection *c, struct mg_http_message *hm);
     static int get_handler_mount(struct mg_connection *c, struct mg_http_message *hm);
+    static int get_handler_hosts(struct mg_connection *c, struct mg_http_message *hm);
+    static int post_handler_hosts(struct mg_connection *c, struct mg_http_message *hm);
     static int get_handler_eject(mg_connection *c, mg_http_message *hm);
 
     static int post_handler_config(struct mg_connection *c, struct mg_http_message *hm);

--- a/lib/http/httpService.h
+++ b/lib/http/httpService.h
@@ -141,8 +141,10 @@ public:
     static esp_err_t get_handler_eject(httpd_req_t *req);
     static esp_err_t get_handler_dir(httpd_req_t *req);
     static esp_err_t get_handler_slot(httpd_req_t *req);
+#ifdef BUILD_ATARI
     static esp_err_t get_handler_hosts(httpd_req_t *req);
     static esp_err_t post_handler_hosts(httpd_req_t *req);
+#endif
     static esp_err_t get_handler_shorturl(httpd_req_t *req);
 
 #ifdef BUILD_ADAM

--- a/lib/http/mgHttpService.cpp
+++ b/lib/http/mgHttpService.cpp
@@ -484,6 +484,7 @@ int fnHttpService::get_handler_eject(mg_connection *c, mg_http_message *hm)
     return 0;
 }
 
+#ifdef BUILD_ATARI
 int fnHttpService::get_handler_hosts(mg_connection *c, mg_http_message *hm)
 {
     std::string response = "";
@@ -510,6 +511,7 @@ int fnHttpService::post_handler_hosts(mg_connection *c, mg_http_message *hm)
     mg_http_reply(c, 200, "", "%s", response.c_str());
     return 0;
 }
+#endif
 
 std::string fnHttpService::shorten_url(std::string url)
 {
@@ -631,12 +633,14 @@ void fnHttpService::cb(struct mg_connection *c, int ev, void *ev_data)
                 fnSystem.reboot(500, true); // deferred exit with code 75 -> should be started again
             }
         }
+#ifdef BUILD_ATARI
         else if (mg_http_match_uri(hm, "/hosts")) {
             if (mg_vcasecmp(&hm->method, "POST") == 0)
                 post_handler_hosts(c, hm);
             else
                 get_handler_hosts(c, hm);
         }
+#endif
         else if (mg_http_match_uri(hm, "/url/*"))
         {
             get_handler_shorturl(c, hm);


### PR DESCRIPTION
Adds `/hosts` endpoint(s) to web server. Primarily for use with "Send to FujiNet" browser extension.

```sh
GET /hosts

# Returns

SD
fujinet.online
apps.irata.online
fujinet.diller.org
https://bocianu.atari.pl
atarionline.eu
fujinet.pl
tnfs.abbuc.social
```

```sh
POST /hosts?hostslot=7&hostname=tnfs.example.com

# Sets host slot 8 to `tnfs.example.com` and returns

SD
fujinet.online
apps.irata.online
fujinet.diller.org
https://bocianu.atari.pl
atarionline.eu
fujinet.pl
tnfs.example.com
```