### PR TITLE
sio netstream: use correct baud rate for netstream baud check

### DIFF
--- a/lib/bus/sio/sio.cpp
+++ b/lib/bus/sio/sio.cpp
@@ -380,7 +380,7 @@ void systemBus::service()
         else
         {
             const int netstream_baud = _streamDev->netstream_baud;
-            if (getBaudrate() != netstream_baud)
+            if (getCurrentBaudrate() != netstream_baud)
             {
                 // Ensure NetStream baud
 #ifdef DEBUG_NETSTREAM
@@ -678,6 +678,14 @@ int systemBus::getBaudrate()
     }
 
     return SIO_STANDARD_BAUDRATE;
+}
+
+int systemBus::getCurrentBaudrate()
+{
+    if (isBoIP())
+        return _netsio.getBaudrate();
+
+    return _serial.getBaudrate();
 }
 
 // This method is called by devices to change the "UART" baudrate, it

--- a/lib/bus/sio/sio.h
+++ b/lib/bus/sio/sio.h
@@ -264,6 +264,7 @@ public:
     void changeDeviceId(virtualDevice *pDevice, int device_id);
 
     int getBaudrate();                                          // Gets current SIO baud rate setting
+    int getCurrentBaudrate();                                   // Gets current I/O channel baud rate
     void setBaudrate(int baud);                                 // Sets SIO to specific baud rate
     void toggleBaudrate();                                      // Toggle between standard and high speed SIO baud rate
 


### PR DESCRIPTION
Use the correct baud rate for comparison in netstream functions