### PR TITLE
Make SP-over-SLIP over USB generally work

### DIFF
--- a/fujinet_pc.cmake
+++ b/fujinet_pc.cmake
@@ -63,6 +63,7 @@ if(FUJINET_TARGET STREQUAL "APPLE")
         add_compile_definitions(SLIP_PROTOCOL_NET=1)
     elseif(SLIP_PROTOCOL STREQUAL "COM")
         add_compile_definitions(SLIP_PROTOCOL_COM=1)
+        set(USE_LIBSERIAL TRUE)
     endif()
 
     message(STATUS "SLIP_PROTOCOL is ${SLIP_PROTOCOL}")

--- a/lib/bus/iwm/connector_com.cpp
+++ b/lib/bus/iwm/connector_com.cpp
@@ -4,56 +4,7 @@
 #include "connector_com.h"
 #include <libserialport.h>
 #include <iostream>
-#include "fnConfig.h"
-
-sp_parity parity_from_int(int parity_int)
-{
-	sp_parity parity;
-	switch (parity_int)
-	{
-	case 0:
-		parity = SP_PARITY_NONE;
-		break;
-	case 1:
-		parity = SP_PARITY_ODD;
-		break;
-	case 2:
-		parity = SP_PARITY_EVEN;
-		break;
-	case 3:
-		parity = SP_PARITY_MARK;
-		break;
-	case 4:
-		parity = SP_PARITY_SPACE;
-		break;
-	default:
-		parity = SP_PARITY_NONE; // Default / in case of invalid input
-	}
-	return parity;
-}
-
-sp_flowcontrol flowcontrol_from_int(int flowcontrol_int)
-{
-	sp_flowcontrol flowcontrol;
-	switch (flowcontrol_int)
-	{
-	case 0:
-		flowcontrol = SP_FLOWCONTROL_NONE;
-		break;
-	case 1:
-		flowcontrol = SP_FLOWCONTROL_XONXOFF;
-		break;
-	case 2:
-		flowcontrol = SP_FLOWCONTROL_RTSCTS;
-		break;
-	case 3:
-		flowcontrol = SP_FLOWCONTROL_DTRDSR;
-		break;
-	default:
-		flowcontrol = SP_FLOWCONTROL_NONE; // Default / in case of invalid input
-	}
-	return flowcontrol;
-}
+#include "debug.h"
 
 void cleanup_port(struct sp_port *port)
 {
@@ -66,44 +17,68 @@ void cleanup_port(struct sp_port *port)
 
 std::shared_ptr<Connection> connector_com::create_connection()
 {
-	Debug_printf("SP OVER SLIP, COM - Creating connection to target to service devices\n");
-
-	std::string port_name = Config.get_bos_port_name();
-	Debug_printf("COM: port_name = %s\n", port_name.c_str());
-	struct sp_port *port = nullptr;
-	enum sp_return result = sp_get_port_by_name(port_name.c_str(), &port);
+	struct sp_port **port_list;
+	enum sp_return result = sp_list_ports(&port_list);
 	if (result != SP_OK)
 	{
 		std::ostringstream msg;
-		msg << "Unable to get serial port from the given name: " << port_name.c_str();
+		msg << "Unable to list serial ports";
 		throw std::runtime_error(msg.str());
 	}
 
-	sp_set_baudrate(port, Config.get_bos_baud());
-	sp_set_bits(port, Config.get_bos_bits());
-	sp_set_parity(port, parity_from_int(Config.get_bos_parity()));
-	sp_set_stopbits(port, Config.get_bos_stop_bits());
-	sp_set_flowcontrol(port, flowcontrol_from_int(Config.get_bos_flowcontrol()));
-	
-	Debug_printf("COM: baud = %d\n", Config.get_bos_baud());
-	Debug_printf("COM: bits = %d\n", Config.get_bos_bits());
-	Debug_printf("COM: parity = %d\n", Config.get_bos_parity());
-	Debug_printf("COM: stopbits = %d\n", Config.get_bos_stop_bits());
-	Debug_printf("COM: flow_control = %d\n", Config.get_bos_flowcontrol());
+	struct sp_port *port = nullptr;
+	for (int i = 0; port_list[i] != NULL; i++)
+	{
+		if (sp_get_port_transport(port_list[i]) == SP_TRANSPORT_USB)
+		{
+			result = sp_copy_port(port_list[i], &port);
+			if (result != SP_OK)
+			{
+				std::ostringstream msg;
+				msg << "Unable to copy serial port";
+				throw std::runtime_error(msg.str());
+			}
+			break;
+		}
+	}
+	sp_free_port_list(port_list);
+	if (port == nullptr)
+	{
+		return nullptr;
+	}
 
-	result = sp_open(port, SP_MODE_READ_WRITE);
+	std::string port_name = sp_get_port_name(port);
+	Debug_printf("COM: port_name = %s\n", port_name.c_str());
+
+	for (int i = 0; i < 10; i++)
+	{
+	 	usleep(10 * 1000);
+		Debug_printf(".");
+		result = sp_open(port, SP_MODE_READ_WRITE);
+		if (result == SP_OK)
+		{
+			break;
+		}
+	}
 	if (result != SP_OK)
 	{
 		cleanup_port(port);
 		std::ostringstream msg;
-		msg << "Unable to get open serial port: " << port_name.c_str();
+		msg << "Unable to open serial port: " << port_name.c_str();
 		throw std::runtime_error(msg.str());
 	}
 
-	// we now need to do some handshake to check the other end is what we expect it to be, as so far, all we've done is open a port.
-	
+	result = sp_set_dtr(port, SP_DTR_ON);
+	if (result != SP_OK)
+	{
+		cleanup_port(port);
+		std::ostringstream msg;
+		msg << "Unable to set DTR on serial port: " << port_name.c_str();
+		throw std::runtime_error(msg.str());
+	}
 
 	auto conn = std::make_shared<COMConnection>(port_name, port, true);
+	conn->create_read_channel();
 	return conn;
 }
 

--- a/lib/config/fnConfig.h
+++ b/lib/config/fnConfig.h
@@ -284,26 +284,6 @@ public:
     void store_boip_host(const char *host);
     void store_boip_port(int port);
 
-#ifndef ESP_PLATFORM
-    // BUS over Serial
-    bool get_bos_enabled() { return _bos.bos_enabled; } // unused
-    std::string get_bos_port_name() { return _bos.port_name; }
-    int get_bos_baud() { return _bos.baud; }
-    int get_bos_bits() { return _bos.bits; }
-    int get_bos_parity() { return _bos.parity; }
-    int get_bos_stop_bits() { return _bos.stop_bits; }
-    int get_bos_flowcontrol() { return _bos.flowcontrol; }
-
-    void store_bos_enabled(bool bos_enabled);
-    void store_bos_port_name(char *port_name);
-    void store_bos_baud(int baud);
-    void store_bos_bits(int bits);
-    void store_bos_parity(int parity);
-    void store_bos_stop_bits(int stop_bits);
-    void store_bos_flowcontrol(int flowcontrol);
-
-#endif
-
     void load();
     void save();
 
@@ -334,9 +314,6 @@ private:
 #if defined(BUILD_RS232) || !defined(ESP_PLATFORM)
     void _read_section_serial(std::stringstream &ss);
 #endif /* BUILD_RS232 || ! ESP_PLATFORM */
-#ifndef ESP_PLATFORM
-    void _read_section_bos(std::stringstream &ss);
-#endif /* ! ESP_PLATFORM */
 
     enum section_match
     {
@@ -358,9 +335,6 @@ private:
 #if defined(BUILD_RS232) || !defined(ESP_PLATFORM)
         SECTION_SERIAL,
 #endif /* BUILD_RS232 || ! ESP_PLATFORM */
-#ifndef ESP_PLATFORM
-        SECTION_BOS,
-#endif /* ! ESP_PLATFORM */
         SECTION_UNKNOWN
     };
     section_match _find_section_in_line(std::string &line, int &index);
@@ -504,20 +478,6 @@ private:
     };
 #endif /* BUILD_RS232 || ! ESP_PLATFORM */
 
