### PR TITLE
modified build.sh to detect and run your pio activation sequence for …

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -57,6 +57,34 @@ if ! check_python_version "${PYTHON}" ; then
   fi
 fi
 
+# Function to check if we're in the PlatformIO virtual environment
+check_pio_venv() {
+  # Check if VIRTUAL_ENV variable exists and contains platformio
+  if [[ -z "${VIRTUAL_ENV}" || ! "${VIRTUAL_ENV}" == *".platformio/venv"* ]]; then
+    return 1
+  fi
+  return 0
+}
+
+# Check if we're in the PlatformIO virtual environment
+if ! check_pio_venv; then
+  echo "Not running in PlatformIO virtual environment."
+  echo "Activating PlatformIO environment..."
+  
+  # Check if the activation file exists - try different paths
+  if [ -f ~/.platformio/penv/bin/activate ]; then
+    source ~/.platformio/penv/bin/activate
+    echo "Environment activated, continuing with build..."
+  elif [ -f "${HOME}/.platformio/penv/bin/activate" ]; then
+    source "${HOME}/.platformio/penv/bin/activate"
+    echo "Environment activated, continuing with build..."
+  else
+    echo "Could not find PlatformIO environment activation file."
+    echo "Please check if PlatformIO is correctly installed."
+    exit 1
+  fi
+fi
+
 function display_board_names {
   while IFS= read -r piofile; do
     BOARD_NAME=$(echo $(basename $piofile) | sed 's#^platformio-##;s#.ini$##')


### PR DESCRIPTION
…proper builds using build.sh- finds and activates your pio env for you when using build.sh.

```
~/code/fujinet-firmware(auto-activate-pio)]$ ./build.sh -c
Not running in PlatformIO virtual environment.
Activating PlatformIO environment...
Environment activated, continuing with build...
Merged INI file created as '/Users/dillera/code/fujinet-firmware/platformio-generated.ini'.
Processing fujiapple-rev0 (platform: espressif32@6.10.0; board: fujinet-v1-8mb; framework: espidf)
--------------------------------------------------------------------------------------------------------------------------------------------------------
Verbose mode can be enabled via `-v, --verbose` option
Replacing MKSPIFFSTOOL with mklittlefs
Automatic versioning disabled
Building webUI into data/BUILD_APPLE
  build_platform: BUILD_APPLE
  build_board: fujiapple-rev0
  config file: /Users/dillera/code/fujinet-firmware/platformio-generated.ini
processing template file data/webui/template/www/css/core.tmpl.css
processing template file data/webui/template/www/js/utils.tmpl.js
processing template file data/webui/template/www/js/settings.tmpl.js
processing template file data/webui/template/www/header.tmpl.html
processing template file data/webui/template/www/index.tmpl.html
Removing .pio/build/fujiapple-rev0
Done cleaning
```
