### PR TITLE
[fujiDevice] disk swap blink behavior.

### DIFF
--- a/lib/device/fujiDevice.cpp
+++ b/lib/device/fujiDevice.cpp
@@ -27,6 +27,7 @@
 #include "fsFlash.h"
 #include "fnFsTNFS.h"
 
+#include "led.h"
 #include "utils.h"
 #include "directoryPageGroup.h"
 #include "compat_string.h"
@@ -211,12 +212,14 @@ void fujiDevice::fujicmd_image_rotate()
     Debug_println("Fuji cmd: IMAGE ROTATE");
 
     int count = 0;
-    // Find the first empty slot
-    while (_fnDisks[count].fileh != nullptr && count < _totalDiskDevices)
+    while (count < (int)_totalDiskDevices && _fnDisks[count].fileh != nullptr)
         count++;
 
     if (count > 1)
     {
+        _active_rotate_slot = (_active_rotate_slot + 1) % count;
+        fnLedManager.blink(LED_BUS, _active_rotate_slot + 1);
+
         count--;
 
         // Save the device ID of the disk in the last slot

--- a/lib/device/fujiDevice.h
+++ b/lib/device/fujiDevice.h
@@ -145,6 +145,7 @@ protected:
     uint8_t _countScannedSSIDs = 0;
 
     std::atomic<bool> _startup_mount_lock{false};
+    unsigned char _active_rotate_slot = 0;
 
     Hash::Algorithm algorithm = Hash::Algorithm::UNKNOWN;
 
@@ -197,7 +198,7 @@ public:
     void fujicmd_net_get_wifi_enabled();
     virtual success_is_true fujicmd_mount_disk_image_success(uint8_t deviceSlot, disk_access_flags_t access_mode);
     success_is_true fujicmd_unmount_disk_image_success(uint8_t deviceSlot);
-    void fujicmd_image_rotate();
+    virtual void fujicmd_image_rotate();
     success_is_true fujicmd_open_directory_success(uint8_t hostSlot);
     virtual void fujicmd_close_directory();
     virtual void fujicmd_read_directory_entry(size_t maxlen, uint8_t addtl);

--- a/lib/device/fujiDevice.h
+++ b/lib/device/fujiDevice.h
@@ -198,7 +198,7 @@ public:
     void fujicmd_net_get_wifi_enabled();
     virtual success_is_true fujicmd_mount_disk_image_success(uint8_t deviceSlot, disk_access_flags_t access_mode);
     success_is_true fujicmd_unmount_disk_image_success(uint8_t deviceSlot);
-    virtual void fujicmd_image_rotate();
+    void fujicmd_image_rotate();
     success_is_true fujicmd_open_directory_success(uint8_t hostSlot);
     virtual void fujicmd_close_directory();
     virtual void fujicmd_read_directory_entry(size_t maxlen, uint8_t addtl);


### PR DESCRIPTION
The disk swap blink behavior had fallen out after the 1108 merge. This PR adds it back into the base fuji device for all targets.