### PR TITLE
Add Lynx Rev1 ESP32 S3 support

### DIFF
--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -29,6 +29,7 @@ jobs:
           - IEC-LOLIN-D32
           - IEC-NUGGET
           - LYNX
+          - LYNX-S3
           - RS232
 
     steps:

--- a/.github/workflows/platformio.release-LYNX-S3.ini
+++ b/.github/workflows/platformio.release-LYNX-S3.ini
@@ -1,0 +1,14 @@
+[fujinet]
+build_platform = BUILD_LYNX
+build_bus      = comlynx
+build_board    = fujinet-lynx-rev1
+
+[env:fujinet-lynx-rev1]
+platform = espressif32@${fujinet.esp32s3_platform_version}
+platform_packages = ${fujinet.esp32s3_platform_packages}
+board = esp32-s3-wroom-1-n16r8
+build_type = debug
+build_flags =
+    ${env.build_flags}
+    -D PINMAP_LYNX_S3
+board_build.cmake_extra_args = -D CONFIG_IDF_TARGET_ESP32S3=1 ; extra arguments for CMake

--- a/build-platforms/platformio-fujinet-lynx-rev1.ini
+++ b/build-platforms/platformio-fujinet-lynx-rev1.ini
@@ -1,0 +1,18 @@
+[fujinet]
+build_platform = BUILD_LYNX
+build_bus      = comlynx
+build_board    = fujinet-lynx-rev1
+
+[env]
+upload_port = /dev/ttyACM0 ; Linux esp32s3
+monitor_port = /dev/ttyACM0 ; Linux esp32s3
+
+[env:fujinet-lynx-rev1]
+platform = espressif32@${fujinet.esp32s3_platform_version}
+platform_packages = ${fujinet.esp32s3_platform_packages}
+board = esp32-s3-wroom-1-n16r8
+build_type = debug
+build_flags =
+    ${env.build_flags}
+    -D PINMAP_LYNX_S3
+board_build.cmake_extra_args = -D CONFIG_IDF_TARGET_ESP32S3=1 ; extra arguments for CMake

--- a/data/webui/config/fujinet-lynx-rev1.yaml
+++ b/data/webui/config/fujinet-lynx-rev1.yaml
@@ -1,0 +1,21 @@
+paths:
+  font_path: /file?
+  css_path: /file?css
+  js_path: /file?js
+components:
+  network: true
+  hardware: true
+  hosts_list: true
+  mount_list: true
+  printer_settings: false
+  modem_settings: false
+  hsio_settings: false
+  timezone: true
+  udp_stream: true
+  program_recorder: false
+  disk_swap: false
+  boot_settings: true
+  apetime: false
+  pclink: false
+tweaks:
+  # webui tweaks, if any

--- a/include/debug.h
+++ b/include/debug.h
@@ -25,7 +25,7 @@
     // Use FujiNet debug serial output
     #include "../lib/hardware/ESP32UARTChannel.h"
     #define Serial fnDebugConsole
-#ifdef PINMAP_RS232_S3
+#if defined( PINMAP_RS232_S3 ) || defined( PINMAP_LYNX_S3 )
     #define Debug_print(...) printf( __VA_ARGS__ )
     #define Debug_printf(...) printf( __VA_ARGS__ )
     #define Debug_println(...) do { printf(__VA_ARGS__); printf("\n"); } while (0)

--- a/include/pinmap.h
+++ b/include/pinmap.h
@@ -23,6 +23,7 @@
 #include "pinmap/esp32s3.h"
 #include "pinmap/esp32s3-wroom-1.h"
 #include "pinmap/lynx.h"
+#include "pinmap/lynx-s3.h"
 #include "pinmap/rs232_rev0.h"
 #include "pinmap/rs232_s3.h"
 #include "pinmap/cx16.h"

