### PR TITLE
allow ::start() to be called before ::stop() so that it can be used to change drives #886

### DIFF
--- a/lib/bus/iwm/iwm.cpp
+++ b/lib/bus/iwm/iwm.cpp
@@ -585,8 +585,11 @@ bool IRAM_ATTR iwmBus::serviceDiskII()
     if (current_disk2 != diskii_xface.iwm_active_drive())
     {
       current_disk2 = diskii_xface.iwm_active_drive();
-      if (IWM_ACTIVE_DISK2->device_active)
+      if (IWM_ACTIVE_DISK2->device_active) {
         IWM_ACTIVE_DISK2->change_track(0); // copy current track in for this drive
+        diskii_xface.start(diskii_xface.iwm_active_drive() - 1,
+                           IWM_ACTIVE_DISK2->readonly); // start it up
+      }
     }
     diskii_xface.d2_enable_seen |= diskii_xface.iwm_active_drive();
 #ifdef DEBUG

--- a/lib/bus/iwm/iwm.cpp
+++ b/lib/bus/iwm/iwm.cpp
@@ -555,7 +555,7 @@ bool IRAM_ATTR iwmBus::serviceSmartPort()
 bool IRAM_ATTR iwmBus::serviceDiskII()
 {
   // check on the diskii status
-  switch (iwm_drive_enabled())
+  switch (iwm_motor_state())
   {
   case iwm_enable_state_t::off:
     return false;
@@ -565,11 +565,11 @@ bool IRAM_ATTR iwmBus::serviceDiskII()
     if (IWM_ACTIVE_DISK2->device_active)
     {
       fnSystem.delay(1); // need a better way to figure out persistence
-      if (iwm_drive_enabled() == iwm_enable_state_t::on)
+      if (iwm_motor_state() == iwm_enable_state_t::on)
       {
-        current_disk2 = diskii_xface.iwm_enable_states();
+        current_disk2 = diskii_xface.iwm_active_drive();
         IWM_ACTIVE_DISK2->change_track(0); // copy current track in for this drive
-        diskii_xface.start(diskii_xface.iwm_enable_states() - 1,
+        diskii_xface.start(diskii_xface.iwm_active_drive() - 1,
                            IWM_ACTIVE_DISK2->readonly); // start it up
       }
     } // make a call to start the RMT stream
@@ -582,18 +582,18 @@ bool IRAM_ATTR iwmBus::serviceDiskII()
     break;
 
   case iwm_enable_state_t::on:
-    if (current_disk2 != diskii_xface.iwm_enable_states())
+    if (current_disk2 != diskii_xface.iwm_active_drive())
     {
-      current_disk2 = diskii_xface.iwm_enable_states();
+      current_disk2 = diskii_xface.iwm_active_drive();
       if (IWM_ACTIVE_DISK2->device_active)
         IWM_ACTIVE_DISK2->change_track(0); // copy current track in for this drive
     }
-    diskii_xface.d2_enable_seen |= diskii_xface.iwm_enable_states();
+    diskii_xface.d2_enable_seen |= diskii_xface.iwm_active_drive();
 #ifdef DEBUG
     new_track = IWM_ACTIVE_DISK2->get_track_pos();
     if (old_track != new_track)
     {
-      Debug_printf("\ntrk pos %03d on d%d", new_track, diskii_xface.iwm_enable_states());
+      Debug_printf("\ntrk pos %03d on d%d", new_track, diskii_xface.iwm_active_drive());
       old_track = new_track;
     }
 #endif
@@ -699,10 +699,10 @@ bool IRAM_ATTR iwmBus::serviceDiskIIWrite()
   return true;
 }
 
-iwm_enable_state_t IRAM_ATTR iwmBus::iwm_drive_enabled()
+iwm_enable_state_t IRAM_ATTR iwmBus::iwm_motor_state()
 {
   uint8_t phases = smartport.iwm_phase_vector();
-  uint8_t newstate = diskii_xface.iwm_enable_states();
+  uint8_t newstate = diskii_xface.iwm_active_drive();
 
   if (!((phases & 0b1000) && (phases & 0b0010))) // SP bus not enabled
   {
@@ -722,7 +722,7 @@ iwm_enable_state_t IRAM_ATTR iwmBus::iwm_drive_enabled()
       break;
     }
     if (_old_enable_state != _new_enable_state)
-      Debug_printf("\ndisk ii enable states: %02x", newstate);
+      Debug_printf("\ndisk ii [%i] enable states: %02x", newstate, _new_enable_state);
 
     _old_enable_state = _new_enable_state;
 

--- a/lib/bus/iwm/iwm.h
+++ b/lib/bus/iwm/iwm.h
@@ -181,8 +181,8 @@ enum class iwm_enable_state_t
 {
   off,
   off2on,
+  on2off,
   on,
-  on2off
 };
 
 struct iwm_device_info_block_t
@@ -307,7 +307,7 @@ private:
 #endif
   uint8_t current_disk2 = 0;
 
-  iwm_enable_state_t iwm_drive_enabled();
+  iwm_enable_state_t iwm_motor_state();
   iwm_enable_state_t _old_enable_state;
   iwm_enable_state_t _new_enable_state;
   // uint8_t enable_values;
@@ -359,6 +359,6 @@ public:
 
 extern iwmBus IWM;
 
-#define IWM_ACTIVE_DISK2 ((iwmDisk2 *) theFuji.get_disk_dev(MAX_SP_DEVICES + diskii_xface.iwm_enable_states() - 1))
+#define IWM_ACTIVE_DISK2 ((iwmDisk2 *) theFuji.get_disk_dev(MAX_SP_DEVICES + diskii_xface.iwm_active_drive() - 1))
 #endif // guard
 #endif /* BUILD_APPLE */

--- a/lib/bus/iwm/iwm_ll.h
+++ b/lib/bus/iwm/iwm_ll.h
@@ -280,6 +280,7 @@ private:
   size_t track_location = 0;
   int track_bit_period = 4000;
 
+  bool rmt_started = false;
   void set_output_to_rmt();
 
   bool enabledD2 = true;

--- a/lib/bus/iwm/iwm_ll.h
+++ b/lib/bus/iwm/iwm_ll.h
@@ -297,7 +297,7 @@ public:
 
   // Phase lines and ACK handshaking
   uint8_t iwm_phase_vector() { return (uint8_t)(GPIO.in1.val & (uint32_t)0b1111); };
-  uint8_t iwm_enable_states();
+  uint8_t iwm_active_drive();
 
   // Disk II handling by RMT peripheral
   void setup_rmt(); // install the RMT device


### PR DESCRIPTION
Fixes https://github.com/FujiNetWIFI/fujinet-firmware/issues/884 and https://github.com/FujiNetWIFI/fujinet-firmware/issues/882

Pointed to v1.5-rc this time. But you better double check me!