### PR TITLE
[fuji] set_slot_hostname: repopulate config

### DIFF
--- a/lib/device/adamnet/fuji.cpp
+++ b/lib/device/adamnet/fuji.cpp
@@ -1003,6 +1003,7 @@ void adamFuji::adamnet_get_host_prefix()
 fujiHost *adamFuji::set_slot_hostname(int host_slot, char *hostname)
 {
     _fnHosts[host_slot].set_hostname(hostname);
+    _populate_config_from_slots();
     return &_fnHosts[host_slot];
 }
 

--- a/lib/device/comlynx/fuji.cpp
+++ b/lib/device/comlynx/fuji.cpp
@@ -952,6 +952,7 @@ void lynxFuji::comlynx_get_host_prefix()
 fujiHost *lynxFuji::set_slot_hostname(int host_slot, char *hostname)
 {
     _fnHosts[host_slot].set_hostname(hostname);
+    _populate_config_from_slots();
     return &_fnHosts[host_slot];
 }
 

--- a/lib/device/cx16_i2c/fuji.cpp
+++ b/lib/device/cx16_i2c/fuji.cpp
@@ -1130,6 +1130,7 @@ void cx16Fuji::get_host_prefix()
 fujiHost *cx16_i2c::set_slot_hostname(int host_slot, char *hostname)
 {
     _fnHosts[host_slot].set_hostname(hostname);
+    _populate_config_from_slots();
     return &_fnHosts[host_slot];
 }
 

--- a/lib/device/drivewire/fuji.cpp
+++ b/lib/device/drivewire/fuji.cpp
@@ -1641,6 +1641,7 @@ std::string drivewireFuji::get_host_prefix(int host_slot)
 fujiHost *drivewireFuji::set_slot_hostname(int host_slot, char *hostname)
 {
     _fnHosts[host_slot].set_hostname(hostname);
+    _populate_config_from_slots();
     return &_fnHosts[host_slot];
 }
 

--- a/lib/device/h89/fuji.cpp
+++ b/lib/device/h89/fuji.cpp
@@ -249,6 +249,7 @@ void H89Fuji::H89_get_host_prefix()
 fujiHost *H89Fuji::set_slot_hostname(int host_slot, char *hostname)
 {
     _fnHosts[host_slot].set_hostname(hostname);
+    _populate_config_from_slots();
     return &_fnHosts[host_slot];
 }
 

--- a/lib/device/iec/fuji.cpp
+++ b/lib/device/iec/fuji.cpp
@@ -1863,6 +1863,7 @@ void iecFuji::get_host_prefix()
 fujiHost *iecFuji::set_slot_hostname(int host_slot, char *hostname)
 {
     _fnHosts[host_slot].set_hostname(hostname);
+    _populate_config_from_slots();
     return &_fnHosts[host_slot];
 }
 

--- a/lib/device/iwm/fuji.cpp
+++ b/lib/device/iwm/fuji.cpp
@@ -1377,6 +1377,7 @@ std::string iwmFuji::get_host_prefix(int host_slot) { return std::string(); }
 fujiHost *iwmFuji::set_slot_hostname(int host_slot, char *hostname)
 {
     _fnHosts[host_slot].set_hostname(hostname);
+    _populate_config_from_slots();
     return &_fnHosts[host_slot];
 }
 

--- a/lib/device/mac/fuji.cpp
+++ b/lib/device/mac/fuji.cpp
@@ -1108,6 +1108,7 @@ void iwmFuji::iwm_stat_get_host_prefix()
 fujiHost *iwmFuji::set_slot_hostname(int host_slot, char *hostname)
 {
     _fnHosts[host_slot].set_hostname(hostname);
+    _populate_config_from_slots();
     return &_fnHosts[host_slot];
 }
 

--- a/lib/device/new/fuji.cpp
+++ b/lib/device/new/fuji.cpp
@@ -784,6 +784,7 @@ void adamFuji::adamnet_get_host_prefix()
 fujiHost *adamFuji::set_slot_hostname(int host_slot, char *hostname)
 {
     _fnHosts[host_slot].set_hostname(hostname);
+    _populate_config_from_slots();
     return &_fnHosts[host_slot];
 }
 

--- a/lib/device/rc2014/fuji.cpp
+++ b/lib/device/rc2014/fuji.cpp
@@ -761,6 +761,7 @@ void rc2014Fuji::rc2014_get_host_prefix()
 fujiHost *rc2014Fuji::set_slot_hostname(int host_slot, char *hostname)
 {
     _fnHosts[host_slot].set_hostname(hostname);
+    _populate_config_from_slots();
     return &_fnHosts[host_slot];
 }
 

--- a/lib/device/rs232/fuji.cpp
+++ b/lib/device/rs232/fuji.cpp
@@ -1668,6 +1668,7 @@ std::string rs232Fuji::get_host_prefix(int host_slot)
 fujiHost *rs232Fuji::set_slot_hostname(int host_slot, char *hostname)
 {
     _fnHosts[host_slot].set_hostname(hostname);
+    _populate_config_from_slots();
     return &_fnHosts[host_slot];
 }
 

--- a/lib/device/s100spi/fuji.cpp
+++ b/lib/device/s100spi/fuji.cpp
@@ -780,6 +780,7 @@ void s100spiFuji::s100spi_get_host_prefix()
 fujiHost *s100spiFuji::set_slot_hostname(int host_slot, char *hostname)
 {
     _fnHosts[host_slot].set_hostname(hostname);
+    _populate_config_from_slots();
     return &_fnHosts[host_slot];
 }
 


### PR DESCRIPTION
when updating slot hostname (from webui), also call `_populate_config_from_slots` so the updated name gets copied over there as well