### PR TITLE
[atari][network] re-add INQDS command $FF post-refactor.

### DIFF
--- a/include/fujiCommandID.h
+++ b/include/fujiCommandID.h
@@ -107,7 +107,8 @@ enum fujiCommandID_t : uint8_t {
     DISKCMD_FORMAT_MEDIUM              = 0x22, // "
     DISKCMD_FORMAT                     = 0x21, // !
 
-    NETCMD_SPECIAL_INQUIRY             = 0xFF,
+    NETCMD_GET_DSTATS_VALUE            = 0xFF, // Get DSTATS value for a command
+    NETCMD_SPECIAL_INQUIRY             = 0xFF, // (same as NETCMD_GET_DSTATS_VALUE, for backward compatibility)
     NETCMD_PASSWORD                    = 0xFE,
     NETCMD_USERNAME                    = 0xFD,
     NETCMD_CHANNEL_MODE                = 0xFC,

--- a/lib/device/sio/network.cpp
+++ b/lib/device/sio/network.cpp
@@ -871,14 +871,14 @@ uint8_t sioNetwork::get_dstats_for_command(uint8_t command)
     case NETCMD_PARSE:
     case NETCMD_CONTROL:
     case NETCMD_CLOSE_CLIENT:
-        return 0x00;
+        return SIO_DIRECTION_NONE;
 
     // Payload from FujiNet to Atari (0x40)
     case NETCMD_HSIO_INDEX:
     case NETCMD_READ:
     case NETCMD_STATUS:
     case NETCMD_GETCWD:
-        return 0x40;
+        return SIO_DIRECTION_READ;
 
     // Payload from Atari to FujiNet (0x80)
     case NETCMD_OPEN:
@@ -898,11 +898,11 @@ uint8_t sioNetwork::get_dstats_for_command(uint8_t command)
     case NETCMD_MKDIR:
     case NETCMD_RMDIR:
     case NETCMD_SET_DESTINATION:
-        return 0x80;
+        return SIO_DIRECTION_WRITE;
 
     // Invalid/unknown command
     default:
-        return 0xFF;
+        return SIO_DIRECTION_INVALID;
     }
 }
 

--- a/lib/device/sio/network.cpp
+++ b/lib/device/sio/network.cpp
@@ -692,6 +692,19 @@ void sioNetwork::sio_set_password()
 }
 
 /**
+ * Get DSTATS value for a given command.
+ * This command allows CIO programs to query the data direction (DSTATS) for any network command.
+ * The command code to query is passed in DAUX1 (aux1).
+ * Returns a single byte: 0x00 (no payload), 0x40 (FujiNet→Atari), 0x80 (Atari→FujiNet), or 0xFF (invalid command).
+ */
+void sioNetwork::sio_get_dstats_value()
+{
+    uint8_t command = cmdFrame.aux1;
+    uint8_t dstats = get_dstats_for_command(command);
+    bus_to_computer(&dstats, 1, false);
+}
+
+/**
  * Process incoming SIO command for device 0x7X
  * @param comanddata incoming 4 bytes containing command and aux bytes
  * @param checksum 8 bit checksum
@@ -769,6 +782,11 @@ void sioNetwork::sio_process(uint32_t commanddata, uint8_t checksum)
         sio_set_password();
         return;
 
+    case NETCMD_GET_DSTATS_VALUE:
+        sio_ack();
+        sio_get_dstats_value();
+        break;
+
     case NETCMD_RENAME:
     case NETCMD_DELETE:
     case NETCMD_LOCK:
@@ -832,6 +850,61 @@ void sioNetwork::sio_poll_interrupt()
 }
 
 /** PRIVATE METHODS ************************************************************/
