### PR TITLE
Bring things up to date with platform-espressif32 v6.10.0 (2nd try)

### DIFF
--- a/lib/bus/cx16_i2c/cx16_i2c.h
+++ b/lib/bus/cx16_i2c/cx16_i2c.h
@@ -7,6 +7,7 @@
 #include <freertos/queue.h>
 #include <utility>
 #include <string>
+#include <driver/i2c.h>
 
 #define CX16_DEVICEID_DISK 0x31
 #define CX16_DEVICEID_DISK_LAST 0x3F
@@ -258,7 +259,7 @@ private:
     /**
      * @brief I²C slave port
      */
-    int i2c_slave_port = 0;
+    i2c_port_t i2c_slave_port = I2C_NUM_0;
 
     /**
      * @brief I²C receive buffer

--- a/lib/bus/rc2014bus/rc2014bus.h
+++ b/lib/bus/rc2014bus/rc2014bus.h
@@ -11,6 +11,7 @@
 #include <mutex>
 #include <string>
 #include <vector>
+#include <array>
 
 #include <map>
 

--- a/lib/device/cx16_i2c/fuji.cpp
+++ b/lib/device/cx16_i2c/fuji.cpp
@@ -1127,7 +1127,7 @@ void cx16Fuji::get_host_prefix()
 }
 
 // Public method to update host in specific slot
-fujiHost *cx16_i2c::set_slot_hostname(int host_slot, char *hostname)
+fujiHost *cx16Fuji::set_slot_hostname(int host_slot, char *hostname)
 {
     _fnHosts[host_slot].set_hostname(hostname);
     _populate_config_from_slots();

--- a/lib/device/iwm/disk.cpp
+++ b/lib/device/iwm/disk.cpp
@@ -461,7 +461,7 @@ mediatype_t iwmDisk::mount(fnFile *f, const char *filename, uint32_t disksize, m
       device_active = false;
       is_config_device = false;
   }
-  else if (_disk && _disk->_disk_filename)
+  else if (_disk && strlen(_disk->_disk_filename))
       strcpy(_disk->_disk_filename, filename);
 
   return disk_type;

--- a/lib/device/mac/fuji.cpp
+++ b/lib/device/mac/fuji.cpp
@@ -237,6 +237,14 @@ std::string macFuji::get_host_prefix(int host_slot)
     return _fnHosts[host_slot].get_prefix();
 }
 
+// Public method to update host in specific slot
+fujiHost *macFuji::set_slot_hostname(int host_slot, char *hostname)
+{
+    _fnHosts[host_slot].set_hostname(hostname);
+    _populate_config_from_slots();
+    return &_fnHosts[host_slot];
+}
+
 // This gets called when we're about to shutdown/reboot
 void macFuji::shutdown()
 {

--- a/lib/device/rs232/apetime.cpp
+++ b/lib/device/rs232/apetime.cpp
@@ -3,6 +3,7 @@
 #include "apetime.h"
 
 #include <cstring>
+#include <ctime>
 
 #include "../../include/debug.h"
 

--- a/lib/device/rs232/disk.h
+++ b/lib/device/rs232/disk.h
@@ -1,6 +1,8 @@
 #ifndef DISK_H
 #define DISK_H
 
+#include <ctime>
+
 #include "bus.h"
 #include "media.h"
 

--- a/lib/hardware/Esp.cpp
+++ b/lib/hardware/Esp.cpp
@@ -151,7 +151,7 @@ uint32_t EspClass::getMaxAllocHeap(void) {
 }
 
 uint32_t EspClass::getPsramSize(void) {
-#ifdef PSRAM_SIZE
+#ifdef BOARD_HAS_PSRAM
     if (esp_psram_is_initialized()) {
         return heap_caps_get_total_size(MALLOC_CAP_SPIRAM);
     }
@@ -160,7 +160,7 @@ uint32_t EspClass::getPsramSize(void) {
 }
 
 uint32_t EspClass::getFreePsram(void) {
-#ifdef PSRAM_SIZE
+#ifdef BOARD_HAS_PSRAM
     if (esp_psram_is_initialized()) {
         return heap_caps_get_free_size(MALLOC_CAP_SPIRAM);
     }
@@ -169,7 +169,7 @@ uint32_t EspClass::getFreePsram(void) {
 }
 
 uint32_t EspClass::getMinFreePsram(void) {
-#ifdef PSRAM_SIZE
+#ifdef BOARD_HAS_PSRAM
     if (esp_psram_is_initialized()) {
         return heap_caps_get_minimum_free_size(MALLOC_CAP_SPIRAM);
     }
@@ -178,7 +178,7 @@ uint32_t EspClass::getMinFreePsram(void) {
 }
 
 uint32_t EspClass::getMaxAllocPsram(void) {
-#ifdef PSRAM_SIZE
+#ifdef BOARD_HAS_PSRAM
     if (esp_psram_is_initialized()) {
         return heap_caps_get_largest_free_block(MALLOC_CAP_SPIRAM);
     }
@@ -195,7 +195,8 @@ uint16_t EspClass::getChipRevision(void) {
 const char *EspClass::getChipModel(void) {
 #if CONFIG_IDF_TARGET_ESP32
     uint32_t chip_ver =
-        REG_GET_FIELD(EFUSE_BLK0_RDATA3_REG, EFUSE_RD_CHIP_VER_PKG);
+        //REG_GET_FIELD(EFUSE_BLK0_RDATA3_REG, EFUSE_RD_CHIP_VER_PKG);
+        REG_GET_FIELD(EFUSE_BLK0_RDATA3_REG, EFUSE_RD_CHIP_PACKAGE);
     uint32_t pkg_ver = chip_ver & 0x7;
     switch (pkg_ver) {
         case EFUSE_RD_CHIP_VER_PKG_ESP32D0WDQ6:

--- a/lib/meatloaf/meat_media.h
+++ b/lib/meatloaf/meat_media.h
@@ -8,6 +8,7 @@
 #include <bitset>
 #include <unordered_map>
 #include <sstream>
+#include <algorithm>
 
 #include "../../include/debug.h"
 

--- a/lib/media/adam/mediaTypeDDP.cpp
+++ b/lib/media/adam/mediaTypeDDP.cpp
@@ -5,6 +5,10 @@
 #include <cstdint>
 #include <cstring>
 
+#ifdef ESP_PLATFORM
+#include <unistd.h>  // for fsync
+#endif
+
 #include "../../include/debug.h"
 
 

--- a/lib/media/adam/mediaTypeDSK.cpp
+++ b/lib/media/adam/mediaTypeDSK.cpp
@@ -6,6 +6,10 @@
 #include <cstring>
 #include <utility>
 
+#ifdef ESP_PLATFORM
+#include <unistd.h>  // for fsync
+#endif
+
 #include "../../include/debug.h"
 
 #define INTERLEAVE 5 // 5:1 sector layout in image files (WHY?!?!!?)

--- a/lib/media/h89/mediaTypeIMG.cpp
+++ b/lib/media/h89/mediaTypeIMG.cpp
@@ -7,6 +7,10 @@
 #include <map>
 #include <utility>
 
+#ifdef ESP_PLATFORM
+#include <unistd.h>  // for fsync
+#endif
+
 #include "../../include/debug.h"
 
 // From https://github.com/wwarthen/RomWBW/blob/master/Source/CPM3/biosldr.z80

--- a/lib/media/rc2014/mediaTypeIMG.cpp
+++ b/lib/media/rc2014/mediaTypeIMG.cpp
@@ -7,6 +7,10 @@
 #include <map>
 #include <utility>
 
+#ifdef ESP_PLATFORM
+#include <unistd.h>  // for fsync
+#endif
+
 #include "../../include/debug.h"
 
 // From https://github.com/wwarthen/RomWBW/blob/master/Source/CPM3/biosldr.z80

--- a/lib/media/s100spi/mediaTypeDSK.cpp
+++ b/lib/media/s100spi/mediaTypeDSK.cpp
@@ -6,6 +6,10 @@
 #include <cstring>
 #include <utility>
 
+#ifdef ESP_PLATFORM
+#include <unistd.h>  // for fsync
+#endif
+
 #include "../../include/debug.h"
 
 

--- a/platformio-ini-files/platformio.common.ini
+++ b/platformio-ini-files/platformio.common.ini
@@ -2,7 +2,6 @@
 ;
 ; PUT YOUR LOCAL CHANGES IN platformio.local.ini
 
-
 ;FujiNet PlatformIO Common Project Configuration File
 ;
 ;   Build options: build flags, source filter
@@ -14,7 +13,8 @@
 ; https://docs.platformio.org/page/projectconf.html
 
 [fujinet]
-esp32_platform_version = 6.3.2
+;esp32_platform_version = 6.3.2
+esp32_platform_version = 6.10.0
 esp32_platform_packages = 
 
 ; SPIFFS/LITTLEFS

--- a/platformio-sample.ini
+++ b/platformio-sample.ini
@@ -19,7 +19,8 @@
 ; Espressif32 PlatformIO Version to use for building
 ;esp32_platform_version = 3.2.0 ; For Bluetooth support
 ;esp32_platform_version = 3.4.0 ; old stable
-esp32_platform_version = 6.3.2 ; latest
+;esp32_platform_version = 6.3.2 ; last stable
+esp32_platform_version = 6.10.0 ; latest
 esp32_platform_packages = 
 ;    toolchain-riscv32-esp @ 8.4.0+2021r2-patch5 ; required for platform version < 5.3.0, remove this line when upgrading to the >=5.3.0
 esp32s3_platform_version = 6.3.2


### PR DESCRIPTION
Changes needed to compile for v6.10.  Needs to be tested on all platforms.

This PR is without the changes to components.