### PR TITLE
coco/msdos - implement full APETIME clock.  Atari: Fix APPLE3_SOS_BIN…

### DIFF
--- a/fujinet_pc.cmake
+++ b/fujinet_pc.cmake
@@ -389,6 +389,7 @@ if(FUJINET_TARGET STREQUAL "COCO")
     lib/device/drivewire/disk.h lib/device/drivewire/disk.cpp
     lib/device/drivewire/printer.h lib/device/drivewire/printer.cpp
     lib/device/drivewire/printerlist.h lib/device/drivewire/printerlist.cpp
+    lib/device/drivewire/clock.h lib/device/drivewire/clock.cpp
 
     )
 endif()

--- a/lib/bus/drivewire/drivewire.cpp
+++ b/lib/bus/drivewire/drivewire.cpp
@@ -4,6 +4,7 @@
 
 #include "drivewire.h"
 #include "drivewire/drivewireFuji.h"
+#include "drivewire/clock.h"
 
 #include "../../include/debug.h"
 
@@ -344,6 +345,11 @@ void systemBus::op_cpm()
 #endif /* ESP_PLATFORM */
 }
 
+void systemBus::op_clock()
+{
+    platformClock.process();
+}
+
 void systemBus::op_net()
 {
     // Get device ID
@@ -627,6 +633,9 @@ void systemBus::_drivewire_process_cmd()
             break;
         case OP_CPM:
             op_cpm();
+            break;
+        case OP_CLOCK:
+            op_clock();
             break;
         default:
             op_unhandled(c);

--- a/lib/bus/drivewire/drivewire.h
+++ b/lib/bus/drivewire/drivewire.h
@@ -67,6 +67,7 @@
 #define OP_FUJI        0xE2
 #define OP_NET         0xE3
 #define OP_CPM         0xE4
+#define OP_CLOCK       0xE5
 #define OP_NAMEOBJ_MNT 0x01
 
 #define FEATURE_EMCEE    0x01
@@ -226,6 +227,7 @@ private:
     void op_fuji();
     void op_net();
     void op_cpm();
+    void op_clock();
     void op_write();
     void op_time();
     void op_init();

--- a/lib/device/drivewire/clock.cpp
+++ b/lib/device/drivewire/clock.cpp
@@ -3,7 +3,125 @@
 #include "clock.h"
 
 #include <cstring>
+#include <ctime>
+#include <optional>
 
+#include "fnConfig.h"
+#include "fujiCommandID.h"
+#include "../../bus/drivewire/drivewire.h"
 #include "../../include/debug.h"
+
+drivewireClock platformClock;
+
+std::optional<std::string> drivewireClock::read_tz_from_host()
+{
+    uint8_t lenl = SYSTEM_BUS.read();
+    uint8_t lenh = SYSTEM_BUS.read();
+    uint16_t bufsz = ((uint16_t)lenh << 8) | lenl;
+
+    if (bufsz == 0) {
+        Debug_printv("ERROR: No timezone sent");
+        return std::nullopt;
+    }
+
+    std::string timezone;
+    timezone.reserve(bufsz);
+    for (uint16_t i = 0; i < bufsz; i++)
+        timezone.push_back((char)SYSTEM_BUS.read());
+    while (!timezone.empty() && timezone.back() == '\0')
+        timezone.pop_back();
+    return timezone;
+}
+
+void drivewireClock::set_fn_tz()
+{
+    auto result = read_tz_from_host();
+    if (result)
+        Config.store_general_timezone(result->c_str());
+}
+
+void drivewireClock::set_alternate_tz()
+{
+    auto result = read_tz_from_host();
+    if (result)
+        alternate_tz = result.value();
+}
+
+void drivewireClock::process()
+{
+    uint8_t cmd = SYSTEM_BUS.read();
+    uint8_t aux1;
+    bool use_alt;
+
+    switch (cmd)
+    {
+    case APETIMECMD_GETTZTIME:
+    case APETIMECMD_GETTIME: {
+        aux1 = SYSTEM_BUS.read();
+        use_alt = (cmd == APETIMECMD_GETTZTIME) || (aux1 == 0x01);
+        auto t = Clock::get_current_time_apetime(
+            Clock::tz_to_use(use_alt, alternate_tz, Config.get_general_timezone()));
+        SYSTEM_BUS.write(t.data(), t.size());
+        break;
+    }
+    case APETIMECMD_SETTZ_ALT2: {
+        aux1 = SYSTEM_BUS.read();
+        use_alt = (aux1 == 0x01);
+        auto t = Clock::get_current_time_simple(
+            Clock::tz_to_use(use_alt, alternate_tz, Config.get_general_timezone()));
+        SYSTEM_BUS.write(t.data(), t.size());
+        break;
+    }
+    case APETIMECMD_GET_PRODOS: {
+        aux1 = SYSTEM_BUS.read();
+        use_alt = (aux1 == 0x01);
+        auto t = Clock::get_current_time_prodos(
+            Clock::tz_to_use(use_alt, alternate_tz, Config.get_general_timezone()));
+        SYSTEM_BUS.write(t.data(), t.size());
+        break;
+    }
+    case APETIMECMD_GET_SOS: {
+        aux1 = SYSTEM_BUS.read();
+        use_alt = (aux1 == 0x01);
+        std::string s = Clock::get_current_time_sos(
+            Clock::tz_to_use(use_alt, alternate_tz, Config.get_general_timezone()));
+        SYSTEM_BUS.write((const uint8_t *)s.c_str(), s.size() + 1);
+        break;
+    }
+    case APETIMECMD_GET_ISO_LOCAL: {
+        aux1 = SYSTEM_BUS.read();
+        use_alt = (aux1 == 0x01);
+        std::string s = Clock::get_current_time_iso(
+            Clock::tz_to_use(use_alt, alternate_tz, Config.get_general_timezone()));
+        SYSTEM_BUS.write((const uint8_t *)s.c_str(), s.size() + 1);
+        break;
+    }
+    case APETIMECMD_GET_ISO_UTC: {
+        SYSTEM_BUS.read();
+        std::string s = Clock::get_current_time_iso("UTC+0");
+        SYSTEM_BUS.write((const uint8_t *)s.c_str(), s.size() + 1);
+        break;
+    }
+    case APETIMECMD_SETTZ:
+        set_alternate_tz();
+        break;
+    case APETIMECMD_SETTZ_ALT:
+        set_fn_tz();
+        break;
+    case APETIMECMD_GET_GENERAL: {
+        const std::string &tz = Config.get_general_timezone();
+        SYSTEM_BUS.write((const uint8_t *)tz.c_str(), tz.size() + 1);
+        break;
+    }
+    case APETIMECMD_GETTZ_LEN: {
+        uint8_t len = Config.get_general_timezone().size() + 1;
+        SYSTEM_BUS.write(len);
+        break;
+    }
+    default:
+        Debug_printv("Unknown drivewire clock cmd: %02x", cmd);
+        break;
+    }
+}
 
 #endif /* BUILD_COCO */

--- a/lib/device/drivewire/clock.h
+++ b/lib/device/drivewire/clock.h
@@ -1,15 +1,24 @@
-#ifndef APETIME_H
-#define APETIME_H
+#ifndef DRIVEWIRE_CLOCK_H
+#define DRIVEWIRE_CLOCK_H
+
+#include <optional>
+#include <string>
 
 #include "bus.h"
+#include "../../clock/Clock.h"
 
 class drivewireClock : public virtualDevice
 {
 private:
-    void _sio_get_time(bool use_timezone);
-    void _sio_set_tz();
+    std::string alternate_tz = "";
+    std::optional<std::string> read_tz_from_host();
+    void set_fn_tz();
+    void set_alternate_tz();
 
 public:
+    void process();
 };
 
-#endif // APETIME_H
+extern drivewireClock platformClock;
+
+#endif // DRIVEWIRE_CLOCK_H

--- a/lib/device/rs232/apetime.cpp
+++ b/lib/device/rs232/apetime.cpp
@@ -1,95 +1,157 @@
 #ifdef BUILD_RS232
 
 #include "apetime.h"
-#include "fujiCommandID.h"
 
 #include <cstring>
 #include <ctime>
 
+#include "fujiCommandID.h"
+#include "fnConfig.h"
+#include "../../clock/Clock.h"
 #include "../../include/debug.h"
 
-#ifdef _WIN32
-#define setenv(name, value, overwrite) _putenv_s(name, value)
-#define unsetenv(name) _putenv_s(name, "")
-#endif /* _WIN32 */
-
-void rs232ApeTime::_rs232_get_time(bool use_timezone)
+std::optional<std::string> rs232ApeTime::_read_tz(const FujiBusPacket &packet)
 {
-    char old_tz[64];
-
-    transaction_continue(TRANS_STATE::NO_GET);
-
-    if (use_timezone) {
-      Debug_println("APETIME time query (timezone)");
-    } else {
-      Debug_println("APETIME time query (classic)");
+    auto s = packet.dataAsString();
+    if (!s || s->empty()) {
+        Debug_printv("ERROR: No timezone sent");
+        return std::nullopt;
     }
-
-    uint8_t rs232_reply[6] = { 0 };
-
-    time_t tt = time(nullptr);
-
-    if (ape_timezone.size() && use_timezone) {
-        Debug_printf("Using time zone %s\n", ape_timezone.c_str());
-        strncpy(old_tz, getenv("TZ"), sizeof(old_tz));
-        setenv("TZ", ape_timezone.c_str(), 1);
-        tzset();
-    }
-
-    struct tm * now = localtime(&tt);
-
-    if (ape_timezone.size() && use_timezone) {
-        setenv("TZ", old_tz, 1);
-        tzset();
-    }
-
-    now->tm_mon++;
-    now->tm_year-=100;
-
-    rs232_reply[0] = now->tm_mday;
-    rs232_reply[1] = now->tm_mon;
-    rs232_reply[2] = now->tm_year;
-    rs232_reply[3] = now->tm_hour;
-    rs232_reply[4] = now->tm_min;
-    rs232_reply[5] = now->tm_sec;
-
-    Debug_printf("Returning %02d/%02d/%02d %02d:%02d:%02d\n", now->tm_year, now->tm_mon, now->tm_mday, now->tm_hour, now->tm_min, now->tm_sec);
-
-    transaction_put(rs232_reply, sizeof(rs232_reply), false);
+    std::string tz = s.value();
+    while (!tz.empty() && tz.back() == '\0')
+        tz.pop_back();
+    return tz;
 }
 
-void rs232ApeTime::_rs232_set_tz(std::string newTZ)
+void rs232ApeTime::_set_alternate_tz(const FujiBusPacket &packet)
 {
     transaction_continue(TRANS_STATE::NO_GET);
-
-    if (newTZ.size())
-    {
-        ape_timezone = newTZ;
-        Debug_printf("TZ set to <%s>\n", ape_timezone.c_str());
+    auto tz = _read_tz(packet);
+    if (tz) {
+        alternate_tz = tz.value();
+        Debug_printf("Alt TZ set to <%s>\n", alternate_tz.c_str());
     }
-    else
-      Debug_printf("TZ unset\n");
-
     transaction_complete();
-    return;
+}
+
+void rs232ApeTime::_set_fn_tz(const FujiBusPacket &packet)
+{
+    transaction_continue(TRANS_STATE::NO_GET);
+    auto tz = _read_tz(packet);
+    if (tz)
+        Config.store_general_timezone(tz->c_str());
+    transaction_complete();
+}
+
+void rs232ApeTime::_get_time_apetime(const FujiBusPacket &packet, bool force_alt)
+{
+    transaction_continue(TRANS_STATE::NO_GET);
+    bool use_alt = force_alt ||
+                   (packet.paramCount() > 0 && packet.param(0) == 0x01);
+    auto t = Clock::get_current_time_apetime(
+        Clock::tz_to_use(use_alt, alternate_tz, Config.get_general_timezone()));
+    transaction_put(t.data(), t.size(), false);
+}
+
+void rs232ApeTime::_get_time_simple(const FujiBusPacket &packet)
+{
+    transaction_continue(TRANS_STATE::NO_GET);
+    bool use_alt = packet.paramCount() > 0 && packet.param(0) == 0x01;
+    auto t = Clock::get_current_time_simple(
+        Clock::tz_to_use(use_alt, alternate_tz, Config.get_general_timezone()));
+    transaction_put(t.data(), t.size(), false);
+}
+
+void rs232ApeTime::_get_time_prodos(const FujiBusPacket &packet)
+{
+    transaction_continue(TRANS_STATE::NO_GET);
+    bool use_alt = packet.paramCount() > 0 && packet.param(0) == 0x01;
+    auto t = Clock::get_current_time_prodos(
+        Clock::tz_to_use(use_alt, alternate_tz, Config.get_general_timezone()));
+    transaction_put(t.data(), t.size(), false);
+}
+
+void rs232ApeTime::_get_time_sos(const FujiBusPacket &packet)
+{
+    transaction_continue(TRANS_STATE::NO_GET);
+    bool use_alt = packet.paramCount() > 0 && packet.param(0) == 0x01;
+    std::string s = Clock::get_current_time_sos(
+        Clock::tz_to_use(use_alt, alternate_tz, Config.get_general_timezone()));
+    transaction_put(s.c_str(), s.size() + 1, false);
+}
+
+void rs232ApeTime::_get_time_iso_local(const FujiBusPacket &packet)
+{
+    transaction_continue(TRANS_STATE::NO_GET);
+    bool use_alt = packet.paramCount() > 0 && packet.param(0) == 0x01;
+    std::string s = Clock::get_current_time_iso(
+        Clock::tz_to_use(use_alt, alternate_tz, Config.get_general_timezone()));
+    transaction_put(s.c_str(), s.size() + 1, false);
+}
+
+void rs232ApeTime::_get_time_iso_utc()
+{
+    transaction_continue(TRANS_STATE::NO_GET);
+    std::string s = Clock::get_current_time_iso("UTC+0");
+    transaction_put(s.c_str(), s.size() + 1, false);
+}
+
+void rs232ApeTime::_get_general_tz()
+{
+    transaction_continue(TRANS_STATE::NO_GET);
+    const std::string tz = Config.get_general_timezone();
+    transaction_put(tz.c_str(), tz.size() + 1, false);
+}
+
+void rs232ApeTime::_get_general_tz_len()
+{
+    transaction_continue(TRANS_STATE::NO_GET);
+    uint8_t len = Config.get_general_timezone().size() + 1;
+    transaction_put(&len, 1, false);
 }
 
 void rs232ApeTime::rs232_process(FujiBusPacket &packet)
 {
     switch (packet.command())
     {
+    case APETIMECMD_GETTZTIME:
+        _get_time_apetime(packet, true);
+        break;
     case APETIMECMD_GETTIME:
-        _rs232_get_time(false);
+        _get_time_apetime(packet, false);
+        break;
+    case APETIMECMD_SETTZ_ALT2:
+        _get_time_simple(packet);
+        break;
+    case APETIMECMD_GET_PRODOS:
+        _get_time_prodos(packet);
+        break;
+    case APETIMECMD_GET_SOS:
+        _get_time_sos(packet);
+        break;
+    case APETIMECMD_GET_ISO_LOCAL:
+        _get_time_iso_local(packet);
+        break;
+    case APETIMECMD_GET_ISO_UTC:
+        _get_time_iso_utc();
         break;
     case APETIMECMD_SETTZ:
-        _rs232_set_tz(packet.dataAsString().value_or(""));
+        _set_alternate_tz(packet);
         break;
-    case APETIMECMD_GETTZTIME:
-        _rs232_get_time(true);
+    case APETIMECMD_SETTZ_ALT:
+        _set_fn_tz(packet);
+        break;
+    case APETIMECMD_GET_GENERAL:
+        _get_general_tz();
+        break;
+    case APETIMECMD_GETTZ_LEN:
+        _get_general_tz_len();
         break;
     default:
+        Debug_printv("Unknown rs232 clock cmd: %02x", packet.command());
         transaction_error();
         break;
-    };
+    }
 }
+
 #endif /* BUILD_RS232 */

--- a/lib/device/rs232/apetime.h
+++ b/lib/device/rs232/apetime.h
@@ -1,15 +1,27 @@
 #ifndef APETIME_H
 #define APETIME_H
 
+#include <optional>
+#include <string>
+
 #include "bus.h"
 
 class rs232ApeTime : public virtualDevice
 {
 private:
-    std::string ape_timezone;
+    std::string alternate_tz;
 
-    void _rs232_get_time(bool use_timezone);
-    void _rs232_set_tz(std::string newTZ);
+    std::optional<std::string> _read_tz(const FujiBusPacket &packet);
+    void _set_alternate_tz(const FujiBusPacket &packet);
+    void _set_fn_tz(const FujiBusPacket &packet);
+    void _get_time_apetime(const FujiBusPacket &packet, bool force_alt);
+    void _get_time_simple(const FujiBusPacket &packet);
+    void _get_time_prodos(const FujiBusPacket &packet);
+    void _get_time_sos(const FujiBusPacket &packet);
+    void _get_time_iso_local(const FujiBusPacket &packet);
+    void _get_time_iso_utc();
+    void _get_general_tz();
+    void _get_general_tz_len();
 
 public:
     void rs232_process(FujiBusPacket &packet) override;

--- a/lib/device/sio/clock.cpp
+++ b/lib/device/sio/clock.cpp
@@ -93,6 +93,7 @@ void sioClock::sio_process(uint32_t commanddata, uint8_t checksum)
     }
     case 'S': {
         // Date and time, ASCII string in Apple /// SOS format: YYYYMMDD0HHMMSS000
+        sio_ack();
         std::string sosTime = Clock::get_current_time_sos(Clock::tz_to_use(use_alternate_tz, alternate_tz, Config.get_general_timezone()));
         bus_to_computer((uint8_t *) sosTime.c_str(), sosTime.size() + 1, false);
         break;


### PR DESCRIPTION
…ARY format.

This has been tested with updates to fujinet-lib-experimental (PR for that to come), and a test program that tests every function AND EVERY FORMAT in fujinet-clock.h on Apple2, Atari, CoCo, and MS-DOS.