### PR TITLE
rs232-s3: fix sdcard detect, send debug output to usb, enable button A, pinmap fixes

### DIFF
--- a/include/debug.h
+++ b/include/debug.h
@@ -25,11 +25,17 @@
     // Use FujiNet debug serial output
     #include "../lib/hardware/fnUART.h"
     #define Serial fnUartDebug
-
+#ifdef PINMAP_RS232_S3
+    #define Debug_print(...) printf( __VA_ARGS__ )
+    #define Debug_printf(...) printf( __VA_ARGS__ )
+    #define Debug_println(...) do { printf(__VA_ARGS__); printf("\n"); } while (0)
+    #define Debug_printv(format, ...) {printf( ANSI_YELLOW "[%s:%u] %s(): " ANSI_GREEN_BOLD format ANSI_RESET "\r\n", __FILE__, __LINE__, __FUNCTION__, ##__VA_ARGS__);}
+#else
     #define Debug_print(...) fnUartDebug.print( __VA_ARGS__ )
     #define Debug_printf(...) fnUartDebug.printf( __VA_ARGS__ )
     #define Debug_println(...) fnUartDebug.println( __VA_ARGS__ )
     #define Debug_printv(format, ...) {fnUartDebug.printf( ANSI_YELLOW "[%s:%u] %s(): " ANSI_GREEN_BOLD format ANSI_RESET "\r\n", __FILE__, __LINE__, __FUNCTION__, ##__VA_ARGS__);}
+#endif // PINMAP_RS232_S3
 
     #define HEAP_CHECK(x) Debug_printf("HEAP CHECK %s " x "\r\n", heap_caps_check_integrity_all(true) ? "PASSED":"FAILED")
 #else
@@ -42,7 +48,7 @@
     #define Debug_printv(format, ...) {util_debug_printf( ANSI_YELLOW "[%s:%u] %s(): " ANSI_GREEN_BOLD format ANSI_RESET "\r\n", __FILE__, __LINE__, __FUNCTION__, ##__VA_ARGS__);}
 
     #define HEAP_CHECK(x) Debug_printf("HEAP CHECK %s " x "\r\n", heap_caps_check_integrity_all(true) ? "PASSED":"FAILED")
-#endif
+#endif // ESP_PLATFORM
 #endif // DEBUG
 
 #ifndef DEBUG

--- a/include/pinmap/rs232_s3.h
+++ b/include/pinmap/rs232_s3.h
@@ -2,13 +2,15 @@
 #ifdef PINMAP_RS232_S3
 
 /* SD Card - fnFsSD.cpp */
+/* Card detect pin on RS232-REV1 goes high when card inserted */
+#define CARD_DETECT_HIGH        1
 #define PIN_CARD_DETECT         GPIO_NUM_9 // fnSystem.h
 #define PIN_CARD_DETECT_FIX     GPIO_NUM_9 // fnSystem.h
 
 #define PIN_SD_HOST_CS          GPIO_NUM_10  // fnFsSD.cpp
 #define PIN_SD_HOST_MISO        GPIO_NUM_13
 #define PIN_SD_HOST_MOSI        GPIO_NUM_11
-#define PIN_SD_HOST_SCK         GPIO_NUM_12
+#define PIN_SD_HOST_SCK         GPIO_NUM_21
 
 /* UART */
 #define PIN_UART0_RX            GPIO_NUM_44  // USB to Serial secondary
@@ -28,14 +30,14 @@
 #define PIN_DAC1                GPIO_NUM_21
 
 /* RS232 Pins */
-#define PIN_UART1_RX            GPIO_NUM_41 // RS232 35
-#define PIN_UART1_TX            GPIO_NUM_42 // RS232 36
+#define PIN_UART1_RX            GPIO_NUM_41 // (IN) ESP32S3 RX
+#define PIN_UART1_TX            GPIO_NUM_42 // (OUT) ESP32S3 TX
 #define PIN_RS232_RI            GPIO_NUM_16 // (OUT) Ring Indicator
