### PR TITLE
remove SD::available() stub

### DIFF
--- a/lib/network-protocol/SD.h
+++ b/lib/network-protocol/SD.h
@@ -64,8 +64,6 @@ public:
      */
     fujiError_t unlock(PeoplesUrlParser *url) override;
 
-    size_t available() override { return 0; }
-
 protected:
 
     /**


### PR DESCRIPTION
looks like forgotten stub left in SD protocol, relates to https://github.com/FujiNetWIFI/fujinet-firmware/issues/1119
no one reading from SD? :-)