### PR TITLE
Lynx firmware cleanup and regresssion fix

### DIFF
--- a/build-platforms/platformio-fujinet-lynx-devkitc.ini
+++ b/build-platforms/platformio-fujinet-lynx-devkitc.ini
@@ -1,0 +1,13 @@
+[fujinet]
+build_platform = BUILD_LYNX
+build_bus      = comlynx
+build_board    = fujinet-lynx-devkitc
+
+[env:fujinet-lynx-devkitc]
+platform = espressif32@${fujinet.esp32_platform_version}
+platform_packages = ${fujinet.esp32_platform_packages}
+board = fujinet-v1-8mb
+build_type = debug
+build_flags =
+    ${env.build_flags}
+    -D PINMAP_LYNX

--- a/lib/bus/comlynx/comlynx.cpp
+++ b/lib/bus/comlynx/comlynx.cpp
@@ -15,8 +15,6 @@
 
 #define IDLE_TIME 500 // Idle tolerance in microseconds (roughly three characters at 62500 baud)
 
-//systemBus SYSTEM_BUS.;
-
 static QueueHandle_t reset_evt_queue = NULL;
 
 static void IRAM_ATTR comlynx_reset_isr_handler(void *arg)
@@ -367,34 +365,8 @@ void systemBus::addDevice(virtualDevice *pDevice, fujiDeviceID_t device_id)
     }
 
     pDevice->_devnum = device_id;
-    //_daisyChain[device_id] = pDevice;
     _daisyChain.push_front(pDevice);
-
-    /*switch (device_id)
-    {
-    case FUJI_DEVICEID_PRINTER:
-        _printerDev = (lynxPrinter *)pDevice;
-        break;
-    case FUJI_DEVICEID_FUJINET:
-        _fujiDev = (lynxFuji *)pDevice;
-        break;
-    default:
-        break;
-    }*/
 }
-
-/*bool systemBus::deviceExists(fujiDeviceID_t device_id)
-{
-    return _daisyChain.find(device_id) != _daisyChain.end();
-}*/
-
-/*bool systemBus::deviceEnabled(fujiDeviceID_t device_id)
-{
-    if (deviceExists(device_id))
-        return _daisyChain[device_id]->device_active;
-    else
-        return false;
-}*/
 
 void systemBus::remDevice(virtualDevice *pDevice)
 {
@@ -403,10 +375,6 @@ void systemBus::remDevice(virtualDevice *pDevice)
 
 void systemBus::remDevice(fujiDeviceID_t device_id)
 {
-    /*if (deviceExists(device_id))
-    {
-        _daisyChain.erase(device_id);
-    }*/
 }
 
 int systemBus::numDevices()
@@ -446,18 +414,10 @@ void systemBus::reset()
 
 void systemBus::enableDevice(fujiDeviceID_t device_id)
 {
-    /*Debug_printf("Enabling Comlynx Device %d\n", device_id);
-
-    if (_daisyChain.find(device_id) != _daisyChain.end())
-        _daisyChain[device_id]->device_active = true;*/
 }
 
 void systemBus::disableDevice(fujiDeviceID_t device_id)
 {
-    /*Debug_printf("Disabling Comlynx Device %d\n", device_id);
-
-    if (_daisyChain.find(device_id) != _daisyChain.end())
-        _daisyChain[device_id]->device_active = false;*/
 }
 
 void systemBus::setUDPHost(const char *hostname, int port)
@@ -509,14 +469,12 @@ void systemBus::setUDPHost(const char *hostname, int port)
     }
 }
 
-
 void systemBus::setRedeyeMode(bool enable)
 {
     Debug_printf("setRedeyeMode, %d\n", enable);
     _udpDev->redeye_mode = enable;
     _udpDev->redeye_logon = true;
 }
