### PR TITLE
Fix/atari ssh stability and startup mount idempotency

### DIFF
--- a/components/libssh/src/knownhosts.c
+++ b/components/libssh/src/knownhosts.c
@@ -222,6 +222,22 @@ static int ssh_known_hosts_read_entries(const char *match,
     FILE *fp;
     int rc;
 
+    /* Fix (2026-05-19, fujinet): the LIBSSH_FUJINET branch of
+     * ssh_options_apply() leaves session->opts.knownhosts and
+     * global_knownhosts as NULL (FujiNet has no persistent
+     * known_hosts file).  Callers (ssh_known_hosts_get_algorithms_names,
+     * ssh_session_has_known_hosts_entry, ...) pass that NULL straight
+     * through to here.  Plain libssh tolerates that because glibc's
+     * fopen(NULL, "r") returns NULL with errno=EFAULT, but ESP32 newlib's
+     * fopen() passes the NULL path to strlen() inside get_vfs_for_path()
+     * which then dereferences it and panics the firmware with
+     * "Guru Meditation Error: LoadProhibited" at strlen+0x5 in ROM.
+     * Treat a NULL filename the same as a missing file: success with
+     * no entries appended. */
+    if (filename == NULL) {
+        return SSH_OK;
+    }
+
     fp = fopen(filename, "r");
     if (fp == NULL) {
         SSH_LOG(SSH_LOG_WARN, "Failed to open the known_hosts file '%s': %s",

--- a/components/libssh/src/options.c
+++ b/components/libssh/src/options.c
@@ -1452,8 +1452,20 @@ int ssh_options_apply(ssh_session session) {
     free(session->opts.knownhosts);
     session->opts.knownhosts = tmp;
     #else
+    /*
+     * Fix (2026-05-19): the previous code assigned the RODATA literal
+     * "" to session->opts.knownhosts.  ssh_free() in session.c later
+     * calls SAFE_FREE(session->opts.knownhosts), which invokes free()
+     * on a non-heap pointer and aborts the firmware with
+     * "heap_caps_free target pointer is outside heap areas" on every
+     * SSH close.  All consumers in known_hosts.c / knownhosts.c
+     * already treat NULL as "no known_hosts file", and they emit the
+     * spurious log "Failed to open the known_hosts file '': Is a
+     * directory" when given an empty path, so NULL is both safer and
+     * cleaner than "".
+     */
     if (session->opts.knownhosts != NULL) free(session->opts.knownhosts);
-    session->opts.knownhosts = "";
+    session->opts.knownhosts = NULL;
     #endif
 
     #ifndef LIBSSH_FUJINET
@@ -1468,8 +1480,11 @@ int ssh_options_apply(ssh_session session) {
     free(session->opts.global_knownhosts);
     session->opts.global_knownhosts = tmp;
     #else
+    /* Fix (2026-05-19): same root cause as knownhosts above — the
+     * RODATA "" assignment crashes ssh_free() at session.c:311.
+     */
     if (session->opts.global_knownhosts != NULL) free(session->opts.global_knownhosts);
-    session->opts.global_knownhosts = "";
+    session->opts.global_knownhosts = NULL;
     #endif
 
     if (session->opts.ProxyCommand != NULL) {

--- a/lib/device/fujiDevice.cpp
+++ b/lib/device/fujiDevice.cpp
@@ -175,6 +175,51 @@ success_is_true fujiDevice::fujicmd_mount_all_success()
     RETURN_SUCCESS_AS_TRUE();
 }
 
+// Idempotent mount-all for the startup path.
+//
+// Two callers race for the boot-time mount of config slots:
+//   1. fn_service_loop() in src/main.cpp, immediately after starting
+//      WiFi but before WiFi has acquired an IP.
+//   2. The IP_EVENT_STA_GOT_IP handler in lib/hardware/fnWiFi.cpp,
+//      after WiFi successfully obtains an IP.
+//
+// Both call paths only fire when general_config_enabled == false, so
+// they target the same set of saved mount slots.  Letting them both
+// run risked deleting and recreating the FileSystemTNFS instance
+// underneath an in-flight first call, which invalidated any open
+// disk-image file handles (symptom: EBADF, "failed seeking to header
+// on disk image (-1, 9)").
+//
+// This wrapper claims an atomic lock on entry.  Whichever caller
+// arrives first proceeds with the mount; the other one returns
+// success immediately and does not touch the host filesystems.
+// On a failed mount the lock is released so a later caller can
+// retry (typical scenario: main_setup() loses the race only because
+// WiFi has not yet acquired an IP -> mount fails fast -> lock
+// released -> IP_GOT handler succeeds a few seconds later).
+//
+// User- and bus-initiated remounts use fujicmd_mount_all_success()
+// or fujicore_mount_all_success() directly and are unaffected by
+// this guard.
+success_is_true fujiDevice::fujicore_mount_all_at_startup()
+{
+    bool was_locked = _startup_mount_lock.exchange(true);
+    if (was_locked) {
+        Debug_println("::fujicore_mount_all_at_startup: another caller "
+                      "already owns the startup mount, skipping");
+        RETURN_SUCCESS_AS_TRUE();
+    }
+
+    success_is_true result = fujicore_mount_all_success();
+    if (!result) {
+        // Release the lock so a later startup caller (typically the
+        // IP_EVENT_STA_GOT_IP handler) can retry.  On success we
+        // intentionally keep the lock held forever.
+        _startup_mount_lock.store(false);
+    }
+    return result;
+}
+
 // This gets called when we're about to shutdown/reboot
 void fujiDevice::shutdown()
 {

--- a/lib/device/fujiDevice.h
+++ b/lib/device/fujiDevice.h
@@ -11,6 +11,7 @@
 #include <string>
 #include <optional>
 #include <map>
+#include <atomic>
 
 #if defined(BUILD_ATARI) || defined(BUILD_LYNX)
 #define SYSTEM_BUS_IS_UDP 1
@@ -143,6 +144,29 @@ protected:
     int _current_open_directory_slot = -1;
     uint8_t _countScannedSSIDs = 0;
 
+    // Idempotent guard for the startup mount-all path.
+    // Two startup callers race for the mount: main_setup() at boot
+    // (before WiFi has an IP) and the IP_EVENT_STA_GOT_IP handler in
+    // fnWiFi.cpp (after WiFi connects).  Without coordination, the
+    // second caller deletes/recreates the FileSystemTNFS underneath
+    // an in-flight first call, invalidating any opened disk image
+    // file handles (EBADF / "failed seeking to header on disk image
+    // (-1, 9)").
+    //
+    // The lock is cleared on a *failed* attempt so a later startup
+    // caller can retry (e.g. main_setup attempt fails because WiFi
+    // has not yet acquired IP -> lock released -> IP_GOT handler
+    // retries successfully a moment later).  After a successful
+    // mount the lock stays held forever; the firmware does not
+    // re-mount config slots at startup more than once.
+    //
+    // This guard is intentionally restricted to the startup path
+    // (fujicore_mount_all_at_startup) and does NOT cover user- or
+    // bus-initiated remounts (fujicmd_mount_all_success and the many
+    // platform fujicmd_* callers), which must continue to work on
+    // demand.
+    std::atomic<bool> _startup_mount_lock{false};
+
     Hash::Algorithm algorithm = Hash::Algorithm::UNKNOWN;
 
     virtual void transaction_begin(transState_t expectMoreData) = 0;
@@ -255,6 +279,10 @@ public:
     success_is_true fujicore_unmount_disk_image_success(uint8_t deviceSlot);
     success_is_true fujicore_mount_host_success(unsigned hostSlot);
     success_is_true fujicore_mount_all_success();
+    // Idempotent wrapper around fujicore_mount_all_success() for the
+    // startup mount-all path.  See _startup_mount_lock for the design
+    // notes and intended call sites.
+    success_is_true fujicore_mount_all_at_startup();
     void fujicore_net_scan_networks();
     success_is_true fujicore_net_set_ssid_success(const char *ssid, const char *password, bool save);
 

--- a/lib/hardware/fnWiFi.cpp
+++ b/lib/hardware/fnWiFi.cpp
@@ -637,8 +637,17 @@ void WiFiManager::_wifi_event_handler(void *arg, esp_event_base_t event_base,
 //             IWM.startup_hack();
 // #endif
 #ifdef BUILD_ATARI // temporary
+            // Mount saved config slots once WiFi has an IP.
+            // fn_service_loop() in src/main.cpp also attempts this
+            // mount earlier, before WiFi was up.  Both paths share
+            // fujicore_mount_all_at_startup() -- an idempotent
+            // wrapper that lets whichever caller arrives first do
+            // the work and turns the other into a no-op, avoiding
+            // the previous double-mount race that invalidated open
+            // disk image file handles (EBADF / "failed seeking to
+            // header on disk image (-1, 9)").
             if (Config.get_general_config_enabled() == false)
-                theFuji->fujicore_mount_all_success();
+                theFuji->fujicore_mount_all_at_startup();
 #endif /* BUILD_ATARI */
             mdns_init();
             mdns_hostname_set(Config.get_general_devicename().c_str());

--- a/lib/network-protocol/SSH.cpp
+++ b/lib/network-protocol/SSH.cpp
@@ -45,16 +45,39 @@ NetworkProtocolSSH::NetworkProtocolSSH(std::string *rx_buf, std::string *tx_buf,
 #else
     rxbuf = (char *)malloc(RXBUF_SIZE);
 #endif
+    if (rxbuf == nullptr)
+    {
+        /*
+         * Fix (2026-05-19): heap_caps_malloc(MALLOC_CAP_SPIRAM) can
+         * fail when PSRAM is unavailable or exhausted.  Previously
+         * the NULL pointer was used unguarded in ssh_channel_read()
+         * and std::string::append() below, which crashed the firmware.
+         * The destructor now also tolerates a NULL rxbuf, but log the
+         * allocation failure so the operator can see it.
+         */
+        Debug_printf("NetworkProtocolSSH::NetworkProtocolSSH() - rxbuf allocation FAILED (%u bytes)\r\n",
+                     (unsigned)RXBUF_SIZE);
+    }
 }
 
 NetworkProtocolSSH::~NetworkProtocolSSH()
 {
     Debug_printf("NetworkProtocolSSH::~NetworkProtocolSSH()\r\n");
+    /*
+     * Fix (2026-05-19): guard against a NULL rxbuf so a failed
+     * heap_caps_malloc() in the ctor doesn't crash the dtor.  Null
+     * the pointer after the free so a (hypothetical) second dtor
+     * invocation would not double-free.
+     */
+    if (rxbuf != nullptr)
+    {
 #ifdef ESP_PLATFORM
-    heap_caps_free(rxbuf);
+        heap_caps_free(rxbuf);
 #else
-    free(rxbuf);
+        free(rxbuf);
 #endif
+        rxbuf = nullptr;
+    }
 }
 
 /* ------------------------------------------------------------------ */
@@ -339,9 +362,35 @@ fujiError_t NetworkProtocolSSH::open(PeoplesUrlParser *urlParser,
 
 fujiError_t NetworkProtocolSSH::close()
 {
-    ssh_disconnect(session);
-    ssh_free(session);
-    return FUJI_ERROR::NONE;
+    /*
+     * Fix (2026-05-19): the previous implementation unconditionally
+     * called ssh_disconnect()/ssh_free() on `session` without
+     *   - tearing down `channel` first (ssh_channel_send_eof /
+     *     ssh_channel_close / ssh_channel_free),
+     *   - guarding against a NULL or already-freed `session`, and
+     *   - chaining to NetworkProtocol::close() (which clears and
+     *     shrinks the std::string buffers, like TCP::close() does).
+     * That left libssh internal channel state half-freed when the
+     * remote host had already closed the shell (after "exit\n"),
+     * and a second CLOSE from the host would double-free the session.
+     * Both cases corrupted the heap and crashed the next free().
+     */
+    if (channel != nullptr)
+    {
+        ssh_channel_send_eof(channel);
+        ssh_channel_close(channel);
+        ssh_channel_free(channel);
+        channel = nullptr;
+    }
+
+    if (session != nullptr)
+    {
+        ssh_disconnect(session);
+        ssh_free(session);
+        session = nullptr;
+    }
+
+    return NetworkProtocol::close();
 }
 
 fujiError_t NetworkProtocolSSH::read(unsigned short len)
@@ -377,12 +426,23 @@ size_t NetworkProtocolSSH::available()
 {
     if (receiveBuffer->length() == 0)
     {
-        if (ssh_channel_is_eof(channel) == 0)
+        if (channel != nullptr && ssh_channel_is_eof(channel) == 0)
         {
             int len = ssh_channel_read(channel, rxbuf, RXBUF_SIZE, 0);
-            if (len != SSH_AGAIN)
+            /*
+             * Fix (2026-05-19): ssh_channel_read() returns a signed int
+             * that can be SSH_AGAIN, SSH_EOF (0) or SSH_ERROR (-1).
+             * The previous code only filtered SSH_AGAIN, so SSH_ERROR
+             * (-1) was implicitly cast to size_t (~4 GB) inside
+             * std::string::append(), trashing the PSRAM heap.  The
+             * corruption only surfaced later as
+             * "heap_caps_free target pointer is outside heap areas"
+             * during ~NetworkProtocolSSH() in sio_close().
+             * Accept only strictly positive byte counts.
+             */
+            if (len > 0)
             {
-                receiveBuffer->append(rxbuf, len);
+                receiveBuffer->append(rxbuf, (size_t)len);
                 translate_receive_buffer();
             }
         }

--- a/lib/network-protocol/SSH.h
+++ b/lib/network-protocol/SSH.h
@@ -72,14 +72,18 @@ public:
 
 private:
     /**
-     * The libssh session structure
+     * The libssh session structure.
+     * Initialised to nullptr so close() can safely null-check it on
+     * teardown paths where open() failed before ssh_new().
      */
-    ssh_session session;
+    ssh_session session = nullptr;
 
     /**
-     * The libssh communication channel
+     * The libssh communication channel.
+     * Initialised to nullptr so close() can safely null-check it on
+     * teardown paths where open() failed before ssh_channel_new().
      */
-    ssh_channel channel;
+    ssh_channel channel = nullptr;
 
     /**
      * The underlying TCP client

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -533,10 +533,42 @@ void fn_service_loop(void *param)
         fnWiFi.connect();
     }
 
-    // if we dont have config enabled, and no alternate config disk selected, then just mount what we have
-    // in here so we are after all of the setup and wifi has been started
+    // If we don't have config enabled, and no alternate config disk
+    // selected, then just mount what we have so we are after all of
+    // the setup and wifi has been started.
+    //
+    // Bug fix history:
+    //   * The original code called fujicmd_mount_all_success() here,
+    //     which wraps the work in transaction_begin / transaction_complete
+    //     intended for an incoming SIO command frame -- not appropriate
+    //     from this startup context.  The right entrypoint is the
+    //     transaction-free fujicore_mount_all_success() instead.
+    //   * An earlier attempt to fix the double-mount race (see below)
+    //     gated this call on !Config.get_wifi_enabled().  That broke
+    //     two important scenarios:
+    //       - WiFi enabled but the router is unreachable / wrong
+    //         credentials: no IP_EVENT_STA_GOT_IP ever fires, so the
+    //         config slots were never mounted.  FujiNet would happily
+    //         answer the SIO bus but every slot was empty.
+    //       - Config-disabled startup with a slow / failing WiFi:
+    //         same symptom.
+    //     Both regressions matched the "test from far away from your
+    //     router" / "with config disabled" feedback from the FujiNet
+    //     team.  The condition is intentionally reverted here.
+    //
+    // Race avoidance: this same set of slots is also mounted by the
+    // IP_EVENT_STA_GOT_IP handler in lib/hardware/fnWiFi.cpp.  When
+    // WiFi has not yet acquired an IP at this point, this attempt
+    // fails fast (~ms) and the IP_GOT handler picks it up later.
+    // Both call paths now go through fujicore_mount_all_at_startup()
+    // which holds an atomic startup-mount lock: whichever caller
+    // arrives first mounts; the other returns success immediately
+    // without touching the host filesystems.  A failed first attempt
+    // releases the lock so the IP_GOT handler can retry once WiFi
+    // is up.  See fujiDevice::fujicore_mount_all_at_startup() for
+    // details.
     if (!Config.get_general_config_enabled() && Config.get_config_filename().empty())
-        theFuji->fujicmd_mount_all_success();
+        theFuji->fujicore_mount_all_at_startup();
 
     // Main service loop
 #ifdef ESP_PLATFORM


### PR DESCRIPTION
## Summary

  Three independent but related fixes discovered and verified while
  debugging SSH (`N:SSH://`) on a real Atari + real FujiNet hardware
  against a macOS-hosted TNFS server.  Each commit stands on its own and
  can be reverted independently, but together they make the SSH boot →
  connect → use → disconnect cycle stable for FujiNet.

  ### Commits

  1. **`8daea7e` — Make startup mount-all idempotent to avoid double-init race after WiFi async bring-up**

     `main_setup()` and the `IP_EVENT_STA_GOT_IP` handler in `fnWiFi.cpp`
     both ran the full TNFS mount-all sequence in parallel.  The second
     caller deleted and re-created the FileSystemTNFS underneath
     already-opened disk-image file handles, producing:

     failed seeking to header on disk image (-1, 9)
     read sector: error reading from disk image (...): -1

  (errno 9 = EBADF).

  Adds a tiny atomic guard `_startup_mount_lock` in `fujiDevice`
  plus a wrapper `fujicore_mount_all_at_startup()` used by both
  callers.  Whichever arrives first wins; the loser logs *"another
  caller already owns the startup mount, skipping"* and returns
  success.  On a **failed** attempt the lock is released so a later
  caller can retry (e.g. `main_setup` early → fails because WiFi has
  not yet acquired IP → releases → IP-GOT handler retries).  On a
  **successful** mount the lock stays held forever.

  User- and bus-initiated remounts intentionally **bypass** the
  guard so on-demand remount continues to work — only the startup
  path is gated.

  *A previous attempt to fix this with `!Config.get_wifi_enabled()`
  was correctly flagged by the FujiNet team for regressing two
  real-world scenarios (WiFi enabled + router out of range, Config
  disabled + WiFi enabled + no association).  The idempotent-guard
  approach keeps the original "always mount at startup" semantics
  intact for both scenarios.*

  2. **`5cb116b` — Fix heap corruption in NetworkProtocolSSH lifecycle and read path**

  Four defensive fixes that together stop the firmware crashing
  with *"heap_caps_free target pointer is outside heap areas"* on
  N: CLOSE after an SSH session:

  - **A.** NULL-initialise `session` and `channel` in `SSH.h` so
    close()/dtor are safe when `open()` failed early.
  - **B.** Tolerate failed `heap_caps_malloc(MALLOC_CAP_SPIRAM)` for
    `rxbuf` in both ctor and dtor.
  - **C.** Tear down `channel` before `session` in `close()`, with
    NULL guards, and chain to `NetworkProtocol::close()` like
    `TCP::close()` does (so the std::string buffers are properly
    cleared/shrunk).  Previously a remote "exit\n" left libssh
    channel state half-freed and the next N: CLOSE double-freed
    the session.
  - **D.** Filter `ssh_channel_read()` return value — accept only
    strictly positive byte counts.  `SSH_ERROR` (-1) was previously
    cast to `size_t` and fed to `std::string::append()`, which
    corrupted the PSRAM heap and only surfaced as the
    `heap_caps_free` abort later in the dtor.

  3. **`3f5c529` — libssh: stop assigning RODATA `""` to freed fields; NULL-check fopen path on ESP32**

  - **`options.c`:** `ssh_options_apply()` LIBSSH_FUJINET branch was
    assigning the RODATA literal `""` to `session->opts.knownhosts`
    and `session->opts.global_knownhosts`.  `ssh_free()` later
    `SAFE_FREE()`s those fields, calling `free()` on a pointer into
    read-only flash → `heap_caps_free` abort on every SSH close.
    Assigning `NULL` instead matches what all the known_hosts.c /
    knownhosts.c consumers already expect for "no file configured".

  - **`knownhosts.c`:** After the options.c fix above,
    `ssh_known_hosts_read_entries()` started receiving NULL
    filenames.  Plain libssh tolerates that because glibc's
    `fopen(NULL, "r")` returns NULL with `errno=EFAULT`, but **ESP32
    newlib's `fopen()` passes the path straight to `strlen()` inside
    `get_vfs_for_path()`** which dereferences it and panics:

    ```
    Guru Meditation Error: LoadProhibited
    PC: 0x40090815 (strlen+0x5 in ROM)  EXCVADDR: 0x00000000
    ```

    Treat NULL the same as "file does not exist": early return
    `SSH_OK` with no entries appended (matching the existing
    contract at the original lines 226-230).  `SSH_ERROR` was
    considered and rejected because it would propagate as
    `"Can't find a known_hosts file"` and break SSH connect for
    FujiNet, which has no persistent known_hosts file by design.

  ## How they relate

  All three were uncovered by the same end-to-end test (booting a real
  Atari, mounting boot disks over TNFS, then running `sshtest.com` /
  `ssh.com` against `N:SSH://`):

  - The startup mount race (#1) blocked boot from even completing
    reliably enough to test SSH.
  - The libssh RODATA bug (#3) crashed the firmware on the **first**
    N: CLOSE.
  - Fixing (#3) revealed that `ssh_known_hosts_read_entries()` was
    being reached on the connect path with a NULL filename — hence the
    second part of #3.
  - Fixing libssh exposed the latent heap-corruption in
    `NetworkProtocolSSH` (#2), which had been masked by the libssh
    crash happening first.

  ## Verification

  Tested end-to-end on real hardware (Atari 800XL + FujiNet ESP32 +
  macOS-hosted tnfsd) with:

  - Cold boot with WiFi enabled, router in range — boot mount succeeds
    via `main_setup`'s first attempt; IP-GOT handler logs the
    "skipping" message; no EBADF, no double mount.
  - Cold boot with WiFi enabled, router *not* in range — `main_setup`
    retries; eventually times out gracefully; SIO service loop runs
    normally (per FujiNet team feedback this scenario must always
    reach the bus loop).
  - `sshtest.com` open → banner → key-exchange → channel → write/read
    → exit cleanly; firmware logs the orderly teardown and remains
    responsive on N: for the next session.
  - Multiple back-to-back SSH connects from the same Atari boot session
    without firmware panic, heap-corruption warning, or `LoadProhibited`.

  ## Notes for reviewers

  - `_startup_mount_lock` is `std::atomic<bool>` with `exchange()` —
    no mutex, no allocations on the hot path; the wrapper itself
    cannot deadlock.
  - The libssh changes are inside the existing `LIBSSH_FUJINET`
    ifdef blocks, so upstream libssh consumers (glibc-based) are
    unaffected.
  - `knownhosts.c`'s NULL check is platform-agnostic and harmless on
    glibc — it just short-circuits the same failure path one frame
    earlier.
  - `NetworkProtocolSSH::close()` now chains to `NetworkProtocol::close()`,
    matching the pattern in `TCP::close()` and `UDP::close()`.

  ## Credit

  Bug #1 (startup mount race) regression scope was correctly identified
  by feedback from Mozwalld after the first attempted fix — the
  final idempotent-guard approach is the result of that review.
