### PR TITLE
[webui] add edit button to host slots

### DIFF
--- a/data/webui/template/www/index.tmpl.html
+++ b/data/webui/template/www/index.tmpl.html
@@ -281,7 +281,10 @@
 				<header class="module-header">HOSTS<span class="logowob"></span>LIST</header>
 				{% for hs in range(1, 9) %}
 				<div class="{{ loop.cycle('detline', 'detline alt') }}">
-					<div class="deth detlinecol">Host {{ hs }}</div>
+					<div class="deth detlinecol">
+						Host {{ hs }}
+						<a href="#" class="edit-host" data-hostslot="{{ hs }}" data-hostname="<%FN_HOST{{ hs }}%>">[EDIT]</a>
+					</div>
 					{% if tweaks.fujinet_pc %}
 					<div class="det detlinecol"><a href="/browse/host/{{ hs }}"><%FN_HOST{{ hs }}%> :: <%FN_HOST{{ hs }}PREFIX%></a></div>
 					{% else %}

--- a/data/webui/template/www/js/settings.tmpl.js
+++ b/data/webui/template/www/js/settings.tmpl.js
@@ -14,6 +14,32 @@ function toggleExperimental(evt) {
   localStorage.setItem('fujinet.experimental', evt.target.checked);
 }
 
+function setupHostEditing() {
+  const editLinks = document.querySelectorAll('a.edit-host');
+  editLinks.forEach(link => {
+    link.addEventListener('click', e => {
+      e.preventDefault();
+      const hs = Number(link.dataset.hostslot) - 1;
+      const currentHostname = link.dataset.hostname;
+
+      const updatedHostname = prompt(`Enter hostname for slot ${hs + 1}`, currentHostname);
+
+      // Abort on [Cancel]
+      if (updatedHostname === null) {
+        return;
+      }
+
+      fetch(`/hosts?hostslot=${hs}&hostname=${updatedHostname}`, { method: 'POST' })
+        .then(() => {
+          location.reload();
+        })
+        .catch(e => {
+          alert("Error: Could not update host");
+        });
+    });
+  });
+}
+
 function changeTz() {
 	const selElement = document.getElementById("select_tz");
 	const setElement = document.getElementById("txt_timezone")
@@ -170,3 +196,4 @@ setInputValue(current_pclink == 1, "pclink-yes", "pclink-no");
 {% endif %}
 
 setupExperimentalToggle();
+setupHostEditing();

--- a/lib/device/sio/fuji.cpp
+++ b/lib/device/sio/fuji.cpp
@@ -2781,6 +2781,7 @@ std::string sioFuji::get_host_prefix(int host_slot)
 fujiHost *sioFuji::set_slot_hostname(int host_slot, char *hostname)
 {
     _fnHosts[host_slot].set_hostname(hostname);
+    _populate_config_from_slots();
     return &_fnHosts[host_slot];
 }
 


### PR DESCRIPTION
- Adds a little `[EDIT]` link next to host slots
- Ensures host names get updated when endpoint is called

<img width="665" alt="Screenshot 2025-02-14 at 7 09 46 PM" src="https://github.com/user-attachments/assets/ba25113f-dbca-4fa7-b5b5-a3b5efaabd5f" />
<img width="423" alt="Screenshot 2025-02-14 at 7 10 12 PM" src="https://github.com/user-attachments/assets/be476f3e-2d01-422b-86b9-31377eeca59b" />
