### PR TITLE
Atari fixes for alternate boot, config-ng, wrong filesize, and broken…

### DIFF
--- a/lib/device/fujiDevice.cpp
+++ b/lib/device/fujiDevice.cpp
@@ -586,7 +586,7 @@ void fujiDevice::insert_boot_device(std::string boot_img, mediatype_t disk_type,
         return;
     }
 
-    image_size = fsFlash.filesize(fBoot);
+    image_size = FileSystem::filesize(fBoot);
     disk_dev->mount(fBoot, boot_img.c_str(), image_size, DISK_ACCESS_MODE_READ, disk_type);
     disk_dev->is_config_device = true;
 }
@@ -850,13 +850,6 @@ std::optional<std::string> fujiDevice::fujicore_read_directory_entry(size_t maxl
         return std::nullopt;
     }
 
-    // detect block mode in request
-    if ((addtl & 0xC0) == 0xC0)
-    {
-        fujicmd_read_directory_block(maxlen, addtl & 0x3F);
-        return std::nullopt;
-    }
-
     fsdir_entry_t *entry = _fnHosts[_current_open_directory_slot].dir_nextfile();
 
     if (entry == nullptr)
@@ -898,6 +891,21 @@ std::optional<std::string> fujiDevice::fujicore_read_directory_entry(size_t maxl
 
 void fujiDevice::fujicmd_read_directory_entry(size_t maxlen, uint8_t addtl)
 {
+    if (_current_open_directory_slot == -1)
+    {
+        Debug_print("READ DIRECTORY ENTRY: No currently open directory\n");
+        transaction_error();
+        return;
+    }
+
+    // Block mode (addtl $C0-$FF) is handled entirely by fujicmd_read_directory_block,
+    // which owns the SIO transaction. Must not transaction_begin here first.
+    if ((addtl & 0xC0) == 0xC0)
+    {
+        fujicmd_read_directory_block(maxlen, addtl & 0x3F);
+        return;
+    }
+
     transaction_begin(TRANS_STATE::NO_GET);
     Debug_printf("Fuji cmd: READ DIRECTORY ENTRY (max=%hu) (addtl=%02x)\n", maxlen, addtl);
 

--- a/lib/device/fujiDevice.h
+++ b/lib/device/fujiDevice.h
@@ -263,7 +263,7 @@ public:
     success_is_true fujicore_net_set_ssid_success(const char *ssid, const char *password, bool save);
 
     // Should be protected but being called by drivewire.cpp
-    void insert_boot_device(uint8_t image_id, mediatype_t disk_type, DISK_DEVICE *disk_dev);
+    virtual void insert_boot_device(uint8_t image_id, mediatype_t disk_type, DISK_DEVICE *disk_dev);
     void insert_boot_device(std::string boot_img, mediatype_t disk_type, DISK_DEVICE *disk_dev);
 };
 

--- a/lib/device/sio/sioFuji.cpp
+++ b/lib/device/sio/sioFuji.cpp
@@ -2,6 +2,8 @@
 
 #include "sioFuji.h"
 #include "httpService.h"
+#include "fsFlash.h"
+#include "fnFsSD.h"
 #include "utils.h"
 #include "base64.h"
 #include "../../qrcode/qrmanager.h"
@@ -514,6 +516,57 @@ void sioFuji::sio_set_hsio_index()
     }
 
     transaction_complete();
+}
+
+// Mounts the desired boot disk, honoring alternate SD config and CONFIG-NG settings.
+void sioFuji::insert_boot_device(uint8_t image_id, mediatype_t disk_type,
+                                 DISK_DEVICE *disk_dev)
+{
+    if (image_id != 0)
+    {
+        fujiDevice::insert_boot_device(image_id, disk_type, disk_dev);
+        return;
+    }
+
+    std::string altconfigfile = Config.get_config_filename();
+    fnFile *fBoot = nullptr;
+    size_t image_size = 0;
+    std::string boot_img;
+
+    if (!altconfigfile.empty() && fnSDFAT.running())
+    {
+        fBoot = fnSDFAT.fnfile_open(altconfigfile.c_str());
+        if (fBoot != nullptr)
+        {
+            boot_img = altconfigfile;
+            image_size = FileSystem::filesize(fBoot);
+            Debug_printf("Mounted Alternate CONFIG %s\n", boot_img.c_str());
+            disk_dev->mount(fBoot, boot_img.c_str(), image_size, DISK_ACCESS_MODE_READ, disk_type);
+            disk_dev->is_config_device = true;
+            return;
+        }
+    }
+
+    if (Config.get_general_config_ng())
+    {
+        boot_img = "/autorun-cng" + _diskImageExtension;
+        Debug_printf("Mounted CONFIG-NG\n");
+    }
+    else
+    {
+        boot_img = "/autorun" + _diskImageExtension;
+    }
+
+    fBoot = fsFlash.fnfile_open(boot_img.c_str());
+    if (fBoot == nullptr)
+    {
+        Debug_printf("Failed to open boot disk image: %s\n", boot_img.c_str());
+        return;
+    }
+
+    image_size = fsFlash.filesize(fBoot);
+    disk_dev->mount(fBoot, boot_img.c_str(), image_size, DISK_ACCESS_MODE_READ, disk_type);
+    disk_dev->is_config_device = true;
 }
 
 // Initializes base settings and adds our devices to the SIO bus

--- a/lib/device/sio/sioFuji.h
+++ b/lib/device/sio/sioFuji.h
@@ -94,6 +94,8 @@ protected:
 public:
     sioFuji();
     void setup() override;
+    void insert_boot_device(uint8_t image_id, mediatype_t disk_type,
+                            DISK_DEVICE *disk_dev) override;
 
     // Used by sio.cpp
     void debug_tape();


### PR DESCRIPTION
… block directory reading

Restore Atari CONFIG-NG/alternate boot disk selection and fix directory block-mode crash introduced by the fujiDevice unification (#1108).

Boot disk selection was moved into generic fujiDevice::insert_boot_device() without the Atari-specific logic for SD alternate config paths and /autorun-cng.atr. Add an sioFuji override to restore the previous priority: alternate SD file, then CONFIG-NG, then default autorun.

Directory listings from CONFIG-NG crashed on READ DIRECTORY ENTRY in block mode (AUX2 $C0-$FF) because fujicmd_read_directory_entry() started an SIO transaction and then called fujicmd_read_directory_block(), which started a second one. Dispatch block mode before transaction_begin(), matching pre-unification behavior.

Also fix alternate-config SD mounts using FileSystem::filesize() instead of fsFlash.filesize() on handles opened from fnSDFAT.