-#ifndef ESP_PLATFORM
-    // "bus" over serial
-    struct bos_info
-    {
-        bool bos_enabled = false;
-        std::string port_name = "COM1";
-        int baud = 9600;
-        int bits = 8;
-        int parity = 0; // SP_PARITY_NONE
-        int stop_bits = 1;
-        int flowcontrol = 0; // SP_FLOWCONTROL_NONE
-    };
-#endif /* ! ESP_PLATFORM */
-
     struct modem_info
     {
         bool modem_enabled = true;
@@ -576,9 +536,6 @@ private:
 #if defined(BUILD_RS232) || !defined(ESP_PLATFORM)
     serial_info _serial;
 #endif /* BUILD_RS232 || ! ESP_PLATFORM */
-#ifndef ESP_PLATFORM
-    bos_info _bos;
-#endif /* ! ESP_PLATFORM */
     cpm_info _cpm;
     device_enable_info _denable;
     phbook_info _phonebook_slots[MAX_PB_SLOTS];

--- a/lib/config/fnc_load.cpp
+++ b/lib/config/fnc_load.cpp
@@ -192,12 +192,6 @@ New behavior: copy from SD first if available, then read FLASH.
             _read_section_serial(ss);
             break;
 #endif /* BUILD_RS232 || ! ESP_PLATFORM */
-#ifndef ESP_PLATFORM
-        // Bus Over Serial, for APPLE SmartPort over Serial via USB/Serial
-        case SECTION_BOS:
-            _read_section_bos(ss);
-            break;
-#endif /* ! ESP_PLATFORM */
         case SECTION_UNKNOWN:
             break;
         }

