### PR TITLE
Fix PIO venv activate message output

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -160,6 +160,18 @@ if [ $BUILD_ALL -eq 1 ] ; then
 fi
 
 ##############################################################
+# Set up the virtual environment if it exists
+if [[ -d "$PIO_VENV_ROOT" && "$VIRTUAL_ENV" != "$PIO_VENV_ROOT" ]] ; then
+  echo "Activating virtual environment"
+  [[ -z "$VIRTUAL_ENV" ]] && deactivate &>/dev/null
+  source "$PIO_VENV_ROOT/bin/activate"
+elif [[ -d "$PIO_VENV_ROOT" && "$VIRTUAL_ENV" == "$PIO_VENV_ROOT" ]] ; then
+  echo "Virtual environment already activated at $PIO_VENV_ROOT"
+else
+  echo "Warning: Virtual environment not found in $PIO_VENV_ROOT. Continuing without it."
+fi
+
+##############################################################
 # PC BUILD using cmake
 if [ ! -z "$PC_TARGET" ] ; then
   echo "PC Build Mode"
@@ -293,18 +305,6 @@ if [ $create_result -ne 0 ] ; then
 fi
 
 BUILD_BOARD=$(grep '^build_board = ' $INI_FILE | cut -d" " -f 3)
-
-##############################################################
-# Set up the virtual environment if it exists
-if [[ -d "$PIO_VENV_ROOT" && "$VIRTUAL_ENV" != "$PIO_VENV_ROOT" ]] ; then
-  echo "Activating virtual environment"
-  [[ -z "$VIRTUAL_ENV" ]] && deactivate &>/dev/null
-  source "$PIO_VENV_ROOT/bin/activate"
-elif [[ -d "$PIO_VENV_ROOT" && "$VIRTUAL_ENV" == "$PIO_VENV_ROOT" ]] ; then
-  echo "Virtual environment already activated at $PIO_VENV_ROOT"
-else
-  echo "Warning: Virtual environment not found in $PIO_VENV_ROOT. Continuing without it."
-fi
 
 ##############################################################
 # ZIP MODE for building firmware zip file.

--- a/build.sh
+++ b/build.sh
@@ -159,15 +159,6 @@ if [ $BUILD_ALL -eq 1 ] ; then
   exit $?
 fi
 
-# Set up the virtual environment if it exists
-if [[ -d "$PIO_VENV_ROOT" && "$VIRTUAL_ENV" != "$PIO_VENV_ROOT" ]] ; then
-  echo "Activating virtual environment"
-  [[ -z "$VIRTUAL_ENV" ]] && deactivate &>/dev/null
-  source "$PIO_VENV_ROOT/bin/activate"
-else
-  echo "Warning: Virtual environment not found in $PIO_VENV_ROOT. Continuing without it."
-fi
-
 ##############################################################
 # PC BUILD using cmake
 if [ ! -z "$PC_TARGET" ] ; then
@@ -302,6 +293,18 @@ if [ $create_result -ne 0 ] ; then
 fi
 
 BUILD_BOARD=$(grep '^build_board = ' $INI_FILE | cut -d" " -f 3)
+
+##############################################################
+# Set up the virtual environment if it exists
+if [[ -d "$PIO_VENV_ROOT" && "$VIRTUAL_ENV" != "$PIO_VENV_ROOT" ]] ; then
+  echo "Activating virtual environment"
+  [[ -z "$VIRTUAL_ENV" ]] && deactivate &>/dev/null
+  source "$PIO_VENV_ROOT/bin/activate"
+elif [[ -d "$PIO_VENV_ROOT" && "$VIRTUAL_ENV" == "$PIO_VENV_ROOT" ]] ; then
+  echo "Virtual environment already activated at $PIO_VENV_ROOT"
+else
+  echo "Warning: Virtual environment not found in $PIO_VENV_ROOT. Continuing without it."
+fi
 
 ##############################################################
 # ZIP MODE for building firmware zip file.


### PR DESCRIPTION
Fixed the output message to be more accurate if the PIO `penv` has already been activated in the current environment.  

Activating venv (penv directory exists & isn't already activated): 
![image](https://github.com/user-attachments/assets/41468a42-42b7-4ef4-b6a9-ccb4db306e7f)

Activation failed with a bogus or missing PIO penv directory - script continues without it: 
![image](https://github.com/user-attachments/assets/93c159db-cc6c-42a3-b7a0-1e0551d15279)

`$VIRTUAL_ENV` is already set to the PIO penv so just continues without doing anything: 
![image](https://github.com/user-attachments/assets/e401117b-bb0a-4e4b-9989-c392ba932c1f)