-
 
 void systemBus::setRedeyeGameRemap(uint32_t remap)
 {

--- a/lib/bus/comlynx/comlynx.h
+++ b/lib/bus/comlynx/comlynx.h
@@ -18,23 +18,6 @@
 
 #define COMLYNX_BAUDRATE 62500
 
-#define MN_RESET 0x00   // command.control (reset)
-#define MN_STATUS 0x01  // command.control (status)
-#define MN_ACK 0x02     // command.control (ack)
-#define MN_CLR 0x03     // command.control (clr) (aka CTS)
-#define MN_RECEIVE 0x04 // command.control (receive)
-#define MN_CANCEL 0x05  // command.control (cancel)
-#define MN_SEND 0x06    // command.control (send)
-#define MN_NACK 0x07    // command.control (nack)
-#define MN_READY 0x0D   // command.control (ready)
-
-#define NM_STATUS 0x08 // response.control (status)
-#define NM_ACK 0x09    // response.control (ack)
-#define NM_CANCEL 0x0A // response.control (cancel)
-#define NM_SEND 0x0B   // response.data (send)
-#define NM_NACK 0x0C   // response.control (nack)
-
-
 #define COMLYNX_RESET_DEBOUNCE_PERIOD 100 // in ms
 
 class systemBus;
@@ -138,11 +121,6 @@ protected:
     virtual void comlynx_response_nack();
 
     /**
-     * @brief acknowledge if device is ready, but not if cmd took too long.
-     */
-    //virtual void comlynx_control_ready();
-
-    /**
      * @brief Device Number: 0-15
      */
     fujiDeviceID_t _devnum;
@@ -156,34 +134,9 @@ protected:
     virtual void comlynx_process();
 
     /**
-     * @brief Do any tasks that can only be done when the bus is quiet
-     */
-    //virtual void comlynx_idle();
-
-    /**
-     * @brief send current status of device
-     */
-    //virtual void comlynx_control_status();
-
-    /**
-     * @brief lynx says clear to send!
-     */
-    //virtual void comlynx_control_clr();
-
-    /**
-     * @brief send status response
-     */
-    //virtual void comlynx_response_status();
-
-    /**
      * @brief command frame, used by network protocol, ultimately
      */
     cmdFrame_t cmdFrame;
-
-    /**
-     * The response sent in comlynx_response_status()
-     */
-    //uint8_t status_response[6] = {0x80,0x00,0x00,0x01,0x00,0x00};
 
     /**
      * Response buffer and length
@@ -225,7 +178,6 @@ public:
 class systemBus
 {
 private:
-    //std::map<uint8_t, virtualDevice *> _daisyChain;
     std::forward_list<virtualDevice *> _daisyChain;
     virtualDevice *_activeDev = nullptr;
     lynxFuji *_fujiDev = nullptr;
@@ -253,7 +205,7 @@ public:
     /**
      * stopwatch
      */
-    int64_t start_time;
+    //int64_t start_time;
 
     int numDevices();
     void addDevice(virtualDevice *pDevice, fujiDeviceID_t device_id);

--- a/lib/device/comlynx/disk.cpp
+++ b/lib/device/comlynx/disk.cpp
@@ -55,7 +55,6 @@ success_is_true lynxDisk::transaction_get(void *data, size_t len)
     RETURN_SUCCESS_IF(len == to_copy);
 }
 
