### PR TITLE
[adam][fnSystem] fixes #914 - ensure setup_card_detect() is run.

### DIFF
--- a/lib/hardware/fnSystem.cpp
+++ b/lib/hardware/fnSystem.cpp
@@ -1102,6 +1102,7 @@ void SystemManager::check_hardware_ver()
     */  
     _hardware_version = 1;
     safe_reset_gpio = PIN_BUTTON_C;
+    setup_card_detect((gpio_num_t)PIN_CARD_DETECT);
 #elif defined(BUILD_APPLE)
     /*  Apple II
         Check all the madness :zany_face:


### PR DESCRIPTION
With some bits in fnSystem getting shuffled around, Adam no longer had the call to setup_card_detect() to handle resetting or mounting the SD card upon insertion/removal.