### PR TITLE
coco: fix debug/monitor baud rate

### DIFF
--- a/build-platforms/platformio-fujinet-coco-devkitc.ini
+++ b/build-platforms/platformio-fujinet-coco-devkitc.ini
@@ -7,7 +7,7 @@ build_board    = fujinet-coco-devkitc
 upload_port = /dev/ttyUSB0
 upload_speed = 460800
 monitor_port = /dev/ttyUSB0
-monitor_speed = 115200
+monitor_speed = 460800
 
 [env:fujinet-coco-devkitc]
 platform = espressif32@${fujinet.esp32_platform_version}


### PR DESCRIPTION
This sets coco debug baud to match every other platform at 460800 baud