### PR TITLE
Load ROM/ccc to pico on fujiversal coco prototype

### DIFF
--- a/fujinet_pc.cmake
+++ b/fujinet_pc.cmake
@@ -388,6 +388,7 @@ if(FUJINET_TARGET STREQUAL "COCO")
     lib/media/drivewire/mediaTypeDSK.h lib/media/drivewire/mediaTypeDSK.cpp
     lib/media/drivewire/mediaTypeMRM.h lib/media/drivewire/mediaTypeMRM.cpp
     lib/media/drivewire/mediaTypeVDK.h lib/media/drivewire/mediaTypeVDK.cpp
+    lib/media/drivewire/mediaTypeROM.h lib/media/drivewire/mediaTypeROM.cpp
 
     lib/device/drivewire/drivewireFuji.h lib/device/drivewire/drivewireFuji.cpp
     lib/device/drivewire/network.h lib/device/drivewire/network.cpp

--- a/lib/bus/drivewire/drivewire.cpp
+++ b/lib/bus/drivewire/drivewire.cpp
@@ -543,7 +543,7 @@ void systemBus::op_namedobj_mnt()
 // Read and process a command frame from DRIVEWIRE
 void systemBus::_drivewire_process_cmd()
 {
-    int c = _readByte();
+    int c = read();
     if (c < 0)
     {
         Debug_println("Failed to read cmd!");

--- a/lib/bus/drivewire/drivewire.cpp
+++ b/lib/bus/drivewire/drivewire.cpp
@@ -543,7 +543,7 @@ void systemBus::op_namedobj_mnt()
 // Read and process a command frame from DRIVEWIRE
 void systemBus::_drivewire_process_cmd()
 {
-    int c = _port->read();
+    int c = _readByte();
     if (c < 0)
     {
         Debug_println("Failed to read cmd!");
@@ -712,7 +712,7 @@ void systemBus::service()
         }
     }
 
-    if (_port->available())
+    if (available())
         _drivewire_process_cmd();
 }
 
@@ -904,4 +904,45 @@ void systemBus::setBaudrate(int baud)
     _drivewireBaud = baud;
     //_modemDev->get_uart()->set_baudrate(baud); // TODO COME BACK HERE.
 }
+
+#ifdef PINMAP_FUJIVERSAL_DRIVEWIRE
+std::unique_ptr<FujiBusPacket> systemBus::readBusPacket(int first)
+{
+    ByteBuffer packet;
+    int count = 0;
+
+    auto processByte = [&](int val) -> bool
+    {
+        if (val < 0)
+            return false;
+        // Pre-frame bytes are CoCo DriveWire traffic on the shared link;
+        // stash them for the bus reader instead of letting them be discarded.
+        if (count == 0 && val != SLIP_END) {
+            _dbc_pushback.push_back(static_cast<uint8_t>(val));
+            return true;
+        }
+        packet.push_back(static_cast<uint8_t>(val));
+        if (val == SLIP_END)
+            count++;
+        return true;
+    };
+
+    processByte(first);
+
+    while (count < 2)
+    {
+        if (!processByte(_port->read()))
+            break;
+    }
+
+    return FujiBusPacket::fromSerialized(packet);
+}
+
+void systemBus::writeBusPacket(FujiBusPacket &packet)
+{
+    ByteBuffer encoded = packet.serialize();
+    _port->write(encoded.data(), encoded.size());
+}
+#endif /* PINMAP_FUJIVERSAL_DRIVEWIRE */
+
 #endif               /* BUILD_COCO */

--- a/lib/bus/drivewire/drivewire.h
+++ b/lib/bus/drivewire/drivewire.h
@@ -198,17 +198,6 @@ private:
     std::deque<uint8_t> _dbc_pushback;
 #endif
 
-    int _readByte() {
-#ifdef PINMAP_FUJIVERSAL_DRIVEWIRE
-        if (!_dbc_pushback.empty()) {
-            uint8_t b = _dbc_pushback.front();
-            _dbc_pushback.pop_front();
-            return b;
-        }
-#endif
-        return _port->read();
-    }
-
     virtualDevice *_activeDev = nullptr;
     drivewireModem *_modemDev = nullptr;
     drivewireFuji *_fujiDev = nullptr;
