### PR TITLE
Feat/apple2 fujinet pc tweaks

### DIFF
--- a/data/webui/config/fujinet-pc-apple.yaml
+++ b/data/webui/config/fujinet-pc-apple.yaml
@@ -20,3 +20,4 @@ components:
 tweaks:
   # webui tweaks, if any
   fujinet_pc: true
+  fujiapple: true

--- a/data/webui/template/www/index.tmpl.html
+++ b/data/webui/template/www/index.tmpl.html
@@ -307,9 +307,15 @@
 				{% for ds in range(1, 7) %}
 				<div class="{{ loop.cycle('detline', 'detline alt') }}">
 					{% if ds < 5 %}
-					<div class="deth detlinecol">SmartPort Drive {{ ds }}<%FN_DRIVE{{ ds }}DEVICE%> <a href="/unmount?deviceslot={{ ds-1 }}">[EJECT]</a></div>
+					<div class="deth detlinecol" data-mountslot="{{ ds-1 }}" data-mountslotname="SmartPort Drive {{ ds }}" data-mount="<%FN_DRIVE{{ ds }}MOUNT%>>">
+					    SmartPort Drive {{ ds }}<%FN_DRIVE{{ ds }}DEVICE%>
+						<a href="/unmount?deviceslot={{ ds-1 }}">[EJECT]</a>
+					</div>
 					{% else %}
-					<div class="deth detlinecol">Disk ][ Drive {{ ds - 4 }}<%FN_DRIVE{{ ds }}DEVICE%> <a href="/unmount?deviceslot={{ ds-1 }}">[EJECT]</a></div>
+					<div class="deth detlinecol" data-mountslot="{{ ds-1 }}" data-mountslotname="Disk ][ Drive {{ ds - 4 }}" data-mount="<%FN_DRIVE{{ ds }}MOUNT%>>">
+					    Disk ][ Drive {{ ds - 4 }}<%FN_DRIVE{{ ds }}DEVICE%>
+						<a href="/unmount?deviceslot={{ ds-1 }}">[EJECT]</a>
+					</div>
 					{% endif %}
 					{% if tweaks.fujinet_pc %}
 					<div class="det detlinecol"><a href="<%FN_DRIVE{{ ds }}BROWSER%>"><%FN_DRIVE{{ ds }}HOST%> :: <%FN_DRIVE{{ ds }}MOUNT%></a></div>
@@ -321,9 +327,14 @@
 				{% else %}
 				{% for ds in range(1, 9) %}
 				<div class="{{ loop.cycle('detline', 'detline alt') }}">
-					<div class="deth detlinecol">Drive Slot {{ ds }}<%FN_DRIVE{{ ds }}DEVICE%> <a href="/unmount?deviceslot={{ ds-1 }}">[EJECT]</a></div>
+					<div class="deth detlinecol" data-mountslot="{{ ds-1 }}" data-mountslotname="Drive Slot {{ ds }}" data-mount="<%FN_DRIVE{{ ds }}MOUNT%>">
+					   Drive Slot {{ ds }}<%FN_DRIVE{{ ds }}DEVICE%>
+					   <a href="/unmount?deviceslot={{ ds-1 }}">[EJECT]</a>
+					</div>
 					{% if tweaks.fujinet_pc %}
-					<div class="det detlinecol"><a href="<%FN_DRIVE{{ ds }}BROWSER%>"><%FN_DRIVE{{ ds }}HOST%> :: <%FN_DRIVE{{ ds }}MOUNT%></a></div>
+					<div class="det detlinecol">
+					   <a href="<%FN_DRIVE{{ ds }}BROWSER%>"><%FN_DRIVE{{ ds }}HOST%> :: <%FN_DRIVE{{ ds }}MOUNT%></a>
+					</div>
 					{% else %}
 					<div class="det detlinecol"><%FN_DRIVE{{ ds }}HOST%> :: <%FN_DRIVE{{ ds }}MOUNT%></div>
 					{% endif %}


### PR DESCRIPTION
- make web ui drive slots for apple 2 on fujinet-pc look same as on real hardware
- add some `data-` attributes to drive slots to make it easier to hook onto them for browser extension stuff