### PR TITLE
[drivewire] New channel mode is in aux1 not aux2

### DIFF
--- a/lib/device/drivewire/network.cpp
+++ b/lib/device/drivewire/network.cpp
@@ -1115,7 +1115,7 @@ void drivewireNetwork::process_http()
     switch (cmdFrame.comnd)
     {
     case NETCMD_UNLISTEN:
-        err = http->set_channel_mode((netProtoHTTPChannelMode_t) cmdFrame.aux2);
+        err = http->set_channel_mode((netProtoHTTPChannelMode_t) cmdFrame.aux1);
         break;
     default:
         err = FUJI_ERROR::UNSPECIFIED;


### PR DESCRIPTION
Fixes HTTP POST test on CoCo.

Test using attached disk image: [fnettest.dsk.zip](https://github.com/user-attachments/files/28965118/fnettest.dsk.zip)

Before fix:

<img width="1664" height="1360" alt="image" src="https://github.com/user-attachments/assets/d35e58df-f3e6-457a-96ca-b3f7b7d252dd" />

After fix:

<img width="1664" height="1360" alt="image" src="https://github.com/user-attachments/assets/70be3b9c-98d2-4eab-bfe6-4664aee97ac5" />
