### PR TITLE
NetSIO, stop eating my CPU.

### DIFF
--- a/lib/bus/sio/NetSIO.cpp
+++ b/lib/bus/sio/NetSIO.cpp
@@ -155,6 +155,18 @@ void NetSIO::end()
     _initialized = false;
 }
 
+bool NetSIO::poll(int ms)
+{
+    if (_initialized)
+    {
+        if (handle_netsio() > 0)
+            return true;
+        return (wait_sock_readable(ms));
+    }
+    fnSystem.delay(ms);
+    return false;
+}
+
 void NetSIO::suspend(int ms)
 {
     Debug_printf("Suspending NetSIO for %d ms\n", ms);

--- a/lib/bus/sio/NetSIO.h
+++ b/lib/bus/sio/NetSIO.h
@@ -97,6 +97,8 @@ public:
     void begin(std::string host, int port, int baud);
     void end() override;
 
+    bool poll(int ms);
+
     void setBaudrate(uint32_t baud);
     uint32_t getBaudrate();
 

--- a/lib/bus/sio/sio.cpp
+++ b/lib/bus/sio/sio.cpp
@@ -461,6 +461,8 @@ void systemBus::service()
 #else
         if (!SYSTEM_BUS.isBoIP())
             _port->discardInput();
+        else
+            _netsio.poll(1); // wait 1 ms for something to happen (reliefs CPU usage)
 #endif
     }
 


### PR DESCRIPTION
Added poll() back to netsio class (lost in refactoring).
Without poll(), SIO bus service() runs a busy loop, loading CPU on LWM and spinning fans.
Note: A similar change is needed for SIO serial port and probably Becker port too. I'll try to update them later.