### PR TITLE
[qr] validate params; error if input > capacity

### DIFF
--- a/lib/qrcode/qrcode.c
+++ b/lib/qrcode/qrcode.c
@@ -66,6 +66,14 @@ static const uint16_t NUM_RAW_DATA_MODULES[40] = {
        19723, 20891, 22091, 23008, 24272, 25568, 26896, 28256, 29648
 };
 
+static const uint16_t NUM_ALPHANUMERIC_CAPACITY[4][40] = {
+  // 1, 2, 3, ...                                                                                                                                                                   ...40
+  { 25,47,77,114,154,195,224,279,335,395,468,535,619,667,758,854,938,1046,1153,1249,1352,1460,1588,1704,1853,1990,2132,2223,2369,2520,2677,2840,3009,3183,3351,3537,3729,3927,4087,4296 }, // ECC 0
+  { 20,38,61,90,122,154,178,221,262,311,366,419,483,528,600,656,734,816,909,970,1035,1134,1248,1326,1451,1542,1637,1732,1839,1994,2113,2238,2369,2506,2632,2780,2894,3054,3220,3391 },     // ECC 1
+  { 16,29,47,67,87,108,125,157,189,221,259,296,352,376,426,470,531,574,644,702,742,823,890,963,1041,1094,1172,1263,1322,1429,1499,1618,1700,1787,1867,1966,2071,2181,2298,2420 },          // ECC 2
+  { 10,20,35,50,64,84,93,122,143,174,200,227,259,283,321,365,408,452,493,557,587,640,672,744,779,864,910,958,1016,1080,1150,1226,1307,1394,1431,1530,1591,1658,1774,1852 }                 // ECC 3
+};
+
 // @TODO: Put other LOCK_VERSIONS here
 #elif LOCK_VERSION == 3
 
@@ -827,7 +835,11 @@ int8_t qrcode_initBytes(QRCode *qrcode, uint8_t *modules, uint8_t version, uint8
 }
 
 int8_t qrcode_initText(QRCode *qrcode, uint8_t *modules, uint8_t version, uint8_t ecc, const char *data) {
-    return qrcode_initBytes(qrcode, modules, version, ecc, (uint8_t*)data, strlen(data));
+    uint16_t len = strlen(data);
+    if (len > NUM_ALPHANUMERIC_CAPACITY[ecc][version-1]) {
+      return 1;
+    }
+    return qrcode_initBytes(qrcode, modules, version, ecc, (uint8_t*)data, len);
 }
 
 bool qrcode_getModule(QRCode *qrcode, uint8_t x, uint8_t y) {

--- a/lib/qrcode/qrmanager.cpp
+++ b/lib/qrcode/qrmanager.cpp
@@ -11,18 +11,26 @@
 QRManager qrManager;
 
 std::vector<uint8_t> QRManager::encode(const void* src, size_t len, size_t version, size_t ecc, size_t *out_len) {
+    qrManager.version = version;
+    qrManager.ecc_mode = ecc;
+
+    *out_len = 0;
+    qrManager.out_buf.clear();
+    qrManager.out_buf.shrink_to_fit();
+
+    if (version < 1 || version > 40 || ecc < 0 || ecc > 3) {
+        return qrManager.out_buf;
+    }
+
     QRCode qr_code;
     uint8_t qr_bytes[qrcode_getBufferSize(version)];
 
     uint8_t err = qrcode_initText(&qr_code, qr_bytes, version, ecc, (const char*)src);
 
-    size_t size = qr_code.size;
-    *out_len = size*size;
-
-    qrManager.out_buf.clear();
-    qrManager.out_buf.shrink_to_fit();
-
     if (err == 0) {
+        size_t size = qr_code.size;
+        *out_len = size*size;
+
         for (uint8_t x = 0; x < size; x++) {
             for (uint8_t y = 0; y < size; y++) {
                 uint8_t on = qrcode_getModule(&qr_code, x, y);
@@ -30,9 +38,6 @@ std::vector<uint8_t> QRManager::encode(const void* src, size_t len, size_t versi
             }
         }
     }
-
-    qrManager.version = version;
-    qrManager.ecc_mode = ecc;
 
     return qrManager.out_buf;
 }


### PR DESCRIPTION
The underlying QR generation library silently generates invalid QR codes if the input text exceeds the capacity for the given size/error correction level.

Unfortunately there's no straightforward formula for calculating capacity, so this uses a table to validate and returns an error if not. Also adds checking for version and error correction level parameters. For Atari implementation, an SIO error is generated in this case.