@@ -364,15 +353,9 @@ public:
         return _port->read(buffer, length);
 #endif
     }
-    size_t read() {
-#ifdef PINMAP_FUJIVERSAL_DRIVEWIRE
-        if (!_dbc_pushback.empty()) {
-            uint8_t b = _dbc_pushback.front();
-            _dbc_pushback.pop_front();
-            return b;
-        }
-#endif
-        return _port->read();
+    int read() {
+        uint8_t b;
+        return read(&b, 1) == 1 ? b : -1;
     }
     size_t write(const void *buffer, size_t length) { return _port->write(buffer, length); }
     size_t write(int n) { return _port->write(n); }

--- a/lib/bus/drivewire/drivewire.h
+++ b/lib/bus/drivewire/drivewire.h
@@ -24,6 +24,10 @@
 #include "UARTChannel.h"
 #include "ACMChannel.h"
 #include "fujiDeviceID.h"
+#ifdef PINMAP_FUJIVERSAL_DRIVEWIRE
+#include "../rs232/FujiBusPacket.h"
+#include <deque>
+#endif
 
 #ifdef ESP32_PLATFORM
 #include <freertos/FreeRTOS.h>
@@ -190,6 +194,21 @@ private:
 #endif /* FUJINET_OVER_USB */
     BeckerSocket _becker;
 
+#ifdef PINMAP_FUJIVERSAL_DRIVEWIRE
+    std::deque<uint8_t> _dbc_pushback;
+#endif
+
+    int _readByte() {
+#ifdef PINMAP_FUJIVERSAL_DRIVEWIRE
+        if (!_dbc_pushback.empty()) {
+            uint8_t b = _dbc_pushback.front();
+            _dbc_pushback.pop_front();
+            return b;
+        }
+#endif
+        return _port->read();
+    }
+
     virtualDevice *_activeDev = nullptr;
     drivewireModem *_modemDev = nullptr;
     drivewireFuji *_fujiDev = nullptr;
@@ -331,12 +350,63 @@ public:
 
     // Everybody thinks "oh I know how a serial port works, I'll just
     // access it directly and bypass the bus!" ಠ_ಠ
-    size_t read(void *buffer, size_t length) { return _port->read(buffer, length); }
-    size_t read() { return _port->read(); }
+    size_t read(void *buffer, size_t length) {
+#ifdef PINMAP_FUJIVERSAL_DRIVEWIRE
+        size_t n = 0;
+        while (!_dbc_pushback.empty() && n < length) {
+            ((uint8_t *)buffer)[n++] = _dbc_pushback.front();
+            _dbc_pushback.pop_front();
+        }
+        if (n < length)
+            n += _port->read((uint8_t *)buffer + n, length - n);
+        return n;
+#else
+        return _port->read(buffer, length);
+#endif
+    }
+    size_t read() {
+#ifdef PINMAP_FUJIVERSAL_DRIVEWIRE
+        if (!_dbc_pushback.empty()) {
+            uint8_t b = _dbc_pushback.front();
+            _dbc_pushback.pop_front();
+            return b;
+        }
+#endif
+        return _port->read();
+    }
     size_t write(const void *buffer, size_t length) { return _port->write(buffer, length); }
     size_t write(int n) { return _port->write(n); }
-    size_t available() { return _port->available(); }
+    size_t available() {
+#ifdef PINMAP_FUJIVERSAL_DRIVEWIRE
+        return _dbc_pushback.size() + _port->available();
+#else
+        return _port->available();
+#endif
+    }
     void flushOutput() { _port->flushOutput(); }
+
+#ifdef PINMAP_FUJIVERSAL_DRIVEWIRE
+    std::unique_ptr<FujiBusPacket> readBusPacket(int first = -1);
+    void writeBusPacket(FujiBusPacket &packet);
+
+    template<typename... Args>
+    std::unique_ptr<FujiBusPacket> sendCommand(fujiDeviceID_t device,
+                                               fujiCommandID_t command,
+                                               Args&&... args)
+    {
+        FujiBusPacket packet(device, command, std::forward<Args>(args)...);
+        writeBusPacket(packet);
+        return readBusPacket();
+    }
+
+    std::unique_ptr<FujiBusPacket> sendCommand(fujiDeviceID_t device,
+                                               fujiCommandID_t command,
+                                               void *buf, size_t len)
+    {
+        std::string data(reinterpret_cast<const char *>(buf), static_cast<size_t>(len));
+        return sendCommand(device, command, std::move(data));
+    }
+#endif /* PINMAP_FUJIVERSAL_DRIVEWIRE */
 
 #ifdef ESP32_PLATFORM
     QueueHandle_t qDrivewireMessages = nullptr;

--- a/lib/device/drivewire/disk.cpp
+++ b/lib/device/drivewire/disk.cpp
@@ -48,6 +48,11 @@ mediatype_t drivewireDisk::mount(fnFile *f, const char *filename, uint32_t disks
     case MEDIATYPE_VDK:
         _media = new MediaTypeVDK();
         break;
+#ifdef PINMAP_FUJIVERSAL_DRIVEWIRE
+    case MEDIATYPE_ROM:
+        _media = new MediaTypeROM();
+        break;
+#endif
     default:
         device_active = false;
         break;

--- a/lib/device/drivewire/disk.cpp
+++ b/lib/device/drivewire/disk.cpp
@@ -48,11 +48,9 @@ mediatype_t drivewireDisk::mount(fnFile *f, const char *filename, uint32_t disks
     case MEDIATYPE_VDK:
         _media = new MediaTypeVDK();
         break;
-#ifdef PINMAP_FUJIVERSAL_DRIVEWIRE
     case MEDIATYPE_ROM:
         _media = new MediaTypeROM();
         break;
-#endif
     default:
         device_active = false;
         break;
@@ -62,7 +60,16 @@ mediatype_t drivewireDisk::mount(fnFile *f, const char *filename, uint32_t disks
     {
         strcpy(_media->_disk_filename,filename);
         mt = _media->mount(f, disksize);
-        device_active = true;
+        if (mt == MEDIATYPE_UNKNOWN)
+        {
+            delete _media;
+            _media = nullptr;
+            device_active = false;
+        }
+        else
+        {
+            device_active = true;
+        }
     }
 
     return mt;

--- a/lib/media/drivewire/mediaType.cpp
+++ b/lib/media/drivewire/mediaType.cpp
@@ -63,6 +63,12 @@ mediatype_t MediaType::discover_mediatype(const char *filename)
         {
             return MEDIATYPE_VDK;
         }
+#ifdef PINMAP_FUJIVERSAL_DRIVEWIRE
+        else if (strcasecmp(ext, "ROM") == 0 || strcasecmp(ext, "CCC") == 0)
+        {
+            return MEDIATYPE_ROM;
+        }
+#endif
     }
     return MEDIATYPE_UNKNOWN;
 }

--- a/lib/media/drivewire/mediaType.cpp
+++ b/lib/media/drivewire/mediaType.cpp
@@ -63,12 +63,10 @@ mediatype_t MediaType::discover_mediatype(const char *filename)
         {
             return MEDIATYPE_VDK;
         }
-#ifdef PINMAP_FUJIVERSAL_DRIVEWIRE
         else if (strcasecmp(ext, "ROM") == 0 || strcasecmp(ext, "CCC") == 0)
         {
             return MEDIATYPE_ROM;
         }
-#endif
     }
     return MEDIATYPE_UNKNOWN;
 }

