### PR TITLE
Fix crash when trying to do FUJICMD_RANDOM_NUMBER

### DIFF
--- a/lib/device/sio/sioFuji.cpp
+++ b/lib/device/sio/sioFuji.cpp
@@ -843,8 +843,9 @@ void sioFuji::sio_base64_encode_output()
 
 void sioFuji::sio_random_number()
 {
+    transaction_begin(TRANS_STATE::NO_GET);
     int r = rand();
-    transaction_put(&r,sizeof(int),true);
+    transaction_put(&r,sizeof(int),false);
 }
 
 void sioFuji::sio_base64_decode_input()


### PR DESCRIPTION
Fixes #1335 

[lcltest.atr.zip](https://github.com/user-attachments/files/28797044/lcltest.atr.zip)

To test: run the attached disk image on Atari with current firmware, choose CRYPTO.TST. Flash to new firmware build by this PR under Checks, run CRYPTO.TST again.

Before fix:

<img width="1237" height="1100" alt="image" src="https://github.com/user-attachments/assets/1d934d36-55de-4776-9c89-aa93372738e7" />

After fix:

<img width="1237" height="1100" alt="image" src="https://github.com/user-attachments/assets/08b8108b-d2e1-43f2-9ef0-28910cdf7d64" />
