### PR TITLE
Reworked the QRCode library

### DIFF
--- a/lib/device/iwm/fuji.cpp
+++ b/lib/device/iwm/fuji.cpp
@@ -1545,50 +1545,44 @@ void iwmFuji::iwm_ctrl_qrcode_input()
     Debug_printf("FUJI: QRCODE INPUT (len: %d)\n", data_len);
     std::vector<uint8_t> data(data_len, 0);
     std::copy(&data_buffer[0], &data_buffer[0] + data_len, data.begin());
-    qrManager.in_buf += std::string((const char *)data.data(), data_len);
+    _qrManager.data += std::string((const char *)data.data(), data_len);
 }
 
 void iwmFuji::iwm_ctrl_qrcode_encode()
 {
-    size_t out_len = 0;
-
-    qrManager.output_mode = 0;
-    qrManager.version = data_buffer[0] & 0b01111111;
-    qrManager.ecc_mode = data_buffer[1];
+    uint8_t version = data_buffer[0] & 0b01111111;
+    uint8_t ecc_mode = data_buffer[1];
     bool shorten = data_buffer[2];
 
     Debug_printf("FUJI: QRCODE ENCODE\n");
-    Debug_printf("QR Version: %d, ECC: %d, Shorten: %s\n", qrManager.version, qrManager.ecc_mode, shorten ? "Y" : "N");
+    Debug_printf("QR Version: %d, ECC: %d, Shorten: %s\n", version, ecc_mode, shorten ? "Y" : "N");
 
-    std::string url = qrManager.in_buf;
+    std::string url = _qrManager.data;
 
     if (shorten) {
         url = fnHTTPD.shorten_url(url);
     }
 
-    std::vector<uint8_t> p = QRManager::encode(
-        url.c_str(),
-        url.size(),
-        qrManager.version,
-        qrManager.ecc_mode,
-        &out_len
-    );
+	_qrManager.version(version);
+	_qrManager.ecc((qr_ecc_t)ecc_mode);
+	_qrManager.output_mode = QR_OUTPUT_MODE_BINARY;
+	_qrManager.encode();
 
-    qrManager.in_buf.clear();
+    _qrManager.data.clear();
 
-    if (!out_len)
+    if (!_qrManager.code.size())
     {
         Debug_printf("QR code encoding failed\n");
         return;
     }
 
-    Debug_printf("Resulting QR code is: %u modules\n", out_len);
+    Debug_printf("Resulting QR code is: %u modules\n", _qrManager.code.size());
 }
 
 void iwmFuji::iwm_stat_qrcode_length()
 {
     Debug_printf("FUJI: QRCODE LENGTH\n");
-    size_t len = qrManager.out_buf.size();
+    size_t len = _qrManager.code.size();
 	data_buffer[0] = (uint8_t)(len >> 0);
     data_buffer[1] = (uint8_t)(len >> 8);
 	data_len = 2;
@@ -1601,19 +1595,11 @@ void iwmFuji::iwm_ctrl_qrcode_output()
     uint8_t output_mode = data_buffer[0];
     Debug_printf("Output mode: %i\n", output_mode);
 
-    size_t len = qrManager.out_buf.size();
+    size_t len = _qrManager.code.size();
 
-    if (len && (output_mode != qrManager.output_mode)) {
-        if (output_mode == QR_OUTPUT_MODE_BINARY) {
-            qrManager.to_binary();
-        }
-        else if (output_mode == QR_OUTPUT_MODE_ATASCII) {
-            qrManager.to_atascii();
-        }
-        else if (output_mode == QR_OUTPUT_MODE_BITMAP) {
-            qrManager.to_bitmap();
-        }
-        qrManager.output_mode = output_mode;
+    if (len && (output_mode != _qrManager.output_mode)) {
+		_qrManager.output_mode = (ouput_mode_t)output_mode;
+		_qrManager.encode();
     }
 }
 
@@ -1622,11 +1608,11 @@ void iwmFuji::iwm_stat_qrcode_output()
     Debug_printf("FUJI: QRCODE OUTPUT STAT\n");
 	memset(data_buffer, 0, sizeof(data_buffer));
 
-	data_len = qrManager.out_buf.size();
-	memcpy(data_buffer, &qrManager.out_buf[0], data_len);
+	data_len = _qrManager.code.size();
+	memcpy(data_buffer, &_qrManager.code[0], data_len);
 
-	qrManager.out_buf.erase(qrManager.out_buf.begin(), qrManager.out_buf.begin() + data_len);
-    qrManager.out_buf.shrink_to_fit();
+	_qrManager.code.clear();
+    _qrManager.code.shrink_to_fit();
 }
 
 #endif /* BUILD_APPLE */

--- a/lib/device/iwm/fuji.h
+++ b/lib/device/iwm/fuji.h
@@ -21,7 +21,7 @@
 #include "../fuji/fujiCmd.h"
 
 #include "hash.h"
-#include "../../qrcode/qrmanager.h"
+#include "qrmanager.h"
 
 #define MAX_HOSTS 8
 #define MAX_DISK_DEVICES 6 // 4 SP devices + 2 DiskII devices
@@ -146,6 +146,8 @@ private:
 
     Hash::Algorithm algorithm = Hash::Algorithm::UNKNOWN;
     bool hash_is_hex_output = false;
+
+    QRManager _qrManager = QRManager();
 
 protected:
     void iwm_dummy_command();                     // control 0xAA

--- a/lib/device/sio/fuji.h
+++ b/lib/device/sio/fuji.h
@@ -20,6 +20,7 @@
 #include "fujiCmd.h"
 
 #include "hash.h"
