### PR TITLE
fix iic rom0 issue with fn-lib-experimental

### DIFF
--- a/lib/bus/iwm/iwm_ll.cpp
+++ b/lib/bus/iwm/iwm_ll.cpp
@@ -495,9 +495,9 @@ int IRAM_ATTR iwm_sp_ll::iwm_read_packet_spi(uint8_t* buffer, int packet_len)
   {
     return 0; // all good
   }
-  else if (((numodd + numgrps * 7) > 0xff && (numodd + numgrps * 7) < 0x200) && (checksum == smartport.last_checksum)) // Liron bug workaround
+  else if (((numodd + numgrps * 7) > 0xff && (numodd + numgrps * 7) < 0x200)) // Liron, IIc rom0 bug workaround
   {
-    return 0; // just assume its ok due to last checksum being the same as this one for the Liron affected size data packets
+    return 0; // just assume its ok
   }
   else
   {


### PR DESCRIPTION
this removes a condition on the workaround previously added for the Liron. Its the same firmware bug in the IIc rom0. Looks like fn-lib-exp is sending the control cmds with the correct length and it triggers this problem to happen.