### PR TITLE
Fix UDP reception for NTP connections

### DIFF
--- a/lib/device/sio/network.cpp
+++ b/lib/device/sio/network.cpp
@@ -513,7 +513,12 @@ void sioNetwork::sio_status_channel()
             status.error = NDEV_STATUS::NOT_CONNECTED;
         } else {
             err = protocol->status(&status);
-            avail = protocol->available();
+            // Check receiveBuffer first — protocol->status() may have
+            // auto-read data into it, but protocol->available() only
+            // checks the underlying socket (which is now empty).
+            avail = receiveBuffer->length();
+            if (avail == 0)
+                avail = protocol->available();
         }
         break;
     case JSON:

--- a/lib/tcpip/fnUDP.cpp
+++ b/lib/tcpip/fnUDP.cpp
@@ -172,7 +172,6 @@ bool fnUDP::beginPacket(in_addr_t ip, uint16_t port)
 
 bool fnUDP::beginPacket(const char *host, uint16_t port)
 {
-
     remote_ip = get_ip4_addr_by_name(host);
     remote_port = port;
     return beginPacket();
@@ -305,6 +304,10 @@ int fnUDP::read(unsigned char *buffer, size_t len)
 
 int fnUDP::available()
 {
+    if (!rx_buffer)
+    {
+        parsePacket();  // Try to receive pending data from socket
+    }
     if (!rx_buffer)
         return 0;
     return rx_buffer->available();


### PR DESCRIPTION
Fix UDP receive: available() never polled socket, status reported 0 bytes despite buffered data