### PR TITLE
[atari] fix copy file on fujinet-pc serial

### DIFF
--- a/lib/device/sio/sioFuji.cpp
+++ b/lib/device/sio/sioFuji.cpp
@@ -229,6 +229,7 @@ void sioFuji::sio_copy_file()
 
     memset(&csBuf, 0, sizeof(csBuf));
 
+    sio_late_ack(); // quick fix to permit copy to work again
     ck = bus_to_peripheral(csBuf, sizeof(csBuf));
 
     if (ck != sio_checksum(csBuf, sizeof(csBuf)))


### PR DESCRIPTION
copy file on fnconfig on atari with sio2pc was not triggering a copy operation. 