--- a/lib/config/fnc_save.cpp
+++ b/lib/config/fnc_save.cpp
@@ -193,18 +193,6 @@ void fnConfig::save()
     ss << "command=" << std::string(_serial_command_pin_names[_serial.command]) << LINETERM;
     ss << "proceed=" << std::string(_serial_proceed_pin_names[_serial.proceed]) << LINETERM;
 #endif
-
-#ifdef BUILD_APPLE
-    // Bus Over Serial - not used, yet
-    ss << LINETERM << "[BOS]" << LINETERM;
-    ss << "enabled=" << _bos.bos_enabled << LINETERM;
-    ss << "port_name=" << _bos.port_name.c_str() << LINETERM;
-    ss << "baud=" << _bos.baud << LINETERM;
-    ss << "bits=" << _bos.bits << LINETERM;
-    ss << "parity=" << _bos.parity << LINETERM;
-    ss << "stop_bits=" << _bos.stop_bits << LINETERM;
-    ss << "flowcontrol=" << _bos.flowcontrol << LINETERM;
-#endif
 #endif
 
 #ifdef BUILD_RS232

--- a/lib/config/fnc_serial.cpp
+++ b/lib/config/fnc_serial.cpp
@@ -11,7 +11,7 @@
 // Bus Over IP configuration - used by CoCo and Apple (TODO consider to move Atari here too)
 
 /*
- * TODO! Create a Web configuration section for the Bus Over IP and Bus Over Serial data so it can be configured from WebUI.
+ * TODO! Create a Web configuration section for the Bus Over IP data so it can be configured from WebUI.
 */
 
 void fnConfig::store_boip_enabled(bool enabled) {
@@ -115,62 +115,6 @@ void fnConfig::store_serial_proceed(serial_proceed_pin proceed_pin)
     _serial.proceed = proceed_pin;
     _dirty = true;
 }