+
+/**
+ * Get the DSTATS value for a given network command.
+ * DSTATS indicates the direction of data for a command:
+ * - 0x00: No payload
+ * - 0x40: Payload from FujiNet to Atari
+ * - 0x80: Payload from Atari to FujiNet
+ * - 0xFF: Invalid/unknown command
+ *
+ * @param command The network command code (typically from aux1)
+ * @return The DSTATS byte value for that command
+ */
+uint8_t sioNetwork::get_dstats_for_command(uint8_t command)
+{
+    switch (command)
+    {
+    // No payload commands (0x00)
+    case NETCMD_CLOSE:
+    case NETCMD_PARSE:
+    case NETCMD_CONTROL:
+    case NETCMD_CLOSE_CLIENT:
+        return 0x00;
+
+    // Payload from FujiNet to Atari (0x40)
+    case NETCMD_HSIO_INDEX:
+    case NETCMD_READ:
+    case NETCMD_STATUS:
+    case NETCMD_GETCWD:
+        return 0x40;
+
+    // Payload from Atari to FujiNet (0x80)
+    case NETCMD_OPEN:
+    case NETCMD_WRITE:
+    case NETCMD_TRANSLATION:
+    case NETCMD_SET_INT_RATE:
+    case NETCMD_SET_PARAMETERS:
+    case NETCMD_CHANNEL_MODE:
+    case NETCMD_CHDIR:
+    case NETCMD_QUERY:
+    case NETCMD_USERNAME:
+    case NETCMD_PASSWORD:
+    case NETCMD_RENAME:
+    case NETCMD_DELETE:
+    case NETCMD_LOCK:
+    case NETCMD_UNLOCK:
+    case NETCMD_MKDIR:
+    case NETCMD_RMDIR:
+    case NETCMD_SET_DESTINATION:
+        return 0x80;
+
+    // Invalid/unknown command
+    default:
+        return 0xFF;
+    }
+}
 
 /**
  * Instantiate protocol object

--- a/lib/device/sio/network.h
+++ b/lib/device/sio/network.h
@@ -121,6 +121,12 @@ public:
     virtual void sio_set_password();
 
     /**
+     * @brief Get DSTATS value for a given network command
+     * Allows programs to query the data direction for any command.
+     */
+    virtual void sio_get_dstats_value();
+
+    /**
      * Check to see if PROCEED needs to be asserted.
      */
     void sio_poll_interrupt();
@@ -287,6 +293,13 @@ private:
      * Create a urlParser from deviceSpec
     */
    void create_url_parser();
+
+    /**
+     * Get the DSTATS value for a given network command
+     * @param command The network command code
+     * @return The DSTATS byte value (0x00, 0x40, 0x80, or 0xFF for invalid)
+     */
+    uint8_t get_dstats_for_command(uint8_t command);
 
     /**
      * Start the Interrupt rate limiting timer


### PR DESCRIPTION
Add NETCMD_GET_DSTATS_VALUE (0xFF) Command Handler for SIO Network Device
Summary
Add a new SIO command (0xFF) that allows programs to query the DSTATS (data status) value for any network command. This is essential for programs using CIO that cannot pass the DSTATS value explicitly, as direct SIO programmers can.

Motivation
Every FujiNet network command requires a DSTATS value to indicate the direction of data flow:

0x00 — No payload
0x40 — Payload from FujiNet to Atari (read-like operations)
0x80 — Payload from Atari to FujiNet (write-like operations)
0xFF — Invalid/unknown command
Direct SIO programmers can hardcode DSTATS values from documentation, but CIO programs have no mechanism to specify this value. This command enables them to query it dynamically before issuing the actual network command.

Changes
Added constant NETCMD_GET_DSTATS_VALUE = 0xFF to fujiCommandID.h

Kept existing NETCMD_SPECIAL_INQUIRY as alias for backward compatibility
Implemented helper function uint8_t get_dstats_for_command(uint8_t command) in network.cpp

Private method with lookup table for all 25 network commands
Returns appropriate DSTATS value or 0xFF for unknown commands
Implemented command handler void sio_get_dstats_value() in network.cpp

Reads command code from DAUX1 parameter
Performs lookup via helper function
Returns single-byte DSTATS response via bus_to_computer()
Wired into command processor in network.cpp

Added case in sio_process() switch statement for 0xFF command
Added method declarations to network.h

DSTATS Mapping Reference
All 25 supported commands and their DSTATS values:

DSTATS	Commands
0x00	CLOSE, PARSE, CONTROL, CLOSE_CLIENT
0x40	HSIO_INDEX, READ, STATUS, GETCWD
0x80	OPEN, WRITE, TRANSLATION, SET_INT_RATE, SET_PARAMETERS, CHANNEL_MODE, CHDIR, QUERY, USERNAME, PASSWORD, RENAME, DELETE, LOCK, UNLOCK, MKDIR, RMDIR, SET_DESTINATION
Usage Example (Atari 8-bit)

; Query DSTATS for NETCMD_OPEN (0x4F)LDA #$FF        ; Command 0xFFLDX #$4F        ; DAUX1 = NETCMD_OPENLDY #0          ; DAUX2 = 0 (unused)JSR SIOV        ; Call SIO; Returns DSTATS in status byte (0x80 for OPEN)
Testing
✅ Compiles without errors
✅ Handles all 25 documented network commands
✅ Returns 0xFF for invalid/unknown commands
Ready for functional testing on Atari hardware
Notes
No data payload expected (stateless lookup operation)
Command follows same pattern as existing sio_high_speed() (single-byte response)
Does not affect any existing functionality