### PR TITLE
Remove what appears to be dead code for disabling Disk II drive 2

### DIFF
--- a/lib/bus/iwm/iwm_ll.cpp
+++ b/lib/bus/iwm/iwm_ll.cpp
@@ -1158,12 +1158,6 @@ uint8_t IRAM_ATTR iwm_diskii_ll::iwm_enable_states()
     }
   }
 
-  // Check if Drive 2 is being accessed but disabled
-  if ((states == 0x02) && !isDrive2Enabled()) {
-    // Drive is disabled, return 0
-    return 0;
-  }
-
   return states;
 }
 

--- a/lib/bus/iwm/iwm_ll.h
+++ b/lib/bus/iwm/iwm_ll.h
@@ -282,8 +282,6 @@ private:
 
   void set_output_to_rmt();
 
-  bool enabledD2 = true;
-
   // write state
   bool d2w_writing = false, d2w_started = false;
   uint8_t *d2w_buffer;
@@ -311,10 +309,6 @@ public:
   void copy_track(uint8_t *track, size_t tracklen, size_t trackbits, int bitperiod);
 
   void set_output_to_low();
-
-  void enableD2(){ enabledD2 = true; };
-  void disableD2(){ enabledD2 = false; };
-  bool isDrive2Enabled(){ return enabledD2; };
 };
 
 extern iwm_sp_ll smartport;

--- a/lib/device/iwm/disk2.h
+++ b/lib/device/iwm/disk2.h
@@ -22,7 +22,6 @@ protected:
 
     void shutdown() override;
     char disk_num;
-    bool enabledD2 = true;
     int track_pos;
     int old_pos;
     uint8_t oldphases;
@@ -37,19 +36,6 @@ public:
     bool phases_valid(uint8_t phases);
     bool move_head();
     void change_track(int indicator);
-    void disableD2() { 
-        enabledD2 = false;
-#ifndef DEV_RELAY_SLIP
-        diskii_xface.enableD2();
-#endif
-    };
-    void enableD2() {
-        enabledD2 = true;
-#ifndef DEV_RELAY_SLIP
-        diskii_xface.disableD2();
-#endif
-    };
-    bool isDrive2Enabled() { return enabledD2; };
     // void set_disk_number(char c) { disk_num = c; }
     // char get_disk_number() { return disk_num; };
 


### PR DESCRIPTION
I can't find anything that calls these functions. This code appears to be dead. Especially since in disk2.h `disableD2()` calls `diskii_xface.enableD2()` which seems entirely backwards.