### PR TITLE
Standardize pin names for bus signals

### DIFF
--- a/include/pinmap/coco-common.h
+++ b/include/pinmap/coco-common.h
@@ -7,9 +7,9 @@
 #ifndef PIN_CASS_DATA_OUT
 #define PIN_CASS_DATA_OUT       GPIO_NUM_26                    // use count: 3
 #endif /* PIN_CASS_DATA_OUT */
-#ifndef PIN_CD
-#define PIN_CD                  GPIO_NUM_22                    // use count: 3
-#endif /* PIN_CD */
+#ifndef PIN_RS232_DCD
+#define PIN_RS232_DCD           GPIO_NUM_22                    // use count: 3
+#endif /* PIN_RS232_DCD */
 #ifndef PIN_EPROM_A14
 #define PIN_EPROM_A14           GPIO_NUM_36                    // use count: 3
 #endif /* PIN_EPROM_A14 */

--- a/include/pinmap/coco_esp32s3.h
+++ b/include/pinmap/coco_esp32s3.h
@@ -29,7 +29,7 @@
 #define PIN_CASS_MOTOR          GPIO_NUM_NC // Second motor pin is tied to +3V
 #define PIN_CASS_DATA_IN        GPIO_NUM_NC
 #define PIN_CASS_DATA_OUT       GPIO_NUM_NC
-#define PIN_CD                  GPIO_NUM_NC // same as atari PROC
+#define PIN_RS232_DCD           GPIO_NUM_NC // same as atari PROC
 #define PIN_EPROM_A14           GPIO_NUM_NC // Used to set the serial baud rate
 #define PIN_EPROM_A15           GPIO_NUM_NC // based on the HDB-DOS image selected
 

--- a/include/pinmap/fujiloaf-rev0.h
+++ b/include/pinmap/fujiloaf-rev0.h
@@ -21,7 +21,6 @@
 #define PIN_LED_BT              GPIO_NUM_NC // No BT LED
 #define PIN_LED_RGB             GPIO_NUM_4
 
-#define PIN_I2S                 GPIO_NUM_25
 #define PIN_IEC_RESET           GPIO_NUM_14
 #define PIN_IEC_DATA_IN         GPIO_NUM_26
 #define PIN_IEC_DATA_OUT        GPIO_NUM_26

--- a/include/pinmap/heathkit_h89.h
+++ b/include/pinmap/heathkit_h89.h
@@ -23,8 +23,8 @@
 #define PIN_BUS_DEVICE_MOSI     GPIO_NUM_25
 #define PIN_BUS_DEVICE_SCK      GPIO_NUM_33
 
-#define PIN_CMD_RDY             GPIO_NUM_27
-#define PIN_CMD                 GPIO_NUM_32
+#define PIN_CMD_ACK             GPIO_NUM_27
+#define PIN_CMD_REQ             GPIO_NUM_32
 #define PIN_DATA                GPIO_NUM_34 // input only
 #define PIN_PROCEED             GPIO_NUM_4
 

--- a/include/pinmap/rc2014spi_rev0.h
+++ b/include/pinmap/rc2014spi_rev0.h
@@ -22,8 +22,8 @@
 #define PIN_BUS_DEVICE_MOSI     GPIO_NUM_25
 #define PIN_BUS_DEVICE_SCK      GPIO_NUM_33
 
-#define PIN_CMD_RDY             GPIO_NUM_27
-#define PIN_CMD                 GPIO_NUM_32
+#define PIN_CMD_ACK             GPIO_NUM_27
+#define PIN_CMD_REQ             GPIO_NUM_32
 #define PIN_DATA                GPIO_NUM_34 // input only
 #define PIN_PROCEED             GPIO_NUM_4
 

--- a/lib/bus/drivewire/drivewire.cpp
+++ b/lib/bus/drivewire/drivewire.cpp
@@ -731,8 +731,8 @@ void systemBus::configureGPIO()
     gpio_isr_handler_add((gpio_num_t)PIN_CASS_MOTOR, drivewire_isr_handler, (void *)PIN_CASS_MOTOR);
 
     // Configure CD pin.
-    fnSystem.set_pin_mode(PIN_CD, gpio_mode_t::GPIO_MODE_OUTPUT_OD, SystemManager::pull_updown_t::PULL_UP);
-    fnSystem.digital_write(PIN_CD, DIGI_HIGH);
+    fnSystem.set_pin_mode(PIN_RS232_DCD, gpio_mode_t::GPIO_MODE_OUTPUT_OD, SystemManager::pull_updown_t::PULL_UP);
+    fnSystem.digital_write(PIN_RS232_DCD, DIGI_HIGH);
 
     // Start in DRIVEWIRE mode
     // Set the initial buad rate based on which ROM image is selected by the A14/A15 dip switch on Rev000 or newer.

--- a/lib/bus/h89/h89.cpp
+++ b/lib/bus/h89/h89.cpp
@@ -36,11 +36,11 @@ void systemBus::setup()
     Debug_println("H89 SETUP");
 
     // // Do any first time setup here
-    // fnSystem.set_pin_mode(PIN_CMD, gpio_mode_t::GPIO_MODE_INPUT); // There's no PULLUP/PULLDOWN on pins 34-39
+    // fnSystem.set_pin_mode(PIN_CMD_REQ, gpio_mode_t::GPIO_MODE_INPUT); // There's no PULLUP/PULLDOWN on pins 34-39
     // fnSystem.set_pin_mode(PIN_DATA, gpio_mode_t::GPIO_MODE_INPUT); // There's no PULLUP/PULLDOWN on pins 34-39
 
