### PR TITLE
coco/pc: add chunked serial write throttle for USB-bridged downstream

### DIFF
--- a/lib/bus/drivewire/drivewire.cpp
+++ b/lib/bus/drivewire/drivewire.cpp
@@ -818,6 +818,10 @@ void systemBus::setup()
                       .baud(_drivewireBaud)
                       .deviceID(DW_UART_DEVICE)
                       .readTimeout(500)
+#ifndef ESP_PLATFORM
+                      .chunkSize(Config.get_serial_chunk_size())
+                      .chunkDelayUs(Config.get_serial_chunk_delay_us())
+#endif /* ! ESP_PLATFORM */
 #ifdef ESP_PLATFORM
                       .inverted(DW_UART_DEVICE == UART_NUM_2)
 #endif /* ESP_PLATFORM */

--- a/lib/config/fnConfig.h
+++ b/lib/config/fnConfig.h
@@ -149,8 +149,12 @@ public:
     // SERIAL PORT
     serial_command_pin get_serial_command() { return _serial.command; };
     serial_proceed_pin get_serial_proceed() { return _serial.proceed; };
+    int get_serial_chunk_size() { return _serial.chunk_size; };
+    int get_serial_chunk_delay_us() { return _serial.chunk_delay_us; };
     void store_serial_command(serial_command_pin command_pin);
     void store_serial_proceed(serial_proceed_pin proceed_pin);
+    void store_serial_chunk_size(int chunk_size);
+    void store_serial_chunk_delay_us(int chunk_delay_us);
 #endif /* ! ESP_PLATFORM */
 #if defined(BUILD_RS232) || !defined(ESP_PLATFORM)
     std::string get_serial_port() { return _serial.port; };
@@ -497,6 +501,8 @@ private:
 #ifndef ESP_PLATFORM
         serial_command_pin command = SERIAL_COMMAND_DSR; // Used by Atari, ignored by CoCo
         serial_proceed_pin proceed = SERIAL_PROCEED_DTR; // Used by Atari, ignored by CoCo
+        int chunk_size = 0; // 0 = single write, >0 = max bytes per ::write() with tcdrain between chunks
+        int chunk_delay_us = 0; // microseconds to sleep after tcdrain between chunks (only applied when chunk_size > 0)
 #endif /* ESP_PLATFORM */
     };
 #endif /* BUILD_RS232 || ! ESP_PLATFORM */

--- a/lib/config/fnc_save.cpp
+++ b/lib/config/fnc_save.cpp
@@ -189,6 +189,10 @@ void fnConfig::save()
     ss << "command=" << std::string(_serial_command_pin_names[_serial.command]) << LINETERM;
     ss << "proceed=" << std::string(_serial_proceed_pin_names[_serial.proceed]) << LINETERM;
 #endif
+    if (_serial.chunk_size > 0)
+        ss << "chunk_size=" << _serial.chunk_size << LINETERM;
+    if (_serial.chunk_delay_us > 0)
+        ss << "chunk_delay_us=" << _serial.chunk_delay_us << LINETERM;
 
 #ifdef BUILD_APPLE
     // Bus Over Serial - not used, yet

--- a/lib/config/fnc_serial.cpp
+++ b/lib/config/fnc_serial.cpp
@@ -116,6 +116,24 @@ void fnConfig::store_serial_proceed(serial_proceed_pin proceed_pin)
     _dirty = true;
 }
 
+void fnConfig::store_serial_chunk_size(int chunk_size)
+{
+    if (chunk_size < 0 || _serial.chunk_size == chunk_size)
+        return;
+
+    _serial.chunk_size = chunk_size;
+    _dirty = true;
+}
+
+void fnConfig::store_serial_chunk_delay_us(int chunk_delay_us)
+{
+    if (chunk_delay_us < 0 || _serial.chunk_delay_us == chunk_delay_us)
+        return;
+
+    _serial.chunk_delay_us = chunk_delay_us;
+    _dirty = true;
+}
+
 void fnConfig::store_bos_enabled(bool bos_enabled) {
     if (_bos.bos_enabled == bos_enabled)
         return;
@@ -200,6 +218,18 @@ void fnConfig::_read_section_serial(std::stringstream &ss)
             else if (strcasecmp(name.c_str(), "proceed") == 0)
             {
                 _serial.proceed = serial_proceed_from_string(value.c_str());
+            }
+            else if (strcasecmp(name.c_str(), "chunk_size") == 0)
+            {
+                int cs = atoi(value.c_str());
+                if (cs >= 0)
+                    _serial.chunk_size = cs;
+            }
+            else if (strcasecmp(name.c_str(), "chunk_delay_us") == 0)
+            {
+                int cd = atoi(value.c_str());
+                if (cd >= 0)
+                    _serial.chunk_delay_us = cd;
             }
 #endif /* ESP_PLATFORM */
         }

