### PR TITLE
QR: new bitmap output + fix

### DIFF
--- a/lib/device/sio/fuji.cpp
+++ b/lib/device/sio/fuji.cpp
@@ -2136,10 +2136,6 @@ sioDisk *sioFuji::bootdisk()
 }
 
 
-
-
-
-
 void sioFuji::sio_qrcode_input()
 {
     uint16_t len = sio_get_aux();
@@ -2207,11 +2203,14 @@ void sioFuji::sio_qrcode_length()
     // to specify version, ecc, *and* output mode for the encode command. Also can't
     // just wait for output command, because output mode determines buffer length,
     if (output_mode != qrManager.output_mode) {
-        if (output_mode == QR_OUTPUT_MODE_BITS) {
-            qrManager.to_bits();
+        if (output_mode == QR_OUTPUT_MODE_BINARY) {
+            qrManager.to_binary();
         }
-        if (output_mode == QR_OUTPUT_MODE_ATASCII) {
+        else if (output_mode == QR_OUTPUT_MODE_ATASCII) {
             qrManager.to_atascii();
+        }
+        else if (output_mode == QR_OUTPUT_MODE_BITMAP) {
+            qrManager.to_bitmap();
         }
         qrManager.output_mode = output_mode;
     }
@@ -2263,12 +2262,6 @@ void sioFuji::sio_qrcode_output()
     qrManager.out_buf.shrink_to_fit();
 
 }
-
-
-
-
-
-
 
 
 void sioFuji::sio_base64_encode_input()

--- a/lib/device/sio/fuji.cpp
+++ b/lib/device/sio/fuji.cpp
@@ -2159,6 +2159,7 @@ void sioFuji::sio_qrcode_encode()
 {
     size_t out_len = 0;
 
+    qrManager.output_mode = 0;
     uint16_t aux = sio_get_aux();
     qrManager.version = aux;
     qrManager.ecc_mode = (aux >> 8) & 0b00000011;
@@ -2198,6 +2199,7 @@ void sioFuji::sio_qrcode_length()
 {
     Debug_printf("FUJI: QRCODE LENGTH\n");
     uint8_t output_mode = sio_get_aux();
+    Debug_printf("Output mode: %i\n", output_mode);
 
     // A bit gross to have a side effect from length command, but not enough aux bytes
     // to specify version, ecc, *and* output mode for the encode command. Also can't

--- a/lib/qrcode/qrmanager.cpp
+++ b/lib/qrcode/qrmanager.cpp
@@ -1,6 +1,7 @@
 #include <cstdint>
 #include <cstring>
 #include <cstdlib>
+#include <cmath>
 #include <memory>
 #include <vector>
 #include "../../include/debug.h"

--- a/lib/qrcode/qrmanager.cpp
+++ b/lib/qrcode/qrmanager.cpp
@@ -36,7 +36,7 @@ std::vector<uint8_t> QRManager::encode(const void* src, size_t len, size_t versi
     return qrManager.out_buf;
 }
 
-void QRManager::to_bits(void) {
+void QRManager::to_binary(void) {
     auto bytes = qrManager.out_buf;
     size_t len = bytes.size();
     std::vector<uint8_t> out;
@@ -51,6 +51,41 @@ void QRManager::to_bits(void) {
         val |= bytes[i+bit] << bit;
     }
     out.push_back(val);
+
+    qrManager.out_buf = out;
+}
+
+void QRManager::to_bitmap(void) {
+    auto bytes = qrManager.out_buf;
+    size_t size = 17 + 4 * qrManager.version;
+    size_t len = bytes.size();
+    size_t bytes_per_row = ceil(size / 8.0);
+    std::vector<uint8_t> out;
+
+    uint8_t val = 0;
+    uint8_t x = 0;
+    uint8_t y = 0;
+    for (auto i = 0; i < len; i++) {
+        val |= bytes[i];
+        x++;
+        if (x == size) {
+            val = val << (bytes_per_row * 8 - x);
+            out.push_back(val);
+            val = 0;
+            x = 0;
+            y++;
+        }
+        else if (x % 8 == 0 && i > 0) {
+            out.push_back(val);
+            val = 0;
+        }
+        else {
+            val = val << 1;
+        }
+        if (y == size) {
+            break;
+        }
+    }
 
     qrManager.out_buf = out;
 }

--- a/lib/qrcode/qrmanager.h
+++ b/lib/qrcode/qrmanager.h
@@ -16,8 +16,9 @@
 #include "qrcode.h"
 
 #define QR_OUTPUT_MODE_BYTES   0
-#define QR_OUTPUT_MODE_BITS    1
+#define QR_OUTPUT_MODE_BINARY  1
 #define QR_OUTPUT_MODE_ATASCII 2
+#define QR_OUTPUT_MODE_BITMAP  3
 
 class QRManager {
 public:
@@ -37,13 +38,24 @@ public:
     static std::vector<uint8_t> encode(const void* src, size_t len, size_t version, size_t ecc, size_t* out_len);
 
     /**
-    * to_bits - Convert QR code in out_buf to compact binary format
+    * to_binary - Convert QR code in out_buf to compact binary format
     *
     * Replaces data in out_buf, where each byte is 0x00 or 0x01 with, with
     * compact data where each bit represents a single QR module (pixel).
     * So a 21x21 QR code will be 56 bytes (21*21/8). Data is returned LSB->MSB.
     */
-    void to_bits(void);
+    void to_binary(void);
+
+    /**
+    * to_bitmap - Convert QR code in out_buf to compact binary format
+    *
+    * Replaces data in out_buf, with data suitable for copying directly into
+    * bitmap graphics memory. Each QR module (pixel) is represented by 1 bit.
+    * Most significant bit is leftmost pixel. The last bits of the final byte
+    * of each row are returned as 0s. A 21x21 QR code will be 63 bytes (3 bytes
+    * per row of 21 bits (= 24 bits with 3 unused) * 21 rows).
+    */
+    void to_bitmap(void);
 
     /**
     * to_atascii - Convert QR code in out_buf to ATASCII


### PR DESCRIPTION
- fix bug where output formats other than bytes wouldn't work after the 1st encode in atari implementation
- new "bitmap" output option for QR encoder, that outputs things in MSB->LSB order suitable to copy directly into e.g. sprite data
- renamed `QR_OUTPUT_MODE_BITS` to `QR_OUTPUT_MODE_BINARY` and `::to_bits` to `::to_binary` to make less confusing(?) with new bitmap mode

![bitmapped](https://github.com/user-attachments/assets/3eb04f82-7233-4f99-a6c8-848d5ca202bc)
