### PR TITLE
Few small fixes

### DIFF
--- a/data/webui/template/www/index.tmpl.html
+++ b/data/webui/template/www/index.tmpl.html
@@ -166,9 +166,7 @@
 				<header class="module-header">
 					HARD<span class="logowob"></span>WARE
 					<span style="float: right">
-						{% if tweaks.fujinet_pc %}
-						<input type="button" id="restartButton" value="Restart..." onclick="restartButton()" style="width: 7em">
-						{% else %}
+						{% if not tweaks.fujinet_pc %}
 						<form action="/config" method="post">
 							<input type="hidden" name="resetfuji" value="resetfuji">
 							<button type="submit" value="Reset FujiNet">Reset FujiNet</button>
@@ -176,7 +174,7 @@
 						{% endif %}
 					</span>
 				</header>
-				{% if tweaks.fujinet_pc %}
+			{% if tweaks.fujinet_pc %}
 				<div class="detline">
 					<div class="deth detlinecol">Detected Hardware Version</div>
 					<div class="det detlinecol"><%FN_HARDWARE_VER%></div>
@@ -208,7 +206,7 @@
 					<div class="deth detlinecol">Restart FujiNet</div>
 					<div class="det detlinecol"><input type="button" id="restartButton" value="Restart..." onclick="restartButton()" style="width: 7em"></div>
 				</div>
-				{% else %}
+			{% else %}
 				<div class="detline">
 					<div class="deth detlinecol">Detected Hardware Version</div>
 					<div class="det detlinecol"><%FN_HARDWARE_VER%></div>
@@ -273,7 +271,7 @@
 					</div>
 				</div>
 				{% endif %}
-				{% endif %}
+			{% endif %}
 			</div>
 			{% endif %}
 			{% if components.hosts_list %}

--- a/lib/FileSystem/fnDirCache.cpp
+++ b/lib/FileSystem/fnDirCache.cpp
@@ -8,47 +8,47 @@
 #include "utils.h"
 
 
-bool _fsdir_sort_name_ascend(fsdir_entry &left, fsdir_entry &right)
+bool _fsdir_sort_name_ascend(const fsdir_entry* left, const fsdir_entry* right)
 {
-    if (left.isDir == right.isDir)
-        return strcasecmp(left.filename, right.filename) < 0;
+    if (left->isDir == right->isDir)
+        return strcasecmp(left->filename, right->filename) < 0;
     else
-        return left.isDir;
+        return left->isDir;
 }
 
-bool _fsdir_sort_name_descend(fsdir_entry &left, fsdir_entry &right)
+bool _fsdir_sort_name_descend(const fsdir_entry* left, const fsdir_entry* right)
 {
-    if (left.isDir == right.isDir)
-        return strcasecmp(left.filename, right.filename) > 0;
+    if (left->isDir == right->isDir)
+        return strcasecmp(left->filename, right->filename) > 0;
     else
-        return left.isDir;
+        return left->isDir;
 }
 
-bool _fsdir_sort_time_ascend(fsdir_entry &left, fsdir_entry &right)
+bool _fsdir_sort_time_ascend(const fsdir_entry* left, const fsdir_entry* right)
 {
-    if (left.isDir == right.isDir)
-        return left.modified_time > right.modified_time;
+    if (left->isDir == right->isDir)
+        return left->modified_time > right->modified_time;
     else
-        return left.isDir;
+        return left->isDir;
 }
 
-bool _fsdir_sort_time_descend(fsdir_entry &left, fsdir_entry &right)
+bool _fsdir_sort_time_descend(const fsdir_entry* left, const fsdir_entry* right)
 {
-    if (left.isDir == right.isDir)
-        return left.modified_time < right.modified_time;
+    if (left->isDir == right->isDir)
+        return left->modified_time < right->modified_time;
     else
-        return left.isDir;
+        return left->isDir;
 }
 
-typedef bool (*sort_fn_t)(fsdir_entry &left, fsdir_entry &right);
+typedef bool (*sort_fn_t)(const fsdir_entry* left, const fsdir_entry* right);
 
 
 void DirCache::clear()
 {
-    _entries.clear();
-    _entries.shrink_to_fit();
     _entries_filtered.clear();
     _entries_filtered.shrink_to_fit();
+    _entries.clear();
+    _entries.shrink_to_fit();
     _current = 0;
 }
 
@@ -69,20 +69,20 @@ void DirCache::apply_filter(const char *pattern, uint16_t diropts)
 		realpat[strlen(realpat)-1] = '\0';
 	}
 	//thepat = filter_dirs ? realpat : (char *)pattern;
-    fsdir_entry entry;
+
+    _entries_filtered.clear();
+    _entries_filtered.shrink_to_fit();
 
     // Filter directory entries
-    _entries_filtered.clear();
     for (unsigned i=0; i<_entries.size(); ++i)
     {
-        entry = _entries[i];
+        fsdir_entry& entry = _entries[i];
         // Skip this entry if we have a search filter and it doesn't match it
-		// HCGIII: Include directory filtering if specified
-        if(have_pattern && (
-			!entry.isDir || (entry.isDir && filter_dirs)
-		) && util_wildcard_match(entry.filename, pattern) == false)
+        if (have_pattern && (
+            !entry.isDir || (entry.isDir && filter_dirs)
+            ) && util_wildcard_match(entry.filename, pattern) == false)
             continue;
-        _entries_filtered.push_back(entry);
+        _entries_filtered.push_back(&entry);
     }
 
     // Choose the appropriate sorting function
