### PR TITLE
add qrcode_minVersion() to auto size generated qrcode

### DIFF
--- a/lib/qrcode/qrcode.c
+++ b/lib/qrcode/qrcode.c
@@ -35,6 +35,7 @@
 
 #include "qrcode.h"
 
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -843,6 +844,7 @@ int8_t qrcode_initText(QRCode *qrcode, uint8_t *modules, uint8_t version, uint8_
 }
 
 bool qrcode_getModule(QRCode *qrcode, uint8_t x, uint8_t y) {
+    //if (x < 0 || x >= qrcode->size || y < 0 || y >= qrcode->size) {
     if (x >= qrcode->size || y >= qrcode->size) {
         return false;
     }
@@ -860,3 +862,22 @@ void qrcode_getHex(QRCode *qrcode, char *result) {
 
 }
 */
+
+int8_t qrcode_minVersion(uint8_t ecc, const char *data) {
+    uint16_t len = strlen(data);
+
+    int8_t version = 1;
+    uint16_t capacity;
+    do {
+        capacity = NUM_ALPHANUMERIC_CAPACITY[ecc][version-1];
+        printf("Testing version[%d] ecc[%d] len[%d] capacity[%d]\n", version, ecc, len, capacity);
+        if (len > capacity) {
+            version++;
+        } else {
+            break;
+        }
+    } while (version <= 40);
+
+    printf("Set version[%d] ecc[%d] len[%d] capacity[%d]\n", version, ecc, len, capacity);
+    return version;
+}

--- a/lib/qrcode/qrcode.h
+++ b/lib/qrcode/qrcode.h
@@ -83,7 +83,7 @@ int8_t qrcode_initText(QRCode *qrcode, uint8_t *modules, uint8_t version, uint8_
 int8_t qrcode_initBytes(QRCode *qrcode, uint8_t *modules, uint8_t version, uint8_t ecc, uint8_t *data, uint16_t length);
 
 bool qrcode_getModule(QRCode *qrcode, uint8_t x, uint8_t y);
-
+int8_t qrcode_minVersion(uint8_t ecc, const char *data);
 
 
 #ifdef __cplusplus

--- a/lib/qrcode/qrmanager.h
+++ b/lib/qrcode/qrmanager.h
@@ -73,7 +73,7 @@ public:
     * PETSCII character can represent 4 bits. Carriage returns (0x0D) are
     * added at the end of each row to facilitate printing direct to screen.
     */
-   void to_petscii(void);
+    void to_petscii(void);
 
     size_t size() { return version * 4 + 17; }
     void set_buffer(const std::string& buffer) { in_buf = buffer; }


### PR DESCRIPTION
minor tweaks to qrManager::to_petscii()

Now if you set version to "0" when calling QRManager::encode(), it will automatically select the minimum version to fit your data.