--- a/lib/media/drivewire/mediaType.h
+++ b/lib/media/drivewire/mediaType.h
@@ -15,7 +15,8 @@ enum mediatype_t
     MEDIATYPE_UNKNOWN = 0,
     MEDIATYPE_DSK,
     MEDIATYPE_MRM,
-    MEDIATYPE_VDK,    
+    MEDIATYPE_VDK,
+    MEDIATYPE_ROM,
     MEDIATYPE_COUNT
 };
 

--- a/lib/media/drivewire/mediaTypeROM.cpp
+++ b/lib/media/drivewire/mediaTypeROM.cpp
@@ -1,0 +1,85 @@
+#ifdef BUILD_COCO
+#ifdef PINMAP_FUJIVERSAL_DRIVEWIRE
+
+#include "mediaTypeROM.h"
+
+#include <cstdint>
+#include <cstring>
+#include <string>
+
+#include "../../include/debug.h"
+
+#include "bus.h"
+#include "fujiCommandID.h"
+
+error_is_true MediaTypeROM::read(uint32_t blockNum, uint16_t *readcount)
+{
+    Debug_printf("DW ROM READ not supported\n");
+    RETURN_ERROR_AS_TRUE();
+}
+
+error_is_true MediaTypeROM::write(uint32_t blockNum, bool verify)
+{
+    Debug_printf("DW ROM WRITE not supported\n");
+    RETURN_ERROR_AS_TRUE();
+}
+
+error_is_true MediaTypeROM::format(uint16_t *responsesize)
+{
+    RETURN_ERROR_AS_TRUE();
+}
+
+uint8_t MediaTypeROM::status()
+{
+    return 2;
+}
+
+mediatype_t MediaTypeROM::mount(fnFile *f, uint32_t disksize)
+{
+    Debug_printf("DW ROM MOUNT %s (%lu bytes)\n", _disk_filename, (unsigned long)disksize);
+
+    _media_fileh = f;
+    _mediatype = MEDIATYPE_ROM;
+    _media_image_size = disksize;
+
+    if (SYSTEM_BUS.isBoIP())
+    {
+        Debug_printv("ROM media requires a real pico; not supported over BoIP");
+        return MEDIATYPE_UNKNOWN;
+    }
+
+    if (!SYSTEM_BUS.sendCommand(FUJI_DEVICEID_DBC, NETCMD_OPEN, (uint16_t)0))
+    {
+        Debug_printv("Failed to open pico bank");
+        return MEDIATYPE_UNKNOWN;
+    }
+
+    fnio::fseek(_media_fileh, 0, SEEK_SET);
+
+    uint32_t sent = 0;
+    while (sent < disksize)
+    {
+        size_t want = (disksize - sent) > MEDIA_BLOCK_SIZE ? MEDIA_BLOCK_SIZE : (disksize - sent);
+        size_t got = fnio::fread(_media_blockbuff, 1, want, _media_fileh);
+        if (got == 0)
+        {
+            Debug_printv("ROM read short: sent %lu of %lu bytes", (unsigned long)sent, (unsigned long)disksize);
+            break;
+        }
+        if (!SYSTEM_BUS.sendCommand(FUJI_DEVICEID_DBC, NETCMD_WRITE,
+                                    std::string((char *)_media_blockbuff, got)))
+        {
+            Debug_printv("Failed to send ROM block at %lu of %lu bytes", (unsigned long)sent, (unsigned long)disksize);
+            break;
+        }
+        sent += got;
+    }
+
+    SYSTEM_BUS.sendCommand(FUJI_DEVICEID_DBC, NETCMD_CLOSE);
+    Debug_printv("ROM transfer complete: %lu / %lu bytes", (unsigned long)sent, (unsigned long)disksize);
+
+    return _mediatype;
+}
+
+#endif // PINMAP_FUJIVERSAL_DRIVEWIRE
+#endif // BUILD_COCO

