### PR TITLE
Simplify insert_boot_device() in iwm/fuji.cpp

### DIFF
--- a/lib/device/iwm/fuji.cpp
+++ b/lib/device/iwm/fuji.cpp
@@ -1266,54 +1266,29 @@ void iwmFuji::iwm_stat_get_device_filename(uint8_t s)
 // Mounts the desired boot disk number
 void iwmFuji::insert_boot_device(uint8_t d)
 {
-	const char *config_atr = "/autorun.po";
-	const char *mount_all_atr = "/mount-and-boot.po";
-#ifdef ESP_PLATFORM
-	fnFile *fBoot;
+	const char *boot_img = nullptr;
+	fnFile *fBoot = nullptr;
+	DEVICE_TYPE *disk_dev = get_disk_dev(0);
 
 	switch (d)
 	{
 	case 0:
-		fBoot = fsFlash.fnfile_open(config_atr);
-		get_disk_dev(0)->mount(fBoot, config_atr, 143360, MEDIATYPE_PO);
-		break;
-	case 1:
-		fBoot = fsFlash.fnfile_open(mount_all_atr);
-		get_disk_dev(0)->mount(fBoot, mount_all_atr, 143360, MEDIATYPE_PO);
-		break;
-    case 2:
-        Debug_printf("Mounting lobby server\n");
-        if (fnTNFS.start("tnfs.fujinet.online"))
-        {
-            Debug_printf("opening lobby.\n");
-            fBoot = fnTNFS.fnfile_open("/APPLE2/_lobby.po");
-			get_disk_dev(0)->mount(fBoot, "/APPLE2/_lobby.po", 143360, MEDIATYPE_PO);
-        }
-        break;
-	}
-#else
-	const char *boot_img;
-	fnFile *fBoot;
-
-	switch (d)
-	{
-	case 0:
-		boot_img = config_atr;
+		boot_img = "/autorun.po";
 		fBoot = fsFlash.fnfile_open(boot_img);
 		break;
 	case 1:
-		boot_img = mount_all_atr;
+		boot_img = "/mount-and-boot.po";
 		fBoot = fsFlash.fnfile_open(boot_img);
 		break;
-    case 2:
-        Debug_printf("Mounting lobby server\n");
-        if (fnTNFS.start("tnfs.fujinet.online"))
-        {
-            Debug_printf("opening lobby.\n");
+	case 2:
+		Debug_printf("Mounting lobby server\n");
+		if (fnTNFS.start("tnfs.fujinet.online"))
+		{
+			Debug_printf("opening lobby.\n");
 			boot_img = "/APPLE2/_lobby.po";
-            fBoot = fnTNFS.fnfile_open(boot_img);
-        }
-        break;
+			fBoot = fnTNFS.fnfile_open(boot_img);
+		}
+		break;
 	default:
 		Debug_printf("Invalid boot mode: %d\n", d);
 		return;
@@ -1325,10 +1300,7 @@ void iwmFuji::insert_boot_device(uint8_t d)
 		return;
 	}
 
-	_fnDisks[0].disk_dev.mount(fBoot, boot_img, 143360, MEDIATYPE_PO);
-#endif
-
-	DEVICE_TYPE *disk_dev = get_disk_dev(0);
+	disk_dev->mount(fBoot, boot_img, 143360, MEDIATYPE_PO);
 	disk_dev->is_config_device = true;
 }
 


### PR DESCRIPTION
Removed the `#ifdef ESP_PLATFORM` and simplified the method so that it does the same thing on both ESP32 and "PC".

Opened in draft mode, needs testing on both Apple II and FujiNet PC Apple II emulation.

![image](https://github.com/user-attachments/assets/37a7e90e-a4e2-49c7-92e5-6d94c6888d2e)