-
-void fnConfig::store_bos_enabled(bool bos_enabled) {
-    if (_bos.bos_enabled == bos_enabled)
-        return;
-
-    _bos.bos_enabled = bos_enabled;
-    _dirty = true;
-}
-
-void fnConfig::store_bos_port_name(char *port_name) {
-    if (_bos.port_name.compare(port_name) == 0)
-        return;
-
-    _bos.port_name = port_name;
-    _dirty = true;
-}
-
-void fnConfig::store_bos_baud(int baud) {
-    if (_bos.baud == baud)
-        return;
-
-    _bos.baud = baud;
-    _dirty = true;
-}
-
-void fnConfig::store_bos_bits(int bits) {
-    if (_bos.bits == bits)
-        return;
-
-    _bos.bits = bits;
-    _dirty = true;
-}
-
-void fnConfig::store_bos_parity(int parity) {
-    if (_bos.parity == parity)
-        return;
-
-    _bos.parity = parity;
-    _dirty = true;
-}
-
-void fnConfig::store_bos_stop_bits(int stop_bits) {
-    if (_bos.stop_bits == stop_bits)
-        return;
-
-    _bos.stop_bits = stop_bits;
-    _dirty = true;
-}
-
-void fnConfig::store_bos_flowcontrol(int flowcontrol) {
-    if (_bos.flowcontrol == flowcontrol)
-        return;
-
-    _bos.flowcontrol = flowcontrol;
-    _dirty = true;
-}
 #endif /* ! ESP_PLATFORM */
 
 #if defined(BUILD_RS232) || !defined(ESP_PLATFORM)
@@ -208,53 +152,6 @@ void fnConfig::_read_section_serial(std::stringstream &ss)
 #endif /* BUILD_RS232 || ! ESP_PLATFORM */
 
 #ifndef ESP_PLATFORM
-void fnConfig::_read_section_bos(std::stringstream &ss)
-{
-    std::string line;
-    // Read lines until one starts with '[' which indicates a new section
-    while (_read_line(ss, line, '[') >= 0)
-    {
-        std::string name;
-        std::string value;
-        if (_split_name_value(line, name, value))
-        {
-            if (strcasecmp(name.c_str(), "enabled") == 0)
-            {
-                _bos.bos_enabled = util_string_value_is_true(value);
-            }
-            else if (strcasecmp(name.c_str(), "port_name") == 0)
-            {
-                _bos.port_name = value;
-            }
-            else if (strcasecmp(name.c_str(), "baud") == 0)
-            {
-                int baud = atoi(value.c_str());
-                _bos.baud = baud;
-            }
-            else if (strcasecmp(name.c_str(), "bits") == 0)
-            {
-                int bits = atoi(value.c_str());
-                _bos.bits = bits;
-            }
-            else if (strcasecmp(name.c_str(), "parity") == 0)
-            {
-                int parity = atoi(value.c_str());
-                _bos.parity = parity;
-            }
-            else if (strcasecmp(name.c_str(), "stop_bits") == 0)
-            {
-                int stop_bits = atoi(value.c_str());
-                _bos.stop_bits = stop_bits;
-            }
-            else if (strcasecmp(name.c_str(), "flowcontrol") == 0)
-            {
-                int flowcontrol = atoi(value.c_str());
-                _bos.flowcontrol = flowcontrol;
-            }
-        }
-    }
-}
-
 fnConfig::serial_command_pin fnConfig::serial_command_from_string(const char *str)
 {
     int i = 0;

--- a/lib/config/fnc_util.cpp
+++ b/lib/config/fnc_util.cpp
@@ -131,12 +131,6 @@ fnConfig::section_match fnConfig::_find_section_in_line(std::string &line, int &
                 return SECTION_SERIAL;
             }
 #endif // defined(BUILD_RS232) || !defined(ESP_PLATFORM)
-#ifndef ESP_PLATFORM
-            else if (strncasecmp("BOS", s1.c_str(), 3) == 0)
-            {
-                return SECTION_BOS;
-            }
-#endif // ! ESP_PLATFORM
         }
     }
     return SECTION_UNKNOWN;

