### PR TITLE
new set_baudrate command, atari2600 fixes and network protocol changes

### DIFF
--- a/include/pinmap/atari2600.h
+++ b/include/pinmap/atari2600.h
@@ -3,6 +3,7 @@
 
 /* SD Card */
 #define PIN_CARD_DETECT         GPIO_NUM_15 // fnSystem.h
+#define PIN_CARD_DETECT_FIX     GPIO_NUM_NC
 #define PIN_SD_HOST_CS          GPIO_NUM_5  // fnFsSD.cpp
 #define PIN_SD_HOST_MISO        GPIO_NUM_19
 #define PIN_SD_HOST_MOSI        GPIO_NUM_23
@@ -24,6 +25,7 @@
 /* LEDs */
 #define PIN_LED_WIFI            GPIO_NUM_2 // led.cpp
 #define PIN_LED_BUS             GPIO_NUM_4
+#define PIN_LED_BT              GPIO_NUM_NC
 
 /* Atari SIO Pins */
 #define PIN_INT                 GPIO_NUM_27 // sio.h

--- a/lib/device/sio/fuji.cpp
+++ b/lib/device/sio/fuji.cpp
@@ -252,7 +252,6 @@ void sioFuji::sio_net_get_ssid()
 void sioFuji::sio_net_set_ssid()
 {
     Debug_println("Fuji cmd: SET SSID");
-    int i;
 
     // Data for  FUJICMD_SET_SSID
     struct
@@ -310,6 +309,57 @@ void sioFuji::sio_net_get_wifi_enabled()
     uint8_t e = Config.get_wifi_enabled() ? 1 : 0;
     Debug_printf("Fuji cmd: GET WIFI ENABLED: %d\n", e);
     bus_to_computer(&e, sizeof(e), false);
+}
+
+// Set SIO baudrate
+void sioFuji::sio_set_baudrate()
+{
+   
+    int br = 0;
+
+    switch(cmdFrame.aux1) {
+
+        case 0:
+            br = 19200;
+            break;
+
+        case 1:
+            br = 38400;
+            break;
+
+        case 2:
+            br = 57600;
+            break;
+
+        case 3:
+            br = 115200;
+            break;
+
+        case 4:
+            br = 230400;
+            break;
+
+        case 5:
+            br = 460800;
+            break;
+
+        case 6:
+            br = 921600;
+            break;
+
+        default:
+            sio_error();
+            return;
+    }
+  
+    // send complete with current baudrate
+    sio_complete();
+
+#ifdef ESP_PLATFORM
+    SYSTEM_BUS.uart->set_baudrate(br);
+#else
+    fnSioCom.set_baudrate(br);
+#endif
 }
 
 // Mount Server
@@ -2617,6 +2667,10 @@ void sioFuji::sio_process(uint32_t commanddata, uint8_t checksum)
     case FUJICMD_GET_WIFI_ENABLED:
         sio_ack();
         sio_net_get_wifi_enabled();
+        break;
+    case FUJICMD_SET_BAUDRATE:
+        sio_ack();
+        sio_set_baudrate();
         break;
     case FUJICMD_UNMOUNT_IMAGE:
         sio_ack();

--- a/lib/device/sio/fuji.cpp
+++ b/lib/device/sio/fuji.cpp
@@ -356,8 +356,11 @@ void sioFuji::sio_set_baudrate()
     sio_complete();
 
 #ifdef ESP_PLATFORM
+    SYSTEM_BUS.uart->flush();
     SYSTEM_BUS.uart->set_baudrate(br);
 #else
+    fnSioCom.flush();
+    fnSystem.delay_microseconds(2000);
     fnSioCom.set_baudrate(br);
 #endif
 }

--- a/lib/device/sio/fuji.h
+++ b/lib/device/sio/fuji.h
@@ -139,6 +139,7 @@ protected:
     void sio_write_device_slots();     // 0xF1
     void sio_enable_udpstream();       // 0xF0
     void sio_net_get_wifi_enabled();   // 0xEA
+    void sio_set_baudrate();           // 0xEB
 #ifdef ESP_PLATFORM
     void sio_disk_image_umount();      // 0xE9
 #else

--- a/lib/fuji/fujiCmd.h
+++ b/lib/fuji/fujiCmd.h
@@ -21,6 +21,7 @@
 #define FUJICMD_WRITE_DEVICE_SLOTS         0xF1
 #define FUJICMD_ENABLE_UDPSTREAM           0xF0
 #define FUJICMD_GET_WIFI_ENABLED           0xEA
+#define FUJICMD_SET_BAUDRATE               0xEB
 #define FUJICMD_UNMOUNT_IMAGE              0xE9
 #define FUJICMD_GET_ADAPTERCONFIG          0xE8
 #define FUJICMD_NEW_DISK                   0xE7

--- a/lib/network-protocol/Protocol.cpp
+++ b/lib/network-protocol/Protocol.cpp
@@ -181,6 +181,9 @@ bool NetworkProtocol::write(unsigned short len)
  */
 bool NetworkProtocol::status(NetworkStatus *status)
 {
+    if (fromInterrupt)   
+        return false;
+ 
     if (!is_write && receiveBuffer->length() == 0 && status->rxBytesWaiting > 0)
         read(status->rxBytesWaiting);
 


### PR DESCRIPTION
- add new command set_baudrate to change UART baudrate between external host and ESP32 (useful with Pico or other MCU)
- disabling status read when called from sio_poll_interrupt to avoid pauses during data transfer with TNFS
- add some "not used" pins to atari2600.h to allow build
