### PR TITLE
[atari][media] fix sector/offset calculations for 512 b/s on ATR files.

### DIFF
--- a/lib/media/atari/diskTypeAtr.cpp
+++ b/lib/media/atari/diskTypeAtr.cpp
@@ -38,11 +38,11 @@ uint32_t MediaTypeATR::_sector_to_offset(uint16_t sectorNum)
         else
             offset = 272;
         break;
-    default:
+    default: // TODO: refactor this to generalize.
         if (_disk_sector_size == 256)
             offset = ((sectorNum - 3) * 256) + 16 + 128;
         else if (_disk_sector_size == 512)
-            offset = (sectorNum * 512) + 16;
+            offset = ((sectorNum - 1) * 512) + 16;
         else
             offset = ((sectorNum - 1) * 128) + 16;
         break;


### PR DESCRIPTION
Fix reported bug where 512 bytes/sector ATR images were being incorrectly read/written to, due to improperly calculating the sector offset.

The sector offset calculation needs to be the same as the 128 bytes/sector calculations (and in fact can be refactored for a future improvement), and only the 256 bytes/sector calculations need to be the exception.
