### PR TITLE
Fix termios2.h BOTHER compile issue with fujinet-pc

### DIFF
--- a/lib/compat/linux_termios2.h
+++ b/lib/compat/linux_termios2.h
@@ -25,10 +25,16 @@
 #include <termios.h>
 
 #ifndef BOTHER
-
 #define BOTHER		CBAUDEX
+#endif
+
+#ifndef LINUX_NCCS
 #define LINUX_NCCS	19
+#endif
+
+#ifndef LINUX_IBSHIFT
 #define LINUX_IBSHIFT	16
+#endif
 
 struct termios2 {
         tcflag_t c_iflag;               /* input mode flags */
@@ -40,8 +46,6 @@ struct termios2 {
         speed_t c_ispeed;               /* input speed */
         speed_t c_ospeed;               /* output speed */
 };
-
-#endif
 
 #ifndef TCGETS2
 #define TCGETS2 0x2A


### PR DESCRIPTION
On arch, BOTHER is now defined in glibc:

```shell
❯ grep BOTHER /usr/include/bits/*.h
/usr/include/bits/termios-cbaud.h:#define  __BOTHER    0010000
/usr/include/bits/termios.h:# define BOTHER  __BOTHER
```

The original guard around termios2 struct is now skipped because BOTHER was the control for it.
glibc does not define it anywhere in linux, it's in kernel headers, but we don't include those for obvious reasons.

This PR amends the guards to separate each part that's defined, but allows termios2 struct to be defined.

A good hard look at why we do any of this shit is probably required of the whole uart classes code.