### PR TITLE
nightly build: use newer softprops/action-gh-release to fix build crash

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -91,7 +91,7 @@ jobs:
 
     - name: Create Release 
       id: create-release
-      uses: softprops/action-gh-release@v2 
+      uses: softprops/action-gh-release@v2.2.2 
       with: 
 #        body_path: ${{ github.workspace }}/.github/nightly-release.txt
         body: |


### PR DESCRIPTION
Fix for
https://github.com/softprops/action-gh-release/issues/628