### PR TITLE
Fix FS protocol handling and command direction in sioNetwork

### DIFF
--- a/lib/device/sio/network.cpp
+++ b/lib/device/sio/network.cpp
@@ -871,6 +871,10 @@ uint8_t sioNetwork::get_dstats_for_command(uint8_t command)
     case NETCMD_PARSE:
     case NETCMD_CONTROL:
     case NETCMD_CLOSE_CLIENT:
+    case NETCMD_CHANNEL_MODE:
+    case NETCMD_TRANSLATION:
+    case NETCMD_SET_INT_RATE:
+    case NETCMD_SET_PARAMETERS:
         return SIO_DIRECTION_NONE;
 
     // Payload from FujiNet to Atari (0x40)
@@ -883,10 +887,6 @@ uint8_t sioNetwork::get_dstats_for_command(uint8_t command)
     // Payload from Atari to FujiNet (0x80)
     case NETCMD_OPEN:
     case NETCMD_WRITE:
-    case NETCMD_TRANSLATION:
-    case NETCMD_SET_INT_RATE:
-    case NETCMD_SET_PARAMETERS:
-    case NETCMD_CHANNEL_MODE:
     case NETCMD_CHDIR:
     case NETCMD_QUERY:
     case NETCMD_USERNAME:

--- a/lib/device/sio/network.cpp
+++ b/lib/device/sio/network.cpp
@@ -1201,13 +1201,23 @@ void sioNetwork::sio_set_timer_rate()
 
 void sioNetwork::process_fs()
 {
+    sio_late_ack(); // command frame ACK must precede bus_to_peripheral() in parse_and_instantiate_protocol()
+
     parse_and_instantiate_protocol();
+
+    if (protocol == nullptr)
+    {
+        // sio_error() was already called from parse_and_instantiate_protocol()
+        return;
+    }
 
     // Make sure this is really a FS protocol instance
     NetworkProtocolFS *fs = dynamic_cast<NetworkProtocolFS *>(protocol);
     if (!fs)
     {
-        sio_nak();
+        sio_error(); // ACK already sent; host expects C or E, not N
+        delete protocol;
+        protocol = nullptr;
         return;
     }
 
@@ -1234,8 +1244,19 @@ void sioNetwork::process_fs()
         err = fs->rmdir(url);
         break;
     default:
-        sio_nak();
+        sio_error(); // ACK already sent; host expects C or E, not N
+        delete protocol;
+        protocol = nullptr;
         return;
+    }
+
+    // Clean up the one-shot protocol created for this fs operation
+    delete protocol;
+    protocol = nullptr;
+    if (protocolParser != nullptr)
+    {
+        delete protocolParser;
+        protocolParser = nullptr;
     }
 
     if (err != FUJI_ERROR::NONE)


### PR DESCRIPTION
A couple of small stupid bugs squashed here.

* MKDIR was failing due to improper ack/complete/error handling.
* Channel mode, translation, set int rate, set parameters needed correct DSTATS value.
* Fix potential memleak when using idempotent FS commands.
