### PR TITLE
[fnc] fix RS232 baud rate

### DIFF
--- a/lib/config/fnc_save.cpp
+++ b/lib/config/fnc_save.cpp
@@ -203,6 +203,12 @@ void fnConfig::save()
 #endif
 #endif
 
+#ifdef BUILD_RS232
+    // SERIAL
+    ss << LINETERM << "[Serial]" << LINETERM;
+    ss << "baud=" << _serial.baud << LINETERM;
+#endif
+
 #ifdef ESP_PLATFORM
     // Write the results out
     FILE *fout = NULL;

--- a/lib/config/fnc_util.cpp
+++ b/lib/config/fnc_util.cpp
@@ -125,11 +125,11 @@ fnConfig::section_match fnConfig::_find_section_in_line(std::string &line, int &
             {
                 return SECTION_BOIP;
             }
-#ifndef ESP_PLATFORM
             else if (strncasecmp("Serial", s1.c_str(), 6) == 0)
             {
                 return SECTION_SERIAL;
             }
+#ifndef ESP_PLATFORM
             else if (strncasecmp("BOS", s1.c_str(), 3) == 0)
             {
                 return SECTION_BOS;

--- a/lib/config/fnc_util.cpp
+++ b/lib/config/fnc_util.cpp
@@ -125,16 +125,22 @@ fnConfig::section_match fnConfig::_find_section_in_line(std::string &line, int &
             {
                 return SECTION_BOIP;
             }
+#ifndef ESP_PLATFORM
             else if (strncasecmp("Serial", s1.c_str(), 6) == 0)
             {
                 return SECTION_SERIAL;
             }
-#ifndef ESP_PLATFORM
             else if (strncasecmp("BOS", s1.c_str(), 3) == 0)
             {
                 return SECTION_BOS;
             }
 #endif
+#ifdef BUILD_RS232
+            else if (strncasecmp("Serial", s1.c_str(), 6) == 0)
+            {
+                return SECTION_SERIAL;
+            }
+#endif /* BUILD_RS232 */
         }
     }
     return SECTION_UNKNOWN;


### PR DESCRIPTION
Fix so that config file properly persists baud rate in [Serial] for RS232 devices.