-
 void lynxDisk::transaction_put(const void *data, size_t len, bool err)
 {
     uint8_t b;

--- a/lib/device/comlynx/disk.h
+++ b/lib/device/comlynx/disk.h
@@ -5,20 +5,12 @@
 #include "bus.h"
 #include "media.h"
 
-/*
-#define STATUS_OK        0
-#define STATUS_BAD_BLOCK 1
-#define STATUS_NO_BLOCK  2
-#define STATUS_NO_MEDIA  3
-#define STATUS_NO_DRIVE  4
-*/
 
 class lynxDisk : public virtualDevice
 {
 private:
     MediaType *_media = nullptr;
-    TaskHandle_t diskTask;
-
+  
     unsigned long blockNum=INVALID_SECTOR_VALUE;
 
     //void transaction_continue(transState_t expectMoreData) override {};

--- a/lib/device/comlynx/lynxFuji.cpp
+++ b/lib/device/comlynx/lynxFuji.cpp
@@ -130,7 +130,8 @@ success_is_true lynxFuji::transaction_get(void *data, size_t len)
     memcpy(data, recvbuf_pos, to_copy);
     recvbuf_pos += to_copy;
 
-    RETURN_SUCCESS_IF(len == to_copy);
+    //RETURN_SUCCESS_IF(len == to_copy);
+    RETURN_SUCCESS_IF(len != 0);
 }
 
 

--- a/lib/device/comlynx/network.cpp
+++ b/lib/device/comlynx/network.cpp
@@ -769,9 +769,6 @@ void lynxNetwork::parse_and_instantiate_protocol(string d)
 {
 }*/
 
-/*void lynxNetwork::comlynx_set_timer_rate()
-{
-}*/
 
 void lynxNetwork::process_fs(fujiCommandID_t cmd, unsigned pkt_len)
 {

--- a/lib/device/comlynx/network.h
+++ b/lib/device/comlynx/network.h
@@ -1,18 +1,14 @@
 #ifndef NETWORK_H
 #define NETWORK_H
 
-#include <esp_timer.h>
+//#include <esp_timer.h>
 #include <memory>
 #include <string>
 
 #include "bus.h"
-
 #include "peoples_url_parser.h"
-
 #include "Protocol.h"
-
 #include "fnjson.h"
-
 #include "ProtocolParser.h"
 
 /**
@@ -49,13 +45,7 @@ public:
     /**
      * The spinlock for the ESP32 hardware timers. Used for interrupt rate limiting.
      */
-    portMUX_TYPE timerMux = portMUX_INITIALIZER_UNLOCKED;
-
-    /**
-     * Toggled by the rate limiting timer to indicate that the PROCEED interrupt should
-     * be pulsed.
-     */
-    bool interruptProceed = false;
+    //portMUX_TYPE timerMux = portMUX_INITIALIZER_UNLOCKED;
 
     /**
      * Called for LYNX Command 'O' to open a connection to a network protocol, allocate all buffers,
@@ -214,11 +204,6 @@ private:
     nDevStatus_t err = NDEV_STATUS::SUCCESS;
 
     /**
-     * ESP timer handle for the Interrupt rate limiting timer
-     */
-    esp_timer_handle_t rateTimerHandle = nullptr;
-
-    /**
      * Devicespec passed to us, e.g. N:HTTP://WWW.GOOGLE.COM:80/
      */
     std::string deviceSpec;
@@ -253,11 +238,6 @@ private:
      * The password to use for a protocol action
      */
     std::string password;
-
-    /**
-     * Timer Rate for interrupt timer
-     */
-    int timerRate = 100;
 
     /**
      * The channel mode for the currently open LYNX device. By default, it is PROTOCOL, which passes
@@ -305,16 +285,6 @@ private:
    void create_url_parser();
 
     /**
-     * Start the Interrupt rate limiting timer
-     */
-    void timer_start();
-
-    /**
-     * Stop the Interrupt rate limiting timer
-     */
-    void timer_stop();
-
-    /**
      * We were passed a COPY arg from DOS 2. This is complex, because we need to parse the comma,
      * and figure out one of three states:
      *
@@ -360,11 +330,6 @@ private:
      * @brief set translation specified by aux1 to aux2_translation mode.
      */
     void comlynx_set_translation();
-
-    /**
-     * @brief Set timer rate for PROCEED timer in ms
-     */
-    void comlynx_set_timer_rate();
 
     /**
      * @brief parse URL and instantiate protocol

--- a/lib/device/comlynx/printer.cpp
+++ b/lib/device/comlynx/printer.cpp
@@ -61,13 +61,13 @@ lynxPrinter::lynxPrinter(FileSystem *filesystem, printer_type print_type)
     getPrinterPtr()->setTranslate850(false);
     getPrinterPtr()->setEOL(0x0D);
 
-    xTaskCreate(printerTask, "ptsk", 4096, this, PRINTER_PRIORITY, &thPrinter);
+    //xTaskCreate(printerTask, "ptsk", 4096, this, PRINTER_PRIORITY, &thPrinter);
 }
 
 lynxPrinter::~lynxPrinter()
 {
-    if (thPrinter != nullptr)
-        vTaskDelete(thPrinter);
+    //if (thPrinter != nullptr)
+        //vTaskDelete(thPrinter);
 
     if (_pptr != nullptr)
     {
@@ -89,15 +89,6 @@ lynxPrinter::printer_type lynxPrinter::match_modelname(std::string model_name)
 
     return (printer_type)i;
 }
-
-/*
-void lynxPrinter::comlynx_control_status()
-{
-    uint8_t c[6] = {0x82, 0x10, 0x00, 0x00, 0x00, 0x10};
-
-    comlynx_send_buffer(c, sizeof(c));
-}
-*/
 
 void lynxPrinter::perform_print()
 {
@@ -136,20 +127,7 @@ void lynxPrinter::comlynx_control_ready()
 
 void lynxPrinter::comlynx_process()
 {
-    /*unsigned char c = b >> 4;
 
-    switch (c)
-    {
-    case MN_STATUS:
-        comlynx_control_status();
-        break;
-    case MN_SEND:
-        comlynx_control_send();
-        break;
-    case MN_READY:
-        comlynx_control_ready();
-        break;
-    }*/
 }
 
 void lynxPrinter::shutdown()

--- a/lib/device/comlynx/printer.h
+++ b/lib/device/comlynx/printer.h
@@ -1,8 +1,8 @@
 #ifndef LYNX_PRINTER_H
 #define LYNX_PRINTER_H
 
-#include <freertos/FreeRTOS.h>
-#include <freertos/task.h>
+//#include <freertos/FreeRTOS.h>
+//#include <freertos/task.h>
 
 #include <cstdint>
 #include <string>
@@ -20,7 +20,7 @@ class lynxPrinter : public virtualDevice
 {
 protected:
     // SIO THINGS
-    TaskHandle_t thPrinter;
+    //TaskHandle_t thPrinter;
 
     uint8_t _buffer[16];
 
@@ -106,7 +106,7 @@ public:
 
 private:
     printer_type _ptype;
-    TaskHandle_t ioTask = NULL;
+    //TaskHandle_t ioTask = NULL;
     bool _backwards = false;
 
 };

--- a/lib/device/comlynx/udpstream.h
+++ b/lib/device/comlynx/udpstream.h
@@ -1,8 +1,6 @@
 #ifndef UDPSTREAM_H
 #define UDPSTREAM_H
 
-#include <driver/ledc.h>
-
 #include "bus.h"
 
 #include "fnUDP.h"


### PR DESCRIPTION
Cleanup of commented out and also unused code.  Fixed regression for lynx fuji device for open directory (but probably more) where a fixed transfer of 256 was assumed in shared fuji device code, but Lynx Config sends variable length string.  transaction_get was failing if the read wasn't the fixed buffer size in length.