+#include "qrmanager.h"
 
 #define MAX_HOSTS 8
 #define MAX_DISK_DEVICES 8
@@ -114,6 +115,8 @@ private:
     mbedtls_sha512_context _sha512;
 
     Hash::Algorithm algorithm = Hash::Algorithm::UNKNOWN;
+
+    QRManager _qrManager = QRManager();
 
 protected:
     void sio_reset_fujinet();          // 0xFF

--- a/lib/qrcode/qrcode.c
+++ b/lib/qrcode/qrcode.c
@@ -39,6 +39,8 @@
 #include <stdlib.h>
 #include <string.h>
 
+
+
 #if LOCK_VERSION == 0
 
 static const uint16_t NUM_ERROR_CORRECTION_CODEWORDS[4][40] = {
@@ -65,14 +67,6 @@ static const uint16_t NUM_RAW_DATA_MODULES[40] = {
        7211, 7931, 8683, 9252, 10068, 10916, 11796, 12708, 13652, 14628, 15371, 16411, 17483, 18587,
     //    32,    33,    34,    35,    36,    37,    38,    39,    40
        19723, 20891, 22091, 23008, 24272, 25568, 26896, 28256, 29648
-};
-
-static const uint16_t NUM_ALPHANUMERIC_CAPACITY[4][40] = {
-  // 1, 2, 3, ...                                                                                                                                                                   ...40
-  { 25,47,77,114,154,195,224,279,335,395,468,535,619,667,758,854,938,1046,1153,1249,1352,1460,1588,1704,1853,1990,2132,2223,2369,2520,2677,2840,3009,3183,3351,3537,3729,3927,4087,4296 }, // ECC 0
-  { 20,38,61,90,122,154,178,221,262,311,366,419,483,528,600,656,734,816,909,970,1035,1134,1248,1326,1451,1542,1637,1732,1839,1994,2113,2238,2369,2506,2632,2780,2894,3054,3220,3391 },     // ECC 1
-  { 16,29,47,67,87,108,125,157,189,221,259,296,352,376,426,470,531,574,644,702,742,823,890,963,1041,1094,1172,1263,1322,1429,1499,1618,1700,1787,1867,1966,2071,2181,2298,2420 },          // ECC 2
-  { 10,20,35,50,64,84,93,122,143,174,200,227,259,283,321,365,408,452,493,557,587,640,672,744,779,864,910,958,1016,1080,1150,1226,1307,1394,1431,1530,1591,1658,1774,1852 }                 // ECC 3
 };
 
 // @TODO: Put other LOCK_VERSIONS here
@@ -106,6 +100,7 @@ static int abs(int value) {
     return value;
 }
 */
+
 
 static int8_t getAlphanumeric(char c) {
 
@@ -143,6 +138,7 @@ static bool isNumeric(const char *text, uint16_t length) {
     return true;
 }
 
+
 // We store the following tightly packed (less 8) in modeInfo
 //               <=9  <=26  <= 40
 // NUMERIC      ( 10,   12,    14);
@@ -166,6 +162,8 @@ static char getModeBits(uint8_t version, uint8_t mode) {
 
     return result;
 }
+
+
 
 typedef struct BitBucket {
     uint32_t bitOffsetOrWidth;
@@ -247,6 +245,7 @@ static bool bb_getBit(BitBucket *bitGrid, uint8_t x, uint8_t y) {
     uint32_t offset = y * bitGrid->bitOffsetOrWidth + x;
     return (bitGrid->data[offset >> 3] & (1 << (7 - (offset & 0x07)))) != 0;
 }
+
 
 // XORs the data modules in this QR Code with the given mask pattern. Due to XOR's mathematical
 // properties, calling applyMask(m) twice with the same value is equivalent to no change at all.
@@ -468,6 +467,7 @@ static void drawCodewords(BitBucket *modules, BitBucket *isFunction, BitBucket *
 }
 
 
+
 #define PENALTY_N1      3
 #define PENALTY_N2      3
 #define PENALTY_N3     40
@@ -565,6 +565,7 @@ static uint32_t getPenaltyScore(BitBucket *modules) {
     return result;
 }
 
+
 static uint8_t rs_multiply(uint8_t x, uint8_t y) {
     // Russian peasant multiplication
     // See: https://en.wikipedia.org/wiki/Ancient_Egyptian_multiplication
@@ -616,11 +617,10 @@ static void rs_getRemainder(uint8_t degree, uint8_t *coeff, uint8_t *data, uint8
 }
 
 
-static int8_t encodeDataCodewords(BitBucket *dataCodewords, const uint8_t *text, uint16_t length, uint8_t version) {
-    int8_t mode = MODE_BYTE;
+static void encodeDataCodewords(BitBucket *dataCodewords, const uint8_t *text, uint16_t length, uint8_t version, uint8_t mode) {
 
-    if (isNumeric((char*)text, length)) {
-        mode = MODE_NUMERIC;
+    if (mode == MODE_NUMERIC) {
+        //printf("Numeric Encoding\n");
         bb_appendBits(dataCodewords, 1 << MODE_NUMERIC, 4);
         bb_appendBits(dataCodewords, length, getModeBits(version, MODE_NUMERIC));
 
@@ -641,8 +641,8 @@ static int8_t encodeDataCodewords(BitBucket *dataCodewords, const uint8_t *text,
             bb_appendBits(dataCodewords, accumData, accumCount * 3 + 1);
         }
 
-    } else if (isAlphanumeric((char*)text, length)) {
-        mode = MODE_ALPHANUMERIC;
+    } else if (mode == MODE_ALPHANUMERIC) {
+        //printf("Alphanumeric Encoding\n");
         bb_appendBits(dataCodewords, 1 << MODE_ALPHANUMERIC, 4);
         bb_appendBits(dataCodewords, length, getModeBits(version, MODE_ALPHANUMERIC));
 
@@ -664,6 +664,7 @@ static int8_t encodeDataCodewords(BitBucket *dataCodewords, const uint8_t *text,
         }
 
     } else {
+        //printf("Byte Encoding\n");
         bb_appendBits(dataCodewords, 1 << MODE_BYTE, 4);
         bb_appendBits(dataCodewords, length, getModeBits(version, MODE_BYTE));
         for (uint16_t i = 0; i < length; i++) {
@@ -672,9 +673,8 @@ static int8_t encodeDataCodewords(BitBucket *dataCodewords, const uint8_t *text,
     }
 
     //bb_setBits(dataCodewords, length, 4, getModeBits(version, mode));
-
-    return mode;
 }
+
 
 static void performErrorCorrection(uint8_t version, uint8_t ecc, BitBucket *data) {
 
@@ -754,23 +754,42 @@ static void performErrorCorrection(uint8_t version, uint8_t ecc, BitBucket *data
 // The format bits can be determined by ECC_FORMAT_BITS >> (2 * ecc)
 static const uint8_t ECC_FORMAT_BITS = (0x02 << 6) | (0x03 << 4) | (0x00 << 2) | (0x01 << 0);
 
+
+
 uint16_t qrcode_getBufferSize(uint8_t version) {
     return bb_getGridSizeBytes(4 * version + 17);
 }
 
 // @TODO: Return error if data is too big.
-int8_t qrcode_initBytes(QRCode *qrcode, uint8_t *modules, uint8_t version, uint8_t ecc, uint8_t *data, uint16_t length) {
-    uint8_t size = version * 4 + 17;
-    qrcode->version = version;
-    qrcode->size = size;
-    qrcode->ecc = ecc;
-    qrcode->modules = modules;
+uint8_t qrcode_initBytes(QRCode *qrcode, uint8_t *data, uint16_t length) {
 
-    uint8_t eccFormatBits = (ECC_FORMAT_BITS >> (2 * ecc)) & 0x03;
+    // Determine mode
+    if ( qrcode->mode > 3 ) {
+        return 1; // Bad Mode
+    }
+    qrcode->mode = qrcode_determineMode((char*)data, length);
+
+    // If Version is 0, choose the smallest version that can hold the data
+    if (qrcode->version == VERSION_AUTO) {
+        qrcode->version = qrcode_minVersion(qrcode->ecc, qrcode->mode, (char*)data, length);
+    }
+    else if (qrcode->version > 40 || qrcode->ecc > 3)
+    {
+        return 2; // Bad Version
+    }
+
+    // If length is too big, return error
+    if (length > (qrcode_dataCapacity(qrcode->version, qrcode->ecc) - 2)) {
+        return 3; // Bad Length
+    }
+
+    qrcode->size = qrcode->version * 4 + 17;
+
+    uint8_t eccFormatBits = (ECC_FORMAT_BITS >> (2 * qrcode->ecc)) & 0x03;
 
 #if LOCK_VERSION == 0
-    uint16_t moduleCount = NUM_RAW_DATA_MODULES[version - 1];
-    uint16_t dataCapacity = moduleCount / 8 - NUM_ERROR_CORRECTION_CODEWORDS[eccFormatBits][version - 1];
+    uint16_t moduleCount = NUM_RAW_DATA_MODULES[qrcode->version - 1];
+    uint16_t dataCapacity = moduleCount / 8 - NUM_ERROR_CORRECTION_CODEWORDS[eccFormatBits][qrcode->version - 1];
 #else
     version = LOCK_VERSION;
     uint16_t moduleCount = NUM_RAW_DATA_MODULES;
@@ -782,10 +801,7 @@ int8_t qrcode_initBytes(QRCode *qrcode, uint8_t *modules, uint8_t version, uint8
     bb_initBuffer(&codewords, codewordBytes, (int32_t)sizeof(codewordBytes));
 
     // Place the data code words into the buffer
-    int8_t mode = encodeDataCodewords(&codewords, data, length, version);
-
-    if (mode < 0) { return -1; }
-    qrcode->mode = mode;
+    encodeDataCodewords(&codewords, data, length, qrcode->version, qrcode->mode);
 
     // Add terminator and pad up to a byte if applicable
     uint32_t padding = (dataCapacity * 8) - codewords.bitOffsetOrWidth;
@@ -798,16 +814,19 @@ int8_t qrcode_initBytes(QRCode *qrcode, uint8_t *modules, uint8_t version, uint8
         bb_appendBits(&codewords, padByte, 8);
     }
 
+    if (qrcode->modules != NULL) { free(qrcode->modules); }
+    qrcode->modules = malloc(qrcode_getBufferSize(qrcode->version));
+
     BitBucket modulesGrid;
-    bb_initGrid(&modulesGrid, modules, size);
+    bb_initGrid(&modulesGrid, qrcode->modules, qrcode->size);
 
     BitBucket isFunctionGrid;
-    uint8_t isFunctionGridBytes[bb_getGridSizeBytes(size)];
-    bb_initGrid(&isFunctionGrid, isFunctionGridBytes, size);
+    uint8_t isFunctionGridBytes[bb_getGridSizeBytes(qrcode->size)];
+    bb_initGrid(&isFunctionGrid, isFunctionGridBytes, qrcode->size);
 
     // Draw function patterns, draw all codewords, do masking
-    drawFunctionPatterns(&modulesGrid, &isFunctionGrid, version, eccFormatBits);
-    performErrorCorrection(version, eccFormatBits, &codewords);
+    drawFunctionPatterns(&modulesGrid, &isFunctionGrid, qrcode->version, eccFormatBits);
+    performErrorCorrection(qrcode->version, eccFormatBits, &codewords);
     drawCodewords(&modulesGrid, &isFunctionGrid, &codewords);
 
     // Find the best (lowest penalty) mask
@@ -835,22 +854,18 @@ int8_t qrcode_initBytes(QRCode *qrcode, uint8_t *modules, uint8_t version, uint8
     return 0;
 }
 
-int8_t qrcode_initText(QRCode *qrcode, uint8_t *modules, uint8_t version, uint8_t ecc, const char *data) {
+uint8_t qrcode_initText(QRCode *qrcode, const char *data) {
     uint16_t len = strlen(data);
-    if (len > NUM_ALPHANUMERIC_CAPACITY[ecc][version-1]) {
-      return 1;
-    }
-    return qrcode_initBytes(qrcode, modules, version, ecc, (uint8_t*)data, len);
+    return qrcode_initBytes(qrcode, (uint8_t*)data, len);
 }
 
 bool qrcode_getModule(QRCode *qrcode, uint8_t x, uint8_t y) {
-    //if (x < 0 || x >= qrcode->size || y < 0 || y >= qrcode->size) {
     if (x >= qrcode->size || y >= qrcode->size) {
         return false;
     }
 
     uint32_t offset = y * qrcode->size + x;
-    return (qrcode->modules[offset >> 3] & (1 << (7 - (offset & 0x07)))) != 0;
+    return (qrcode->modules[offset >> 3] & (128 >> (offset & 0x07))) != 0;
 }
 
 /*
@@ -863,21 +878,87 @@ void qrcode_getHex(QRCode *qrcode, char *result) {
 }
 */
 
-int8_t qrcode_minVersion(uint8_t ecc, const char *data) {
-    uint16_t len = strlen(data);
 
-    int8_t version = 1;
-    uint16_t capacity;
+uint8_t qrcode_determineMode(const char *data, uint16_t length) {
+
+    if (isNumeric(data, length)) {
+        return MODE_NUMERIC;
+    } else if (isAlphanumeric(data, length)) {
+        return MODE_ALPHANUMERIC;
+    }
+    return MODE_BYTE;
+}
+
+uint16_t qrcode_dataCapacity(uint8_t version, uint8_t ecc) {
+    uint8_t eccFormatBits = (ECC_FORMAT_BITS >> (2 * ecc)) & 0x03;
+
+    uint16_t moduleCount = NUM_RAW_DATA_MODULES[version - 1];
+    uint16_t dataCapacity = moduleCount / 8 - NUM_ERROR_CORRECTION_CODEWORDS[eccFormatBits][version - 1];
+    //printf("dataCapacity[%d]\n", dataCapacity);
+
+    return dataCapacity;
+}
+
+uint8_t qrcode_minVersion(uint8_t ecc, uint8_t mode, const char *data, uint16_t length) {
+
+    uint8_t version = 1;
+    uint8_t lengthMode = getModeBits(version, mode);
+    uint16_t lengthMax;
+
+    uint16_t lengthEncoded = (length * lengthMode) / 8;
     do {
-        capacity = NUM_ALPHANUMERIC_CAPACITY[ecc][version-1];
-        printf("Testing version[%d] ecc[%d] len[%d] capacity[%d]\n", version, ecc, len, capacity);
-        if (len > capacity) {
+        lengthMax = qrcode_dataCapacity(version, ecc) - 2;
+        //printf("Testing version[%d] ecc[%d] len[%d] lengthMode[%d] encoded[%d] max[%d]\n", version, ecc, length, lengthMode, lengthEncoded, lengthMax);
+        if (lengthEncoded > lengthMax) {
             version++;
         } else {
             break;
         }
     } while (version <= 40);
 
-    printf("Set version[%d] ecc[%d] len[%d] capacity[%d]\n", version, ecc, len, capacity);
+    //printf("Set version[%d] ecc[%d] len[%d] lengthMode[%d] encoded[%d] max[%d]\n", version, ecc, length, lengthMode, lengthEncoded, lengthMax);
     return version;
+}
+
+// Encode data to base-45
+uint16_t qrcode_encodeBase45(unsigned char * dst, uint16_t *_max_dst_len, const unsigned char * src, uint16_t src_len) {
+    static const char BASE45_CHARSET[] = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ $%*+-./:";
+
+    //printf("_max_dst_len[%d] src_len[%d] src[%s]\n", *_max_dst_len, src_len, src);
+
+    size_t out_len = 0, max_dst_len;
+    max_dst_len = _max_dst_len ? *_max_dst_len : src_len * 4;
+
+    for (int i = 0; i < src_len; i += 2) {
+        if (src_len - i > 1) {
+            int x = ((src[i]) << 8) + src[i + 1];
+
+            unsigned char e = x / (45 * 45);
+            x %= 45 * 45;
+            unsigned char d = x / 45;
+            unsigned char c = x % 45;
+
+            if (out_len < max_dst_len && dst) dst[out_len] = BASE45_CHARSET[c];
+            out_len++;
+            if (out_len < max_dst_len && dst) dst[out_len] = BASE45_CHARSET[d];
+            out_len++;
+            if (out_len < max_dst_len && dst) dst[out_len] = BASE45_CHARSET[e];
+            out_len++;
+        } else {
+            int x = src[i];
+            unsigned char d = x / 45;
+            unsigned char c = x % 45;
+
+            if (out_len < max_dst_len && dst) dst[out_len] = BASE45_CHARSET[c];
+            out_len++;
+
+            if (out_len < max_dst_len && dst) dst[out_len] = BASE45_CHARSET[d];
+            out_len++;
+        }
+    }
+    /* Same non guarantee as strncpy et.al. */
+    if (out_len < max_dst_len && dst) dst[out_len] = 0;
+
+    if (_max_dst_len) *_max_dst_len = out_len;
+    return 0;
 }

--- a/lib/qrcode/qrcode.h
+++ b/lib/qrcode/qrcode.h
@@ -56,6 +56,7 @@
 
 // If set to non-zero, this library can ONLY produce QR codes at that version
 // This saves a lot of dynamic memory, as the codeword tables are skipped
+#define VERSION_AUTO       0
 #ifndef LOCK_VERSION
 #define LOCK_VERSION       0
 #endif
@@ -75,16 +76,15 @@ typedef struct QRCode {
 extern "C"{
 #endif  /* __cplusplus */
 
-
-
-uint16_t qrcode_getBufferSize(uint8_t version);
-
-int8_t qrcode_initText(QRCode *qrcode, uint8_t *modules, uint8_t version, uint8_t ecc, const char *data);
-int8_t qrcode_initBytes(QRCode *qrcode, uint8_t *modules, uint8_t version, uint8_t ecc, uint8_t *data, uint16_t length);
+uint8_t qrcode_initText(QRCode *qrcode, const char *data);
+uint8_t qrcode_initBytes(QRCode *qrcode, uint8_t *data, uint16_t length);
 
 bool qrcode_getModule(QRCode *qrcode, uint8_t x, uint8_t y);
-int8_t qrcode_minVersion(uint8_t ecc, const char *data);
 
+uint8_t qrcode_determineMode(const char *data, uint16_t length);
+uint16_t qrcode_dataCapacity(uint8_t version, uint8_t ecc);
+uint8_t qrcode_minVersion(uint8_t ecc, uint8_t mode, const char *data, uint16_t length);
+uint16_t qrcode_encodeBase45(unsigned char * dst, uint16_t *_max_dst_len, const unsigned char * src, uint16_t src_len);
 
 #ifdef __cplusplus
 }

--- a/lib/qrcode/qrmanager.cpp
+++ b/lib/qrcode/qrmanager.cpp
@@ -1,93 +1,138 @@
+
+
+#include "qrmanager.h"
+
 #include <cstdint>
 #include <cstring>
 #include <cstdlib>
 #include <cmath>
 #include <memory>
+#include <sstream>
 #include <vector>
-#include "../../include/debug.h"
-#include "qrmanager.h"
+
 #include "qrcode.h"
 
-QRManager qrManager;
+std::vector<uint8_t> QRManager::encode(const void* input, uint16_t length, uint8_t version, qr_ecc_t ecc)
+{
+    if (version)
+        qrcode.version = version;
 
-std::vector<uint8_t> QRManager::encode(const void* src, size_t len, size_t version, size_t ecc, size_t *out_len) {
-    // If version is not specified, choose the smallest version that can hold the data
-    if (version < 1) 
-        version = qrcode_minVersion(ecc, (const char*)src);
+    if (ecc)
+        qrcode.ecc = ecc;
 
-    qrManager.version = version;
-    qrManager.ecc_mode = ecc;
+    int8_t err = 0;
+    if (length)
+    {
+        data = std::string((char*)input, length);
 
-    *out_len = 0;
-    qrManager.out_buf.clear();
-    qrManager.out_buf.shrink_to_fit();
+        //printf("bytes[%d]\n", length);
+        err = qrcode_initBytes(&qrcode, (uint8_t*)data.c_str(), length);
+    }
+    else
+    {
+        if (strlen((char*)input))
+            data = std::string((char*)input);
 
-    //if (version < 1 || version > 40 || ecc < 0 || ecc > 3) {
-    //if (version < 1 || version > 40 || ecc > 3) {
-    if (version > 40 || ecc > 3) {
-        return qrManager.out_buf; // error
+        //printf("text[%s]\n", (char*)data);
+        err = qrcode_initText(&qrcode, (char*)data.c_str());
+    }
+    if (err != 0) {
+        // Error!
+        //printf("error[%d]\n", err);
+        return std::vector<uint8_t>();
     }
 
-    QRCode qr_code;
-    uint8_t qr_bytes[qrcode_getBufferSize(version)];
+    // auto encoded = to_ansi();
+    // printf("%s\n", encoded.data());
 
-    uint8_t err = qrcode_initText(&qr_code, qr_bytes, version, ecc, (const char*)src);
-
-    qrManager.out_buf.push_back(qrManager.size());
-
-    if (err == 0) {
-        size_t size = qr_code.size;
-        *out_len = size*size;
-
-        for (uint8_t x = 0; x < size; x++) {
-            for (uint8_t y = 0; y < size; y++) {
-                uint8_t on = qrcode_getModule(&qr_code, x, y);
-                qrManager.out_buf.push_back(on);
-            }
-        }
+    //printf("version[%d] ecc[%d] mode[%d] output_mode[%d]\n", qrcode.version, qrcode.ecc, qrcode.mode, output_mode);
+    switch (output_mode) {
+        case QR_OUTPUT_MODE_ANSI:
+            //printf("ansi\n");
+            code = to_ansi();
+            break;
+        case QR_OUTPUT_MODE_BITMAP:
+            //printf("bitmap\n");
+            code =  to_bitmap();
+            break;
+        case QR_OUTPUT_MODE_SVG:
+            //printf("svg\n");
+            code =  to_svg();
+            break;
+        case QR_OUTPUT_MODE_ATASCII:
+            //printf("atascii\n");
+            code =  to_atascii();
+            break;
+        case QR_OUTPUT_MODE_PETSCII:
+            //printf("petscii\n");
+            code =  to_petscii();
+            break;
+        case QR_OUTPUT_MODE_BINARY:
+        default:
+            //printf("binary\n");
+            code =  to_binary();
     }
 
-    return qrManager.out_buf;
+    return code;
 }
 
-void QRManager::to_binary(void) {
-    auto bytes = qrManager.out_buf;
-    size_t len = bytes.size();
+std::vector<uint8_t> QRManager::to_ansi() {
+    std::vector<uint8_t> out;
+    std::stringstream out_str;
+
+    size_t size = qrcode.size;
+    for (uint8_t y = 0; y < size; y++) {
+        for (uint8_t x = 0; x < size; x++) {
+            uint8_t on = qrcode_getModule(&qrcode, x, y);
+            if (on == 1)
+                out_str << ANSI_WHITE_BACKGROUND;
+            else
+                out_str << ANSI_RESET;
+
+            out_str << "  ";
+        }
+        out_str << ANSI_RESET "\n";
+    }
+
+    out = std::vector<uint8_t>(out_str.str().begin(), out_str.str().end());
+    return out;
+}
+
+
+std::vector<uint8_t> QRManager::to_binary(void)
+{
     std::vector<uint8_t> out;
 
-    out.push_back(qrManager.size());
+    out.push_back(qrcode.size);
 
     uint8_t val = 0;
-    for (auto i = 0; i < len; i++) {
+    for (auto i = 0; i < qrcode.size; i++) {
         auto bit = i % 8;
         if (bit == 0 && i > 0) {
             out.push_back(val);
             val = 0;
         }
-        val |= bytes[1+i+bit] << bit;
+        val |= qrcode_getModule(&qrcode, i, 0) << bit;
     }
     out.push_back(val);
 
-    qrManager.out_buf = out;
+    return out;
 }
 
-void QRManager::to_bitmap(void) {
-    auto bytes = qrManager.out_buf;
-    size_t size = qrManager.size();
-    size_t len = bytes.size();
-    size_t bytes_per_row = ceil(size / 8.0);
+
+std::vector<uint8_t> QRManager::to_bitmap(void) {
     std::vector<uint8_t> out;
 
-    out.push_back(size);
+    out.push_back(qrcode.size);
 
     uint8_t val = 0;
     uint8_t x = 0;
     uint8_t y = 0;
-    for (auto i = 0; i < len; i++) {
-        val |= bytes[1+i];
+    for (auto i = 0; i < qrcode.size; i++) {
+        val |= qrcode_getModule(&qrcode, x, y);
         x++;
-        if (x == size) {
-            val = val << (bytes_per_row * 8 - x);
+        if (x == qrcode.size) {
+            val = val << (qrcode.size - x);
             out.push_back(val);
             val = 0;
             x = 0;
@@ -100,13 +145,52 @@ void QRManager::to_bitmap(void) {
         else {
             val = val << 1;
         }
-        if (y == size) {
+        if (y == qrcode.size) {
             break;
         }
     }
 
-    qrManager.out_buf = out;
+    return out;
 }
+
+
+std::vector<uint8_t> QRManager::to_svg(uint8_t scale, uint8_t padding) {
+    std::vector<uint8_t> out;
+    std::stringstream out_str;
+
+    // Write SVG to stdout...
+    //printf("<svg width=\"%d\" height=\"%d\" xmlns=\"http://www.w3.org/2000/svg\">\n", (qrcode.size + 2 * padding) * scale, (qrcode.size + 2 * padding) * scale);
+    out_str << "<svg width=\"" << (qrcode.size + 2 * padding) * scale << "\" height=\"" << (qrcode.size + 2 * padding) * scale << "\" xmlns=\"http://www.w3.org/2000/svg\">\n";
+    //printf("  <rect x=\"0\" y=\"0\" width=\"%d\" height=\"%d\" fill=\"white\" />\n", (qrcode.size + 2 * padding) * scale, (qrcode.size + 2 * padding) * scale);
+    out_str << "  <rect x=\"0\" y=\"0\" width=\"" << (qrcode.size + 2 * padding) * scale << "\" height=\"" << (qrcode.size + 2 * padding) * scale << "\" fill=\"white\" />\n";
+
+    for (uint8_t y = 0; y < qrcode.size; y++) {
+        uint8_t xstart = 0, xcount = 0;
+
+        for (uint8_t x = 0; x < qrcode.size; x++) {
+            if (qrcode_getModule(&qrcode, x, y)) {
+                if (xcount == 0) { xstart = x; }
+                xcount ++;
+            } else if (xcount > 0) {
+                //printf("  <rect x=\"%d\" y=\"%d\" width=\"%d\" height=\"%d\" fill=\"black\" />\n", (xstart + padding) * scale, (y + padding) * scale, xcount * scale, scale);
+                out_str << "  <rect x=\"" << (xstart + padding) * scale << "\" y=\"" << (y + padding) * scale << "\" width=\"" << xcount * scale << "\" height=\"" << scale << "\" fill=\"black\" />\n";
+                xcount = 0;
+            }
+        }
+
+        if (xcount > 0) {
+            //printf("  <rect x=\"%d\" y=\"%d\" width=\"%d\" height=\"%d\" fill=\"black\" />\n", (xstart + padding) * scale, (y + padding) * scale, xcount * scale, scale);
+            out_str << "  <rect x=\"" << (xstart + padding) * scale << "\" y=\"" << (y + padding) * scale << "\" width=\"" << xcount * scale << "\" height=\"" << scale << "\" fill=\"black\" />\n";
+        }
+    }
+
+    //puts("</svg>");
+    out_str << "</svg>";
+
+    out = std::vector<uint8_t>(out_str.str().begin(), out_str.str().end());
+    return out;
+}
+
 
 /*
 This collapses each 2x2 groups of modules (pixels) into a single ATASCII character.
@@ -123,26 +207,26 @@ in most cases, but for best results you may want to use custom characters for th
 //                     0    1    2    3    4    5    6    7    8    9    10   11   12   13   14   15
 uint8_t atascii[16] = {32,  12,  11,  149, 15,  25,  6,   137, 9,   7,   153, 143, 21,  139, 140, 160};
 
-void QRManager::to_atascii(void) {
-    auto bytes = qrManager.out_buf;
-    size_t size = qrManager.size();
+std::vector<uint8_t> QRManager::to_atascii(void)
+{
+    uint8_t size = qrcode.size;
     std::vector<uint8_t> out;
 
     out.push_back(size);
 
     for (auto y = 0; y < size; y += 2) {
         for (auto x = 0; x < size; x += 2) {
-            uint8_t val = bytes[1+y*size+x];
+            uint8_t val = qrcode_getModule(&qrcode, x, y);
             // QR Codes have odd number of rows/columns, so last ATASCII char is only half full
-            if (x+1 < size) val |= bytes[1+y*size+x+1] << 1;
-            if (y+1 < size) val |= bytes[1+(y+1)*size+x] << 2;
-            if (y+1 < size && x+1 < size) val |= bytes[1+(y+1)*size+x+1] << 3;
+            if (x+1 < size) val |= qrcode_getModule(&qrcode, x+1, y) << 1;
+            if (y+1 < size) val |= qrcode_getModule(&qrcode, x, y+1) << 2;
+            if (y+1 < size && x+1 < size) val |= qrcode_getModule(&qrcode, x+1, y+1) << 3;
             out.push_back(atascii[val]);
         }
         out.push_back(155); // Atari newline
     }
 
-    qrManager.out_buf = out;
+    return out;
 }
 
 /*
@@ -150,7 +234,7 @@ This collapses each 2x2 groups of modules (pixels) into a single PETSCII charact
 Values for PETSCII look up are as calculated as follows. Some characters need to be
 reversed to get the correct glyph.
 
-0    1    2    3    4    5    6*   7    8    9*   10   11   12   13   14   15
+0    1    2    3    4    5    6    7    8    9    10   11   12   13   14   15
 - -  x -  - x  x x  - -  x -  - x  x x  - -  x -  - x  x x  - -  x -  - x  x x
 - -  - -  - -  - -  x -  x -  x -  x -  - x  - x  - x  - x  x x  x x  x x  x x
 32   190  188  18   187  161  18   18   172  191  18   18   162  18   18   18
@@ -164,26 +248,22 @@ uint8_t petscii[2][16] = {
     {0,   0,   0,   1,   0,   0,   1,   1,   0,   0,   1,   1,   0,   1,   1,   1}   // reverse on?
 };
 
-void QRManager::to_petscii(void) {
-    auto bytes = qrManager.out_buf;
-    size_t size = qrManager.size();
+std::vector<uint8_t> QRManager::to_petscii(void) 
+{
+    uint8_t size = qrcode.size;
     std::vector<uint8_t> out;
     bool reverse = false;
 
-//    out.push_back(0x00); // Load Address
-//    out.push_back(0x04); // Screen RAM 0x0400
-
-//    out.push_back(size);
     out.push_back(13); // Carriage return
 
     for (auto y = 0; y < size; y += 2) {
         out.push_back(32); // Space
         for (auto x = 0; x < size; x += 2) {
-            uint8_t val = bytes[1+y*size+x];
+            uint8_t val = qrcode_getModule(&qrcode, x, y);
             // QR Codes have odd number of rows/columns, so last PETSCII char is only half full
-            if (x+1 < size) val |= bytes[1+y*size+x+1] << 1;
-            if (y+1 < size) val |= bytes[1+(y+1)*size+x] << 2;
-            if (y+1 < size && x+1 < size) val |= bytes[1+(y+1)*size+x+1] << 3;
+            if (x+1 < size) val |= qrcode_getModule(&qrcode, x+1, y) << 1;
+            if (y+1 < size) val |= qrcode_getModule(&qrcode, x, y+1) << 2;
+            if (y+1 < size && x+1 < size) val |= qrcode_getModule(&qrcode, x+1, y+1) << 3;
             if (reverse != petscii[1][val]) {
                 reverse = !reverse;
                 out.push_back(((reverse) ? 18 : 146)); // 18 Reverse On / 146 Reverse Off
@@ -192,8 +272,7 @@ void QRManager::to_petscii(void) {
         }
         out.push_back(13); // Carriage return
     }
-//    out.push_back(00);
-//    out.push_back(00);
 
-    qrManager.out_buf = out;
+    return out;
 }
+

--- a/lib/qrcode/qrmanager.h
+++ b/lib/qrcode/qrmanager.h
@@ -15,27 +15,65 @@
 
 #include "qrcode.h"
 
-#define QR_OUTPUT_MODE_BYTES   0
-#define QR_OUTPUT_MODE_BINARY  1
-#define QR_OUTPUT_MODE_ATASCII 2
-#define QR_OUTPUT_MODE_BITMAP  3
+typedef enum {
+    QR_ECC_LOW,
+    QR_ECC_MEDIUM,
+    QR_ECC_QUARTILE,
+    QR_ECC_HIGH
+} qr_ecc_t;
+
+typedef enum {
+    QR_OUTPUT_MODE_ANSI,
+    QR_OUTPUT_MODE_BINARY,
+    QR_OUTPUT_MODE_BITMAP,
+    QR_OUTPUT_MODE_SVG,
+    QR_OUTPUT_MODE_ATASCII,
+    QR_OUTPUT_MODE_PETSCII
+} ouput_mode_t;
+
+
+#define ANSI_WHITE_BACKGROUND "\e[47m"
+#define ANSI_RESET "\e[0m"
+
+// SVG constants...
+#define SVG_SCALE    5                  // Nominal size of modules
+#define SVG_PADDING  4                  // White padding around QR code
 
 class QRManager {
+    QRCode qrcode{};
+
 public:
+
+    QRManager(uint8_t version = 0, qr_ecc_t ecc = QR_ECC_LOW, ouput_mode_t mode = QR_OUTPUT_MODE_BINARY) {
+        qrcode.version = version;
+        qrcode.ecc = ecc;
+
+        output_mode = mode;
+    };
+    ~QRManager() {
+        free(qrcode.modules);
+    }
+
     /**
     * encode - generate QR code as bytes
     * @src: Data to be encoded
     * @len: Length of the data to be encoded
     * @version: 1-40 (Size=17+4*Version)
     * @ecc: Error correction level (0=Low, 1=Medium, 2=Quartile, 3=High)
-    * @out_len: Pointer to output length variable, or %NULL if not used
     * Returns: Allocated buffer of out_len bytes of encoded data,
     * or nullptr on failure
     *
     * Returned buffer consists of a 1 or 0 for each QR module, indicating
     * whether it is on (black) or off (white).
     */
-    static std::vector<uint8_t> encode(const void* src, size_t len, size_t version, size_t ecc, size_t* out_len);
+    std::vector<uint8_t> encode(const void* input = nullptr, uint16_t length = 0, uint8_t version = 0, qr_ecc_t ecc = QR_ECC_LOW);;
+
+    /**
+    * to_ansi - Convert QR code in out_buf to ATASCII
+    *
+    * Replaces data in out_buf, with ATASCII code for drawing the QR code.
+    */
+    std::vector<uint8_t> to_ansi(void);
 
     /**
     * to_binary - Convert QR code in out_buf to compact binary format
@@ -44,7 +82,7 @@ public:
     * compact data where each bit represents a single QR module (pixel).
     * So a 21x21 QR code will be 56 bytes (21*21/8). Data is returned LSB->MSB.
     */
-    void to_binary(void);
+    std::vector<uint8_t> to_binary(void);
 
     /**
     * to_bitmap - Convert QR code in out_buf to compact binary format
@@ -55,7 +93,14 @@ public:
     * of each row are returned as 0s. A 21x21 QR code will be 63 bytes (3 bytes
     * per row of 21 bits (= 24 bits with 3 unused) * 21 rows).
     */
-    void to_bitmap(void);
+    std::vector<uint8_t> to_bitmap(void);
+
+    /**
+    * to_svg - Convert QR code in out_buf to SVG
+    *
+    * Replaces data in out_buf, with svg code for drawing the QR code.
+    */
+    std::vector<uint8_t> to_svg(uint8_t scale = SVG_SCALE, uint8_t padding = SVG_PADDING);
 
     /**
     * to_atascii - Convert QR code in out_buf to ATASCII
@@ -64,7 +109,7 @@ public:
     * ATASCII character can represent 4 bits. Atari newlines (0x9B) are
     * added at the end of each row to facilitate printing direct to screen.
     */
-    void to_atascii(void);
+    std::vector<uint8_t> to_atascii(void);
 
     /**
     * to_petscii - Convert QR code in out_buf to PETSCII
@@ -73,21 +118,17 @@ public:
     * PETSCII character can represent 4 bits. Carriage returns (0x0D) are
     * added at the end of each row to facilitate printing direct to screen.
     */
-    void to_petscii(void);
+    std::vector<uint8_t> to_petscii(void);
 
-    size_t size() { return version * 4 + 17; }
-    void set_buffer(const std::string& buffer) { in_buf = buffer; }
-    void clear_buffer() { in_buf.clear(); }
-    void add_buffer(const std::string& extra) { in_buf += extra; }
+    uint8_t version() { return qrcode.version; }
+    void version(uint8_t v) { qrcode.version = v; }
+    qr_ecc_t ecc() { return (qr_ecc_t)qrcode.ecc; }
+    void ecc(qr_ecc_t e) { qrcode.ecc = e; }
+    uint8_t size() { return qrcode.size; }
+    ouput_mode_t output_mode = QR_OUTPUT_MODE_BINARY;
 
-    std::string in_buf;
-    std::vector<uint8_t> out_buf;
-
-    uint8_t version = 1;
-    uint8_t ecc_mode = ECC_LOW;
-    uint8_t output_mode = QR_OUTPUT_MODE_BYTES;
+    std::string data;
+    std::vector<uint8_t> code;
 };
-
-extern QRManager qrManager;
 
 #endif /* QRCODE_MANAGER_H */


### PR DESCRIPTION
- If "version" is set to 0 it will automatically select the minimum version to fit the data.
- If encoding mode is not specified it will automatically select the best mode for the provided data.
- Added functions for generating QR Codes in ANSI and SVG formats for use in the serial console or web config.
- Fixed an issue that would not let you generate code versions 6 to 40.
- Eliminated a huge lookup table and replaced with a few calculations.
- Reduced memory usage overall.
- Modified the class interface to make it easier to use.

Minimal usage example
```c++
QRManager qrManager = QRManager(0, ECC_LOW, QR_OUTPUT_MODE_ANSI);
auto qrcode = qrManager.encode("This is some cool text for a QR Code!");
printf("%s\n", qrcode.data());
```