### PR TITLE
[apple2] connect up webui config options

### DIFF
--- a/lib/device/fujiDevice.cpp
+++ b/lib/device/fujiDevice.cpp
@@ -530,7 +530,7 @@ void fujiDevice::insert_boot_device(uint8_t image_id, mediatype_t disk_type,
                 fBoot = fnTNFS.fnfile_open(boot_img.c_str());
             }
         }
-        break;
+        break;     
     default:
         Debug_printf("Invalid boot mode: %d\n", image_id);
         return;
@@ -539,6 +539,26 @@ void fujiDevice::insert_boot_device(uint8_t image_id, mediatype_t disk_type,
     if (fBoot == nullptr)
     {
         Debug_printf("Failed to open boot disk image: %s\n", boot_img.c_str());
+        return;
+    }
+
+    image_size = fsFlash.filesize(fBoot);
+    disk_dev->mount(fBoot, boot_img.c_str(), image_size, DISK_ACCESS_MODE_READ, disk_type);
+    disk_dev->is_config_device = true;
+}
+
+// Mounts the alternate config disk in desired boot disk number
+void fujiDevice::insert_boot_device(std::string boot_img, mediatype_t disk_type,
+                                    DISK_DEVICE *disk_dev)
+{
+    fnFile *fBoot = nullptr;
+    size_t image_size;
+
+    fBoot = fnSDFAT.fnfile_open(boot_img.c_str());
+
+    if (fBoot == nullptr)
+    {
+        Debug_printf("Failed to open alternate config boot disk image: %s\n", boot_img.c_str());
         return;
     }
 

--- a/lib/device/fujiDevice.h
+++ b/lib/device/fujiDevice.h
@@ -260,6 +260,7 @@ public:
 
     // Should be protected but being called by drivewire.cpp
     void insert_boot_device(uint8_t image_id, mediatype_t disk_type, DISK_DEVICE *disk_dev);
+    void insert_boot_device(std::string boot_img, mediatype_t disk_type, DISK_DEVICE *disk_dev);
 };
 
 extern fujiDevice *theFuji;

--- a/lib/device/iwm/iwmFuji.cpp
+++ b/lib/device/iwm/iwmFuji.cpp
@@ -299,7 +299,7 @@ void iwmFuji::setup()
         populate_slots_from_config();
 
         // Disable booting from CONFIG if our settings say to turn it off
-        boot_config = false; // to do - understand?
+        boot_config = Config.get_general_config_enabled();
 
         // add ourselves as a device
         SYSTEM_BUS.addDevice(this, iwm_fujinet_type_t::FujiNet);
@@ -320,8 +320,16 @@ void iwmFuji::setup()
                 SYSTEM_BUS.addDevice(disk_dev, iwm_fujinet_type_t::BlockDisk);
         }
 
-        Debug_printf("\nConfig General Boot Mode: %u\n", Config.get_general_boot_mode());
-        insert_boot_device(Config.get_general_boot_mode(), MEDIATYPE_PO, get_disk_dev(0));
+        if (boot_config)
+        {
+            Debug_printf("\nConfig General Boot Mode: %u\n", Config.get_general_boot_mode());
+            insert_boot_device(Config.get_general_boot_mode(), MEDIATYPE_PO, get_disk_dev(0));
+        }
+        else if (!Config.get_config_filename().empty())
+        {
+            Debug_printf("\nInsert Alternate Config Disk: %s\n", Config.get_config_filename().c_str());
+            insert_boot_device(Config.get_config_filename(), MEDIATYPE_PO, get_disk_dev(0));
+        }
 }
 
 void iwmFuji::send_status_reply_packet()

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -531,6 +531,11 @@ void fn_service_loop(void *param)
         fnWiFi.connect();
     }
 
+    // if we dont have config enabled, and no alternate config disk selected, then just mount what we have
+    // in here so we are after all of the setup and wifi has been started
+    if (!theFuji->boot_config && Config.get_config_filename().empty())
+        theFuji->fujicmd_mount_all_success();
+
     // Main service loop
 #ifdef ESP_PLATFORM
     // We don't have any delays in this loop, so IDLE threads will be starved

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -533,7 +533,7 @@ void fn_service_loop(void *param)
 
     // if we dont have config enabled, and no alternate config disk selected, then just mount what we have
     // in here so we are after all of the setup and wifi has been started
-    if (!theFuji->boot_config && Config.get_config_filename().empty())
+    if (!Config.get_general_config_enabled() && Config.get_config_filename().empty())
         theFuji->fujicmd_mount_all_success();
 
     // Main service loop


### PR DESCRIPTION
Hooked up for the Apple2
- config enable/disable button
- alternate config path to mount from SD card (as per webui help comment)

Added if config is disabled, and no alternate config path is set, then default to mount all. Not sure for this, have a look and see what you think. Needs to be later in the setup as its trying most likely to be mounting off tnfs server, so needs the wifi running.