### PR TITLE
[qr] fix: always clear in buf even if encode fails

### DIFF
--- a/lib/device/sio/fuji.cpp
+++ b/lib/device/sio/fuji.cpp
@@ -2182,14 +2182,14 @@ void sioFuji::sio_qrcode_encode()
         &out_len
     );
 
+    qrManager.in_buf.clear();
+
     if (!out_len)
     {
         Debug_printf("QR code encoding failed\n");
         sio_error();
         return;
     }
-
-    qrManager.in_buf.clear();
 
     Debug_printf("Resulting QR code is: %u modules\n", out_len);
     sio_complete();


### PR DESCRIPTION
Fixes edge case where after QR encoding fails, subsequent attempts also fail