### PR TITLE
Fix create disk

### DIFF
--- a/lib/device/cx16_i2c/cx16Fuji.cpp
+++ b/lib/device/cx16_i2c/cx16Fuji.cpp
@@ -431,7 +431,7 @@ void cx16Fuji::mount_all()
         fujiHost &host = _fnHosts[disk.host_slot];
         char flag[3] = {'r', 0, 0};
 
-        if (disk.access_mode == DISK_ACCESS_MODE_WRITE)
+        if (disk.access_mode & DISK_ACCESS_MODE_WRITE)
             flag[1] = '+';
 
         if (disk.host_slot != INVALID_HOST_SLOT && strlen(disk.filename) > 0)
@@ -1254,7 +1254,7 @@ void cx16Fuji::_populate_config_from_slots()
             Config.clear_mount(i);
         else
             Config.store_mount(i, _fnDisks[i].host_slot, _fnDisks[i].filename,
-                               _fnDisks[i].access_mode == DISK_ACCESS_MODE_WRITE ? fnConfig::mount_modes::MOUNTMODE_WRITE : fnConfig::mount_modes::MOUNTMODE_READ);
+                               (_fnDisks[i].access_mode & DISK_ACCESS_MODE_WRITE) ? fnConfig::mount_modes::MOUNTMODE_WRITE : fnConfig::mount_modes::MOUNTMODE_READ);
     }
 }
 

--- a/lib/device/fujiDevice.cpp
+++ b/lib/device/fujiDevice.cpp
@@ -118,7 +118,7 @@ void fujiDevice::populate_config_from_slots()
             Config.clear_mount(i);
         else
             Config.store_mount(i, _fnDisks[i].host_slot, _fnDisks[i].filename,
-                               _fnDisks[i].access_mode == DISK_ACCESS_MODE_WRITE
+                               (_fnDisks[i].access_mode & DISK_ACCESS_MODE_WRITE)
                                ? fnConfig::mount_modes::MOUNTMODE_WRITE
                                : fnConfig::mount_modes::MOUNTMODE_READ);
     }
@@ -134,7 +134,7 @@ success_is_true fujiDevice::fujicore_mount_all_success()
         fujiDisk &disk = _fnDisks[i];
         fujiHost &host = _fnHosts[disk.host_slot];
         char flag[4] = {'r', 'b', 0, 0};
-        if (disk.access_mode == DISK_ACCESS_MODE_WRITE)
+        if (disk.access_mode & DISK_ACCESS_MODE_WRITE)
             flag[2] = '+';
 
         if (disk.host_slot != INVALID_HOST_SLOT && strlen(disk.filename) > 0)
@@ -472,7 +472,7 @@ success_is_true fujiDevice::fujicore_mount_disk_image_success(uint8_t deviceSlot
 {
     // TODO: Implement FETCH?
     char mode[4] = {'r', 'b', 0, 0};
-    if (access_mode == DISK_ACCESS_MODE_WRITE)
+    if (access_mode & DISK_ACCESS_MODE_WRITE)
         mode[2] = '+';
 
     // Make sure we weren't given a bad hostSlot

--- a/lib/device/iwm/disk.cpp
+++ b/lib/device/iwm/disk.cpp
@@ -465,7 +465,7 @@ mediatype_t iwmDisk::mount(fnFile *f, const char *filename, uint32_t disksize,
   else if (_disk && strlen(_disk->_disk_filename))
       strcpy(_disk->_disk_filename, filename);
 
-    if (access_mode == DISK_ACCESS_MODE_WRITE)
+    if (access_mode & DISK_ACCESS_MODE_WRITE)
     {
         Debug_printv("Setting disk to read/write");
         readonly = false;

--- a/lib/device/mac/macFuji.cpp
+++ b/lib/device/mac/macFuji.cpp
@@ -117,7 +117,7 @@ void macFuji::_populate_config_from_slots()
             Config.clear_mount(i);
         else
             Config.store_mount(i, _fnDisks[i].host_slot, _fnDisks[i].filename,
-                               _fnDisks[i].access_mode == DISK_ACCESS_MODE_WRITE ? fnConfig::mount_modes::MOUNTMODE_WRITE : fnConfig::mount_modes::MOUNTMODE_READ);
+                               (_fnDisks[i].access_mode & DISK_ACCESS_MODE_WRITE) ? fnConfig::mount_modes::MOUNTMODE_WRITE : fnConfig::mount_modes::MOUNTMODE_READ);
     }
 }
 
@@ -132,7 +132,7 @@ bool macFuji::mount_all()
         fujiHost &host = _fnHosts[disk.host_slot];
         char flag[3] = {'r', 0, 0};
 
-        if (disk.access_mode == DISK_ACCESS_MODE_WRITE)
+        if (disk.access_mode & DISK_ACCESS_MODE_WRITE)
             flag[1] = '+';
 
         if (disk.host_slot != 0xFF)
@@ -163,7 +163,7 @@ bool macFuji::mount_all()
             // And now mount it
             disk.disk_type = disk.disk_dev.mount(disk.fileh, disk.filename, disk.disk_size);
             disk.disk_dev.readonly = true;
-            if (disk.access_mode == DISK_ACCESS_MODE_WRITE)
+            if (disk.access_mode & DISK_ACCESS_MODE_WRITE)
             {
               disk.disk_dev.readonly = false;
             }

--- a/lib/device/s100spi/s100spiFuji.cpp
+++ b/lib/device/s100spi/s100spiFuji.cpp
@@ -867,7 +867,7 @@ void s100spiFuji::_populate_config_from_slots()
             Config.clear_mount(i);
         else
             Config.store_mount(i, _fnDisks[i].host_slot, _fnDisks[i].filename,
-                               _fnDisks[i].access_mode == DISK_ACCESS_MODE_WRITE ? fnConfig::mount_modes::MOUNTMODE_WRITE : fnConfig::mount_modes::MOUNTMODE_READ);
+                               (_fnDisks[i].access_mode & DISK_ACCESS_MODE_WRITE) ? fnConfig::mount_modes::MOUNTMODE_WRITE : fnConfig::mount_modes::MOUNTMODE_READ);
     }
 }
 
@@ -1002,7 +1002,7 @@ void s100spiFuji::mount_all()
         fujiHost &host = _fnHosts[disk.host_slot];
         char flag[3] = {'r', 0, 0};
 
-        if (disk.access_mode == DISK_ACCESS_MODE_WRITE)
+        if (disk.access_mode & DISK_ACCESS_MODE_WRITE)
             flag[1] = '+';
 
         if (disk.host_slot != INVALID_HOST_SLOT && strlen(disk.filename) > 0)

--- a/lib/fuji/fujiDisk.cpp
+++ b/lib/fuji/fujiDisk.cpp
@@ -20,6 +20,6 @@ void fujiDisk::reset(const char *fname, uint8_t hostslot, disk_access_flags_t mo
     host = nullptr;
 
     host_slot = hostslot;
-    access_mode = mode;
+    access_mode = (disk_access_flags_t)(mode & ~DISK_ACCESS_MODE_MOUNTED);
 #endif
 }


### PR DESCRIPTION
Two things:
(1) Create Disk was not properly persisting access mode of READ/WRITE when MOUNT IMAGE was applied.
(2) Disk permissions were not properly being persisted when MOUNT IMAGE was applied.

This PR fixes both of those for both pre and post 1108 disk devices.