### PR TITLE
VS Code Dev Container workspace configuration

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,8 @@
+{
+  "permissions": {
+    "allow": [
+      "WebFetch(domain:raw.githubusercontent.com)",
+      "WebFetch(domain:github.com)"
+    ]
+  }
+}

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,13 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(z80asm --version)",
+      "Bash(z80asm)",
+      "Bash(z80asm -h)",
+      "Bash(z80asm -b -r=0xFF00 -o=/tmp/bios_test.bin cbios/bios.asm)",
+      "Bash(z80asm *)",
+      "Bash(python3 *)",
+      "Bash(CPMTOOLSFMT=/home/bkrein/code/fujinet/fujinet-osborne/diskdefs cpmls -f osborne1ss bootdisk.img)"
+    ]
+  }
+}

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,31 @@
+# FujiNet firmware dev container.
+#
+# Wraps the published defoogi build image (https://github.com/FozzTexx/defoogi)
+# so it can be used as a long-lived VS Code Dev Container / GitHub Codespace
+# instead of the one-shot `defoogi <cmd>` invocation it was designed for.
+FROM fozztexx/defoogi:latest
+
+# defoogi's ENTRYPOINT (cntnr-init) is built for one-shot invocation: with no
+# command it drops into `su wario` and exits, which would immediately stop a
+# long-lived dev container. Clear it so the Dev Container / Codespaces runtime
+# manages the container lifecycle and user/UID mapping itself.
+ENTRYPOINT []
+CMD ["sleep", "infinity"]
+
+# Extra packages the base image doesn't carry:
+#   - clang-format: required by the repo's coding-standard pre-commit hook
+#   - libssl-dev / pkg-config: needed by the fujinet-PC CMake build (the
+#     vendored libssh defaults to the OpenSSL crypto backend)
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        clang-format \
+        libssl-dev \
+        pkg-config \
+    && rm -rf /var/lib/apt/lists/*
+
+# defoogi bundles the `abimap` tool. Its mere presence makes the vendored
+# libssh's CMake (ABIMAP_FOUND=TRUE) try to read src/ABI/current from the
+# *parent* fujinet project, a file that doesn't exist there -- which aborts
+# the fujinet-PC CMake build. A normal dev box has no abimap and skips that
+# path, so take it off PATH to match. (abimap is unused by firmware builds.)
+RUN rm -f /usr/local/bin/abimap

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -20,6 +20,7 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         clang-format \
         libssl-dev \
+        openssh-client \
         pkg-config \
     && rm -rf /var/lib/apt/lists/*
 

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,74 @@
+# Dev Container for FujiNet Firmware
+
+This folder lets you build the FujiNet firmware **without installing any
+toolchain on your machine**. Everything — PlatformIO, the ESP32 toolchain,
+CMake, g++, the retro cross-compilers — lives inside the
+[defoogi](https://github.com/FozzTexx/defoogi) container. You clone the repo,
+open it in the container, and run `./build.sh`.
+
+The same configuration works two ways:
+
+- **Locally** with VS Code + Docker ("Reopen in Container")
+- **In the cloud** with GitHub Codespaces ("Create codespace on this branch")
+
+## Quick start (local)
+
+1. Install [Docker](https://docs.docker.com/get-docker/) and VS Code with the
+   **Dev Containers** extension (`ms-vscode-remote.remote-containers`).
+2. Open this repo in VS Code.
+3. Command Palette → **Dev Containers: Reopen in Container**. First build pulls
+   the image and provisions the container.
+4. In the integrated terminal:
+   ```sh
+   ./build.sh -s fujinet-atari-v1   # one-time: pick your board
+   ./build.sh -b                    # compile firmware
+   ./build.sh -p ATARI              # or compile the PC build
+   ```
+
+## Quick start (Codespaces)
+
+1. On GitHub → **Code ▸ Codespaces ▸ Create codespace**.
+2. Wait for it to build, then use the same `./build.sh` commands above.
+
+## What works where
+
+The container can **compile** anything. Talking to **real hardware over USB**
+(flashing, serial monitor) only works locally, because Codespaces is a cloud VM
+with no USB.
+
+| Task                                              | Local | Codespaces |
+| ------------------------------------------------- | :---: | :--------: |
+| PC build (`./build.sh -p ATARI`)                  |   ✅   |     ✅      |
+| Compile ESP32 firmware (`./build.sh -b`)          |   ✅   |     ✅      |
+| Upload / flash a real ESP32 (`-u`, `-cbum`)       |  ✅*   |     ❌      |
+| Serial monitor (`-m`)                             |  ✅*   |     ❌      |
+
+\* Requires the USB opt-in below.
+
+## Enabling USB flashing (local only)
+
+Flashing needs the container to see the USB serial device. Edit
+[devcontainer.json](devcontainer.json) and add (mirroring defoogi's own `start`
+script):
+
+```jsonc
+"runArgs": ["--privileged", "-v", "/dev:/dev"],
+```
+
+Then **Dev Containers: Rebuild Container**. The `wario` user is already in the
+`dialout` group, so `./build.sh -u` / `-m` can reach `/dev/ttyUSB*`.
+
+> Device passthrough is a Linux/Docker-Engine feature. On Docker Desktop for
+> macOS/Windows, USB passthrough to Linux containers is limited — flashing is
+> most reliable on a Linux host. Either way you can always compile in the
+> container and flash with a host-side tool if needed.
+
+## Notes
+
+- **PlatformIO cache:** ESP32 toolchains (several GB) are stored in a named
+  Docker volume (`fujinet-platformio`) mounted at `/home/wario/.platformio`, so
+  they persist across container rebuilds and don't pollute the source tree.
+- **clang-format:** added on top of the base image so the `coding-standard.py`
+  pre-commit hook works inside the container.
+- **Image arch:** `fozztexx/defoogi:latest` ships both `amd64` and `arm64`, so
+  Apple-Silicon machines run natively (no emulation).

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,15 +13,25 @@
   // survive container rebuilds and stay out of the bind-mounted source tree.
   // Overrides the image's default PLATFORMIO_CORE_DIR=/workspace/.platformio.
   "containerEnv": {
-    "PLATFORMIO_CORE_DIR": "/home/wario/.platformio"
+    "PLATFORMIO_CORE_DIR": "/home/wario/.platformio",
+    "GIT_SSH_COMMAND": "ssh -o UserKnownHostsFile=/tmp/fujinet-github-known_hosts",
+    // 1Password CLI v2 agent socket, if present, for GitHub SSH auth. Optional
+    // Comment out if you don't use 1Password or want to set up SSH keys in another way
+    //"SSH_AUTH_SOCK": "/home/wario/.1password/agent.sock"
   },
   "mounts": [
-    "source=fujinet-platformio,target=/home/wario/.platformio,type=volume"
+    "source=fujinet-platformio,target=/home/wario/.platformio,type=volume",
+    "type=bind,source=${localEnv:HOME}/.ssh,target=/home/wario/.ssh,readonly",
+    // 1Password CLI v2 agent socket, if present, for GitHub SSH auth. Optional
+    // Comment out if you don't use 1Password or want to set up SSH keys in another way
+    //"type=bind,source=${localEnv:HOME}/.1password,target=/home/wario/.1password,readonly"
   ],
 
   // Named volumes mount root-owned; hand it to the build user. safe.directory
   // keeps git happy when the host UID differs from the container user.
-  "postCreateCommand": "sudo chown -R wario:wario /home/wario/.platformio && git config --global --add safe.directory ${containerWorkspaceFolder}",
+  // Git-over-SSH uses the read-only ~/.ssh key mount above; known_hosts is
+  // seeded here so the first GitHub connection doesn't prompt.
+  "postCreateCommand": "sudo chown -R wario:wario /home/wario/.platformio && ssh-keyscan -H github.com > /tmp/fujinet-github-known_hosts 2>/dev/null && git config --global --add safe.directory ${containerWorkspaceFolder} && git config --global core.sshCommand 'ssh -o UserKnownHostsFile=/tmp/fujinet-github-known_hosts'",
 
   "customizations": {
     "vscode": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,48 @@
+{
+  "name": "FujiNet Firmware (defoogi)",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+
+  // The defoogi image already has a non-root build user (uid/gid 1000, in the
+  // dialout group for serial access). Run as that user; the runtime maps its
+  // UID to the host user on local Docker so bind-mounted files stay writable.
+  "remoteUser": "wario",
+
+  // Cache the (multi-GB) PlatformIO ESP32 toolchains in a named volume so they
+  // survive container rebuilds and stay out of the bind-mounted source tree.
+  // Overrides the image's default PLATFORMIO_CORE_DIR=/workspace/.platformio.
+  "containerEnv": {
+    "PLATFORMIO_CORE_DIR": "/home/wario/.platformio"
+  },
+  "mounts": [
+    "source=fujinet-platformio,target=/home/wario/.platformio,type=volume"
+  ],
+
+  // Named volumes mount root-owned; hand it to the build user. safe.directory
+  // keeps git happy when the host UID differs from the container user.
+  "postCreateCommand": "sudo chown -R wario:wario /home/wario/.platformio && git config --global --add safe.directory ${containerWorkspaceFolder}",
+
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "platformio.platformio-ide",
+        "ms-vscode.cpptools",
+        "ms-python.python"
+      ],
+      "settings": {
+        "terminal.integrated.defaultProfile.linux": "bash",
+        "C_Cpp.default.compileCommands": "${containerWorkspaceFolder}/build/compile_commands.json"
+      }
+    }
+  }
+
+  // --- Local USB flashing (opt-in; ignored by Codespaces, which has no USB) ---
+  // To upload firmware / use the serial monitor against a real ESP32 over USB,
+  // add the following keys (a privileged container with /dev passed through,
+  // mirroring defoogi's own `start` script) and rebuild the container:
+  //
+  //   "runArgs": ["--privileged", "-v", "/dev:/dev"],
+  //
+  // Then `./build.sh -cbum` etc. can reach the device. See .devcontainer/README.md.
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,131 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What This Is
+
+FujiNet is a multi-function peripheral firmware for an ESP32-based device that connects vintage 8-bit computers (Atari, Apple II, CoCo, Commodore/IEC, ADAM, Lynx, RC2014, RS-232, and others) to modern networks. It emulates disk drives, printers, modems, clocks, and network adapters over each platform's native bus protocol.
+
+There is also a **fujinet-PC** build that compiles the same firmware to run on a Linux/macOS/Windows host for development and testing, using CMake instead of PlatformIO.
+
+## Build System
+
+The project uses **PlatformIO** for ESP32 targets and **CMake** for the PC target. The primary interface is `build.sh`.
+
+### Prerequisites
+
+- PlatformIO CLI (`pio`)
+- Python 3 with modules from `python_modules.txt` (`sh install_python_modules.sh`)
+- CMake (for PC builds)
+- `clang-format` (for the pre-commit coding-standard hook)
+
+### First-time setup
+
+Generate a `platformio.local.ini` for your board (board names come from `build-platforms/platformio-*.ini`):
+
+```sh
+./build.sh -s fujinet-atari-v1       # generates platformio.local.ini
+./build.sh -s fujiapple-rev0 -l platformio.local-apple.ini  # named variant
+```
+
+The local file is git-ignored. The only required key is `[fujinet] build_board = <name>`.
+
+### Common build commands
+
+```sh
+./build.sh -b          # build
+./build.sh -cb         # clean then build
+./build.sh -cbum       # clean, build, upload firmware, monitor serial
+./build.sh -u          # upload firmware only
+./build.sh -f          # upload filesystem (WebUI)
+./build.sh -m          # open serial monitor
+
+# PC (Linux/macOS) builds
+./build.sh -p ATARI -g   # PC build for ATARI target with debug
+./build.sh -p APPLE      # PC build for APPLE target
+./build.sh -p COCO
+
+# Other
+./build.sh -a          # build ALL target platforms (CI smoke test)
+./build.sh -z          # build flashable release ZIP
+./build.sh -S          # list supported board names
+```
+
+Make targets are thin wrappers around `build.sh`: `make build`, `make upload`, `make uploadfs`, `make clean`, `make all`, `make atari-lwm`, `make apple-lwm`, `make coco-lwm`.
+
+### INI file layering
+
+Each build merges three files in order:
+1. `platformio-ini-files/platformio.common.ini` — shared settings (do not edit)
+2. `build-platforms/platformio-<board>.ini` — board-specific settings (do not edit)
+3. `platformio.local.ini` — your local overrides (git-ignored, edit freely)
+
+Use `+=` in the local file to append to existing `build_flags` rather than replace them:
+
+```ini
+[env]
+build_flags +=
+    -D CORE_DEBUG_LEVEL=5
+    -D VERBOSE_HTTP
+```
+
+## Code Architecture
+
+### Platform + bus abstraction
+
+Every supported vintage computer has a **bus** (the hardware protocol) and a set of **devices** (peripherals that speak that protocol). The codebase separates these two concerns:
+
+- `lib/bus/<bus>/` — bus controllers (e.g., `sio/`, `iec/`, `iwm/`, `drivewire/`, `adamnet/`, `comlynx/`)
+- `lib/device/<bus>/` — device implementations per bus (e.g., `sio/disk.cpp`, `iec/drive.cpp`)
+- `lib/media/<platform>/` — disk image format handling per platform (e.g., `atari/diskTypeAtr.*`, `apple/mediaTypeWOZ.*`)
+
+`lib/bus/bus.h` and `lib/device/device.h` are thin dispatch headers: they `#include` the correct bus/device headers for the active `BUILD_*` define and declare the global device instances.
+
+`src/main.cpp` contains `app_main()` (ESP32) or `main()` (PC). It instantiates `systemBus SYSTEM_BUS` and the configured device objects, wires them together, and starts the bus service loop.
+
+### Shared libraries (platform-independent)
+
+Everything under `lib/` that is not under `lib/bus/` or `lib/device/` is shared across all targets:
+
+| Path | Purpose |
+|------|---------|
+| `lib/network-protocol/` | Protocol implementations (TCP, UDP, HTTP, TNFS, FTP, SMB, SSH, NFS, Telnet) exposed via the N: device |
+| `lib/FileSystem/` | Virtual filesystem layer (SPIFFS/LittleFS flash, SD card, TNFS, SMB, FTP, NFS) |
+| `lib/fuji/` | `fujiHost` / `fujiDisk` — host-slot and disk-slot management shared by all bus implementations |
+| `lib/config/` | `fnConfig` — persistent configuration (split into `fnc_*.cpp` by subsystem) |
+| `lib/hardware/` | HAL: `fnSystem`, `fnWiFi`, UART channels, LED, Bluetooth, timers |
+| `lib/http/` | Built-in HTTP server (WebUI + API); ESP32 uses `httpService`, PC uses mongoose (`mgHttpService`) |
+| `lib/tcpip/` | TCP/UDP socket wrappers |
+| `lib/media/` | Disk image format parsers (platform-specific subdirs) |
+| `lib/printer-emulator/` | Printer emulators (Epson, Atari, PDF, PNG, SVG, HTML) |
+| `lib/task/` | `fnTask` / `fnTaskManager` — cooperative task system used by the PC build |
+| `lib/modem/` | Hayes AT-command modem emulation |
+| `lib/fnjson/` | JSON wrapper (used by N: and HTTP APIs) |
+
+### ESP32 vs PC builds
+
+The ESP32 build targets real hardware; the PC build (`-p TARGET`) compiles the same source with stub HAL implementations under `lib/hardware/` (`fnDummyWiFi`, `fnUARTUnix`, `fnSystemNet`, etc.) and uses mongoose for HTTP. Conditional compilation uses `#ifdef ESP_PLATFORM` / `#ifndef ESP_PLATFORM`.
+
+`components/` holds ESP-IDF components for the ESP32 build. `components_pc/` holds third-party libraries used only by the PC build (mongoose, libnfs, libsmb2, libssh, etc.).
+
+### Adding a new target platform
+
+Use `fujinet.py` as a guide — it copies `lib/bus/.template` and `lib/device/.template`, then adds `#include` blocks to the dispatch headers. Create a `build-platforms/platformio-<new-board>.ini` entry.
+
+## Coding Standards
+
+- Style is enforced by `clang-format` using `.clang-format` (LLVM-based, 4-space indent, 95-column limit, no tabs).
+- The pre-commit hook is `coding-standard.py`; install it with `./coding-standard.py --addhook`.
+- Checked rules: no trailing whitespace, no tab alignment, clang-format compliance on changed C/C++ files.
+- Run manually: `./coding-standard.py <file>` or `./coding-standard.py --fix <file>`.
+
+## Key Defines
+
+Build target is selected via `BUILD_*` and `BUILD_BUS` defines set in the board's PlatformIO ini:
+
+- `BUILD_ATARI` / `BUILD_APPLE` / `BUILD_ADAM` / `BUILD_COCO` / `BUILD_IEC` / `BUILD_LYNX` / `BUILD_RS232` / `BUILD_RC2014` / etc.
+- `ESP_PLATFORM` — defined automatically when targeting ESP32; absent for PC builds.
+
+## Testing
+
+Unit tests live in `test/`. Run them via PlatformIO's test runner (`pio test`). The CI workflow (`.github/workflows/autobuild.yml`) builds all platforms on every push/PR.

--- a/build.sh
+++ b/build.sh
@@ -230,9 +230,15 @@ same_dir() {
 }
 
 if [[ "$VIRTUAL_ENV" != "$VENV_ROOT" ]] ; then
-    if [ ! -f "${ACTIVATE}" ] ; then
-        echo Creating venv at "${VENV_ROOT}"
-        mkdir -p $(dirname "${VENV_ROOT}")
+    STALE_VENV=0
+    if [ -f "${ACTIVATE}" ] && ! grep -Fq "${VENV_ROOT}" "${ACTIVATE}" ; then
+        STALE_VENV=1
+    fi
+
+    if [ ! -f "${ACTIVATE}" ] || [ "${STALE_VENV}" -eq 1 ] ; then
+        echo "Refreshing virtual environment at ${VENV_ROOT}"
+        rm -rf "${VENV_ROOT}"
+        mkdir -p "$(dirname "${VENV_ROOT}")"
         ${PYTHON} -m venv "${VENV_ROOT}" || exit 1
     fi
     if [ -f "${ACTIVATE}" ] ; then
@@ -251,8 +257,10 @@ if [[ "$VIRTUAL_ENV" != "$VENV_ROOT" ]] ; then
         echo "VIRTAUL_ENV = ${VIRTUAL_ENV}"
         echo "VENV_ACTUAL = ${VENV_ACTUAL}"
         echo "VENV_ROOT = ${VENV_ROOT}"
-        ls -Fla "$(dirname ${ACTIVATE})" || true
-        ls -Fla "$(dirname ${ALT_ACTIVATE})" || true
+        ls -Fla "$(dirname "${ACTIVATE}")" || true
+        if [ -d "$(dirname "${ALT_ACTIVATE}")" ] ; then
+            ls -Fla "$(dirname "${ALT_ACTIVATE}")" || true
+        fi
         exit 1
     fi
 fi
@@ -311,6 +319,11 @@ if [ ! -z "$PC_TARGET" ] ; then
     echo "Removing old build artifacts"
     rm -rf $SCRIPT_DIR/build/*
     rm -f $SCRIPT_DIR/build/.ninja* 2>/dev/null
+  fi
+
+  if [ -f "$SCRIPT_DIR/build/CMakeCache.txt" ] && grep -q "/home/bkrein/code/fujinet/fujinet-firmware" "$SCRIPT_DIR/build/CMakeCache.txt" 2>/dev/null ; then
+    echo "Removing stale CMake cache from a previous workspace path"
+    find "$SCRIPT_DIR/build" -mindepth 1 -maxdepth 1 ! -name '.venv' -exec rm -rf {} +
   fi
 
   cd $SCRIPT_DIR/build


### PR DESCRIPTION
## Summary

This PR adds a VS Code Dev Container setup for the FujiNet firmware workspace, including:

- a dedicated dev container image and configuration for local development and Codespaces
- documented build and USB-flashing workflow in the dev container README
- GitHub CLI support for PR and repo tooling inside the container
- optional 1Password SSH-agent integration for GitHub SSH authentication
- workspace guidance for Claude/Copilot tooling and related build helpers

## Testing

- Reopen the repository in the dev container and rebuild the container image
- Verify the container starts with the expected VS Code extensions and environment
- Run the usual firmware/PC build commands from the repo (for example, `./build.sh -b` or `./build.sh -p ATARI`)
