### PR TITLE
Rename fnTcpServer::available() to fnTcpServer::client()

### DIFF
--- a/lib/device/adamnet/keyboard.cpp
+++ b/lib/device/adamnet/keyboard.cpp
@@ -35,7 +35,7 @@ void adamKeyboard::adamnet_control_receive()
     {
         AdamNet.wait_for_idle();
         adamnet_send(0xC1); // NAK
-        client = server->available();
+        client = server->client();
     }
     else if (!client.connected())
     {

--- a/lib/device/adamnet/modem.cpp
+++ b/lib/device/adamnet/modem.cpp
@@ -481,7 +481,7 @@ void adamModem::at_handle_answer()
     Debug_printf("HANDLE ANSWER !!!\n");
     if (tcpServer.hasClient())
     {
-        tcpClient = tcpServer.available();
+        tcpClient = tcpServer.client();
         tcpClient.setNoDelay(true); // try to disable naggle
                                     //        tcpServer.stop();
         answerTimer = fnSystem.millis();

--- a/lib/device/comlynx/keyboard.cpp
+++ b/lib/device/comlynx/keyboard.cpp
@@ -35,7 +35,7 @@ void lynxKeyboard::comlynx_control_receive()
     {
         ComLynx.wait_for_idle();
         comlynx_send(0xC1); // NAK
-        client = server->available();
+        client = server->client();
     }
     else if (!client.connected())
     {

--- a/lib/device/comlynx/modem.cpp
+++ b/lib/device/comlynx/modem.cpp
@@ -481,7 +481,7 @@ void lynxModem::at_handle_answer()
     Debug_printf("HANDLE ANSWER !!!\n");
     if (tcpServer.hasClient())
     {
-        tcpClient = tcpServer.available();
+        tcpClient = tcpServer.client();
         tcpClient.setNoDelay(true); // try to disable naggle
                                     //        tcpServer.stop();
         answerTimer = fnSystem.millis();

--- a/lib/device/drivewire/modem.cpp
+++ b/lib/device/drivewire/modem.cpp
@@ -459,7 +459,7 @@ void drivewireModem::at_handle_answer()
     Debug_printf("HANDLE ANSWER !!!\n");
     if (tcpServer.hasClient())
     {
-        tcpClient = tcpServer.available();
+        tcpClient = tcpServer.client();
         tcpClient.setNoDelay(true); // try to disable naggle
                                     //        tcpServer.stop();
         answerTimer = fnSystem.millis();

--- a/lib/device/h89/modem.cpp
+++ b/lib/device/h89/modem.cpp
@@ -455,7 +455,7 @@ void H89Modem::at_handle_answer()
     Debug_printf("HANDLE ANSWER !!!\n");
     if (tcpServer.hasClient())
     {
-        tcpClient = tcpServer.available();
+        tcpClient = tcpServer.client();
         tcpClient.setNoDelay(true); // try to disable naggle
                                     //        tcpServer.stop();
         answerTimer = fnSystem.millis();

--- a/lib/device/iwm/modem.cpp
+++ b/lib/device/iwm/modem.cpp
@@ -565,7 +565,7 @@ void iwmModem::at_handle_answer()
     Debug_printf("HANDLE ANSWER !!!\n");
     if (tcpServer.hasClient())
     {
-        tcpClient = tcpServer.available();
+        tcpClient = tcpServer.client();
         tcpClient.setNoDelay(true); // try to disable naggle
                                     //        tcpServer.stop();
         answerTimer = fnSystem.millis();

--- a/lib/device/mac/modem.cpp
+++ b/lib/device/mac/modem.cpp
@@ -596,7 +596,7 @@ void iwmModem::at_handle_answer()
     Debug_printf("HANDLE ANSWER !!!\n");
     if (tcpServer.hasClient())
     {
-        tcpClient = tcpServer.available();
+        tcpClient = tcpServer.client();
         tcpClient.setNoDelay(true); // try to disable naggle
                                     //        tcpServer.stop();
         answerTimer = fnSystem.millis();

--- a/lib/device/new/keyboard.cpp
+++ b/lib/device/new/keyboard.cpp
@@ -35,7 +35,7 @@ void adamKeyboard::adamnet_control_receive()
     {
         AdamNet.wait_for_idle();
         adamnet_send(0xC1); // NAK
-        client = server->available();
+        client = server->client();
     }
     else if (!client.connected())
     {

--- a/lib/device/new/modem.cpp
+++ b/lib/device/new/modem.cpp
@@ -481,7 +481,7 @@ void adamModem::at_handle_answer()
     Debug_printf("HANDLE ANSWER !!!\n");
     if (tcpServer.hasClient())
     {
-        tcpClient = tcpServer.available();
+        tcpClient = tcpServer.client();
         tcpClient.setNoDelay(true); // try to disable naggle
                                     //        tcpServer.stop();
         answerTimer = fnSystem.millis();

--- a/lib/device/new/serial.cpp
+++ b/lib/device/new/serial.cpp
@@ -65,7 +65,7 @@ void adamSerial::adamnet_response_status()
     if (!client.connected() && server->hasClient())
     {
         // Accept waiting connection
-        client = server->available();
+        client = server->client();
     }
 
     if (client.available())

--- a/lib/device/rc2014/modem.cpp
+++ b/lib/device/rc2014/modem.cpp
@@ -524,7 +524,7 @@ void rc2014Modem::at_handle_answer()
     Debug_printf("HANDLE ANSWER !!!\n");
     if (tcpServer.hasClient())
     {
-        tcpClient = tcpServer.available();
+        tcpClient = tcpServer.client();
         tcpClient.setNoDelay(true); // try to disable naggle
                                     //        tcpServer.stop();
         answerTimer = fnSystem.millis();

--- a/lib/device/rs232/modem.cpp
+++ b/lib/device/rs232/modem.cpp
@@ -1017,7 +1017,7 @@ void rs232Modem::at_handle_answer()
     Debug_printf("HANDLE ANSWER !!!\n");
     if (tcpServer.hasClient())
     {
-        tcpClient = tcpServer.available();
+        tcpClient = tcpServer.client();
         tcpClient.setNoDelay(true); // try to disable naggle
                                     //        tcpServer.stop();
         answerTimer = fnSystem.millis();

--- a/lib/device/s100spi/modem.cpp
+++ b/lib/device/s100spi/modem.cpp
@@ -481,7 +481,7 @@ void s100spiModem::at_handle_answer()
     Debug_printf("HANDLE ANSWER !!!\n");
     if (tcpServer.hasClient())
     {
-        tcpClient = tcpServer.available();
+        tcpClient = tcpServer.client();
         tcpClient.setNoDelay(true); // try to disable naggle
                                     //        tcpServer.stop();
         answerTimer = fnSystem.millis();

--- a/lib/device/sio/modem.cpp
+++ b/lib/device/sio/modem.cpp
@@ -1058,7 +1058,7 @@ void modem::at_handle_answer()
     Debug_printf("HANDLE ANSWER !!!\n");
     if (tcpServer.hasClient())
     {
-        tcpClient = tcpServer.available();
+        tcpClient = tcpServer.client();
         tcpClient.setNoDelay(true); // try to disable naggle
                                     //        tcpServer.stop();
         answerTimer = fnSystem.millis();

--- a/lib/network-protocol/TCP.cpp
+++ b/lib/network-protocol/TCP.cpp
@@ -362,7 +362,7 @@ bool NetworkProtocolTCP::special_accept_connection()
         unsigned char remotePort;
         char *remoteIPString;
 
-        client = server->available();
+        client = server->client();
 
         if (client.connected())
         {

--- a/lib/tcpip/fnTcpServer.cpp
+++ b/lib/tcpip/fnTcpServer.cpp
@@ -31,17 +31,6 @@ int fnTcpServer::begin(uint16_t port)
         return 0;
     }
 
-    // Bind socket to our interface
-    struct sockaddr_in server;
-    server.sin_family = AF_INET;
-    server.sin_addr.s_addr = INADDR_ANY;
-    server.sin_port = htons(_port);
-    if (bind(_sockfd, (struct sockaddr *)&server, sizeof(server)) < 0)
-    {
-        Debug_printf("fnTcpServer::begin failed to bind socket, err %d\r\n", compat_getsockerr());
-        return 0;
-    }
-
     int enable = 1;
 #if defined(_WIN32)
     if (setsockopt(_sockfd, SOL_SOCKET, SO_EXCLUSIVEADDRUSE, (char *) &enable, sizeof(enable)) != 0)
@@ -58,6 +47,17 @@ int fnTcpServer::begin(uint16_t port)
 #endif
 
     Debug_printf("Max clients is currently %u\r\n",_max_clients);
+
+    // Bind socket to our interface
+    struct sockaddr_in server;
+    server.sin_family = AF_INET;
+    server.sin_addr.s_addr = INADDR_ANY;
+    server.sin_port = htons(_port);
+    if (bind(_sockfd, (struct sockaddr *)&server, sizeof(server)) < 0)
+    {
+        Debug_printf("fnTcpServer::begin failed to bind socket, err %d\r\n", compat_getsockerr());
+        return 0;
+    }
 
     // Now listen in on this socket
     if (listen(_sockfd, _max_clients) < 0)
@@ -107,7 +107,7 @@ bool fnTcpServer::hasClient()
 
 // Returns a new fnTcpClient initialized with the client currently connected to the socket
 // or disconnected (uninitialized) fnTcpClient
-fnTcpClient fnTcpServer::available()
+fnTcpClient fnTcpServer::client()
 {
     // Return initialized fnTcpClient if we're not in listening mode
     if (!_listening)

--- a/lib/tcpip/fnTcpServer.h
+++ b/lib/tcpip/fnTcpServer.h
@@ -23,14 +23,14 @@ class fnTcpServer
 
     int begin(uint16_t port=0);
 
-    fnTcpClient accept(){ return available(); }
+    fnTcpClient accept(){ return client(); }
     void setNoDelay(bool nodelay) { _noDelay = nodelay; };
     bool getNoDelay() {return _noDelay; };
     int setTimeout(uint32_t seconds);
     void setMaxClients(int maxClients) { _max_clients = maxClients; }
 
     bool hasClient();
-    fnTcpClient available();
+    fnTcpClient client();
 
     void stop();
 


### PR DESCRIPTION
The available() method should return the number of bytes available to be read to be consistent with the rest of FujiNet. It returns fnTcpClient so it makes more sense to call it client().