### PR TITLE
feature/ssh_keyauth

### DIFF
--- a/fujinet_pc.cmake
+++ b/fujinet_pc.cmake
@@ -253,6 +253,8 @@ set(SOURCES src/main.cpp
     lib/network-protocol/SMB.h lib/network-protocol/SMB.cpp
     lib/network-protocol/NFS.h lib/network-protocol/NFS.cpp
     lib/network-protocol/SSH.h lib/network-protocol/SSH.cpp
+    lib/network-protocol/SSHKeygen.h lib/network-protocol/SSHKeygen.cpp
+    lib/network-protocol/SSHCopyId.h lib/network-protocol/SSHCopyId.cpp
     lib/network-protocol/SD.h lib/network-protocol/SD.cpp
     lib/fuji/fujiHost.h lib/fuji/fujiHost.cpp
     lib/fuji/fujiDisk.h lib/fuji/fujiDisk.cpp

--- a/lib/network-protocol/ProtocolParser.cpp
+++ b/lib/network-protocol/ProtocolParser.cpp
@@ -10,6 +10,8 @@
 #include "FTP.h"
 #include "HTTP.h"
 #include "SSH.h"
+#include "SSHKeygen.h"
+#include "SSHCopyId.h"
 #include "SMB.h"
 #include "NFS.h"
 #include "SD.h"
@@ -52,6 +54,12 @@ NetworkProtocol* ProtocolParser::createProtocol(std::string scheme, std::string 
             break;
         case "SSH"_sh:
             protocol = new NetworkProtocolSSH(receiveBuffer, transmitBuffer, specialBuffer);
+            break;
+        case "SSH.KEYGEN"_sh:
+            protocol = new NetworkProtocolSSHKeygen(receiveBuffer, transmitBuffer, specialBuffer);
+            break;
+        case "SSH.COPYID"_sh:
+            protocol = new NetworkProtocolSSHCopyId(receiveBuffer, transmitBuffer, specialBuffer);
             break;
         case "SMB"_sh:
             protocol = new NetworkProtocolSMB(receiveBuffer, transmitBuffer, specialBuffer);

--- a/lib/network-protocol/SSH.cpp
+++ b/lib/network-protocol/SSH.cpp
@@ -1,5 +1,15 @@
 /**
  * SSH protocol implementation
+ *
+ * Supports two authentication modes, inferred from the URL:
+ *
+ *   N:SSH://user:pass@host:port/   => password authentication
+ *   N:SSH://user@host:port/        => public-key authentication
+ *                                     using default key from SD card:
+ *                                     /.ssh/id_ed25519
+ *
+ * The auth mode is determined solely by whether the URL contains a
+ * password component.  No query parameters are needed.
  */
 
 #include "SSH.h"
@@ -11,6 +21,20 @@
 #include <vector>
 
 #define RXBUF_SIZE 65535
+
+/**
+ * Default SSH private key path relative to SD card root.
+ */
+#define SSH_DEFAULT_KEY_REL "/.ssh/id_ed25519"
+
+/**
+ * SD card base path differs between ESP and PC builds.
+ */
+#ifdef ESP_PLATFORM
+#define SD_BASE_PATH "/sd"
+#else
+#define SD_BASE_PATH "SD"
+#endif
 
 NetworkProtocolSSH::NetworkProtocolSSH(std::string *rx_buf, std::string *tx_buf, std::string *sp_buf)
     : NetworkProtocol(rx_buf, tx_buf, sp_buf)
@@ -33,6 +57,98 @@ NetworkProtocolSSH::~NetworkProtocolSSH()
 #endif
 }
 
+/* ------------------------------------------------------------------ */
+/* Helper: check if URL provided a password                           */
+/* ------------------------------------------------------------------ */
+bool NetworkProtocolSSH::hasPassword()
+{
+    return password != nullptr && !password->empty();
+}
+
+/* ------------------------------------------------------------------ */
+/* Helper: build absolute filesystem path to default private key      */
+/* ------------------------------------------------------------------ */
+std::string NetworkProtocolSSH::getDefaultPrivateKeyPath()
+{
+    return std::string(SD_BASE_PATH) + SSH_DEFAULT_KEY_REL;
+}
+
+/* ------------------------------------------------------------------ */
+/* Helper: authenticate with password                                 */
+/* ------------------------------------------------------------------ */
+bool NetworkProtocolSSH::authenticateWithPassword()
+{
+    Debug_printf("SSH auth mode: password\r\n");
+
+    int ret = ssh_userauth_list(session, NULL);
+    bool allowsPassword = ret & SSH_AUTH_METHOD_PASSWORD;
+
+    if (!allowsPassword) {
+        error = NDEV_STATUS::GENERAL;
+        Debug_printf("NetworkProtocolSSH::authenticateWithPassword() - Server does not allow password auth.\r\n");
+        return false;
+    }
+
+    ret = ssh_userauth_password(session, NULL, password->c_str());
+    if (ret != SSH_AUTH_SUCCESS) {
+        error = NDEV_STATUS::ACCESS_DENIED;
+        const char *message = ssh_get_error(session);
+        Debug_printf("NetworkProtocolSSH::authenticateWithPassword() - Password auth failed, error: %s.\r\n", message);
+        return false;
+    }
+
+    return true;
+}
+
+/* ------------------------------------------------------------------ */
+/* Helper: authenticate with default private key from SD card         */
+/* ------------------------------------------------------------------ */
+bool NetworkProtocolSSH::authenticateWithDefaultKey()
+{
+    Debug_printf("SSH auth mode: publickey\r\n");
+
+    int ret = ssh_userauth_list(session, NULL);
+    bool allowsPublicKey = ret & SSH_AUTH_METHOD_PUBLICKEY;
+
+    if (!allowsPublicKey) {
+        error = NDEV_STATUS::GENERAL;
+        Debug_printf("NetworkProtocolSSH::authenticateWithDefaultKey() - Server does not allow public key auth.\r\n");
+        return false;
+    }
+
+    std::string keyPath = getDefaultPrivateKeyPath();
+    Debug_printf("SSH private key: %s\r\n", keyPath.c_str());
+
+    /* Import the private key from file */
+    ssh_key privkey = NULL;
+    ret = ssh_pki_import_privkey_file(keyPath.c_str(), NULL, NULL, NULL, &privkey);
+    if (ret != SSH_OK) {
+        error = NDEV_STATUS::GENERAL;
+        Debug_printf("NetworkProtocolSSH::authenticateWithDefaultKey() - "
+                     "Could not load private key from %s (error code: %d). "
+                     "Check that the file exists and is a valid SSH private key.\r\n",
+                     keyPath.c_str(), ret);
+        return false;
+    }
+
+    /* Authenticate with the imported key */
+    ret = ssh_userauth_publickey(session, NULL, privkey);
+    ssh_key_free(privkey);
+
+    if (ret != SSH_AUTH_SUCCESS) {
+        error = NDEV_STATUS::ACCESS_DENIED;
+        const char *message = ssh_get_error(session);
+        Debug_printf("NetworkProtocolSSH::authenticateWithDefaultKey() - "
+                     "Public key auth failed, error: %s.\r\n", message);
+        return false;
+    }
+
+    return true;
+}
+
+/* ------------------------------------------------------------------ */
+/* open() — main connection and authentication flow                   */
+/* ------------------------------------------------------------------ */
 fujiError_t NetworkProtocolSSH::open(PeoplesUrlParser *urlParser,
                                          fileAccessMode_t access,
                                          netProtoTranslation_t translate)
@@ -40,6 +156,7 @@ fujiError_t NetworkProtocolSSH::open(PeoplesUrlParser *urlParser,
     NetworkProtocol::open(urlParser, access, translate);
     int ret;
 
+    /* ---- Parse credentials from URL ---- */
     if (!urlParser->user.empty()) {
         login = &urlParser->user;
     }
@@ -48,9 +165,20 @@ fujiError_t NetworkProtocolSSH::open(PeoplesUrlParser *urlParser,
         password = &urlParser->password;
     }
 
-    if (!login || !password || (login->empty() && password->empty()))
-    {
+    /* Determine auth mode: password if URL has password, key otherwise */
+    usePasswordAuth = hasPassword();
+
+    /* Username is always required */
+    if (!login || login->empty()) {
         error = NDEV_STATUS::INVALID_USERNAME_OR_PASSWORD;
+        Debug_printf("NetworkProtocolSSH::open() - Missing SSH username.\r\n");
+        return FUJI_ERROR::UNSPECIFIED;
+    }
+
+    /* For password auth, password must be present */
+    if (usePasswordAuth && (!password || password->empty())) {
+        error = NDEV_STATUS::INVALID_USERNAME_OR_PASSWORD;
+        Debug_printf("NetworkProtocolSSH::open() - Password auth selected but password is empty.\r\n");
         return FUJI_ERROR::UNSPECIFIED;
     }
 
@@ -95,6 +223,7 @@ fujiError_t NetworkProtocolSSH::open(PeoplesUrlParser *urlParser,
         return FUJI_ERROR::UNSPECIFIED;
     }
 
+    /* ---- Host key verification ---- */
     ssh_key srv_pubkey = NULL;
     ret = ssh_get_server_publickey(session, &srv_pubkey);
     if (ret < 0) {
@@ -121,19 +250,17 @@ fujiError_t NetworkProtocolSSH::open(PeoplesUrlParser *urlParser,
     ssh_key_free(srv_pubkey);
 
     Debug_printf("SSH Host Key Fingerprint with length %d is: ", hlen);
-    // ODE FOR string.join();
-    for (int i = 0; i < hlen; i++)
+    for (int i = 0; i < (int)hlen; i++)
     {
         Debug_printf("%02X", fingerprint[i]);
-        if (i < (hlen - 1))
+        if (i < (int)(hlen - 1))
             Debug_printf(":");
     }
     Debug_printf("\r\n");
     ssh_clean_pubkey_hash(&fingerprint);
 
-
+    /* ---- Probe server auth methods ---- */
     ret = ssh_userauth_none(session, NULL);
-    // TODO: Are we in blocking mode? If we are not, then we will have to deal with SSH_AUTH_AGAIN
     if (ret == SSH_AUTH_ERROR) {
         error = NDEV_STATUS::GENERAL;
         const char *message = ssh_get_error(session);
@@ -141,40 +268,36 @@ fujiError_t NetworkProtocolSSH::open(PeoplesUrlParser *urlParser,
         return FUJI_ERROR::UNSPECIFIED;
     }
 
-    ret = ssh_userauth_list(session, NULL);
-    bool allowsPassword = ret & SSH_AUTH_METHOD_PASSWORD;
-    bool allowsPublicKey = ret & SSH_AUTH_METHOD_PUBLICKEY;
-    bool allowsHostBased = ret & SSH_AUTH_METHOD_HOSTBASED;
-    bool allowsInteractive = ret & SSH_AUTH_METHOD_INTERACTIVE;
-    Debug_printf("Authentication methods:\r\n"
-                 "Password:    %s\r\n"
-                 "Public Key:  %s\r\n"
-                 "Host Based:  %s\r\n"
-                 "Interactive: %s\r\n",
-        allowsPassword ? "true":"false",
-        allowsPublicKey ? "true":"false",
-        allowsHostBased ? "true":"false",
-        allowsInteractive ? "true":"false"
-    );
+    /* Log available methods */
+    {
+        int methods = ssh_userauth_list(session, NULL);
+        Debug_printf("Authentication methods:\r\n"
+                     "Password:    %s\r\n"
+                     "Public Key:  %s\r\n"
+                     "Host Based:  %s\r\n"
+                     "Interactive: %s\r\n",
+            (methods & SSH_AUTH_METHOD_PASSWORD) ? "true":"false",
+            (methods & SSH_AUTH_METHOD_PUBLICKEY) ? "true":"false",
+            (methods & SSH_AUTH_METHOD_HOSTBASED) ? "true":"false",
+            (methods & SSH_AUTH_METHOD_INTERACTIVE) ? "true":"false"
+        );
+    }
 
-    if (!allowsPassword) {
-        // May as well stop here, as our only ability (password) isn't allowed
-        error = NDEV_STATUS::GENERAL;
-        Debug_printf("NetworkProtocolSSH::open() - Could not login to server as it does not allow password auth.\r\n");
+    /* ---- Authenticate ---- */
+    bool authOk;
+    if (usePasswordAuth) {
+        authOk = authenticateWithPassword();
+    } else {
+        authOk = authenticateWithDefaultKey();
+    }
+
+    if (!authOk) {
+        ssh_disconnect(session);
+        ssh_free(session);
         return FUJI_ERROR::UNSPECIFIED;
     }
 
-    ret = ssh_userauth_password(session, NULL, password->c_str());
-    // SSH_AUTH_AGAIN may need to be handled here too, if we're in non-blocking mode.
-
-    if (ret != SSH_AUTH_SUCCESS) {
-        error = NDEV_STATUS::ACCESS_DENIED;
-        const char *message = ssh_get_error(session);
-        Debug_printf("NetworkProtocolSSH::open() - Unable to authorise with given password, error: %s.\r\n", message);
-        ssh_disconnect(session);
-        ssh_free(session);
-    }
-
+    /* ---- Open channel, PTY, shell ---- */
     channel = ssh_channel_new(session);
     if (channel == NULL) {
         error = NDEV_STATUS::GENERAL;
@@ -189,7 +312,6 @@ fujiError_t NetworkProtocolSSH::open(PeoplesUrlParser *urlParser,
         Debug_printf("NetworkProtocolSSH::open() - Could not open session, error: %s.\r\n", message);
         return FUJI_ERROR::UNSPECIFIED;
     }
-
 
     ret = ssh_channel_request_pty_size(channel, "vanilla", 80, 24);
     if (ret != SSH_OK)

--- a/lib/network-protocol/SSH.h
+++ b/lib/network-protocol/SSH.h
@@ -102,10 +102,39 @@ private:
     char *rxbuf = nullptr;
 
     /**
-     * Return if bytes available by injecting into RX buffer.
+     * @brief Return if bytes available by injecting into RX buffer.
      * @return number of bytes available
      */
     size_t available() override;
+
+    /**
+     * @brief Check if URL has a password (user:pass@host vs user@host)
+     * @return true if password-based authentication should be used
+     */
+    bool hasPassword();
+
+    /**
+     * @brief Authenticate using password
+     * @return true on success
+     */
+    bool authenticateWithPassword();
+
+    /**
+     * @brief Authenticate using default private key from SD card
+     * @return true on success
+     */
+    bool authenticateWithDefaultKey();
+
+    /**
+     * @brief Get the filesystem path to the default SSH private key on SD card
+     * @return absolute path to /.ssh/id_ed25519 on the SD card
+     */
+    std::string getDefaultPrivateKeyPath();
+
+    /**
+     * @brief True if URL provided a password (password auth), false for key auth
+     */
+    bool usePasswordAuth = true;
 };
 
 #endif /* NETWORKPROTOCOL_SSH */

--- a/lib/network-protocol/SSHCopyId.cpp
+++ b/lib/network-protocol/SSHCopyId.cpp
@@ -1,0 +1,535 @@
+/**
+ * SSH.COPYID protocol implementation
+ *
+ * Installs the FujiNet default SSH public key on a remote server.
+ *
+ * URL:   N:SSH.COPYID://user:pass@host:port/
+ *
+ * Reads /.ssh/id_ed25519.pub from SD card, connects to the remote
+ * host using password authentication, and appends the public key
+ * to ~/.ssh/authorized_keys (skipping if already present).
+ */
+
+#include "SSHCopyId.h"
+
+#include "../../include/debug.h"
+#include "status_error_codes.h"
+
+#include <libssh/libssh.h>
+
+#include <cstdio>
+#include <cstring>
+#include <algorithm>
+
+/* ------------------------------------------------------------------ */
+/* SD card base path — same convention as SSH.cpp / SSHKeygen.cpp     */
+/* ------------------------------------------------------------------ */
+#ifdef ESP_PLATFORM
+#define SD_BASE_PATH "/sd"
+#else
+#define SD_BASE_PATH "SD"
+#endif
+
+#define PUBKEY_REL_PATH "/.ssh/id_ed25519.pub"
+
+/* ------------------------------------------------------------------ */
+/* ctor / dtor                                                        */
+/* ------------------------------------------------------------------ */
+NetworkProtocolSSHCopyId::NetworkProtocolSSHCopyId(std::string *rx_buf,
+                                                   std::string *tx_buf,
+                                                   std::string *sp_buf)
+    : NetworkProtocol(rx_buf, tx_buf, sp_buf)
+{
+    Debug_printf("NetworkProtocolSSHCopyId::ctor(%p,%p,%p)\r\n",
+                 rx_buf, tx_buf, sp_buf);
+}
+
+NetworkProtocolSSHCopyId::~NetworkProtocolSSHCopyId()
+{
+    Debug_printf("NetworkProtocolSSHCopyId::~dtor()\r\n");
+    statusResponse.clear();
+}
+
+/* ------------------------------------------------------------------ */
+/* Path helper                                                        */
+/* ------------------------------------------------------------------ */
+std::string NetworkProtocolSSHCopyId::getPublicKeyPath()
+{
+    return std::string(SD_BASE_PATH) + PUBKEY_REL_PATH;
+}
+
+/* ------------------------------------------------------------------ */
+/* Read public key from SD card                                       */
+/* ------------------------------------------------------------------ */
+bool NetworkProtocolSSHCopyId::readDefaultPublicKey(std::string &pubkeyLine)
+{
+    std::string path = getPublicKeyPath();
+    Debug_printf("SSH.COPYID: reading public key from %s\r\n", path.c_str());
+
+    FILE *fp = fopen(path.c_str(), "r");
+    if (fp == NULL) {
+        Debug_printf("SSH.COPYID: cannot open %s\r\n", path.c_str());
+        return false;
+    }
+
+    char buf[1024];
+    pubkeyLine.clear();
+
+    while (fgets(buf, sizeof(buf), fp) != NULL) {
+        pubkeyLine += buf;
+    }
+    fclose(fp);
+
+    /* Trim trailing whitespace / newlines */
+    while (!pubkeyLine.empty() &&
+           (pubkeyLine.back() == '\n' || pubkeyLine.back() == '\r' ||
+            pubkeyLine.back() == ' '  || pubkeyLine.back() == '\t')) {
+        pubkeyLine.pop_back();
+    }
+
+    if (pubkeyLine.empty()) {
+        Debug_printf("SSH.COPYID: public key file is empty.\r\n");
+        return false;
+    }
+
+    return true;
+}
+
+/* ------------------------------------------------------------------ */
+/* Validate Ed25519 public key format                                 */
+/* ------------------------------------------------------------------ */
+bool NetworkProtocolSSHCopyId::validateEd25519PublicKey(const std::string &line)
+{
+    const char *prefix = "ssh-ed25519 ";
+    size_t prefixLen = strlen(prefix);
+
+    if (line.length() < prefixLen + 10) {
+        return false;
+    }
+
+    if (line.compare(0, prefixLen, prefix) != 0) {
+        return false;
+    }
+
+    /* Check that there is base64 content after the prefix */
+    size_t spacePos = line.find(' ', prefixLen);
+    std::string b64;
+    if (spacePos == std::string::npos) {
+        b64 = line.substr(prefixLen);
+    } else {
+        b64 = line.substr(prefixLen, spacePos - prefixLen);
+    }
+
+    if (b64.length() < 10) {
+        return false;
+    }
+
+    return true;
+}
+
+/* ------------------------------------------------------------------ */
+/* Shell-quote a string using single quotes                           */
+/*                                                                    */
+/* 'hello'        => 'hello'                                          */
+/* it's           => 'it'"'"'s'                                       */
+/* ------------------------------------------------------------------ */
+std::string NetworkProtocolSSHCopyId::shellQuoteSingle(const std::string &s)
+{
+    std::string result = "'";
+    for (size_t i = 0; i < s.length(); i++) {
+        if (s[i] == '\'') {
+            /* End current single-quoted segment, add escaped quote,
+               start new single-quoted segment */
+            result += "'\"'\"'";
+        } else {
+            result += s[i];
+        }
+    }
+    result += "'";
+    return result;
+}
+
+/* ------------------------------------------------------------------ */
+/* Build remote install command                                       */
+/* ------------------------------------------------------------------ */
+std::string NetworkProtocolSSHCopyId::buildRemoteInstallCommand(
+    const std::string &pubkeyLine)
+{
+    std::string quoted = shellQuoteSingle(pubkeyLine);
+
+    std::string cmd;
+    cmd  = "umask 077; ";
+    cmd += "mkdir -p \"$HOME/.ssh\"; ";
+    cmd += "touch \"$HOME/.ssh/authorized_keys\"; ";
+    cmd += "chmod 700 \"$HOME/.ssh\"; ";
+    cmd += "chmod 600 \"$HOME/.ssh/authorized_keys\"; ";
+    cmd += "if grep -qxF " + quoted + " \"$HOME/.ssh/authorized_keys\"; then ";
+    cmd += "echo ALREADY_PRESENT; ";
+    cmd += "else ";
+    cmd += "printf '%s\\n' " + quoted + " >> \"$HOME/.ssh/authorized_keys\"; ";
+    cmd += "chmod 600 \"$HOME/.ssh/authorized_keys\"; ";
+    cmd += "echo INSTALLED; ";
+    cmd += "fi";
+
+    return cmd;
+}
+
+/* ------------------------------------------------------------------ */
+/* Connect to remote host with password authentication                */
+/* ------------------------------------------------------------------ */
+bool NetworkProtocolSSHCopyId::connectWithPassword(
+    const std::string &host, int port,
+    const std::string &user, const std::string &pass,
+    ssh_session &sess)
+{
+    int ret;
+
+    ret = ssh_init();
+    if (ret != 0) {
+        Debug_printf("SSH.COPYID: ssh_init failed (rc=%d).\r\n", ret);
+        setErrorResponse("SSH.COPYID error: SSH library init failed");
+        return false;
+    }
+
+    sess = ssh_new();
+    if (sess == NULL) {
+        Debug_printf("SSH.COPYID: ssh_new failed.\r\n");
+        setErrorResponse("SSH.COPYID error: cannot create SSH session");
+        return false;
+    }
+
+    int verbosity = SSH_LOG_PROTOCOL;
+    ssh_options_set(sess, SSH_OPTIONS_USER, user.c_str());
+    ssh_options_set(sess, SSH_OPTIONS_HOST, host.c_str());
+    ssh_options_set(sess, SSH_OPTIONS_LOG_VERBOSITY, &verbosity);
+    ssh_options_set(sess, SSH_OPTIONS_PORT, &port);
+#ifdef ESP_PLATFORM
+    sess->opts.config_processed = true;
+#endif
+
+    Debug_printf("SSH.COPYID: connecting to %s:%d as %s\r\n",
+                 host.c_str(), port, user.c_str());
+
+    ret = ssh_connect(sess);
+    if (ret != SSH_OK) {
+        const char *msg = ssh_get_error(sess);
+        Debug_printf("SSH.COPYID: ssh_connect failed: %s\r\n", msg);
+        setErrorResponse("SSH.COPYID error: cannot connect to host");
+        ssh_free(sess);
+        sess = NULL;
+        return false;
+    }
+
+    /* Host key verification — get and log fingerprint */
+    ssh_key srv_pubkey = NULL;
+    ret = ssh_get_server_publickey(sess, &srv_pubkey);
+    if (ret < 0) {
+        Debug_printf("SSH.COPYID: cannot get server public key.\r\n");
+        setErrorResponse("SSH.COPYID error: cannot verify host key");
+        ssh_disconnect(sess);
+        ssh_free(sess);
+        sess = NULL;
+        return false;
+    }
+
+    unsigned char *hash = NULL;
+    size_t hlen;
+    ret = ssh_get_publickey_hash(srv_pubkey, SSH_PUBLICKEY_HASH_SHA1,
+                                 &hash, &hlen);
+    ssh_key_free(srv_pubkey);
+
+    if (ret == 0 && hash != NULL) {
+        Debug_printf("SSH.COPYID host key fingerprint: ");
+        for (size_t i = 0; i < hlen; i++) {
+            Debug_printf("%02X%s", hash[i], (i < hlen - 1) ? ":" : "");
+        }
+        Debug_printf("\r\n");
+        ssh_clean_pubkey_hash(&hash);
+    }
+
+    /* Probe server auth methods */
+    ret = ssh_userauth_none(sess, NULL);
+    if (ret == SSH_AUTH_ERROR) {
+        Debug_printf("SSH.COPYID: userauth_none failed.\r\n");
+        setErrorResponse("SSH.COPYID error: authentication handshake failed");
+        ssh_disconnect(sess);
+        ssh_free(sess);
+        sess = NULL;
+        return false;
+    }
+
+    int methods = ssh_userauth_list(sess, NULL);
+    if (!(methods & SSH_AUTH_METHOD_PASSWORD)) {
+        Debug_printf("SSH.COPYID: server does not allow password auth.\r\n");
+        setErrorResponse("SSH.COPYID error: server does not allow password authentication");
+        ssh_disconnect(sess);
+        ssh_free(sess);
+        sess = NULL;
+        return false;
+    }
+
+    /* Authenticate with password */
+    ret = ssh_userauth_password(sess, NULL, pass.c_str());
+    if (ret != SSH_AUTH_SUCCESS) {
+        Debug_printf("SSH.COPYID: password auth failed.\r\n");
+        setErrorResponse("SSH.COPYID error: authentication failed");
+        ssh_disconnect(sess);
+        ssh_free(sess);
+        sess = NULL;
+        return false;
+    }
+
+    Debug_printf("SSH.COPYID: authenticated successfully.\r\n");
+    return true;
+}
+
+/* ------------------------------------------------------------------ */
+/* Execute remote install command                                     */
+/* ------------------------------------------------------------------ */
+bool NetworkProtocolSSHCopyId::installPublicKey(
+    ssh_session sess, const std::string &pubkeyLine, bool &installed)
+{
+    int ret;
+
+    ssh_channel chan = ssh_channel_new(sess);
+    if (chan == NULL) {
+        Debug_printf("SSH.COPYID: cannot create channel.\r\n");
+        setErrorResponse("SSH.COPYID error: cannot open SSH channel");
+        return false;
+    }
+
+    ret = ssh_channel_open_session(chan);
+    if (ret != SSH_OK) {
+        Debug_printf("SSH.COPYID: cannot open channel session.\r\n");
+        setErrorResponse("SSH.COPYID error: cannot open SSH channel");
+        ssh_channel_free(chan);
+        return false;
+    }
+
+    std::string cmd = buildRemoteInstallCommand(pubkeyLine);
+    Debug_printf("SSH.COPYID: executing remote command (%u bytes).\r\n",
+                 (unsigned)cmd.length());
+
+    ret = ssh_channel_request_exec(chan, cmd.c_str());
+    if (ret != SSH_OK) {
+        Debug_printf("SSH.COPYID: channel_request_exec failed.\r\n");
+        setErrorResponse("SSH.COPYID error: cannot execute remote command");
+        ssh_channel_close(chan);
+        ssh_channel_free(chan);
+        return false;
+    }
+
+    /* Read stdout */
+    char buf[256];
+    std::string output;
+    int nbytes;
+
+    do {
+        nbytes = ssh_channel_read(chan, buf, sizeof(buf) - 1, 0);
+        if (nbytes > 0) {
+            buf[nbytes] = '\0';
+            output += buf;
+        }
+    } while (nbytes > 0);
+
+    /* Read stderr for diagnostics */
+    std::string stderr_output;
+    do {
+        nbytes = ssh_channel_read(chan, buf, sizeof(buf) - 1, 1);
+        if (nbytes > 0) {
+            buf[nbytes] = '\0';
+            stderr_output += buf;
+        }
+    } while (nbytes > 0);
+
+    if (!stderr_output.empty()) {
+        Debug_printf("SSH.COPYID: remote stderr: %s\r\n", stderr_output.c_str());
+    }
+
+    /* Wait for command to finish and get exit status */
+    ssh_channel_send_eof(chan);
+    ssh_channel_close(chan);
+
+    int exit_status = ssh_channel_get_exit_status(chan);
+    Debug_printf("SSH.COPYID: remote exit status: %d\r\n", exit_status);
+    Debug_printf("SSH.COPYID: remote stdout: %s\r\n", output.c_str());
+
+    ssh_channel_free(chan);
+
+    if (exit_status != 0) {
+        Debug_printf("SSH.COPYID: remote command failed (exit=%d).\r\n",
+                     exit_status);
+        setErrorResponse("SSH.COPYID error: remote install failed");
+        return false;
+    }
+
+    /* Parse output to determine if key was installed or already present */
+    if (output.find("INSTALLED") != std::string::npos) {
+        installed = true;
+    } else if (output.find("ALREADY_PRESENT") != std::string::npos) {
+        installed = false;
+    } else {
+        /* Unexpected output — treat as success but log */
+        Debug_printf("SSH.COPYID: unexpected remote output, assuming installed.\r\n");
+        installed = true;
+    }
+
+    return true;
+}
+
+/* ------------------------------------------------------------------ */
+/* Status response helpers                                            */
+/* ------------------------------------------------------------------ */
+void NetworkProtocolSSHCopyId::setStatusResponse(
+    const std::string &host, const std::string &user, bool installed)
+{
+    statusResponse  = "OK SSH.COPYID\r\n";
+    statusResponse += "HOST " + host + "\r\n";
+    statusResponse += "USER " + user + "\r\n";
+    statusResponse += "KEY " + std::string(PUBKEY_REL_PATH) + "\r\n";
+    statusResponse += std::string("STATUS ") +
+                      (installed ? "installed" : "already-present") + "\r\n";
+}
+
+void NetworkProtocolSSHCopyId::setErrorResponse(const std::string &msg)
+{
+    statusResponse = msg + "\r\n";
+}
+
+/* ------------------------------------------------------------------ */
+/* open() — main entry point                                          */
+/* ------------------------------------------------------------------ */
+fujiError_t NetworkProtocolSSHCopyId::open(PeoplesUrlParser *urlParser,
+                                           fileAccessMode_t access,
+                                           netProtoTranslation_t translate)
+{
+    NetworkProtocol::open(urlParser, access, translate);
+
+    /* ---- Parse credentials from URL ---- */
+    if (!urlParser->user.empty()) {
+        login = &urlParser->user;
+    }
+    if (!urlParser->password.empty()) {
+        password = &urlParser->password;
+    }
+
+    std::string host = urlParser->host;
+    std::string user = login ? *login : "";
+    std::string pass = password ? *password : "";
+
+    /* Default port */
+    if (urlParser->port.empty()) {
+        urlParser->port = "22";
+    }
+    int port = urlParser->getPort();
+
+    Debug_printf("SSH.COPYID host: %s\r\n", host.c_str());
+    Debug_printf("SSH.COPYID user: %s\r\n", user.c_str());
+    Debug_printf("SSH.COPYID port: %d\r\n", port);
+
+    /* ---- Validate URL ---- */
+    if (user.empty()) {
+        setErrorResponse("SSH.COPYID error: missing SSH username");
+        error = NDEV_STATUS::INVALID_USERNAME_OR_PASSWORD;
+        Debug_printf("SSH.COPYID: missing username.\r\n");
+        return FUJI_ERROR::UNSPECIFIED;
+    }
+
+    if (pass.empty()) {
+        setErrorResponse("SSH.COPYID error: password required");
+        error = NDEV_STATUS::INVALID_USERNAME_OR_PASSWORD;
+        Debug_printf("SSH.COPYID: password required.\r\n");
+        return FUJI_ERROR::UNSPECIFIED;
+    }
+
+    if (host.empty()) {
+        setErrorResponse("SSH.COPYID error: missing hostname");
+        error = NDEV_STATUS::GENERAL;
+        Debug_printf("SSH.COPYID: missing hostname.\r\n");
+        return FUJI_ERROR::UNSPECIFIED;
+    }
+
+    /* ---- Read and validate local public key ---- */
+    std::string pubkeyLine;
+    if (!readDefaultPublicKey(pubkeyLine)) {
+        setErrorResponse("SSH.COPYID error: public key not found");
+        error = NDEV_STATUS::GENERAL;
+        return FUJI_ERROR::UNSPECIFIED;
+    }
+
+    Debug_printf("SSH.COPYID public key path: %s\r\n", getPublicKeyPath().c_str());
+
+    if (!validateEd25519PublicKey(pubkeyLine)) {
+        setErrorResponse("SSH.COPYID error: invalid public key");
+        error = NDEV_STATUS::GENERAL;
+        Debug_printf("SSH.COPYID: public key validation failed.\r\n");
+        return FUJI_ERROR::UNSPECIFIED;
+    }
+
+    /* ---- Connect and authenticate ---- */
+    ssh_session sess = NULL;
+    if (!connectWithPassword(host, port, user, pass, sess)) {
+        /* Error response already set by connectWithPassword */
+        error = NDEV_STATUS::GENERAL;
+        return FUJI_ERROR::UNSPECIFIED;
+    }
+
+    /* ---- Install public key on remote host ---- */
+    bool installed = false;
+    bool ok = installPublicKey(sess, pubkeyLine, installed);
+
+    /* ---- Clean up SSH session ---- */
+    ssh_disconnect(sess);
+    ssh_free(sess);
+
+    if (!ok) {
+        /* Error response already set by installPublicKey */
+        error = NDEV_STATUS::GENERAL;
+        return FUJI_ERROR::UNSPECIFIED;
+    }
+
+    /* ---- Build success response ---- */
+    setStatusResponse(host, user, installed);
+
+    Debug_printf("SSH.COPYID: success — %s.\r\n",
+                 installed ? "key installed" : "key already present");
+
+    return FUJI_ERROR::NONE;
+}
+
+/* ------------------------------------------------------------------ */
+/* read() — return status response                                    */
+/* ------------------------------------------------------------------ */
+fujiError_t NetworkProtocolSSHCopyId::read(unsigned short len)
+{
+    if (receiveBuffer->length() == 0 && !statusResponse.empty()) {
+        *receiveBuffer += statusResponse.substr(0, len);
+        if (len < statusResponse.length())
+            statusResponse.erase(0, len);
+        else
+            statusResponse.clear();
+    }
+
+    error = NDEV_STATUS::SUCCESS;
+    return NetworkProtocol::read(len);
+}
+
+/* ------------------------------------------------------------------ */
+/* write() — not supported                                            */
+/* ------------------------------------------------------------------ */
+fujiError_t NetworkProtocolSSHCopyId::write(unsigned short len)
+{
+    error = NDEV_STATUS::GENERAL;
+    return FUJI_ERROR::UNSPECIFIED;
+}
+
+/* ------------------------------------------------------------------ */
+/* status()                                                           */
+/* ------------------------------------------------------------------ */
+fujiError_t NetworkProtocolSSHCopyId::status(NetworkStatus *status)
+{
+    status->connected = 1;
+    status->error = error;
+    NetworkProtocol::status(status);
+    return FUJI_ERROR::NONE;
+}

--- a/lib/network-protocol/SSHCopyId.h
+++ b/lib/network-protocol/SSHCopyId.h
@@ -1,0 +1,154 @@
+/**
+ * SSH.COPYID Protocol Adapter
+ *
+ * Installs the FujiNet default SSH public key on a remote server,
+ * similar to the Unix ssh-copy-id command.
+ *
+ * Usage:
+ *   N:SSH.COPYID://user:pass@host:port/
+ *
+ * Reads:
+ *   /.ssh/id_ed25519.pub  (public key in authorized_keys format)
+ *
+ * Remote effect:
+ *   Appends the public key to ~/.ssh/authorized_keys on the remote
+ *   host (creating the directory/file if needed), skipping the
+ *   append if the key is already present.
+ *
+ * Returns a textual status response that can be read back by the
+ * Atari client.
+ */
+
+#ifndef NETWORKPROTOCOL_SSHCOPYID
+#define NETWORKPROTOCOL_SSHCOPYID
+
+#include <string>
+
+#include "Protocol.h"
+
+#include <libssh/libssh.h>
+
+class NetworkProtocolSSHCopyId : public NetworkProtocol
+{
+
+public:
+    /**
+     * ctor
+     */
+    NetworkProtocolSSHCopyId(std::string *rx_buf, std::string *tx_buf, std::string *sp_buf);
+
+    /**
+     * dtor
+     */
+    virtual ~NetworkProtocolSSHCopyId();
+
+    /**
+     * @brief Open — parse URL, connect, install public key, populate status response.
+     * @param urlParser The URL object passed in to open.
+     * @return FUJI_ERROR::NONE on success, FUJI_ERROR::UNSPECIFIED on error
+     */
+    fujiError_t open(PeoplesUrlParser *urlParser, fileAccessMode_t access,
+                         netProtoTranslation_t translate) override;
+
+    /**
+     * @brief Close — no-op (session cleaned up in open).
+     */
+    fujiError_t close() override { return FUJI_ERROR::NONE; }
+
+    /**
+     * @brief Read status response.
+     * @param len Number of bytes to read.
+     * @return FUJI_ERROR::NONE on success
+     */
+    fujiError_t read(unsigned short len) override;
+
+    /**
+     * @brief Write — not supported for SSH.COPYID.
+     */
+    fujiError_t write(unsigned short len) override;
+
+    /**
+     * @brief Return protocol status information.
+     */
+    fujiError_t status(NetworkStatus *status) override;
+
+    /**
+     * @brief Return available bytes in status response.
+     */
+    size_t available() override { return statusResponse.length(); }
+
+private:
+    /**
+     * Textual status response returned to the Atari client on read().
+     */
+    std::string statusResponse;
+
+    /**
+     * @brief Get absolute filesystem path to the public key on SD card.
+     */
+    std::string getPublicKeyPath();
+
+    /**
+     * @brief Read the default public key from SD card.
+     * @param[out] pubkeyLine The public key line (trimmed, no trailing newline).
+     * @return true on success
+     */
+    bool readDefaultPublicKey(std::string &pubkeyLine);
+
+    /**
+     * @brief Validate that a string looks like an Ed25519 authorized_keys entry.
+     * @param line The public key line to validate.
+     * @return true if valid
+     */
+    bool validateEd25519PublicKey(const std::string &line);
+
+    /**
+     * @brief Connect to remote host with password authentication.
+     * @param host Remote hostname.
+     * @param port Remote port.
+     * @param user SSH username.
+     * @param pass SSH password.
+     * @param[out] sess The created ssh_session (caller must free on success).
+     * @return true on success
+     */
+    bool connectWithPassword(const std::string &host, int port,
+                             const std::string &user, const std::string &pass,
+                             ssh_session &sess);
+
+    /**
+     * @brief Execute the remote install command and read back result.
+     * @param sess An authenticated ssh_session.
+     * @param pubkeyLine The public key line to install.
+     * @param[out] installed true if key was newly installed, false if already present.
+     * @return true on success
+     */
+    bool installPublicKey(ssh_session sess, const std::string &pubkeyLine,
+                          bool &installed);
+
+    /**
+     * @brief Build the remote shell command that installs the public key.
+     * @param pubkeyLine The public key line.
+     * @return The shell command string.
+     */
+    std::string buildRemoteInstallCommand(const std::string &pubkeyLine);
+
+    /**
+     * @brief Shell-quote a string using single quotes.
+     * @param s The string to quote.
+     * @return The safely quoted string.
+     */
+    static std::string shellQuoteSingle(const std::string &s);
+
+    /**
+     * @brief Set success status response.
+     */
+    void setStatusResponse(const std::string &host, const std::string &user,
+                           bool installed);
+
+    /**
+     * @brief Set error status response.
+     */
+    void setErrorResponse(const std::string &msg);
+};
+
+#endif /* NETWORKPROTOCOL_SSHCOPYID */

--- a/lib/network-protocol/SSHCopyId.h
+++ b/lib/network-protocol/SSHCopyId.h
@@ -27,6 +27,10 @@
 #include "Protocol.h"
 
 #include <libssh/libssh.h>
+#ifdef ESP_PLATFORM
+// apc: this is libssh private header!
+#include "libssh/session.h"
+#endif
 
 class NetworkProtocolSSHCopyId : public NetworkProtocol
 {

--- a/lib/network-protocol/SSHKeygen.cpp
+++ b/lib/network-protocol/SSHKeygen.cpp
@@ -1,0 +1,383 @@
+/**
+ * SSH.KEYGEN protocol implementation
+ *
+ * Generates an Ed25519 SSH key pair on the FujiNet SD card.
+ *
+ * URL:   N:SSH.KEYGEN://ed25519/             (fail if key exists)
+ *        N:SSH.KEYGEN://ed25519/?overwrite=1 (replace existing key)
+ *
+ * Keys:  /.ssh/id_ed25519      (private, OpenSSH format)
+ *        /.ssh/id_ed25519.pub  (public, authorized_keys format)
+ */
+
+#include "SSHKeygen.h"
+
+#include "../../include/debug.h"
+#include "status_error_codes.h"
+
+#include <libssh/libssh.h>
+
+#include <cstdio>
+#include <cstring>
+#include <sys/stat.h>
+#include <algorithm>
+
+/* ------------------------------------------------------------------ */
+/* SD card base path — same convention as SSH.cpp                     */
+/* ------------------------------------------------------------------ */
+#ifdef ESP_PLATFORM
+#define SD_BASE_PATH "/sd"
+#else
+#define SD_BASE_PATH "SD"
+#endif
+
+#define SSH_DIR_REL      "/.ssh"
+#define PRIVKEY_FILENAME "/id_ed25519"
+#define PUBKEY_FILENAME  "/id_ed25519.pub"
+#define PUBKEY_COMMENT   "FujiNet"
+
+/* ------------------------------------------------------------------ */
+/* ctor / dtor                                                        */
+/* ------------------------------------------------------------------ */
+NetworkProtocolSSHKeygen::NetworkProtocolSSHKeygen(std::string *rx_buf,
+                                                   std::string *tx_buf,
+                                                   std::string *sp_buf)
+    : NetworkProtocol(rx_buf, tx_buf, sp_buf)
+{
+    Debug_printf("NetworkProtocolSSHKeygen::ctor(%p,%p,%p)\r\n",
+                 rx_buf, tx_buf, sp_buf);
+}
+
+NetworkProtocolSSHKeygen::~NetworkProtocolSSHKeygen()
+{
+    Debug_printf("NetworkProtocolSSHKeygen::~dtor()\r\n");
+    statusResponse.clear();
+}
+
+/* ------------------------------------------------------------------ */
+/* Path helpers                                                       */
+/* ------------------------------------------------------------------ */
+std::string NetworkProtocolSSHKeygen::getSshDirPath()
+{
+    return std::string(SD_BASE_PATH) + SSH_DIR_REL;
+}
+
+std::string NetworkProtocolSSHKeygen::getPrivateKeyPath()
+{
+    return getSshDirPath() + PRIVKEY_FILENAME;
+}
+
+std::string NetworkProtocolSSHKeygen::getPublicKeyPath()
+{
+    return getSshDirPath() + PUBKEY_FILENAME;
+}
+
+/* ------------------------------------------------------------------ */
+/* Ensure /.ssh directory exists                                      */
+/* ------------------------------------------------------------------ */
+bool NetworkProtocolSSHKeygen::ensureSshDirectoryExists()
+{
+    std::string dirPath = getSshDirPath();
+    struct stat st;
+
+    if (stat(dirPath.c_str(), &st) == 0) {
+        /* Path exists — check it's a directory */
+        if (S_ISDIR(st.st_mode)) {
+            return true;
+        }
+        Debug_printf("SSH.KEYGEN: %s exists but is not a directory.\r\n",
+                     dirPath.c_str());
+        return false;
+    }
+
+    /* Directory does not exist — create it */
+    Debug_printf("SSH.KEYGEN: creating directory %s\r\n", dirPath.c_str());
+    if (mkdir(dirPath.c_str(), 0755) != 0) {
+        Debug_printf("SSH.KEYGEN: mkdir(%s) failed.\r\n", dirPath.c_str());
+        return false;
+    }
+
+    return true;
+}
+
+/* ------------------------------------------------------------------ */
+/* Check if key files already exist                                   */
+/* ------------------------------------------------------------------ */
+bool NetworkProtocolSSHKeygen::keyFilesAlreadyExist()
+{
+    struct stat st;
+    std::string privPath = getPrivateKeyPath();
+    std::string pubPath  = getPublicKeyPath();
+
+    if (stat(privPath.c_str(), &st) == 0) {
+        Debug_printf("SSH.KEYGEN: private key already exists: %s\r\n",
+                     privPath.c_str());
+        return true;
+    }
+    if (stat(pubPath.c_str(), &st) == 0) {
+        Debug_printf("SSH.KEYGEN: public key already exists: %s\r\n",
+                     pubPath.c_str());
+        return true;
+    }
+
+    return false;
+}
+
+/* ------------------------------------------------------------------ */
+/* Write public key in authorized_keys one-line format                */
+/*   ssh-ed25519 AAAA...base64... FujiNet\n                           */
+/* ------------------------------------------------------------------ */
+bool NetworkProtocolSSHKeygen::writePublicKey(void *key,
+                                              const std::string &path)
+{
+    ssh_key sshKey = (ssh_key)key;
+    char *b64_key = NULL;
+
+    int rc = ssh_pki_export_pubkey_base64(sshKey, &b64_key);
+    if (rc != SSH_OK || b64_key == NULL) {
+        Debug_printf("SSH.KEYGEN: ssh_pki_export_pubkey_base64 failed.\r\n");
+        return false;
+    }
+
+    const char *type_str = ssh_key_type_to_char(ssh_key_type(sshKey));
+    if (type_str == NULL) {
+        Debug_printf("SSH.KEYGEN: ssh_key_type_to_char failed.\r\n");
+        free(b64_key);
+        return false;
+    }
+
+    FILE *fp = fopen(path.c_str(), "w");
+    if (fp == NULL) {
+        Debug_printf("SSH.KEYGEN: cannot open %s for writing.\r\n",
+                     path.c_str());
+        free(b64_key);
+        return false;
+    }
+
+    fprintf(fp, "%s %s %s\n", type_str, b64_key, PUBKEY_COMMENT);
+    fclose(fp);
+    free(b64_key);
+
+    Debug_printf("SSH.KEYGEN: public key written to %s\r\n", path.c_str());
+    return true;
+}
+
+/* ------------------------------------------------------------------ */
+/* Remove a file, ignoring errors if it doesn't exist.                */
+/* ------------------------------------------------------------------ */
+void NetworkProtocolSSHKeygen::removeFile(const std::string &path)
+{
+    remove(path.c_str());
+}
+
+/* ------------------------------------------------------------------ */
+/* Parse query string for overwrite=1.                                */
+/* Only the exact value "1" enables overwrite.                        */
+/* ------------------------------------------------------------------ */
+bool NetworkProtocolSSHKeygen::parseOverwrite(const std::string &query)
+{
+    /* Look for "overwrite=1" in the query string.
+       Query may contain multiple params separated by '&'. */
+    std::string::size_type pos = 0;
+    while (pos < query.length()) {
+        std::string::size_type amp = query.find('&', pos);
+        std::string param = (amp == std::string::npos)
+            ? query.substr(pos)
+            : query.substr(pos, amp - pos);
+
+        if (param == "overwrite=1")
+            return true;
+
+        if (amp == std::string::npos)
+            break;
+        pos = amp + 1;
+    }
+    return false;
+}
+
+/* ------------------------------------------------------------------ */
+/* Generate Ed25519 key pair and save to SD card.                     */
+/*                                                                    */
+/* When useTempFiles is true (overwrite mode), writes to .tmp files   */
+/* first, then renames both into place.  This avoids leaving          */
+/* mismatched private/public key files if a write fails partway.      */
+/*                                                                    */
+/* Note: rename() on FAT/POSIX is not atomic but is the safest       */
+/* available sequence — both files are only replaced after both       */
+/* temp writes succeed.                                               */
+/* ------------------------------------------------------------------ */
+bool NetworkProtocolSSHKeygen::generateEd25519KeyPair(bool useTempFiles)
+{
+    ssh_key key = NULL;
+    int rc;
+
+    Debug_printf("SSH.KEYGEN: generating Ed25519 key pair...\r\n");
+
+    /* Generate key — parameter 0 for Ed25519 (no variable size) */
+    rc = ssh_pki_generate(SSH_KEYTYPE_ED25519, 0, &key);
+    if (rc != SSH_OK || key == NULL) {
+        Debug_printf("SSH.KEYGEN: ssh_pki_generate(ED25519) failed (rc=%d).\r\n", rc);
+        return false;
+    }
+
+    std::string privPath = getPrivateKeyPath();
+    std::string pubPath  = getPublicKeyPath();
+
+    /* Paths to write to — either final or temporary */
+    std::string privWrite = useTempFiles ? (privPath + ".tmp") : privPath;
+    std::string pubWrite  = useTempFiles ? (pubPath  + ".tmp") : pubPath;
+
+    /* Write private key (OpenSSH format, no passphrase) */
+    Debug_printf("SSH.KEYGEN: writing private key to %s\r\n", privWrite.c_str());
+    rc = ssh_pki_export_privkey_file(key, NULL, NULL, NULL, privWrite.c_str());
+    if (rc != SSH_OK) {
+        Debug_printf("SSH.KEYGEN: ssh_pki_export_privkey_file failed (rc=%d).\r\n", rc);
+        if (useTempFiles) removeFile(privWrite);
+        ssh_key_free(key);
+        return false;
+    }
+
+    /* Write public key (authorized_keys format with comment) */
+    if (!writePublicKey(key, pubWrite)) {
+        if (useTempFiles) removeFile(privWrite);
+        ssh_key_free(key);
+        return false;
+    }
+
+    ssh_key_free(key);
+
+    /* If using temp files, rename both into final position.
+       Remove old files first (rename over existing may fail on some
+       filesystems like FAT). */
+    if (useTempFiles) {
+        removeFile(privPath);
+        removeFile(pubPath);
+
+        if (rename(privWrite.c_str(), privPath.c_str()) != 0) {
+            Debug_printf("SSH.KEYGEN: rename %s -> %s failed.\r\n",
+                         privWrite.c_str(), privPath.c_str());
+            removeFile(privWrite);
+            removeFile(pubWrite);
+            return false;
+        }
+        if (rename(pubWrite.c_str(), pubPath.c_str()) != 0) {
+            Debug_printf("SSH.KEYGEN: rename %s -> %s failed.\r\n",
+                         pubWrite.c_str(), pubPath.c_str());
+            /* Private key already renamed — remove it to avoid mismatch */
+            removeFile(privPath);
+            removeFile(pubWrite);
+            return false;
+        }
+    }
+
+    Debug_printf("SSH.KEYGEN: key pair generated successfully.\r\n");
+    return true;
+}
+
+/* ------------------------------------------------------------------ */
+/* open() — parse URL, validate, generate keys                        */
+/* ------------------------------------------------------------------ */
+fujiError_t NetworkProtocolSSHKeygen::open(PeoplesUrlParser *urlParser,
+                                           fileAccessMode_t access,
+                                           netProtoTranslation_t translate)
+{
+    NetworkProtocol::open(urlParser, access, translate);
+
+    /* The algorithm is in the host field of the URL:
+       N:SSH.KEYGEN://ed25519/  =>  host = "ed25519" */
+    std::string algo = urlParser->host;
+    std::transform(algo.begin(), algo.end(), algo.begin(), ::tolower);
+
+    /* Parse overwrite flag from query string:
+       N:SSH.KEYGEN://ed25519/?overwrite=1 */
+    bool overwrite = parseOverwrite(urlParser->query);
+
+    Debug_printf("SSH.KEYGEN algorithm: %s\r\n", algo.c_str());
+    Debug_printf("SSH.KEYGEN overwrite: %s\r\n", overwrite ? "yes" : "no");
+
+    /* Only Ed25519 is supported */
+    if (algo != "ed25519") {
+        statusResponse = "SSH.KEYGEN error: unsupported algorithm: " + algo + "\r\n";
+        error = NDEV_STATUS::GENERAL;
+        Debug_printf("SSH.KEYGEN: unsupported algorithm '%s'.\r\n", algo.c_str());
+        return FUJI_ERROR::UNSPECIFIED;
+    }
+
+    /* Ensure /.ssh directory exists */
+    if (!ensureSshDirectoryExists()) {
+        statusResponse = "SSH.KEYGEN error: cannot create .ssh directory\r\n";
+        error = NDEV_STATUS::GENERAL;
+        return FUJI_ERROR::UNSPECIFIED;
+    }
+
+    /* Check for existing keys */
+    bool keysExist = keyFilesAlreadyExist();
+    if (keysExist && !overwrite) {
+        statusResponse = "SSH.KEYGEN error: key already exists\r\n";
+        error = NDEV_STATUS::GENERAL;
+        Debug_printf("SSH.KEYGEN: refusing to overwrite existing keys.\r\n");
+        return FUJI_ERROR::UNSPECIFIED;
+    }
+
+    /* Generate the key pair.
+       When overwriting, use temp files to avoid leaving mismatched
+       private/public keys if a write fails partway. */
+    if (!generateEd25519KeyPair(keysExist && overwrite)) {
+        statusResponse = "SSH.KEYGEN error: key generation failed\r\n";
+        error = NDEV_STATUS::GENERAL;
+        return FUJI_ERROR::UNSPECIFIED;
+    }
+
+    /* Build success status response */
+    std::string privRel = std::string(SSH_DIR_REL) + PRIVKEY_FILENAME;
+    std::string pubRel  = std::string(SSH_DIR_REL) + PUBKEY_FILENAME;
+
+    statusResponse  = "OK SSH.KEYGEN\r\n";
+    statusResponse += "TYPE ed25519\r\n";
+    statusResponse += std::string("OVERWRITE ") + (overwrite ? "1" : "0") + "\r\n";
+    statusResponse += "PRIVATE " + privRel + "\r\n";
+    statusResponse += "PUBLIC "  + pubRel  + "\r\n";
+
+    Debug_printf("SSH.KEYGEN: success.\r\n");
+    Debug_printf("SSH.KEYGEN private key path: %s\r\n", getPrivateKeyPath().c_str());
+    Debug_printf("SSH.KEYGEN public key path: %s\r\n",  getPublicKeyPath().c_str());
+
+    return FUJI_ERROR::NONE;
+}
+
+/* ------------------------------------------------------------------ */
+/* read() — return status response                                    */
+/* ------------------------------------------------------------------ */
+fujiError_t NetworkProtocolSSHKeygen::read(unsigned short len)
+{
+    if (receiveBuffer->length() == 0 && !statusResponse.empty()) {
+        *receiveBuffer += statusResponse.substr(0, len);
+        if (len < statusResponse.length())
+            statusResponse.erase(0, len);
+        else
+            statusResponse.clear();
+    }
+
+    error = NDEV_STATUS::SUCCESS;
+    return NetworkProtocol::read(len);
+}
+
+/* ------------------------------------------------------------------ */
+/* write() — not supported                                            */
+/* ------------------------------------------------------------------ */
+fujiError_t NetworkProtocolSSHKeygen::write(unsigned short len)
+{
+    error = NDEV_STATUS::GENERAL;
+    return FUJI_ERROR::UNSPECIFIED;
+}
+
+/* ------------------------------------------------------------------ */
+/* status()                                                           */
+/* ------------------------------------------------------------------ */
+fujiError_t NetworkProtocolSSHKeygen::status(NetworkStatus *status)
+{
+    status->connected = 1;
+    status->error = error;
+    NetworkProtocol::status(status);
+    return FUJI_ERROR::NONE;
+}

--- a/lib/network-protocol/SSHKeygen.cpp
+++ b/lib/network-protocol/SSHKeygen.cpp
@@ -20,6 +20,9 @@
 #include <cstdio>
 #include <cstring>
 #include <sys/stat.h>
+#ifdef _WIN32
+#include <direct.h>
+#endif
 #include <algorithm>
 
 /* ------------------------------------------------------------------ */
@@ -92,7 +95,11 @@ bool NetworkProtocolSSHKeygen::ensureSshDirectoryExists()
 
     /* Directory does not exist — create it */
     Debug_printf("SSH.KEYGEN: creating directory %s\r\n", dirPath.c_str());
+#ifdef _WIN32
+    if (mkdir(dirPath.c_str()) != 0) {
+#else
     if (mkdir(dirPath.c_str(), 0755) != 0) {
+#endif
         Debug_printf("SSH.KEYGEN: mkdir(%s) failed.\r\n", dirPath.c_str());
         return false;
     }

--- a/lib/network-protocol/SSHKeygen.h
+++ b/lib/network-protocol/SSHKeygen.h
@@ -1,0 +1,135 @@
+/**
+ * SSH.KEYGEN Protocol Adapter
+ *
+ * Generates an SSH key pair on the FujiNet SD card.
+ *
+ * Usage:
+ *   N:SSH.KEYGEN://ed25519/             — generate (fail if key exists)
+ *   N:SSH.KEYGEN://ed25519/?overwrite=1 — generate (replace existing key)
+ *
+ * Creates:
+ *   /.ssh/id_ed25519      (private key, OpenSSH format)
+ *   /.ssh/id_ed25519.pub  (public key, authorized_keys format)
+ *
+ * Returns a textual status response that can be read back by the
+ * Atari client.
+ */
+
+#ifndef NETWORKPROTOCOL_SSHKEYGEN
+#define NETWORKPROTOCOL_SSHKEYGEN
+
+#include <string>
+
+#include "Protocol.h"
+
+class NetworkProtocolSSHKeygen : public NetworkProtocol
+{
+
+public:
+    /**
+     * ctor
+     */
+    NetworkProtocolSSHKeygen(std::string *rx_buf, std::string *tx_buf, std::string *sp_buf);
+
+    /**
+     * dtor
+     */
+    virtual ~NetworkProtocolSSHKeygen();
+
+    /**
+     * @brief Open connection — parses URL, generates key pair, populates status response.
+     * @param urlParser The URL object passed in to open.
+     * @return FUJI_ERROR::NONE on success, FUJI_ERROR::UNSPECIFIED on error
+     */
+    fujiError_t open(PeoplesUrlParser *urlParser, fileAccessMode_t access,
+                         netProtoTranslation_t translate) override;
+
+    /**
+     * @brief Close — no-op.
+     */
+    fujiError_t close() override { return FUJI_ERROR::NONE; }
+
+    /**
+     * @brief Read status response.
+     * @param len Number of bytes to read.
+     * @return FUJI_ERROR::NONE on success, FUJI_ERROR::UNSPECIFIED on error
+     */
+    fujiError_t read(unsigned short len) override;
+
+    /**
+     * @brief Write — not supported for keygen.
+     */
+    fujiError_t write(unsigned short len) override;
+
+    /**
+     * @brief Return protocol status information.
+     */
+    fujiError_t status(NetworkStatus *status) override;
+
+    /**
+     * @brief Return available bytes in status response.
+     */
+    size_t available() override { return statusResponse.length(); }
+
+private:
+    /**
+     * Textual status response returned to the Atari client on read().
+     */
+    std::string statusResponse;
+
+    /**
+     * @brief Get absolute filesystem path to the SSH directory on SD card.
+     */
+    std::string getSshDirPath();
+
+    /**
+     * @brief Get absolute filesystem path to the private key.
+     */
+    std::string getPrivateKeyPath();
+
+    /**
+     * @brief Get absolute filesystem path to the public key.
+     */
+    std::string getPublicKeyPath();
+
+    /**
+     * @brief Ensure /.ssh directory exists on SD card; create if missing.
+     * @return true on success
+     */
+    bool ensureSshDirectoryExists();
+
+    /**
+     * @brief Check if either key file already exists.
+     * @return true if at least one key file exists
+     */
+    bool keyFilesAlreadyExist();
+
+    /**
+     * @brief Generate an Ed25519 key pair and save to SD card.
+     * @param useTempFiles If true, write to .tmp files first then rename.
+     * @return true on success
+     */
+    bool generateEd25519KeyPair(bool useTempFiles);
+
+    /**
+     * @brief Write public key in authorized_keys one-line format with comment.
+     * @param key The generated key
+     * @param path Absolute filesystem path
+     * @return true on success
+     */
+    bool writePublicKey(void *key, const std::string &path);
+
+    /**
+     * @brief Parse query string for overwrite=1 parameter.
+     * @param query Raw query string from URL
+     * @return true only if query contains exactly "overwrite=1"
+     */
+    bool parseOverwrite(const std::string &query);
+
+    /**
+     * @brief Remove a file, ignoring errors if it doesn't exist.
+     */
+    void removeFile(const std::string &path);
+};
+
+#endif /* NETWORKPROTOCOL_SSHKEYGEN */


### PR DESCRIPTION
Current: 
  Protocol: SSH (password)
  URL Format: N:SSH://user:pass@host:port/
  Purpose: Interactive SSH terminal with password authentication
  Notes: Existing protocol, extended with auth mode detection

Added:
  Protocol: SSH (public key)
  URL Format: N:SSH://user@host:port/
  Purpose: Interactive SSH terminal with public key authentication
  Notes: Uses /.ssh/id_ed25519 from SD card
  ────────────────────────────────────────
  Protocol: SSH.KEYGEN
  URL Format: N:SSH.KEYGEN://ed25519/
  Purpose: Generate Ed25519 SSH key pair on SD card
  Notes: Fails if key already exists
  ────────────────────────────────────────
  Protocol: SSH.KEYGEN (overwrite)
  URL Format: N:SSH.KEYGEN://ed25519/?overwrite=1
  Purpose: Regenerate key pair, replacing existing keys
  Notes: Safe overwrite via temp files + rename
  ────────────────────────────────────────
  Protocol: SSH.COPYID
  URL Format: N:SSH.COPYID://user:pass@host:port/
  Purpose: Install public key on remote server's authorized_keys
  Notes: Skips if key already present; requires password auth