@@ -105,7 +105,7 @@ void DirCache::apply_filter(const char *pattern, uint16_t diropts)
 fsdir_entry *DirCache::read()
 {
     if(_current < _entries_filtered.size())
-        return &_entries_filtered[_current++];
+        return _entries_filtered[_current++];
     else
         return nullptr;
 }

--- a/lib/FileSystem/fnDirCache.h
+++ b/lib/FileSystem/fnDirCache.h
@@ -14,10 +14,10 @@ class DirCache
 private:
 #ifdef ESP_PLATFORM
     std::vector<fsdir_entry,PSRAMAllocator<fsdir_entry>> _entries;
-    std::vector<fsdir_entry,PSRAMAllocator<fsdir_entry>> _entries_filtered;
+    std::vector<fsdir_entry *,PSRAMAllocator<fsdir_entry *>> _entries_filtered;
 #else
     std::vector<fsdir_entry> _entries;
-    std::vector<fsdir_entry> _entries_filtered;
+    std::vector<fsdir_entry *> _entries_filtered;
 #endif
     uint16_t _current = 0;
 

--- a/lib/device/drivewire/fuji.cpp
+++ b/lib/device/drivewire/fuji.cpp
@@ -306,6 +306,8 @@ void drivewireFuji::disk_image_mount()
     uint8_t deviceSlot = fnDwCom.read();
     uint8_t options = fnDwCom.read(); // DISK_ACCESS_MODE
 
+    errorCode = 1;
+
     // TODO: Implement FETCH?
     char flag[3] = {'r', 0, 0};
     if (options == DISK_ACCESS_MODE_WRITE)
@@ -322,6 +324,12 @@ void drivewireFuji::disk_image_mount()
     disk.disk_dev.host = &host;
 
     disk.fileh = host.fnfile_open(disk.filename, disk.filename, sizeof(disk.filename), flag);
+    if (disk.fileh == nullptr)
+    {
+        Debug_printf("disk_image_mount Couldn't open file: \"%s\"\n", disk.filename);
+        errorCode = 144;
+        return;
+    }
 
     // We've gotten this far, so make sure our bootable CONFIG disk is disabled
     boot_config = false;
@@ -787,6 +795,8 @@ void drivewireFuji::open_directory()
 {
     Debug_println("Fuji cmd: OPEN DIRECTORY");
 
+    errorCode = 1;
+
     uint8_t hostSlot = fnDwCom.read();
 
     fnDwCom.readBytes((uint8_t *)&dirpath, 256);
@@ -813,6 +823,10 @@ void drivewireFuji::open_directory()
         if (_fnHosts[hostSlot].dir_open(dirpath, pattern, 0))
         {
             _current_open_directory_slot = hostSlot;
+        }
+        else
+        {
+            errorCode = 144;
         }
     }
 }

--- a/lib/device/drivewire/network.cpp
+++ b/lib/device/drivewire/network.cpp
@@ -130,9 +130,9 @@ void drivewireNetwork::open()
     Debug_printf("drivewireNetwork::sio_open(%02x,%02x)\n",cmdFrame.aux1,cmdFrame.aux2);
 
     char tmp[256];
-    memset(tmp,0,sizeof(tmp));
 
     size_t bytes_read = fnDwCom.readBytes((uint8_t *)tmp, 256);
+    tmp[sizeof(tmp)-1] = '\0';
 
     Debug_printf("tmp = %s\n",tmp);
 
@@ -142,7 +142,7 @@ void drivewireNetwork::open()
         return;
     }
 
-    deviceSpec = std::string(tmp,256);
+    deviceSpec = std::string(tmp);
     
     channelMode = PROTOCOL;
 
@@ -1260,7 +1260,7 @@ void drivewireNetwork::json_query()
     *receiveBuffer += std::string(tmp.begin(), null_pos);
 
     for (int i=0;i<in_string.length();i++)
-        Debug_printf("%02X ",in_string[i]);
+        Debug_printf("%02X ",(unsigned char)in_string[i]);
     
     Debug_printf("\n");
 

--- a/lib/utils/peoples_url_parser.cpp
+++ b/lib/utils/peoples_url_parser.cpp
@@ -101,7 +101,8 @@ void PeoplesUrlParser::cleanPath() {
     path = util_get_canonical_path(path);
 }
 
-void PeoplesUrlParser::processPath() {
+void PeoplesUrlParser::processPath()
+{
     if(path.size() == 0)
         return;
 
@@ -146,7 +147,9 @@ void PeoplesUrlParser::processPath() {
     // file base name
     if (extension.size() > 0)
         base_name = name.substr(0, name.size() - extension.size() - 1);
-    }
+    else
+        base_name = name;
+}
 
 
 std::string PeoplesUrlParser::pathToFile(void)


### PR DESCRIPTION
[coco] fuji device: check nullptr on disk image open
- check for nullptr on disk image open
- set errorCode on file (disk image) open
- set errorCode on dir open

[coco] network device open - deviceSpec from null terminated string

url parser: properly set base_name if there is no extension

[HTTP FS] fix dir_open
- use proper buffer size (COPY_BLK_SIZE) when reading data from HTTP client
- fix file size parsing
- make sure the directory url ends with '/' to avoid unnecessary redirect

fnDirCache - use pointers for sorted entries
- no need to copy directory entries when sorting/filtering

[PC] WebUI - one restart button is enough