-#define PIN_RS232_DCD           GPIO_NUM_NC // (OUT) Data Carrier Detect
-#define PIN_RS232_RTS           GPIO_NUM_NC // (IN) Request to Send
-#define PIN_RS232_CTS           GPIO_NUM_NC // (OUT) Clear to Send
-#define PIN_RS232_DTR           GPIO_NUM_17 // (IN) Data Terminal Ready
-#define PIN_RS232_DSR           GPIO_NUM_NC  // (OUT) Data Set Ready
-#define PIN_RS232_INVALID       GPIO_NUM_NC // (IN) RS232 Invalid Data (from TRS3238E)
+#define PIN_RS232_DCD           GPIO_NUM_4  // (OUT) Data Carrier Detect
+#define PIN_RS232_RTS           GPIO_NUM_15 // (IN) Request to Send
+#define PIN_RS232_CTS           GPIO_NUM_7  // (OUT) Clear to Send
+#define PIN_RS232_DTR           GPIO_NUM_6  // (IN) Data Terminal Ready
+#define PIN_RS232_DSR           GPIO_NUM_5  // (OUT) Data Set Ready
+#define PIN_RS232_INVALID       GPIO_NUM_18 // (IN) RS232 Invalid Data (from TRS3238E)
 
 #endif /* PINMAP_RS232_REV0 */

--- a/lib/hardware/fnSystem.cpp
+++ b/lib/hardware/fnSystem.cpp
@@ -108,12 +108,20 @@ static void card_detect_intr_task(void *arg)
     // Assert valid initial card status
     vTaskDelay(1);
     // Set card status before we enter the infinite loop
+#ifdef CARD_DETECT_HIGH
+    int card_detect_status = !gpio_get_level((gpio_num_t)(int)arg);
+#else
     int card_detect_status = gpio_get_level((gpio_num_t)(int)arg);
+#endif
 
     for (;;) {
         gpio_num_t gpio_num;
         if(xQueueReceive(card_detect_evt_queue, &gpio_num, portMAX_DELAY)) {
+#ifdef CARD_DETECT_HIGH
+            int level = !gpio_get_level(gpio_num);
+#else
             int level = gpio_get_level(gpio_num);
+#endif
             if (card_detect_status == level) {
                 printf("SD Card detect ignored (debounce)\r\n");
             }
@@ -1003,6 +1011,9 @@ const char *SystemManager::get_hardware_ver_str()
     case 1 :
         return "RS232 Prototype";
         break;
+    case 2 :
+        return "RS232 Rev1 ESP32S3";
+        break;
 #elif defined(BUILD_RC2014)
     /* RC2014 */
     case 1 :
@@ -1256,9 +1267,15 @@ void SystemManager::check_hardware_ver()
 #elif defined(BUILD_RS232)
     /* RS232
     */
+#if CONFIG_IDF_TARGET_ESP32S3
+    _hardware_version = 2;
+    safe_reset_gpio = PIN_BUTTON_C;
+    setup_card_detect((gpio_num_t)PIN_CARD_DETECT); // enable SD card detect
+#else
     _hardware_version = 1;
     safe_reset_gpio = PIN_BUTTON_C;
     setup_card_detect((gpio_num_t)PIN_CARD_DETECT); // enable SD card detect
+#endif
 #elif defined(BUILD_RC2014)
     /* RC2014
     */

--- a/lib/hardware/keys.cpp
+++ b/lib/hardware/keys.cpp
@@ -210,10 +210,6 @@ void KeyManager::_keystate_task(void *param)
     pKM->_keys[eKey::BUTTON_B].disabled = true;
 #endif
 
-#ifdef BUILD_RS232
-    // No button A onboard
-    pKM->_keys[eKey::BUTTON_A].disabled = true;
-#endif
     while (true)
     {
         vTaskDelay(100 / portTICK_PERIOD_MS);


### PR DESCRIPTION
for upcoming RS232-REV1 hardware using ESP32-S3:
 * Fix inverted SD Card detect pin
 * Use printf for debug output so it's sent over USB instead of UART
 * Enable button A for RS232
 * GPIO pinmap updates/fixes