--- a/lib/devrelay/service/COMConnection.cpp
+++ b/lib/devrelay/service/COMConnection.cpp
@@ -1,7 +1,11 @@
 #if defined(DEV_RELAY_SLIP) && defined(SLIP_PROTOCOL_COM)
 
-#include "COMConnection.h"
+#include <cstring>
 #include <iostream>
+#include <thread>
+
+#include "COMConnection.h"
+#include "Log.h"
 #include "../slip/SLIP.h"
 
 COMConnection::COMConnection(const std::string &port_name, struct sp_port *port, bool is_connected) : port_name_(port_name), port_(port) { set_is_connected(is_connected); }
@@ -17,19 +21,40 @@ void COMConnection::send_data(const std::vector<uint8_t> &data)
 	}
 
 	const auto slip_data = SLIP::encode(data);
-	sp_nonblocking_write(port_, slip_data.data(), slip_data.size());
+	sp_blocking_write(port_, slip_data.data(), slip_data.size(), 60 * 1000);
 }
 
 void COMConnection::create_read_channel()
 {
 	reading_thread_ = std::thread([self = shared_from_this()]() {
+	    std::vector<uint8_t> complete_data;
 		std::vector<uint8_t> buffer(1024);
 		while (self->is_connected())
 		{
-			int bytes_read = sp_nonblocking_read(self->port_, buffer.data(), buffer.size());
-			if (bytes_read > 0)
+			int bytes_read = 0;
+			do
 			{
-				std::vector<std::vector<uint8_t>> decoded_packets = SLIP::split_into_packets(buffer.data(), buffer.size());
+				bytes_read = sp_nonblocking_read(self->port_, buffer.data(), buffer.size());
+				if (bytes_read < 0)
+				{
+					LogFileOutput("Error in sp_nonblocking_read(): %d (%s)\n", sp_last_error_code(), sp_last_error_message());
+					self->set_is_connected(false);
+					sp_close(self->port_);
+					sp_free_port(self->port_);
+					self->port_ = nullptr;
+				}
+				if (bytes_read > 0)
+				{
+					// LogFileOutput("SmartPortOverSlip COMConnection, inserting data, bytes_read: %d\n", bytes_read);
+					complete_data.insert(complete_data.end(), buffer.begin(), buffer.begin() + bytes_read);
+				}
+			} while (bytes_read > 0);
+
+			if (!complete_data.empty())			
+			{
+				std::vector<std::vector<uint8_t>> decoded_packets = SLIP::split_into_packets(complete_data.data(), complete_data.size());
+				// LogFileOutput("SmartPortOverSlip COMConnection, packets decoded: %d\n", decoded_packets.size());
+
 				if (!decoded_packets.empty())
 				{
 					for (const auto &packet : decoded_packets)
@@ -44,6 +69,7 @@ void COMConnection::create_read_channel()
 						}
 					}
 				}
+				complete_data.clear();				
 			}
 		}
 	});


### PR DESCRIPTION
* The whole 'Bus Over Serial' (BOS) configuration settings are removed. The serial port name is determined by enumerating the exsisting serial ports and choosing the one that is a virtual port using USB. The classic serial connection parameters are meaningless for USB CDC-ACM.
* COMConnection::create_read_channel() is now structured like TCPConnection::create_read_channel().
* The COMConnection lifecycle is different from the TCPConnection one. I don't know if that is beneficial or a mere artifact. Anyhow, after a successful connection establishment and shutdown, no new connection can be established. Rather the process needs to be restarted. Hopefully somebody with a better understanding of the overall connection lifecycle management can improve that aspect.