--- a/lib/media/drivewire/mediaTypeROM.cpp
+++ b/lib/media/drivewire/mediaTypeROM.cpp
@@ -1,5 +1,4 @@
 #ifdef BUILD_COCO
-#ifdef PINMAP_FUJIVERSAL_DRIVEWIRE
 
 #include "mediaTypeROM.h"
 
@@ -42,6 +41,7 @@ mediatype_t MediaTypeROM::mount(fnFile *f, uint32_t disksize)
     _mediatype = MEDIATYPE_ROM;
     _media_image_size = disksize;
 
+#ifdef PINMAP_FUJIVERSAL_DRIVEWIRE
     if (SYSTEM_BUS.isBoIP())
     {
         Debug_printv("ROM media requires a real pico; not supported over BoIP");
@@ -79,7 +79,10 @@ mediatype_t MediaTypeROM::mount(fnFile *f, uint32_t disksize)
     Debug_printv("ROM transfer complete: %lu / %lu bytes", (unsigned long)sent, (unsigned long)disksize);
 
     return _mediatype;
+#else
+    Debug_printv("ROM mount not supported on this FujiNet hardware.");
+    return MEDIATYPE_UNKNOWN;
+#endif
 }
 
-#endif // PINMAP_FUJIVERSAL_DRIVEWIRE
 #endif // BUILD_COCO