-    // fnSystem.set_pin_mode(PIN_CMD_RDY, gpio_mode_t::GPIO_MODE_OUTPUT);
-    // fnSystem.digital_write(PIN_CMD_RDY, DIGI_HIGH);
+    // fnSystem.set_pin_mode(PIN_CMD_ACK, gpio_mode_t::GPIO_MODE_OUTPUT);
+    // fnSystem.digital_write(PIN_CMD_ACK, DIGI_HIGH);
 
     // fnSystem.set_pin_mode(PIN_PROCEED, gpio_mode_t::GPIO_MODE_OUTPUT);
     // fnSystem.digital_write(PIN_PROCEED, DIGI_HIGH);

--- a/lib/bus/rc2014bus/rc2014bus.cpp
+++ b/lib/bus/rc2014bus/rc2014bus.cpp
@@ -335,7 +335,7 @@ void systemBus::service()
     }    
 #endif
     // Go process a command frame if the RC2014 CMD line is asserted
-    if (fnSystem.digital_read(PIN_CMD) == DIGI_LOW)
+    if (fnSystem.digital_read(PIN_CMD_REQ) == DIGI_LOW)
     {
         Debug_println("RC2014 CMD low");
         _rc2014_process_cmd();
@@ -350,12 +350,12 @@ void systemBus::service()
 //Called after a transaction is queued and ready for pickup by master.
 // Note: called after master asserts CS.
 void my_post_setup_cb(spi_slave_transaction_t *trans) {
-    gpio_set_level(PIN_CMD_RDY, DIGI_LOW);
+    gpio_set_level(PIN_CMD_ACK, DIGI_LOW);
 }
 
 //Called after transaction is sent/received.
 void my_post_trans_cb(spi_slave_transaction_t *trans) {
-    gpio_set_level(PIN_CMD_RDY, DIGI_HIGH);
+    gpio_set_level(PIN_CMD_ACK, DIGI_HIGH);
 }
     
 void systemBus::setup()
@@ -363,11 +363,11 @@ void systemBus::setup()
     Debug_println("RC2014 SETUP");
 
     // CMD PIN
-    fnSystem.set_pin_mode(PIN_CMD, gpio_mode_t::GPIO_MODE_INPUT); // There's no PULLUP/PULLDOWN on pins 34-39
+    fnSystem.set_pin_mode(PIN_CMD_REQ, gpio_mode_t::GPIO_MODE_INPUT); // There's no PULLUP/PULLDOWN on pins 34-39
     fnSystem.set_pin_mode(PIN_DATA, gpio_mode_t::GPIO_MODE_INPUT); // There's no PULLUP/PULLDOWN on pins 34-39
 
-    fnSystem.set_pin_mode(PIN_CMD_RDY, gpio_mode_t::GPIO_MODE_OUTPUT);
-    fnSystem.digital_write(PIN_CMD_RDY, DIGI_HIGH);
+    fnSystem.set_pin_mode(PIN_CMD_ACK, gpio_mode_t::GPIO_MODE_OUTPUT);
+    fnSystem.digital_write(PIN_CMD_ACK, DIGI_HIGH);
 
     fnSystem.set_pin_mode(PIN_PROCEED, gpio_mode_t::GPIO_MODE_OUTPUT);
     fnSystem.digital_write(PIN_PROCEED, DIGI_HIGH);

--- a/lib/bus/rc2014sio/rc2014sio.cpp
+++ b/lib/bus/rc2014sio/rc2014sio.cpp
@@ -212,7 +212,7 @@ void systemBus::_rc2014_process_cmd()
     Debug_printf("\nCF: %02x %02x %02x %02x %02x\n",
                  tempFrame.device, tempFrame.comnd, tempFrame.aux1, tempFrame.aux2, tempFrame.cksum);
     // Wait for CMD line to raise again
-    while (fnSystem.digital_read(PIN_CMD) == DIGI_LOW)
+    while (fnSystem.digital_read(PIN_CMD_REQ) == DIGI_LOW)
         vTaskDelay(1);
 
     uint8_t ck = rc2014_checksum((uint8_t *)&tempFrame.commanddata, sizeof(tempFrame.commanddata)); // Calculate Checksum
@@ -272,7 +272,7 @@ void systemBus::service()
     }    
 #endif
     // Go process a command frame if the RS232 CMD line is asserted
-    if (fnSystem.digital_read(PIN_CMD) == DIGI_LOW)
+    if (fnSystem.digital_read(PIN_CMD_REQ) == DIGI_LOW)
     {
         Debug_println("RC2014 CMD low");
         _rc2014_process_cmd();
@@ -306,7 +306,7 @@ void systemBus::setup()
     fnUartBUS.begin(RC2014SIO_BAUDRATE);
 
     // CMD PIN
-    fnSystem.set_pin_mode(PIN_CMD, gpio_mode_t::GPIO_MODE_INPUT); // There's no PULLUP/PULLDOWN on pins 34-39
+    fnSystem.set_pin_mode(PIN_CMD_REQ, gpio_mode_t::GPIO_MODE_INPUT); // There's no PULLUP/PULLDOWN on pins 34-39
     fnSystem.set_pin_mode(PIN_RS232_RTS, gpio_mode_t::GPIO_MODE_INPUT);
     fnSystem.set_pin_mode(PIN_RS232_CTS, gpio_mode_t::GPIO_MODE_OUTPUT);
     fnSystem.digital_write(PIN_RS232_CTS,DIGI_LOW);


### PR DESCRIPTION
Standardized the naming across different bus configs where different names were being used for the exact same underlying signal.