--- a/lib/hardware/COMChannel.h
+++ b/lib/hardware/COMChannel.h
@@ -13,6 +13,8 @@ struct ChannelConfig
 {
     std::string device;
     int baud_rate;
+    int chunk_size = 0;
+    int chunk_delay_us = 0;
     double read_timeout_ms = IOCHANNEL_DEFAULT_TIMEOUT;
     double discard_timeout_ms = IOCHANNEL_DEFAULT_TIMEOUT;
 
@@ -21,6 +23,12 @@ struct ChannelConfig
     }
     ChannelConfig& deviceID(std::string path) {
         device = path; return *this;
+    }
+    ChannelConfig& chunkSize(int n) {
+        chunk_size = n; return *this;
+    }
+    ChannelConfig& chunkDelayUs(int us) {
+        chunk_delay_us = us; return *this;
     }
     ChannelConfig& readTimeout(double millis) {
         read_timeout_ms = millis; return *this;

--- a/lib/hardware/TTYChannel.cpp
+++ b/lib/hardware/TTYChannel.cpp
@@ -108,6 +108,11 @@ void TTYChannel::begin(const ChannelConfig& conf)
         return;
     }
 
+    _chunk_size = conf.chunk_size;
+    _chunk_delay_us = conf.chunk_delay_us;
+    if (_chunk_size > 0)
+        Debug_printf("TTY chunk_size: %d, chunk_delay_us: %d\n", _chunk_size, _chunk_delay_us);
+
     Debug_printf("### TTY initialized ###\n");
     setBaudrate(conf.baud_rate);
 
@@ -192,8 +197,12 @@ size_t TTYChannel::dataOut(const void *buffer, size_t length)
             // Make sure our file descriptor is in the ready to write list
             if (FD_ISSET(_fd, &writefds))
             {
+                size_t want = length - txbytes;
+                if (_chunk_size > 0 && want > (size_t)_chunk_size)
+                    want = _chunk_size;
+
                 // This will write some
-                result = ::write(_fd, &((uint8_t *)buffer)[txbytes], length-txbytes);
+                result = ::write(_fd, &((uint8_t *)buffer)[txbytes], want);
                 // Debug_printf("write: %d\n", result);
                 if (result < 1)
                 {
@@ -213,6 +222,12 @@ size_t TTYChannel::dataOut(const void *buffer, size_t length)
                 }
                 if (txbytes < length)
                 {
+                    if (_chunk_size > 0)
+                    {
+                        tcdrain(_fd);
+                        if (_chunk_delay_us > 0)
+                            usleep(_chunk_delay_us);
+                    }
                     timeout_tv = timeval_from_ms(1000 + result * 12500 / _baud);
                     continue;
                 }

--- a/lib/hardware/TTYChannel.h
+++ b/lib/hardware/TTYChannel.h
@@ -12,6 +12,8 @@ struct ChannelConfig
 {
     std::string device;
     int baud_rate;
+    int chunk_size = 0;
+    int chunk_delay_us = 0;
     double read_timeout_ms = IOCHANNEL_DEFAULT_TIMEOUT;
     double discard_timeout_ms = IOCHANNEL_DEFAULT_TIMEOUT;
 
@@ -20,6 +22,12 @@ struct ChannelConfig
     }
     ChannelConfig& deviceID(std::string path) {
         device = path; return *this;
+    }
+    ChannelConfig& chunkSize(int n) {
+        chunk_size = n; return *this;
+    }
+    ChannelConfig& chunkDelayUs(int us) {
+        chunk_delay_us = us; return *this;
     }
     ChannelConfig& readTimeout(double millis) {
         read_timeout_ms = millis; return *this;
@@ -35,6 +43,8 @@ private:
     int _fd = -1;
     std::string _device;
     uint32_t _baud;
+    int _chunk_size = 0;
+    int _chunk_delay_us = 0;
     bool _dtrState = true, _rtsState = true;
 
 protected:


### PR DESCRIPTION
When fujinet-pc-COCO talks to a USB-tethered bridge cart (e.g. PicoROM), large response writes from drivewireNetwork::send_response can exceed the bridge's downstream buffer because tcdrain() on USB CDC-ACM only waits for USB ACK, not for the bridge to forward bytes to the CoCo bus.

Adds two optional [Serial] settings (PC builds only):
  chunk_size       - max bytes per ::write() syscall (default 0 = single write)
  chunk_delay_us   - usleep after tcdrain between chunks (default 0) - 500 works well for prototype bus cart 1.

Plumbed through TTYChannel::dataOut. Wired into drivewire bus setup. COMChannel ChannelConfig gets matching API stubs so Windows builds compile; behavior unchanged for builds that omit the settings.