--- a/lib/media/drivewire/mediaTypeROM.h
+++ b/lib/media/drivewire/mediaTypeROM.h
@@ -1,0 +1,22 @@
+#ifndef _MEDIATYPE_ROM_
+#define _MEDIATYPE_ROM_
+
+#include <stdio.h>
+
+#include "mediaType.h"
+
+class MediaTypeROM : public MediaType
+{
+public:
+    error_is_true read(uint32_t blockNum, uint16_t *readcount) override;
+    error_is_true write(uint32_t blockNum, bool verify) override;
+
+    error_is_true format(uint16_t *responsesize) override;
+
+    mediatype_t mount(fnFile *f, uint32_t disksize) override;
+
+    uint8_t status() override;
+};
+
+
+#endif // _MEDIATYPE_ROM_

--- a/lib/media/media.h
+++ b/lib/media/media.h
@@ -63,6 +63,7 @@
 # include "drivewire/mediaTypeDSK.h"
 # include "drivewire/mediaTypeMRM.h"
 # include "drivewire/mediaTypeVDK.h"
+# include "drivewire/mediaTypeROM.h"
 #endif
 
 #ifdef NEW_TARGET


### PR DESCRIPTION
This is a DRAFT.  Do not merge yet, until we all agree on it.

## Summary

Adds a `MediaTypeROM` to the drivewire media layer so a `.rom`/`.ccc` file mounted on a device slot is streamed to the fujiversal PicoROM at mount time via the existing DBC `FujiBusPacket` protocol (`NETCMD_OPEN` / `NETCMD_WRITE` × N / `NETCMD_CLOSE`). Modeled on `rs232Disk::mountROM`.

All changes are gated `PINMAP_FUJIVERSAL_DRIVEWIRE` and only affect the `fujiversal-drivewire` build. No effect on rs232, other drivewire boards, or any other platform.

## What's added

- `MediaTypeROM` (`lib/media/drivewire/mediaTypeROM.{h,cpp}`): `mount()` streams the file to the pico in `MEDIA_BLOCK_SIZE` chunks; `read`/`write`/`format` return errors (this is a ROM, not a disk).
- `MEDIATYPE_ROM` enum entry, `.rom`/`.ccc` detection in `discover_mediatype()` (case-insensitive), wiring in `media.h` and the drivewire `disk.cpp` switch.
- Guards mount with `SYSTEM_BUS.isBoIP()` and returns an error under BoIP — the transfer is meaningless without a real pico.

## Drivewire `systemBus` plumbing

To send DBC packets over the bus, the drivewire `systemBus` gained `sendCommand` / `writeBusPacket` / `readBusPacket` mirroring the rs232 implementation.

Because DBC SLIP-framed packets and the CoCo's raw DriveWire bytes share the same USB-CDC link, `readBusPacket` captures any bytes seen before the SLIP frame start into a small pushback buffer (`_dbc_pushback`) instead of letting them be discarded. `_readByte()`, the public `read()`/`read(buf,len)`/`available()`, and `service()` all drain the pushback before consulting `_port`, so a stray CoCo opcode landing during a DBC read replays cleanly into the bus dispatch.

## Out of scope (follow-up)

Pico-side autostart command (drive `CART` low so the loaded ROM runs without the prototype's Q→CART jumper). Requires matching firmware on `~/fujiversal`.

## Testing

Built and flashed on `fujiversal-drivewire`. Verified end-to-end: mounted `.ccc` from the config program → ROM streamed to the pico → `fuji_mount_all()` returns → CoCo proceeds normally. With the Q→CART jumper installed on the prototype, the loaded ROM runs after reset.
