### PR TITLE
[atari] Fixes modem, broken by c682fe6/PR1033

### DIFF
--- a/lib/bus/sio/sio.cpp
+++ b/lib/bus/sio/sio.cpp
@@ -653,22 +653,17 @@ int systemBus::getBaudrate()
     return _sioBaud;
 }
 
+// This method is called by devices to change the "UART" baudrate, it
+// has nothing to do with setting the SIO command baudrate. SIO
+// command baudrate is managed by toggleBaudrate() so _sioBaud is not
+// changed here.
 void systemBus::setBaudrate(int baud)
 {
-    if (_sioBaud == baud)
-    {
-        Debug_printf("Baudrate already at %d - nothing to do\n", baud);
-        return;
-    }
-
-    Debug_printf("Changing baudrate from %d to %d\n", _sioBaud, baud);
-    _sioBaud = baud;
-
     // Yah this looks stupid but C++ doesn't do true polymorphism
     if (isBoIP())
-        _netsio.setBaudrate(_sioBaud);
+        _netsio.setBaudrate(baud);
     else
-        _serial.setBaudrate(_sioBaud);
+        _serial.setBaudrate(baud);
 }
 
 // Set HSIO index. Sets high speed SIO baud and also returns that value.


### PR DESCRIPTION
When using BobTerm and the dialing directory or connecting to the terminal, the SIO command bus would freak out and cause a buzzing noise and lock up the Atari.

The refactor in c682fe6/PR1033 changed the SIO devices to use systemBus::setBaudrate() instead of directly manipulating the UART. setBaudrate() appeared to be the right replacement, but was actually a dead remnant of a previous refactor (now verified by removing it entirely from the pre-refactor of c682fe6/PR1033 codebase and there were no compilation errors). Switching devices to use setBaudrate() caused incorrect updating of _sioBaud. _sioBaud tracks the SIO command baud rate which is unrelated to the physical UART speed, so once devices started actually calling setBaudrate(), baud rate changing broke whenever a device changed the UART speed.