### PR TITLE
Support recursive filtering in TNFS.

### DIFF
--- a/lib/FileSystem/fnFsTNFS.cpp
+++ b/lib/FileSystem/fnFsTNFS.cpp
@@ -270,19 +270,25 @@ bool FileSystemTNFS::dir_open(const char * path, const char *pattern, uint16_t d
 
     if (!!pattern) {
         thepat = realpat;
-        strlcpy (realpat, pattern, sizeof (realpat));
-        if (realpat[strlen(realpat)-1] == '/') {
-            Debug_print (
-                "FileSystemTNFS::dir_open applying pattern to directories\n"
-            );
-            realpat[strlen(realpat)-1] = '\0';
-            d_opt |= TNFS_DIROPT_DIR_PATTERN;
+        if (pattern[0] == '!')
+        {
+            strlcpy (realpat, "**/", sizeof(realpat));
+            int patlen = strlcpy (realpat + 3, pattern + 1, sizeof(realpat) - 4) + 3;
+            realpat[patlen] = '*';
+            realpat[patlen+1] = '\0';
+            d_opt |= TNFS_DIROPT_NO_FOLDERS;
+            d_opt |= TNFS_DIROPT_TRAVERSE;
         }
-        if (strstr(realpat, "**")) {
-            Debug_print (
-                "FileSystemTNFS::dir_open enabling recursive pattern\n"
-            );
-            d_opt |= TNFS_DIROPT_TRAVERSE | TNFS_DIROPT_NO_FOLDERS;
+        else
+        {
+            strlcpy (realpat, pattern, sizeof (realpat));
+            if (realpat[strlen(realpat)-1] == '/') {
+                Debug_print (
+                    "FileSystemTNFS::dir_open applying pattern to directories\n"
+                );
+                realpat[strlen(realpat)-1] = '\0';
+                d_opt |= TNFS_DIROPT_DIR_PATTERN;
+            }
         }
     }
     if(diropts & DIR_OPTION_DESCENDING)

--- a/lib/FileSystem/fnFsTNFS.cpp
+++ b/lib/FileSystem/fnFsTNFS.cpp
@@ -272,10 +272,7 @@ bool FileSystemTNFS::dir_open(const char * path, const char *pattern, uint16_t d
         thepat = realpat;
         if (pattern[0] == '!')
         {
-            strlcpy (realpat, "**/", sizeof(realpat));
-            int patlen = strlcpy (realpat + 3, pattern + 1, sizeof(realpat) - 4) + 3;
-            realpat[patlen] = '*';
-            realpat[patlen+1] = '\0';
+            snprintf(realpat, sizeof(realpat), "**/%s*", pattern+1);
             d_opt |= TNFS_DIROPT_NO_FOLDERS;
             d_opt |= TNFS_DIROPT_TRAVERSE;
         }

--- a/lib/FileSystem/fnFsTNFS.cpp
+++ b/lib/FileSystem/fnFsTNFS.cpp
@@ -3,6 +3,7 @@
 
 #include <sys/stat.h>
 #include <errno.h>
+#include <libgen.h>
 
 #ifdef ESP_PLATFORM
 #include "fnFsTNFSvfs.h"
@@ -262,22 +263,28 @@ bool FileSystemTNFS::dir_open(const char * path, const char *pattern, uint16_t d
     if(!_started)
         return false;
 
-    uint8_t d_opt = 0;
+    uint8_t d_opt = TNFS_DIROPT_IGNORE_CASE;
     uint8_t s_opt = 0;
-	char realpat[TNFS_MAX_FILELEN];
-	char *thepat = 0;
+    char realpat[TNFS_MAX_FILELEN];
+    char *thepat = 0;
 
-	if (!!pattern) {
-		thepat = realpat;
-		strlcpy (realpat, pattern, sizeof (realpat));
-		if (realpat[strlen(realpat)-1] == '/') {
-			Debug_print (
-				"FileSystemTNFS::dir_open applying pattern to directories\n"
-			);
-			realpat[strlen(realpat)-1] = '\0';
-			d_opt |= TNFS_DIROPT_DIR_PATTERN;
-		}
-	}
+    if (!!pattern) {
+        thepat = realpat;
+        strlcpy (realpat, pattern, sizeof (realpat));
+        if (realpat[strlen(realpat)-1] == '/') {
+            Debug_print (
+                "FileSystemTNFS::dir_open applying pattern to directories\n"
+            );
+            realpat[strlen(realpat)-1] = '\0';
+            d_opt |= TNFS_DIROPT_DIR_PATTERN;
+        }
+        if (strstr(realpat, "**")) {
+            Debug_print (
+                "FileSystemTNFS::dir_open enabling recursive pattern\n"
+            );
+            d_opt |= TNFS_DIROPT_TRAVERSE | TNFS_DIROPT_NO_FOLDERS;
+        }
+    }
     if(diropts & DIR_OPTION_DESCENDING)
         s_opt |= TNFS_DIRSORT_DESCENDING;
     if(diropts & DIR_OPTION_FILEDATE)

--- a/lib/FileSystem/fnFsTNFS.cpp
+++ b/lib/FileSystem/fnFsTNFS.cpp
@@ -263,7 +263,7 @@ bool FileSystemTNFS::dir_open(const char * path, const char *pattern, uint16_t d
     if(!_started)
         return false;
 
-    uint8_t d_opt = TNFS_DIROPT_IGNORE_CASE;
+    uint8_t d_opt = 0;
     uint8_t s_opt = 0;
     char realpat[TNFS_MAX_FILELEN];
     char *thepat = 0;

--- a/lib/TNFSlib/tnfslib.h
+++ b/lib/TNFSlib/tnfslib.h
@@ -62,6 +62,9 @@
 #define TNFS_DIROPT_NO_SKIPHIDDEN 0x02   // Don't skip hidden files
 #define TNFS_DIROPT_NO_SKIPSPECIAL 0x04  // Don't skip special files
 #define TNFS_DIROPT_DIR_PATTERN 0x08     // Apply wildcard pattern to directories, too
+#define TNFS_DIROPT_TRAVERSE 0x10        // Traverse all directories recursively
+#define TNFS_DIROPT_IGNORE_CASE 0x20     // Ignore case
+#define TNFS_DIROPT_NO_FOLDERS 0x40      // Skip folders
 
 #define TNFS_DIRSORT_NONE 0x01       // Do not perform any sorting
 #define TNFS_DIRSORT_CASE 0x02       // Perform case-sensitve sort

--- a/lib/TNFSlib/tnfslib.h
+++ b/lib/TNFSlib/tnfslib.h
@@ -63,8 +63,7 @@
 #define TNFS_DIROPT_NO_SKIPSPECIAL 0x04  // Don't skip special files
 #define TNFS_DIROPT_DIR_PATTERN 0x08     // Apply wildcard pattern to directories, too
 #define TNFS_DIROPT_TRAVERSE 0x10        // Traverse all directories recursively
-#define TNFS_DIROPT_IGNORE_CASE 0x20     // Ignore case
-#define TNFS_DIROPT_NO_FOLDERS 0x40      // Skip folders
+#define TNFS_DIROPT_NO_FOLDERS 0x20      // Skip folders
 
 #define TNFS_DIRSORT_NONE 0x01       // Do not perform any sorting
 #define TNFS_DIRSORT_CASE 0x02       // Perform case-sensitve sort

--- a/lib/utils/utils.cpp
+++ b/lib/utils/utils.cpp
@@ -381,10 +381,20 @@ int util_ellipsize(const char *src, char *dst, int dstsize)
     {
         if (strlen(basename) > 1 && dstsize >= 5)
         {
+            basename++; // skip slash
+
+            int result = 4;
             dst[0] = dst[1] = dst[2] = '.';
-            dst[3] = '/';
-            dst[4] = '\0';
-            return 4 + util_ellipsize(basename + 1, dst + 4, dstsize - 4);
+            if (strlen(basename) < dstsize - 3 - 1)
+            {
+                strlcpy(dst + 3, src + srclen - dstsize + 4, dstsize - 3);
+            }
+            else
+            {
+                dst[3] = '/';
+                result += util_ellipsize(basename, dst+4, dstsize-4);
+            }
+            return result;
         }
     }
 

--- a/lib/utils/utils.cpp
+++ b/lib/utils/utils.cpp
@@ -383,18 +383,19 @@ int util_ellipsize(const char *src, char *dst, int dstsize)
         {
             basename++; // skip slash
 
-            int result = 4;
-            dst[0] = dst[1] = dst[2] = '.';
-            if (strlen(basename) < dstsize - 3 - 1)
+            int copied = strlcpy(dst, "...", dstsize);
+            int remaining = dstsize - copied - 1;
+            if (strlen(basename) < remaining)
             {
-                strlcpy(dst + 3, src + srclen - dstsize + 4, dstsize - 3);
+                return strlcat(dst, src + (srclen - remaining), dstsize);
             }
             else
             {
-                dst[3] = '/';
-                result += util_ellipsize(basename, dst+4, dstsize-4);
+                char tmp[dstsize];
+                copied = strlcat(dst, "/", dstsize);
+                util_ellipsize(basename, tmp, dstsize-copied);
+                return strlcat(dst, tmp, dstsize);
             }
-            return result;
         }
     }
 

--- a/lib/utils/utils.cpp
+++ b/lib/utils/utils.cpp
@@ -375,6 +375,19 @@ int util_ellipsize(const char *src, char *dst, int dstsize)
         return strlcpy(dst, src, dstsize);
     }
 
+    // Replace directories with .../ and only leave the basename.
+    const char *basename = strrchr(src, '/');
+    if (basename != NULL)
+    {
+        if (strlen(basename) > 1 && dstsize >= 5)
+        {
+            dst[0] = dst[1] = dst[2] = '.';
+            dst[3] = '/';
+            dst[4] = '\0';
+            return 4 + util_ellipsize(basename + 1, dst + 4, dstsize - 4);
+        }
+    }
+
     // Account for both the 3-character ellipses and the null character that needs to fit in the destination
     int rightlen = (dstsize - 4) / 2;
     // The left side gets one more character if the destination is odd


### PR DESCRIPTION
There are 2 features here:

1. Filtering pattern starting with `!` will be transformed into `**/pattern*`, required by the new tnfsd TNFS_DIROPT_TRAVERSE option (see https://github.com/FujiNetWIFI/tnfsd/pull/16)
2. Add long-path support for `util_ellipsize()` (see below).

Before this PR, the `util_ellipsize()` removes the middle part of the string, replacing it with `...`, to fit into the specified `dstsize`. After this PR, the function checks if the specified string is a long path (and contains slash in the middle). If that's the case, it'll try to return the full basename of the file + as much as the parent path as possible, e.g.:

```
games/s/spy vs spy 2/spy vs spy 2.atr
```

will be translated into:

```
...spy 2/spy vs spy 2.atr
```

If the basename doesn't fit into the specified size, it'll be ellipsized on its own and prefixed by the `.../`, e.g.:

```
.../this is some very very ... long long basename.atr
```