--- a/include/pinmap/lynx-s3.h
+++ b/include/pinmap/lynx-s3.h
@@ -1,0 +1,33 @@
+/* FujiNet Hardware Pin Mapping */
+#ifdef PINMAP_LYNX_S3
+
+/* SD Card */
+#define PIN_CARD_DETECT     GPIO_NUM_9
+#define PIN_CARD_DETECT_FIX GPIO_NUM_NC
+#define PIN_SD_HOST_CS      GPIO_NUM_10
+#define PIN_SD_HOST_MISO    GPIO_NUM_13
+#define PIN_SD_HOST_MOSI    GPIO_NUM_11
+#define PIN_SD_HOST_SCK     GPIO_NUM_21
+
+/* UART */
+#define PIN_UART0_RX GPIO_NUM_NC
+#define PIN_UART0_TX GPIO_NUM_NC
+#define PIN_UART1_RX GPIO_NUM_NC
+#define PIN_UART1_TX GPIO_NUM_NC
+#define PIN_UART2_RX GPIO_NUM_41
+#define PIN_UART2_TX GPIO_NUM_42
+
+/* Buttons */
+#define PIN_BUTTON_A GPIO_NUM_0
+#define PIN_BUTTON_B GPIO_NUM_NC // No Button B
+#define PIN_BUTTON_C GPIO_NUM_39
+
+/* LEDs */
+#define PIN_LED_WIFI    GPIO_NUM_38 
+#define PIN_LED_BUS     GPIO_NUM_2
+#define PIN_LED_BT      GPIO_NUM_40
+
+/* Audio Output */
+#define PIN_DAC1 GPIO_NUM_NC
+
+#endif /* PINMAP_LYNX_S3 */

--- a/lib/bus/comlynx/comlynx.cpp
+++ b/lib/bus/comlynx/comlynx.cpp
@@ -15,57 +15,6 @@
 
 #define IDLE_TIME 500 // Idle tolerance in microseconds (roughly three characters at 62500 baud)
 
-static QueueHandle_t reset_evt_queue = NULL;
-
-static void IRAM_ATTR comlynx_reset_isr_handler(void *arg)
-{
-    uint32_t gpio_num = (uint32_t)arg;
-    xQueueSendFromISR(reset_evt_queue, &gpio_num, NULL);
-}
-
-static void comlynx_reset_intr_task(void *arg)
-{
-    uint32_t io_num;
-    bool was_reset = false;
-    bool reset_debounced = false;
-    uint64_t start, current, elapsed;
-    systemBus *b = (systemBus *)arg;
-
-    // reset_detect_status = gpio_get_level((gpio_num_t)PIN_COMLYNX_RESET);
-    start = current = esp_timer_get_time();
-    for (;;)
-    {
-        if (xQueueReceive(reset_evt_queue, &io_num, portMAX_DELAY))
-        {
-            start = esp_timer_get_time();
-            printf("Comlynx RESET Asserted\n");
-            was_reset = true;
-        }
-        current = esp_timer_get_time();
-
-        elapsed = current - start;
-
-        if (was_reset)
-        {
-            if (elapsed >= COMLYNX_RESET_DEBOUNCE_PERIOD)
-            {
-                reset_debounced = true;
-            }
-        }
-
-        if (was_reset && reset_debounced)
-        {
-            was_reset = false;
-            // debounce period for reset completed
-            reset_debounced = false;
-            ;
-        }
-
-        b->reset();
-        vTaskDelay(1);
-    }
-}
-
 uint8_t comlynx_checksum(uint8_t *buf, unsigned short len)
 {
     uint8_t checksum = 0x00;
@@ -185,7 +134,7 @@ void virtualDevice::comlynx_send_length(uint16_t l)
     comlynx_send(l & 0xFF);
 
     #ifdef DEBUG
-        Debug_printf("comlynx_send_length - len: %ld\n", l);
+        Debug_printf("comlynx_send_length - len: %ld\n", (long int)l);
     #endif
 }
 
@@ -316,15 +265,6 @@ void systemBus::service()
 void systemBus::setup()
 {
     Debug_println("COMLYNX SETUP");
-
-    // Set up interrupt for RESET line
-    reset_evt_queue = xQueueCreate(10, sizeof(uint32_t));
-    // Start card detect task
-    xTaskCreate(comlynx_reset_intr_task, "comlynx_reset_intr_task", 2048, this, 10, NULL);
-    // Enable interrupt for card detection
-    fnSystem.set_pin_mode(PIN_COMLYNX_RESET, gpio_mode_t::GPIO_MODE_INPUT, SystemManager::pull_updown_t::PULL_UP, GPIO_INTR_NEGEDGE);
-    // Add the card detect handler
-    gpio_isr_handler_add((gpio_num_t)PIN_COMLYNX_RESET, comlynx_reset_isr_handler, (void *)PIN_CARD_DETECT_FIX);
 
     // Set up UDP device
     _udpDev = new lynxUDPStream();
@@ -478,7 +418,7 @@ void systemBus::setRedeyeMode(bool enable)
 
 void systemBus::setRedeyeGameRemap(uint32_t remap)
 {
-    Debug_printf("setRedeyeGameRemap, %d\n", remap);
+    Debug_printf("setRedeyeGameRemap, %d\n", (int) remap);
 
     // handle pure updstream games
     if ((remap >> 8) == 0xE1) {

--- a/lib/device/comlynx/disk.cpp
+++ b/lib/device/comlynx/disk.cpp
@@ -144,7 +144,7 @@ void lynxDisk::comlynx_process()
  
      // Get the entire payload from Lynx
     uint16_t len = comlynx_recv_length();
-    Debug_printf("lynxDisk::comlynx_process - len: %ld, ", len);
+    Debug_printf("lynxDisk::comlynx_process - len: %ld, ", (long int)len);
 
     comlynx_recv_buffer(recvbuffer, len);
     if (comlynx_recv_ck()) {

--- a/lib/device/comlynx/lynxFuji.cpp
+++ b/lib/device/comlynx/lynxFuji.cpp
@@ -273,7 +273,7 @@ void lynxFuji::comlynx_process()
     
     // Get the entire payload from Lynx
     uint16_t len = comlynx_recv_length();
-    Debug_printf("lynxFuji::comlynx_process - len: %ld, ", len);
+    Debug_printf("lynxFuji::comlynx_process - len: %ld, ", (long int)len);
 
     comlynx_recv_buffer(recvbuffer, len);
     if (comlynx_recv_ck()) {

--- a/lib/device/comlynx/network.cpp
+++ b/lib/device/comlynx/network.cpp
@@ -122,7 +122,7 @@ void lynxNetwork::open(unsigned short len)
     if (protocol->open(urlParser.get(), (fileAccessMode_t) cmdFrame.aux1, (netProtoTranslation_t) cmdFrame.aux2) != FUJI_ERROR::NONE)
     {
         statusByte.bits.client_error = true;
-        Debug_printf("Protocol unable to make connection. Error: %d\n", err);
+        Debug_printf("Protocol unable to make connection. Error: %d\n", (int)err);
         delete protocol;
         protocol = nullptr;
         if (protocolParser != nullptr)
@@ -315,7 +315,7 @@ void lynxNetwork::status()
     status.conn = s.connected;
     status.err = s.error;
 
-    Debug_printf("lynxNetwork::comlynx_status - avail:%d conn:%d err:%d\n", status.avail, status.conn, status.err);
+    Debug_printf("lynxNetwork::comlynx_status - avail:%d conn:%d err:%d\n", status.avail, status.conn, (int)status.err);
     transaction_put(&status, sizeof(status));
 }
 
@@ -602,7 +602,7 @@ void lynxNetwork::comlynx_process()
 
     // Get the entire payload from Lynx
     uint16_t len = comlynx_recv_length();
-    Debug_printf("lynxNetwork::comlynx_process - len: %ld, ", len);
+    Debug_printf("lynxNetwork::comlynx_process - len: %ld, ", (long int)len);
 
     comlynx_recv_buffer(recvbuffer, len);
     if (comlynx_recv_ck()) {
@@ -849,7 +849,7 @@ void lynxNetwork::process_tcp(fujiCommandID_t cmd)
             if (!status.connected)
             {
                 cmd_err = tcp->accept_connection();
-                Debug_printf("ACCEPT %x CHANMODE %d ERR: %d\n", _devnum, channelMode, cmd_err);
+                Debug_printf("ACCEPT %x CHANMODE %d ERR: %d\n", _devnum, channelMode, (int)cmd_err);
             }
         }
         break;

--- a/lib/hardware/fnSystem.cpp
+++ b/lib/hardware/fnSystem.cpp
@@ -146,7 +146,7 @@ static void setup_card_detect(gpio_num_t pin)
     // Create a queue to handle card detect event from ISR
     card_detect_evt_queue = xQueueCreate(10, sizeof(gpio_num_t));
     // Start card detect task
-    xTaskCreate(card_detect_intr_task, "card_detect_intr_task", 2048, (void *)pin, 10, NULL);
+    xTaskCreate(card_detect_intr_task, "card_detect_intr_task", 6144, (void *)pin, 10, NULL);
     // Enable interrupt for card detection
     fnSystem.set_pin_mode(pin, gpio_mode_t::GPIO_MODE_INPUT, SystemManager::pull_updown_t::PULL_NONE, GPIO_INTR_ANYEDGE);
     // Add the card detect handler
@@ -230,28 +230,7 @@ void SystemManager::set_pin_mode(uint8_t pin, gpio_mode_t mode, pull_updown_t pu
 void IRAM_ATTR SystemManager::digital_write(uint8_t pin, uint8_t val)
 {
 #ifdef ESP_PLATFORM
-    if (val)
-    {
-        if (pin < 32)
-        {
-            GPIO.out_w1ts = ((uint32_t)1 << pin);
-        }
-        else if (pin < 34)
-        {
-            GPIO.out1_w1ts.val = ((uint32_t)1 << (pin - 32));
-        }
-    }
-    else
-    {
-        if (pin < 32)
-        {
-            GPIO.out_w1tc = ((uint32_t)1 << pin);
-        }
-        else if (pin < 34)
-        {
-            GPIO.out1_w1tc.val = ((uint32_t)1 << (pin - 32));
-        }
-    }
+    gpio_set_level((gpio_num_t)pin, val ? 1 : 0);
 #else
     Debug_println("SystemManager::digital_write() not implemented");
 #endif
@@ -262,18 +241,11 @@ void IRAM_ATTR SystemManager::digital_write(uint8_t pin, uint8_t val)
 int IRAM_ATTR SystemManager::digital_read(uint8_t pin)
 {
 #ifdef ESP_PLATFORM
-    if (pin < 32)
-    {
-        return (GPIO.in >> pin) & 0x1;
-    }
-    else if (pin < 40)
-    {
-        return (GPIO.in1.val >> (pin - 32)) & 0x1;
-    }
+    return gpio_get_level((gpio_num_t)pin);
 #else
     Debug_println("SystemManager::digital_read() not implemented");
-#endif
     return 0;
+#endif
 }
 
 #ifdef ESP_PLATFORM
@@ -1023,6 +995,9 @@ const char *SystemManager::get_hardware_ver_str()
     case 2:
         return "Lynx DEVKITC";
         break;
+    case 3:
+        return "Lynx Rev1 (S3)";
+        break;
 #elif defined(BUILD_RS232)
     /* RS232 */
     case 1 :
@@ -1277,6 +1252,9 @@ void SystemManager::check_hardware_ver()
     */
 #   if defined(NO_BUTTONS)
     _hardware_version = 2;
+#   elif CONFIG_IDF_TARGET_ESP32S3
+    _hardware_version = 3;
+    safe_reset_gpio = PIN_BUTTON_C;
 #   else
     _hardware_version = 1;
     safe_reset_gpio = PIN_BUTTON_C;

--- a/lib/hardware/led.cpp
+++ b/lib/hardware/led.cpp
@@ -1,6 +1,8 @@
 
 #include "led.h"
 
+#include "../../include/debug.h"
+
 #include "fnSystem.h"
 #include "fnLedStrip.h"
 
@@ -32,6 +34,15 @@ void LedManager::setup()
 #elif defined(PINMAP_RS232_REV0)
     fnSystem.set_pin_mode(PIN_LED_BUS, gpio_mode_t::GPIO_MODE_INPUT_OUTPUT);
     fnSystem.digital_write(PIN_LED_BUS, DIGI_HIGH);
+
+    fnSystem.set_pin_mode(PIN_LED_WIFI, gpio_mode_t::GPIO_MODE_INPUT_OUTPUT);
+    fnSystem.digital_write(PIN_LED_WIFI, DIGI_HIGH);
+#elif defined(PINMAP_LYNX_S3)
+    fnSystem.set_pin_mode(PIN_LED_BUS, gpio_mode_t::GPIO_MODE_INPUT_OUTPUT);
+    fnSystem.digital_write(PIN_LED_BUS, DIGI_HIGH);
+
+    fnSystem.set_pin_mode(PIN_LED_BT, gpio_mode_t::GPIO_MODE_INPUT_OUTPUT);
+    fnSystem.digital_write(PIN_LED_BT, DIGI_HIGH);
 
     fnSystem.set_pin_mode(PIN_LED_WIFI, gpio_mode_t::GPIO_MODE_INPUT_OUTPUT);
     fnSystem.digital_write(PIN_LED_WIFI, DIGI_HIGH);

--- a/platformio-sample.ini
+++ b/platformio-sample.ini
@@ -67,6 +67,7 @@ flash_filesystem = FLASH_LITTLEFS
 ;build_bus      = comlynx
 ;build_board    = fujinet-lynx-prototype ; Lynx Prototype PCB
 ;build_board    = fujinet-lynx-devkitc   ; Lynx with basic DEVKITC
+;build_board    = fujinet-lynx-rev1      ; Lynx Rev1 ESP32-S3
 
 ;build_platform = BUILD_S100
 ;build_bus      = s100Bus
@@ -224,6 +225,19 @@ build_flags =
     -D NO_BUTTONS
     ;-D DEBUG_UDPSTREAM ; enable UDP to display IN/OUT packets
     ;-D DEBUG_8BITHUB ; debug messages for 8 Bit Hub emulation
+
+; FujiNet Lynx Rev1 (ESP32S3 WROOM 16MB Flash, 8MB PSRAM)
+[env:fujinet-lynx-rev1]
+platform = espressif32@${fujinet.esp32s3_platform_version}
+platform_packages = ${fujinet.esp32s3_platform_packages}
+board = esp32-s3-wroom-1-n16r8
+build_type = debug
+build_flags =
+    ${env.build_flags}
+    -D PINMAP_LYNX_S3
+board_build.cmake_extra_args = -D CONFIG_IDF_TARGET_ESP32S3=1 ; extra arguments for CMake
+upload_port = /dev/ttyACM0 ; Linux esp32s3
+monitor_port = /dev/ttyACM0 ; Linux esp32s3
 
 ; Commodore IEC using Atari FujiNet Hardware (ESP32 WROVER 16MB Flash, 8MB PSRAM)
 [env:fujinet-iec]


### PR DESCRIPTION
* Added FujiNet Lynx Rev1 ESP32-S3 PlatformIO build support in platformio-sample.ini and new build-platforms/platformio-fujinet-lynx-rev1.ini
* Added Lynx Rev1 web UI config at data/webui/config/fujinet-lynx-rev1.yaml.
* Added new PINMAP_LYNX_S3 pin mapping with SD, UART, button, LED, and COMLYNX assignments ( the right way ;) )
* Enable/fix printf-based debug output for S3 based Lynx
* Added Lynx Rev1 hardware version detection/reporting
* Updated GPIO read/write helpers to use ESP-IDF gpio_get_level / gpio_set_level since S3 has more GPIO than older ESP32
* Increased card-detect task stack size so it doesn't crash
* Added Lynx S3 LED initialization for BUS, BT, and WIFI LEDs
* Remove bogus COMLYNX reset interrupt setup