### PR TITLE
[gdrive] Add Google Drive host-slot support

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,10 @@
+{
+  "permissions": {
+    "additionalDirectories": [
+      "/home/thomc/Workspace/fujinet-config/src"
+    ],
+    "allow": [
+      "Bash(timeout 300 make atari)"
+    ]
+  }
+}

--- a/fujinet_pc.cmake
+++ b/fujinet_pc.cmake
@@ -194,6 +194,7 @@ set(SOURCES src/main.cpp
     lib/FileSystem/fnFsNFS.h lib/FileSystem/fnFsNFS.cpp
     lib/FileSystem/fnFsFTP.h lib/FileSystem/fnFsFTP.cpp
     lib/FileSystem/fnFsHTTP.h lib/FileSystem/fnFsHTTP.cpp
+    lib/FileSystem/fnFsGDrive.h lib/FileSystem/fnFsGDrive.cpp
     lib/FileSystem/fnFile.h lib/FileSystem/fnFile.cpp
     lib/FileSystem/fnFileLocal.h lib/FileSystem/fnFileLocal.cpp
     lib/FileSystem/fnFileTNFS.h lib/FileSystem/fnFileTNFS.cpp
@@ -246,6 +247,7 @@ set(SOURCES src/main.cpp
     lib/network-protocol/ProtocolParser.h lib/network-protocol/ProtocolParser.cpp
     lib/network-protocol/CPM.h lib/network-protocol/CPM.cpp
     lib/network-protocol/GDRIVE.h lib/network-protocol/GDRIVE.cpp
+    lib/network-protocol/GoogleDriveClient.h lib/network-protocol/GoogleDriveClient.cpp
     lib/network-protocol/Test.h lib/network-protocol/Test.cpp
     lib/network-protocol/TCP.h lib/network-protocol/TCP.cpp
     lib/network-protocol/UDP.h lib/network-protocol/UDP.cpp

--- a/lib/FileSystem/fnFS.cpp
+++ b/lib/FileSystem/fnFS.cpp
@@ -92,6 +92,8 @@ const char * FileSystem::type_to_string(fsType type)
             return "FS_FTP";
         case FSTYPE_HTTP:
             return "FS_HTTP";
+        case FSTYPE_GDRIVE:
+            return "FS_GDRIVE";
         default:
             return "UNKNOWN FS TYPE";
     }

--- a/lib/FileSystem/fnFS.h
+++ b/lib/FileSystem/fnFS.h
@@ -111,6 +111,11 @@ public:
 
     virtual bool exists(const char* path) = 0;
 
+    // Push a locally-written file back to its backing store. Filesystems that
+    // cache writes locally (e.g. Google Drive) upload here; the default does
+    // nothing. Called when a disk image opened for writing is unmounted.
+    virtual success_is_true sync_file(const char* path) { RETURN_SUCCESS_AS_TRUE(); }
+
     virtual success_is_true remove(const char* path) = 0;
 
     virtual success_is_true rename(const char* pathFrom, const char* pathTo) = 0;

--- a/lib/FileSystem/fnFS.h
+++ b/lib/FileSystem/fnFS.h
@@ -42,6 +42,7 @@ enum fsType
     FSTYPE_NFS,
     FSTYPE_FTP,
     FSTYPE_HTTP,
+    FSTYPE_GDRIVE,
     FSTYPE_COUNT
 };
 

--- a/lib/FileSystem/fnFS.h
+++ b/lib/FileSystem/fnFS.h
@@ -111,9 +111,8 @@ public:
 
     virtual bool exists(const char* path) = 0;
 
-    // Push a locally-written file back to its backing store. Filesystems that
-    // cache writes locally (e.g. Google Drive) upload here; the default does
-    // nothing. Called when a disk image opened for writing is unmounted.
+    // Push a locally-written file back to its backing store (e.g. upload to
+    // Drive). Called on unmount of a writable disk image. Default: no-op.
     virtual success_is_true sync_file(const char* path) { RETURN_SUCCESS_AS_TRUE(); }
 
     virtual success_is_true remove(const char* path) = 0;

--- a/lib/FileSystem/fnFsGDrive.cpp
+++ b/lib/FileSystem/fnFsGDrive.cpp
@@ -104,12 +104,16 @@ success_is_true FileSystemGDrive::rename(const char *pathFrom, const char *pathT
 FILE *FileSystemGDrive::file_open(const char *path, const char *mode)
 {
 #ifdef FNIO_IS_STDIO
-    // stdio targets (e.g. ADAM) have no FileHandler/FileCache. Cache the Drive
-    // file to the SD card and hand back a FILE*. Local writes are NOT synced
-    // back to Drive — host-slot media from Drive is effectively read-only.
+    // stdio targets (e.g. ADAM) have no FileHandler/FileCache. Drive files are
+    // cached to the SD card and served as a FILE*.
+    //
+    // NOTE: writes/creates are LOCAL ONLY for now — a newly created or modified
+    // image lives in the SD cache (so it can be created and used within this
+    // session) but is NOT uploaded back to Google Drive yet. Pushing changes
+    // back needs an upload on disk-image unmount (TODO).
     Debug_printf("FileSystemGDrive::file_open(\"%s\", \"%s\")\n", path, mode);
 
-    if (!_started || path == nullptr)
+    if (!_started || path == nullptr || mode == nullptr)
         return nullptr;
 
     if (!fnSDFAT.running())
@@ -118,17 +122,25 @@ FILE *FileSystemGDrive::file_open(const char *path, const char *mode)
         return nullptr;
     }
 
+    const bool truncating = (mode[0] == 'w');                  // create/overwrite
+    const bool writing    = (strpbrk(mode, "wa+") != nullptr); // any write intent
+
     std::string cache_path = cache_file_path(path);
 
-    // Reuse a recent cache file if present (avoids re-downloading on re-mount)
-    long mt = fnSDFAT.mtime(cache_path.c_str());
-    if (mt > 0 && (time(nullptr) - mt) < GDRIVE_CACHE_MAX_AGE)
+    // Reuse a recent cache file if present (avoids re-downloading on re-mount,
+    // and lets a just-created local image be mounted in this session). Skip for
+    // 'w' which is meant to start from an empty file.
+    if (!truncating)
     {
-        FILE *cached = fnSDFAT.file_open(cache_path.c_str(), mode);
-        if (cached != nullptr)
+        long mt = fnSDFAT.mtime(cache_path.c_str());
+        if (mt > 0 && (time(nullptr) - mt) < GDRIVE_CACHE_MAX_AGE)
         {
-            Debug_printf("FileSystemGDrive: using cached file %s\n", cache_path.c_str());
-            return cached;
+            FILE *cached = fnSDFAT.file_open(cache_path.c_str(), mode);
+            if (cached != nullptr)
+            {
+                Debug_printf("FileSystemGDrive: using cached file %s\n", cache_path.c_str());
+                return cached;
+            }
         }
     }
 
@@ -138,13 +150,31 @@ FILE *FileSystemGDrive::file_open(const char *path, const char *mode)
         return nullptr;
     }
 
+    // 'w'/'w+' starts from an empty local file regardless of what's on Drive.
+    if (truncating)
+    {
+        Debug_printf("FileSystemGDrive: creating local-only file %s (not uploaded to Drive)\n", path);
+        fnSDFAT.create_path(GDRIVE_CACHE_DIR);
+        return fnSDFAT.file_open(cache_path.c_str(), mode);
+    }
+
     std::string file_id = _gdrive.resolve_path(path);
     if (file_id.empty())
     {
+        // Nothing on Drive. For append-create, start a new local file; for a
+        // pure read this is a genuine "not found".
+        if (writing)
+        {
+            Debug_printf("FileSystemGDrive: creating local-only file %s (not uploaded to Drive)\n", path);
+            fnSDFAT.create_path(GDRIVE_CACHE_DIR);
+            return fnSDFAT.file_open(cache_path.c_str(), mode);
+        }
         Debug_printf("FileSystemGDrive::file_open - not found: %s\n", path);
         return nullptr;
     }
 
+    // File exists on Drive — download it to the cache, then open in the
+    // requested mode (read, or read/write for local-only edits).
     fnSDFAT.create_path(GDRIVE_CACHE_DIR);
     FILE *out = fnSDFAT.file_open(cache_path.c_str(), "wb");
     if (out == nullptr)

--- a/lib/FileSystem/fnFsGDrive.cpp
+++ b/lib/FileSystem/fnFsGDrive.cpp
@@ -77,6 +77,86 @@ bool FileSystemGDrive::exists(const char *path)
     return found;
 }
 
+success_is_true FileSystemGDrive::sync_file(const char *path)
+{
+#ifdef FNIO_IS_STDIO
+    if (!_started || path == nullptr)
+        RETURN_ERROR_AS_FALSE();
+
+    // Only upload files that were opened for writing in this session.
+    auto it = _dirty.find(path);
+    if (it == _dirty.end())
+        RETURN_SUCCESS_AS_TRUE(); // nothing to push back
+
+    if (!fnSDFAT.running())
+        RETURN_ERROR_AS_FALSE();
+
+    std::string cache_path = cache_file_path(path);
+    FILE *in = fnSDFAT.file_open(cache_path.c_str(), "rb");
+    if (in == nullptr)
+    {
+        Debug_printf("FileSystemGDrive::sync_file - no cache file for %s\n", path);
+        _dirty.erase(it);
+        RETURN_ERROR_AS_FALSE();
+    }
+
+    fseek(in, 0, SEEK_END);
+    long sz = ftell(in);
+    fseek(in, 0, SEEK_SET);
+    if (sz < 0)
+    {
+        fclose(in);
+        RETURN_ERROR_AS_FALSE();
+    }
+
+    if (!_gdrive.ensure_access_token())
+    {
+        fclose(in);
+        RETURN_ERROR_AS_FALSE();
+    }
+
+    // Split path into parent folder + file name.
+    std::string p = path;
+    size_t slash = p.find_last_of('/');
+    std::string parent_path = (slash != std::string::npos) ? p.substr(0, slash) : "/";
+    std::string name = (slash != std::string::npos) ? p.substr(slash + 1) : p;
+    if (name.empty())
+    {
+        fclose(in);
+        RETURN_ERROR_AS_FALSE();
+    }
+
+    std::string parent_id = _gdrive.resolve_path(parent_path);
+    if (parent_id.empty())
+        parent_id = "root";
+    std::string file_id = _gdrive.find_child(parent_id, name, false); // "" => create new
+
+    Debug_printf("FileSystemGDrive::sync_file uploading %s (%ld bytes)\n", path, sz);
+
+    std::string id = _gdrive.upload_stream(parent_id, name, file_id, (size_t)sz,
+        [in](uint8_t *buf, int want) -> int {
+            return (int)fread(buf, 1, (size_t)want, in);
+        });
+
+    fclose(in);
+
+    if (id.empty())
+    {
+        Debug_printf("FileSystemGDrive::sync_file - upload failed for %s\n", path);
+        RETURN_ERROR_AS_FALSE();
+    }
+
+    _dirty.erase(it);
+    _last_dir[0] = '\0'; // directory listing may have changed
+    Debug_printf("FileSystemGDrive::sync_file - uploaded %s\n", path);
+    RETURN_SUCCESS_AS_TRUE();
+#else
+    // The FileHandler/FileCache (non-stdio) path doesn't track writes for
+    // upload yet; nothing to push back.
+    RETURN_SUCCESS_AS_TRUE();
+#endif
+}
+
 success_is_true FileSystemGDrive::remove(const char *path)
 {
     if (!_started || path == nullptr)
@@ -124,6 +204,11 @@ FILE *FileSystemGDrive::file_open(const char *path, const char *mode)
 
     const bool truncating = (mode[0] == 'w');                  // create/overwrite
     const bool writing    = (strpbrk(mode, "wa+") != nullptr); // any write intent
+
+    // Remember write-intent opens so the image is uploaded back to Drive when
+    // the disk is unmounted (see sync_file()).
+    if (writing)
+        _dirty.insert(path);
 
     std::string cache_path = cache_file_path(path);
 

--- a/lib/FileSystem/fnFsGDrive.cpp
+++ b/lib/FileSystem/fnFsGDrive.cpp
@@ -2,6 +2,8 @@
 #include "fnFsGDrive.h"
 
 #include <cstring>
+#include <cstdio>
+#include <ctime>
 
 #include "compat_string.h"
 
@@ -9,11 +11,20 @@
 
 #include "fnSystem.h"
 #include "fnFileCache.h"
+#include "fnFsSD.h"
 
 // http timeout in ms while streaming a download
 #define GDRIVE_GET_TIMEOUT 20000
 
 #define COPY_BLK_SIZE 4096
+
+#ifdef FNIO_IS_STDIO
+// On stdio targets (e.g. ADAM) there is no FileHandler/FileCache; Drive files
+// are cached to the SD card and served as a FILE*.
+#define GDRIVE_CACHE_DIR        "/FujiNet/cache"
+// Cached file is reused if it is younger than this (seconds), like fnFileCache.
+#define GDRIVE_CACHE_MAX_AGE    10800
+#endif
 
 FileSystemGDrive::FileSystemGDrive()
 {
@@ -92,9 +103,178 @@ success_is_true FileSystemGDrive::rename(const char *pathFrom, const char *pathT
 
 FILE *FileSystemGDrive::file_open(const char *path, const char *mode)
 {
+#ifdef FNIO_IS_STDIO
+    // stdio targets (e.g. ADAM) have no FileHandler/FileCache. Cache the Drive
+    // file to the SD card and hand back a FILE*. Local writes are NOT synced
+    // back to Drive — host-slot media from Drive is effectively read-only.
+    Debug_printf("FileSystemGDrive::file_open(\"%s\", \"%s\")\n", path, mode);
+
+    if (!_started || path == nullptr)
+        return nullptr;
+
+    if (!fnSDFAT.running())
+    {
+        Debug_println("FileSystemGDrive::file_open - SD card required to cache Drive files");
+        return nullptr;
+    }
+
+    std::string cache_path = cache_file_path(path);
+
+    // Reuse a recent cache file if present (avoids re-downloading on re-mount)
+    long mt = fnSDFAT.mtime(cache_path.c_str());
+    if (mt > 0 && (time(nullptr) - mt) < GDRIVE_CACHE_MAX_AGE)
+    {
+        FILE *cached = fnSDFAT.file_open(cache_path.c_str(), mode);
+        if (cached != nullptr)
+        {
+            Debug_printf("FileSystemGDrive: using cached file %s\n", cache_path.c_str());
+            return cached;
+        }
+    }
+
+    if (!_gdrive.ensure_access_token())
+    {
+        Debug_println("FileSystemGDrive::file_open - no access token");
+        return nullptr;
+    }
+
+    std::string file_id = _gdrive.resolve_path(path);
+    if (file_id.empty())
+    {
+        Debug_printf("FileSystemGDrive::file_open - not found: %s\n", path);
+        return nullptr;
+    }
+
+    fnSDFAT.create_path(GDRIVE_CACHE_DIR);
+    FILE *out = fnSDFAT.file_open(cache_path.c_str(), "wb");
+    if (out == nullptr)
+    {
+        Debug_printf("FileSystemGDrive::file_open - cannot create cache file %s\n", cache_path.c_str());
+        return nullptr;
+    }
+
+    bool ok = stream_download(file_id, [out](const uint8_t *data, int len) -> bool {
+        return fwrite(data, 1, len, out) == (size_t)len;
+    });
+    fclose(out);
+
+    if (!ok)
+    {
+        fnSDFAT.remove(cache_path.c_str());
+        return nullptr;
+    }
+
+    Debug_printf("FileSystemGDrive: cached %s\n", cache_path.c_str());
+    return fnSDFAT.file_open(cache_path.c_str(), mode);
+#else
     Debug_printf("FileSystemGDrive::file_open() - ERROR! Use filehandler_open() instead\n");
     return nullptr;
+#endif
 }
+
+// Stream a Drive file's content (?alt=media) for the given file id, passing
+// each chunk to sink(). Returns true on a complete, successful download.
+bool FileSystemGDrive::stream_download(const std::string &file_id,
+                                       const std::function<bool(const uint8_t *, int)> &sink)
+{
+    GDFS_HTTP_CLIENT http;
+    std::string dl_url = std::string(GDRIVE_FILES_URL) + "/" + file_id + "?alt=media";
+    if (!http.begin(dl_url))
+    {
+        Debug_println("FileSystemGDrive::stream_download - failed to start HTTP client");
+        return false;
+    }
+    http.set_header("Authorization", ("Bearer " + _gdrive.access_token()).c_str());
+
+    Debug_println("Initiating GET request");
+    if (http.GET() > 399)
+    {
+        Debug_println("FileSystemGDrive::stream_download - GET failed");
+        http.close();
+        return false;
+    }
+
+    int tmout_counter = 1 + GDRIVE_GET_TIMEOUT / 50;
+    bool cancel = false;
+    int available;
+
+#ifdef ESP_PLATFORM
+    uint8_t *buf = (uint8_t *)heap_caps_malloc(COPY_BLK_SIZE, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+#else
+    uint8_t *buf = (uint8_t *)malloc(COPY_BLK_SIZE);
+#endif
+    if (buf == nullptr)
+    {
+        Debug_println("FileSystemGDrive::stream_download - failed to allocate buffer");
+        http.close();
+        return false;
+    }
+
+    Debug_println("Retrieving file data");
+    while (!cancel)
+    {
+        available = http.available();
+        if (http.is_transaction_done() && available == 0) // done
+            break;
+
+        if (available == 0) // transaction not completed, wait for data
+        {
+            if (--tmout_counter == 0)
+            {
+                Debug_println("FileSystemGDrive::stream_download - Timeout");
+                cancel = true;
+                break;
+            }
+            fnSystem.delay(50);
+        }
+        else if (available > 0)
+        {
+            while (available > 0)
+            {
+                int to_read = (available > COPY_BLK_SIZE) ? COPY_BLK_SIZE : available;
+                int from_read = http.read(buf, to_read);
+                if (from_read != to_read)
+                {
+                    Debug_println("FileSystemGDrive::stream_download - HTTP read failed");
+                    Debug_printf("  Expected %d bytes, actually got %d bytes.\r\n", to_read, from_read);
+                    cancel = true;
+                    break;
+                }
+                if (!sink(buf, to_read))
+                {
+                    Debug_printf("FileSystemGDrive::stream_download - sink write failed\n");
+                    cancel = true;
+                    break;
+                }
+                available = http.available();
+            }
+            tmout_counter = 1 + GDRIVE_GET_TIMEOUT / 50; // reset timeout counter
+        }
+        else // available < 0
+        {
+            Debug_println("FileSystemGDrive::stream_download - something went wrong");
+            cancel = true;
+        }
+    }
+    free(buf);
+    http.close();
+
+    return !cancel;
+}
+
+#ifdef FNIO_IS_STDIO
+std::string FileSystemGDrive::cache_file_path(const char *path)
+{
+    // Deterministic, filesystem-safe name derived from host + path so the same
+    // Drive file maps to the same cache file (and distinct files don't collide).
+    std::hash<std::string> hasher;
+    unsigned long h1 = (unsigned long)hasher(_rawurl);
+    unsigned long h2 = (unsigned long)hasher(std::string(path));
+    char name[64];
+    snprintf(name, sizeof(name), "%s/gd-%08lx%08lx.tmp", GDRIVE_CACHE_DIR, h1, h2);
+    return std::string(name);
+}
+#endif
 
 #ifndef FNIO_IS_STDIO
 FileHandler *FileSystemGDrive::filehandler_open(const char *path, const char *mode)
@@ -132,103 +312,17 @@ FileHandler *FileSystemGDrive::cache_file(const char *path, const char *mode)
     if (fc == nullptr)
         return nullptr;
 
-    // Stream the file content (?alt=media) into the cache file
-    GDFS_HTTP_CLIENT http;
-    std::string dl_url = std::string(GDRIVE_FILES_URL) + "/" + file_id + "?alt=media";
-    if (!http.begin(dl_url))
-    {
-        Debug_println("FileSystemGDrive::cache_file - failed to start HTTP client");
-        FileCache::remove(fc);
-        return nullptr;
-    }
-    http.set_header("Authorization", ("Bearer " + _gdrive.access_token()).c_str());
+    bool ok = stream_download(file_id, [fc](const uint8_t *data, int len) -> bool {
+        return FileCache::write(fc, data, len) == (size_t)len;
+    });
 
-    Debug_println("Initiating GET request");
-    if (http.GET() > 399)
+    if (!ok)
     {
-        Debug_println("FileSystemGDrive::cache_file - GET failed");
         FileCache::remove(fc);
         return nullptr;
     }
 
-    // Retrieve data
-    int tmout_counter = 1 + GDRIVE_GET_TIMEOUT / 50;
-    bool cancel = false;
-    int available;
-
-#ifdef ESP_PLATFORM
-    uint8_t *buf = (uint8_t *)heap_caps_malloc(COPY_BLK_SIZE, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
-#else
-    uint8_t *buf = (uint8_t *)malloc(COPY_BLK_SIZE);
-#endif
-    if (buf == nullptr)
-    {
-        Debug_println("FileSystemGDrive::cache_file - failed to allocate buffer");
-        FileCache::remove(fc);
-        return nullptr;
-    }
-
-    Debug_println("Retrieving file data");
-    while (!cancel)
-    {
-        available = http.available();
-        if (http.is_transaction_done() && available == 0) // done
-            break;
-
-        if (available == 0) // transaction not completed, wait for data
-        {
-            if (--tmout_counter == 0)
-            {
-                Debug_println("FileSystemGDrive::cache_file - Timeout");
-                cancel = true;
-                break;
-            }
-            fnSystem.delay(50);
-        }
-        else if (available > 0)
-        {
-            while (available > 0)
-            {
-                int to_read = (available > COPY_BLK_SIZE) ? COPY_BLK_SIZE : available;
-                int from_read = http.read(buf, to_read);
-                if (from_read != to_read)
-                {
-                    Debug_println("FileSystemGDrive::cache_file - HTTP read failed");
-                    Debug_printf("  Expected %d bytes, actually got %d bytes.\r\n", to_read, from_read);
-                    cancel = true;
-                    break;
-                }
-                if (FileCache::write(fc, buf, to_read) < (size_t)to_read)
-                {
-                    Debug_printf("FileSystemGDrive::cache_file - Cache write failed\n");
-                    cancel = true;
-                    break;
-                }
-                available = http.available();
-            }
-            tmout_counter = 1 + GDRIVE_GET_TIMEOUT / 50; // reset timeout counter
-        }
-        else // available < 0
-        {
-            Debug_println("FileSystemGDrive::cache_file - something went wrong");
-            cancel = true;
-        }
-    }
-    free(buf);
-    http.close();
-
-    if (cancel)
-    {
-        Debug_println("Cancelled");
-        FileCache::remove(fc);
-        fh = nullptr;
-    }
-    else
-    {
-        Debug_println("File data retrieved");
-        fh = FileCache::reopen(fc, mode);
-    }
-    return fh;
+    return FileCache::reopen(fc, mode);
 }
 #endif //!FNIO_IS_STDIO
 

--- a/lib/FileSystem/fnFsGDrive.cpp
+++ b/lib/FileSystem/fnFsGDrive.cpp
@@ -19,10 +19,10 @@
 #define COPY_BLK_SIZE 4096
 
 #ifdef FNIO_IS_STDIO
-// On stdio targets (e.g. ADAM) there is no FileHandler/FileCache; Drive files
-// are cached to the SD card and served as a FILE*.
+// stdio targets (e.g. ADAM) have no FileHandler/FileCache; Drive files are
+// cached to the SD card and served as a FILE*.
 #define GDRIVE_CACHE_DIR        "/FujiNet/cache"
-// Cached file is reused if it is younger than this (seconds), like fnFileCache.
+// Reuse a cached file younger than this (seconds), like fnFileCache.
 #define GDRIVE_CACHE_MAX_AGE    10800
 #endif
 
@@ -47,14 +47,10 @@ success_is_true FileSystemGDrive::start(const char *url, const char *user, const
     if (url == nullptr || url[0] == '\0')
         RETURN_ERROR_AS_FALSE();
 
-    // The host string is just the GDRIVE:// scheme (Drive itself is the host);
-    // keep it verbatim as the file-cache key so cached images are namespaced
-    // per host slot.
+    // Keep the URL verbatim as the file-cache key (namespaces cache per slot).
     _rawurl = url;
 
-    // We need a usable OAuth2 access token to talk to Drive. If the user has
-    // not authorized (no refresh token), fail the mount so the slot shows as
-    // disconnected rather than silently empty.
+    // Fail the mount if unauthorized, so the slot shows disconnected.
     if (!_gdrive.ensure_access_token())
     {
         Debug_printf("FileSystemGDrive::start() - no Google Drive access token (authorize in web UI first)\n");
@@ -77,8 +73,6 @@ bool FileSystemGDrive::exists(const char *path)
     return found;
 }
 
-// Upload `len` bytes pulled from read_chunk() to Drive at `path` (create or
-// update), then clear the dirty flag on success.
 success_is_true FileSystemGDrive::upload_path(const char *path, size_t len,
         const std::function<int(uint8_t *, int)> &read_chunk)
 {
@@ -108,7 +102,7 @@ success_is_true FileSystemGDrive::upload_path(const char *path, size_t len,
     }
 
     _dirty.erase(path);
-    _last_dir[0] = '\0'; // directory listing may have changed
+    _last_dir[0] = '\0'; // listing may have changed
     Debug_printf("FileSystemGDrive::sync_file - uploaded %s\n", path);
     RETURN_SUCCESS_AS_TRUE();
 }
@@ -118,12 +112,12 @@ success_is_true FileSystemGDrive::sync_file(const char *path)
     if (!_started || path == nullptr)
         RETURN_ERROR_AS_FALSE();
 
-    // Only upload files that were opened for writing in this session.
+    // Only upload files opened for writing this session.
     if (_dirty.find(path) == _dirty.end())
-        RETURN_SUCCESS_AS_TRUE(); // nothing to push back
+        RETURN_SUCCESS_AS_TRUE();
 
 #ifdef FNIO_IS_STDIO
-    // stdio: the image was written straight to an SD cache FILE*; read it back.
+    // stdio: the image is in an SD cache FILE*; read it back.
     if (!fnSDFAT.running())
         RETURN_ERROR_AS_FALSE();
 
@@ -152,8 +146,8 @@ success_is_true FileSystemGDrive::sync_file(const char *path)
     fclose(in);
     return ok;
 #else
-    // FileHandler/FileCache: the writable cache was forced onto SD (see
-    // cache_file), so reopen it for reading and upload.
+    // FileHandler/FileCache: writable cache was forced onto SD (see cache_file);
+    // reopen for reading and upload.
     FileHandler *in = FileCache::open(_rawurl.c_str(), path, "rb");
     if (in == nullptr)
     {
@@ -190,16 +184,14 @@ success_is_true FileSystemGDrive::remove(const char *path)
     if (id.empty())
         RETURN_ERROR_AS_FALSE();
 
-    // Removing changes the listing — invalidate the cached directory.
-    _last_dir[0] = '\0';
+    _last_dir[0] = '\0'; // listing changed
 
     RETURN_SUCCESS_IF(_gdrive.api_delete(std::string(GDRIVE_FILES_URL) + "/" + id));
 }
 
 success_is_true FileSystemGDrive::rename(const char *pathFrom, const char *pathTo)
 {
-    // Google Drive rename requires a PATCH on the file metadata, which is not
-    // implemented here (mirrors NetworkProtocolGDRIVE::rename_implemented=false).
+    // Drive rename needs a metadata PATCH; not implemented.
     Debug_printf("FileSystemGDrive::rename() - not supported\n");
     RETURN_ERROR_AS_FALSE();
 }
@@ -207,13 +199,7 @@ success_is_true FileSystemGDrive::rename(const char *pathFrom, const char *pathT
 FILE *FileSystemGDrive::file_open(const char *path, const char *mode)
 {
 #ifdef FNIO_IS_STDIO
-    // stdio targets (e.g. ADAM) have no FileHandler/FileCache. Drive files are
-    // cached to the SD card and served as a FILE*.
-    //
-    // NOTE: writes/creates are LOCAL ONLY for now — a newly created or modified
-    // image lives in the SD cache (so it can be created and used within this
-    // session) but is NOT uploaded back to Google Drive yet. Pushing changes
-    // back needs an upload on disk-image unmount (TODO).
+    // stdio targets (e.g. ADAM): cache Drive files to SD and serve as a FILE*.
     Debug_printf("FileSystemGDrive::file_open(\"%s\", \"%s\")\n", path, mode);
 
     if (!_started || path == nullptr || mode == nullptr)
@@ -228,16 +214,13 @@ FILE *FileSystemGDrive::file_open(const char *path, const char *mode)
     const bool truncating = (mode[0] == 'w');                  // create/overwrite
     const bool writing    = (strpbrk(mode, "wa+") != nullptr); // any write intent
 
-    // Remember write-intent opens so the image is uploaded back to Drive when
-    // the disk is unmounted (see sync_file()).
+    // Track write-intent opens for upload on unmount (sync_file()).
     if (writing)
         _dirty.insert(path);
 
     std::string cache_path = cache_file_path(path);
 
-    // Reuse a recent cache file if present (avoids re-downloading on re-mount,
-    // and lets a just-created local image be mounted in this session). Skip for
-    // 'w' which is meant to start from an empty file.
+    // Reuse a recent cache file if present. Skip for 'w' (starts empty).
     if (!truncating)
     {
         long mt = fnSDFAT.mtime(cache_path.c_str());
@@ -258,10 +241,10 @@ FILE *FileSystemGDrive::file_open(const char *path, const char *mode)
         return nullptr;
     }
 
-    // 'w'/'w+' starts from an empty local file regardless of what's on Drive.
+    // 'w'/'w+' starts from an empty local file regardless of Drive.
     if (truncating)
     {
-        Debug_printf("FileSystemGDrive: creating local-only file %s (not uploaded to Drive)\n", path);
+        Debug_printf("FileSystemGDrive: creating local file %s\n", path);
         fnSDFAT.create_path(GDRIVE_CACHE_DIR);
         return fnSDFAT.file_open(cache_path.c_str(), mode);
     }
@@ -269,11 +252,10 @@ FILE *FileSystemGDrive::file_open(const char *path, const char *mode)
     std::string file_id = _gdrive.resolve_path(path);
     if (file_id.empty())
     {
-        // Nothing on Drive. For append-create, start a new local file; for a
-        // pure read this is a genuine "not found".
+        // Not on Drive: append-create starts a new local file; read is "not found".
         if (writing)
         {
-            Debug_printf("FileSystemGDrive: creating local-only file %s (not uploaded to Drive)\n", path);
+            Debug_printf("FileSystemGDrive: creating local file %s\n", path);
             fnSDFAT.create_path(GDRIVE_CACHE_DIR);
             return fnSDFAT.file_open(cache_path.c_str(), mode);
         }
@@ -281,8 +263,7 @@ FILE *FileSystemGDrive::file_open(const char *path, const char *mode)
         return nullptr;
     }
 
-    // File exists on Drive — download it to the cache, then open in the
-    // requested mode (read, or read/write for local-only edits).
+    // Exists on Drive: download to cache, then open in the requested mode.
     fnSDFAT.create_path(GDRIVE_CACHE_DIR);
     FILE *out = fnSDFAT.file_open(cache_path.c_str(), "wb");
     if (out == nullptr)
@@ -310,8 +291,6 @@ FILE *FileSystemGDrive::file_open(const char *path, const char *mode)
 #endif
 }
 
-// Stream a Drive file's content (?alt=media) for the given file id, passing
-// each chunk to sink(). Returns true on a complete, successful download.
 bool FileSystemGDrive::stream_download(const std::string &file_id,
                                        const std::function<bool(const uint8_t *, int)> &sink)
 {
@@ -403,8 +382,7 @@ bool FileSystemGDrive::stream_download(const std::string &file_id,
 #ifdef FNIO_IS_STDIO
 std::string FileSystemGDrive::cache_file_path(const char *path)
 {
-    // Deterministic, filesystem-safe name derived from host + path so the same
-    // Drive file maps to the same cache file (and distinct files don't collide).
+    // Deterministic name from host + path: same Drive file -> same cache file.
     std::hash<std::string> hasher;
     unsigned long h1 = (unsigned long)hasher(_rawurl);
     unsigned long h2 = (unsigned long)hasher(std::string(path));
@@ -420,8 +398,8 @@ FileHandler *FileSystemGDrive::filehandler_open(const char *path, const char *mo
     return cache_file(path, mode);
 }
 
-// Download the Drive file at `path` into the local file cache and return a
-// FileHandler for it (memory or SD file). Returns nullptr on error.
+// Download the Drive file at `path` into the local cache and return a
+// FileHandler. nullptr on error.
 FileHandler *FileSystemGDrive::cache_file(const char *path, const char *mode)
 {
     Debug_printf("FileSystemGDrive::cache_file(\"%s\", \"%s\")\n", path, mode);
@@ -429,17 +407,16 @@ FileHandler *FileSystemGDrive::cache_file(const char *path, const char *mode)
     const bool truncating = (mode[0] == 'w');                  // create/overwrite
     const bool writing    = (strpbrk(mode, "wa+") != nullptr); // any write intent
 
-    // Remember write-intent opens so the image is uploaded back to Drive when
-    // the disk is unmounted (see sync_file()).
+    // Track write-intent opens for upload on unmount (sync_file()).
     if (writing)
         _dirty.insert(path);
 
-    // Try the SD cache first (skip for 'w' which should start from empty).
+    // Try the SD cache first (skip for 'w', which starts empty).
     if (!truncating)
     {
         FileHandler *fh = FileCache::open(_rawurl.c_str(), path, mode);
         if (fh != nullptr)
-            return fh; // cache hit, done
+            return fh;
     }
 
     if (!_gdrive.ensure_access_token())
@@ -448,8 +425,7 @@ FileHandler *FileSystemGDrive::cache_file(const char *path, const char *mode)
         return nullptr;
     }
 
-    // Decide whether to seed the cache with the file's current Drive content.
-    // 'w'/'w+' always starts empty; otherwise download the existing file.
+    // Seed the cache with Drive content unless truncating ('w'/'w+').
     std::string file_id;
     if (!truncating)
     {
@@ -461,18 +437,16 @@ FileHandler *FileSystemGDrive::cache_file(const char *path, const char *mode)
         }
     }
 
-    // For write modes force the cache onto the SD card (threshold 0) so the disk
-    // device's writes land in a real file that survives the handle being closed
-    // and can be read back for upload on unmount. Reads keep the faster
-    // memory-first cache.
+    // Write modes force the cache onto SD (threshold 0) so writes survive the
+    // handle closing and can be read back for upload. Reads stay memory-first.
     const int threshold = writing ? 0 : -1;
 
     fc_handle *fc = FileCache::create(_rawurl.c_str(), path, threshold);
     if (fc == nullptr)
         return nullptr;
 
-    // A zero-length write makes the (threshold 0) cache switch to SD right away,
-    // even when there is no Drive content to download (e.g. a brand-new image).
+    // Zero-length write switches the (threshold 0) cache to SD immediately,
+    // even with no Drive content to download (e.g. a brand-new image).
     if (writing)
         FileCache::write(fc, "", 0);
 
@@ -524,7 +498,7 @@ success_is_true FileSystemGDrive::mkdir(const char *path)
 
     _gdrive.ensure_access_token();
 
-    // parent = everything before the last '/'; new folder name = the remainder
+    // Split into parent path + new folder name.
     std::string p = path;
     size_t slash = p.find_last_of('/');
     std::string parent_path = (slash != std::string::npos) ? p.substr(0, slash) : "/";
@@ -540,7 +514,7 @@ success_is_true FileSystemGDrive::mkdir(const char *path)
 
 success_is_true FileSystemGDrive::rmdir(const char *path)
 {
-    // A folder is deleted the same way as a file in Drive.
+    // In Drive a folder is deleted like a file.
     return remove(path);
 }
 
@@ -576,12 +550,11 @@ success_is_true FileSystemGDrive::dir_open(const char *path, const char *pattern
             RETURN_ERROR_AS_FALSE();
         }
 
-        // Resolve the path to a folder id ("root" for the Drive root).
         std::string folder_id = _gdrive.resolve_path(path);
         if (folder_id.empty())
             folder_id = "root";
 
-        // List the children of this folder.
+        // List the folder's children.
         std::string q = "'" + folder_id + "' in parents and trashed=false";
         std::string resp = _gdrive.api_get(std::string(GDRIVE_FILES_URL) +
                                            "?q=" + GoogleDriveClient::url_encode(q) +
@@ -626,7 +599,7 @@ success_is_true FileSystemGDrive::dir_open(const char *path, const char *pattern
             strlcpy(fs_de->filename, name.c_str(), sizeof(fs_de->filename));
             fs_de->isDir = (mime == GDRIVE_FOLDER_MIME);
             fs_de->size = size_str.empty() ? 0 : (uint32_t)atol(size_str.c_str());
-            fs_de->modified_time = 0; // Drive modifiedTime not requested
+            fs_de->modified_time = 0; // modifiedTime not requested
 
             Debug_printf(" add entry: \"%s\"\t%s\n", fs_de->filename,
                          fs_de->isDir ? "DIR" : "");
@@ -634,7 +607,6 @@ success_is_true FileSystemGDrive::dir_open(const char *path, const char *pattern
         cJSON_Delete(root);
     }
 
-    // Apply pattern matching filter and sort entries
     _dircache.apply_filter(pattern, diropts);
 
     RETURN_SUCCESS_AS_TRUE();
@@ -647,7 +619,7 @@ fsdir_entry *FileSystemGDrive::dir_read()
 
 void FileSystemGDrive::dir_close()
 {
-    // Keep the cache populated so repeat dir_open() of the same path is cheap.
+    // Keep the cache so a repeat dir_open() of the same path is cheap.
 }
 
 uint16_t FileSystemGDrive::dir_tell()

--- a/lib/FileSystem/fnFsGDrive.cpp
+++ b/lib/FileSystem/fnFsGDrive.cpp
@@ -77,17 +77,53 @@ bool FileSystemGDrive::exists(const char *path)
     return found;
 }
 
+// Upload `len` bytes pulled from read_chunk() to Drive at `path` (create or
+// update), then clear the dirty flag on success.
+success_is_true FileSystemGDrive::upload_path(const char *path, size_t len,
+        const std::function<int(uint8_t *, int)> &read_chunk)
+{
+    if (!_gdrive.ensure_access_token())
+        RETURN_ERROR_AS_FALSE();
+
+    // Split path into parent folder + file name.
+    std::string p = path;
+    size_t slash = p.find_last_of('/');
+    std::string parent_path = (slash != std::string::npos) ? p.substr(0, slash) : "/";
+    std::string name = (slash != std::string::npos) ? p.substr(slash + 1) : p;
+    if (name.empty())
+        RETURN_ERROR_AS_FALSE();
+
+    std::string parent_id = _gdrive.resolve_path(parent_path);
+    if (parent_id.empty())
+        parent_id = "root";
+    std::string file_id = _gdrive.find_child(parent_id, name, false); // "" => create new
+
+    Debug_printf("FileSystemGDrive::sync_file uploading %s (%u bytes)\n", path, (unsigned)len);
+
+    std::string id = _gdrive.upload_stream(parent_id, name, file_id, len, read_chunk);
+    if (id.empty())
+    {
+        Debug_printf("FileSystemGDrive::sync_file - upload failed for %s\n", path);
+        RETURN_ERROR_AS_FALSE();
+    }
+
+    _dirty.erase(path);
+    _last_dir[0] = '\0'; // directory listing may have changed
+    Debug_printf("FileSystemGDrive::sync_file - uploaded %s\n", path);
+    RETURN_SUCCESS_AS_TRUE();
+}
+
 success_is_true FileSystemGDrive::sync_file(const char *path)
 {
-#ifdef FNIO_IS_STDIO
     if (!_started || path == nullptr)
         RETURN_ERROR_AS_FALSE();
 
     // Only upload files that were opened for writing in this session.
-    auto it = _dirty.find(path);
-    if (it == _dirty.end())
+    if (_dirty.find(path) == _dirty.end())
         RETURN_SUCCESS_AS_TRUE(); // nothing to push back
 
+#ifdef FNIO_IS_STDIO
+    // stdio: the image was written straight to an SD cache FILE*; read it back.
     if (!fnSDFAT.running())
         RETURN_ERROR_AS_FALSE();
 
@@ -96,7 +132,7 @@ success_is_true FileSystemGDrive::sync_file(const char *path)
     if (in == nullptr)
     {
         Debug_printf("FileSystemGDrive::sync_file - no cache file for %s\n", path);
-        _dirty.erase(it);
+        _dirty.erase(path);
         RETURN_ERROR_AS_FALSE();
     }
 
@@ -109,51 +145,38 @@ success_is_true FileSystemGDrive::sync_file(const char *path)
         RETURN_ERROR_AS_FALSE();
     }
 
-    if (!_gdrive.ensure_access_token())
-    {
-        fclose(in);
-        RETURN_ERROR_AS_FALSE();
-    }
-
-    // Split path into parent folder + file name.
-    std::string p = path;
-    size_t slash = p.find_last_of('/');
-    std::string parent_path = (slash != std::string::npos) ? p.substr(0, slash) : "/";
-    std::string name = (slash != std::string::npos) ? p.substr(slash + 1) : p;
-    if (name.empty())
-    {
-        fclose(in);
-        RETURN_ERROR_AS_FALSE();
-    }
-
-    std::string parent_id = _gdrive.resolve_path(parent_path);
-    if (parent_id.empty())
-        parent_id = "root";
-    std::string file_id = _gdrive.find_child(parent_id, name, false); // "" => create new
-
-    Debug_printf("FileSystemGDrive::sync_file uploading %s (%ld bytes)\n", path, sz);
-
-    std::string id = _gdrive.upload_stream(parent_id, name, file_id, (size_t)sz,
+    success_is_true ok = upload_path(path, (size_t)sz,
         [in](uint8_t *buf, int want) -> int {
             return (int)fread(buf, 1, (size_t)want, in);
         });
-
     fclose(in);
-
-    if (id.empty())
+    return ok;
+#else
+    // FileHandler/FileCache: the writable cache was forced onto SD (see
+    // cache_file), so reopen it for reading and upload.
+    FileHandler *in = FileCache::open(_rawurl.c_str(), path, "rb");
+    if (in == nullptr)
     {
-        Debug_printf("FileSystemGDrive::sync_file - upload failed for %s\n", path);
+        Debug_printf("FileSystemGDrive::sync_file - no cache file for %s\n", path);
+        _dirty.erase(path);
         RETURN_ERROR_AS_FALSE();
     }
 
-    _dirty.erase(it);
-    _last_dir[0] = '\0'; // directory listing may have changed
-    Debug_printf("FileSystemGDrive::sync_file - uploaded %s\n", path);
-    RETURN_SUCCESS_AS_TRUE();
-#else
-    // The FileHandler/FileCache (non-stdio) path doesn't track writes for
-    // upload yet; nothing to push back.
-    RETURN_SUCCESS_AS_TRUE();
+    in->seek(0, SEEK_END);
+    long sz = in->tell();
+    in->seek(0, SEEK_SET);
+    if (sz < 0)
+    {
+        in->close();
+        RETURN_ERROR_AS_FALSE();
+    }
+
+    success_is_true ok = upload_path(path, (size_t)sz,
+        [in](uint8_t *buf, int want) -> int {
+            return (int)in->read(buf, 1, (size_t)want);
+        });
+    in->close();
+    return ok;
 #endif
 }
 
@@ -403,10 +426,21 @@ FileHandler *FileSystemGDrive::cache_file(const char *path, const char *mode)
 {
     Debug_printf("FileSystemGDrive::cache_file(\"%s\", \"%s\")\n", path, mode);
 
-    // Try SD cache first
-    FileHandler *fh = FileCache::open(_rawurl.c_str(), path, mode);
-    if (fh != nullptr)
-        return fh; // cache hit, done
+    const bool truncating = (mode[0] == 'w');                  // create/overwrite
+    const bool writing    = (strpbrk(mode, "wa+") != nullptr); // any write intent
+
+    // Remember write-intent opens so the image is uploaded back to Drive when
+    // the disk is unmounted (see sync_file()).
+    if (writing)
+        _dirty.insert(path);
+
+    // Try the SD cache first (skip for 'w' which should start from empty).
+    if (!truncating)
+    {
+        FileHandler *fh = FileCache::open(_rawurl.c_str(), path, mode);
+        if (fh != nullptr)
+            return fh; // cache hit, done
+    }
 
     if (!_gdrive.ensure_access_token())
     {
@@ -414,27 +448,44 @@ FileHandler *FileSystemGDrive::cache_file(const char *path, const char *mode)
         return nullptr;
     }
 
-    // Resolve the Drive file id for this path
-    std::string file_id = _gdrive.resolve_path(path);
-    if (file_id.empty())
+    // Decide whether to seed the cache with the file's current Drive content.
+    // 'w'/'w+' always starts empty; otherwise download the existing file.
+    std::string file_id;
+    if (!truncating)
     {
-        Debug_printf("FileSystemGDrive::cache_file - not found: %s\n", path);
-        return nullptr;
+        file_id = _gdrive.resolve_path(path);
+        if (file_id.empty() && !writing)
+        {
+            Debug_printf("FileSystemGDrive::cache_file - not found: %s\n", path);
+            return nullptr;
+        }
     }
 
-    // Create new cache file (starts in memory)
-    fc_handle *fc = FileCache::create(_rawurl.c_str(), path);
+    // For write modes force the cache onto the SD card (threshold 0) so the disk
+    // device's writes land in a real file that survives the handle being closed
+    // and can be read back for upload on unmount. Reads keep the faster
+    // memory-first cache.
+    const int threshold = writing ? 0 : -1;
+
+    fc_handle *fc = FileCache::create(_rawurl.c_str(), path, threshold);
     if (fc == nullptr)
         return nullptr;
 
-    bool ok = stream_download(file_id, [fc](const uint8_t *data, int len) -> bool {
-        return FileCache::write(fc, data, len) == (size_t)len;
-    });
+    // A zero-length write makes the (threshold 0) cache switch to SD right away,
+    // even when there is no Drive content to download (e.g. a brand-new image).
+    if (writing)
+        FileCache::write(fc, "", 0);
 
-    if (!ok)
+    if (!file_id.empty())
     {
-        FileCache::remove(fc);
-        return nullptr;
+        bool ok = stream_download(file_id, [fc](const uint8_t *data, int len) -> bool {
+            return FileCache::write(fc, data, len) == (size_t)len;
+        });
+        if (!ok)
+        {
+            FileCache::remove(fc);
+            return nullptr;
+        }
     }
 
     return FileCache::reopen(fc, mode);

--- a/lib/FileSystem/fnFsGDrive.cpp
+++ b/lib/FileSystem/fnFsGDrive.cpp
@@ -1,0 +1,401 @@
+
+#include "fnFsGDrive.h"
+
+#include <cstring>
+
+#include "compat_string.h"
+
+#include "../../include/debug.h"
+
+#include "fnSystem.h"
+#include "fnFileCache.h"
+
+// http timeout in ms while streaming a download
+#define GDRIVE_GET_TIMEOUT 20000
+
+#define COPY_BLK_SIZE 4096
+
+FileSystemGDrive::FileSystemGDrive()
+{
+    Debug_printf("FileSystemGDrive::ctor\n");
+    _last_dir[0] = '\0';
+}
+
+FileSystemGDrive::~FileSystemGDrive()
+{
+    Debug_printf("FileSystemGDrive::dtor\n");
+    if (_started)
+        _dircache.clear();
+}
+
+success_is_true FileSystemGDrive::start(const char *url, const char *user, const char *password)
+{
+    if (_started)
+        RETURN_ERROR_AS_FALSE();
+
+    if (url == nullptr || url[0] == '\0')
+        RETURN_ERROR_AS_FALSE();
+
+    // The host string is just the GDRIVE:// scheme (Drive itself is the host);
+    // keep it verbatim as the file-cache key so cached images are namespaced
+    // per host slot.
+    _rawurl = url;
+
+    // We need a usable OAuth2 access token to talk to Drive. If the user has
+    // not authorized (no refresh token), fail the mount so the slot shows as
+    // disconnected rather than silently empty.
+    if (!_gdrive.ensure_access_token())
+    {
+        Debug_printf("FileSystemGDrive::start() - no Google Drive access token (authorize in web UI first)\n");
+        RETURN_ERROR_AS_FALSE();
+    }
+
+    Debug_println("FileSystemGDrive started");
+
+    RETURN_SUCCESS_IF(_started = true);
+}
+
+bool FileSystemGDrive::exists(const char *path)
+{
+    if (!_started || path == nullptr)
+        return false;
+
+    _gdrive.ensure_access_token();
+    bool found = !_gdrive.resolve_path(path).empty();
+    Debug_printf("FileSystemGDrive::exists(\"%s\") = %d\n", path, found);
+    return found;
+}
+
+success_is_true FileSystemGDrive::remove(const char *path)
+{
+    if (!_started || path == nullptr)
+        RETURN_ERROR_AS_FALSE();
+
+    _gdrive.ensure_access_token();
+    std::string id = _gdrive.resolve_path(path);
+    if (id.empty())
+        RETURN_ERROR_AS_FALSE();
+
+    // Removing changes the listing — invalidate the cached directory.
+    _last_dir[0] = '\0';
+
+    RETURN_SUCCESS_IF(_gdrive.api_delete(std::string(GDRIVE_FILES_URL) + "/" + id));
+}
+
+success_is_true FileSystemGDrive::rename(const char *pathFrom, const char *pathTo)
+{
+    // Google Drive rename requires a PATCH on the file metadata, which is not
+    // implemented here (mirrors NetworkProtocolGDRIVE::rename_implemented=false).
+    Debug_printf("FileSystemGDrive::rename() - not supported\n");
+    RETURN_ERROR_AS_FALSE();
+}
+
+FILE *FileSystemGDrive::file_open(const char *path, const char *mode)
+{
+    Debug_printf("FileSystemGDrive::file_open() - ERROR! Use filehandler_open() instead\n");
+    return nullptr;
+}
+
+#ifndef FNIO_IS_STDIO
+FileHandler *FileSystemGDrive::filehandler_open(const char *path, const char *mode)
+{
+    return cache_file(path, mode);
+}
+
+// Download the Drive file at `path` into the local file cache and return a
+// FileHandler for it (memory or SD file). Returns nullptr on error.
+FileHandler *FileSystemGDrive::cache_file(const char *path, const char *mode)
+{
+    Debug_printf("FileSystemGDrive::cache_file(\"%s\", \"%s\")\n", path, mode);
+
+    // Try SD cache first
+    FileHandler *fh = FileCache::open(_rawurl.c_str(), path, mode);
+    if (fh != nullptr)
+        return fh; // cache hit, done
+
+    if (!_gdrive.ensure_access_token())
+    {
+        Debug_println("FileSystemGDrive::cache_file - no access token");
+        return nullptr;
+    }
+
+    // Resolve the Drive file id for this path
+    std::string file_id = _gdrive.resolve_path(path);
+    if (file_id.empty())
+    {
+        Debug_printf("FileSystemGDrive::cache_file - not found: %s\n", path);
+        return nullptr;
+    }
+
+    // Create new cache file (starts in memory)
+    fc_handle *fc = FileCache::create(_rawurl.c_str(), path);
+    if (fc == nullptr)
+        return nullptr;
+
+    // Stream the file content (?alt=media) into the cache file
+    GDFS_HTTP_CLIENT http;
+    std::string dl_url = std::string(GDRIVE_FILES_URL) + "/" + file_id + "?alt=media";
+    if (!http.begin(dl_url))
+    {
+        Debug_println("FileSystemGDrive::cache_file - failed to start HTTP client");
+        FileCache::remove(fc);
+        return nullptr;
+    }
+    http.set_header("Authorization", ("Bearer " + _gdrive.access_token()).c_str());
+
+    Debug_println("Initiating GET request");
+    if (http.GET() > 399)
+    {
+        Debug_println("FileSystemGDrive::cache_file - GET failed");
+        FileCache::remove(fc);
+        return nullptr;
+    }
+
+    // Retrieve data
+    int tmout_counter = 1 + GDRIVE_GET_TIMEOUT / 50;
+    bool cancel = false;
+    int available;
+
+#ifdef ESP_PLATFORM
+    uint8_t *buf = (uint8_t *)heap_caps_malloc(COPY_BLK_SIZE, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+#else
+    uint8_t *buf = (uint8_t *)malloc(COPY_BLK_SIZE);
+#endif
+    if (buf == nullptr)
+    {
+        Debug_println("FileSystemGDrive::cache_file - failed to allocate buffer");
+        FileCache::remove(fc);
+        return nullptr;
+    }
+
+    Debug_println("Retrieving file data");
+    while (!cancel)
+    {
+        available = http.available();
+        if (http.is_transaction_done() && available == 0) // done
+            break;
+
+        if (available == 0) // transaction not completed, wait for data
+        {
+            if (--tmout_counter == 0)
+            {
+                Debug_println("FileSystemGDrive::cache_file - Timeout");
+                cancel = true;
+                break;
+            }
+            fnSystem.delay(50);
+        }
+        else if (available > 0)
+        {
+            while (available > 0)
+            {
+                int to_read = (available > COPY_BLK_SIZE) ? COPY_BLK_SIZE : available;
+                int from_read = http.read(buf, to_read);
+                if (from_read != to_read)
+                {
+                    Debug_println("FileSystemGDrive::cache_file - HTTP read failed");
+                    Debug_printf("  Expected %d bytes, actually got %d bytes.\r\n", to_read, from_read);
+                    cancel = true;
+                    break;
+                }
+                if (FileCache::write(fc, buf, to_read) < (size_t)to_read)
+                {
+                    Debug_printf("FileSystemGDrive::cache_file - Cache write failed\n");
+                    cancel = true;
+                    break;
+                }
+                available = http.available();
+            }
+            tmout_counter = 1 + GDRIVE_GET_TIMEOUT / 50; // reset timeout counter
+        }
+        else // available < 0
+        {
+            Debug_println("FileSystemGDrive::cache_file - something went wrong");
+            cancel = true;
+        }
+    }
+    free(buf);
+    http.close();
+
+    if (cancel)
+    {
+        Debug_println("Cancelled");
+        FileCache::remove(fc);
+        fh = nullptr;
+    }
+    else
+    {
+        Debug_println("File data retrieved");
+        fh = FileCache::reopen(fc, mode);
+    }
+    return fh;
+}
+#endif //!FNIO_IS_STDIO
+
+bool FileSystemGDrive::is_dir(const char *path)
+{
+    if (!_started || path == nullptr)
+        return false;
+
+    _gdrive.ensure_access_token();
+
+    std::string id = _gdrive.resolve_path(path);
+    if (id.empty())
+        return false;
+    if (id == "root")
+        return true;
+
+    std::string resp = _gdrive.api_get(std::string(GDRIVE_FILES_URL) + "/" + id + "?fields=mimeType");
+    if (resp.empty())
+        return false;
+
+    cJSON *j = cJSON_Parse(resp.c_str());
+    if (!j)
+        return false;
+    bool is_folder = (GoogleDriveClient::json_str(j, "mimeType") == GDRIVE_FOLDER_MIME);
+    cJSON_Delete(j);
+    return is_folder;
+}
+
+success_is_true FileSystemGDrive::mkdir(const char *path)
+{
+    if (!_started || path == nullptr)
+        RETURN_ERROR_AS_FALSE();
+
+    _gdrive.ensure_access_token();
+
+    // parent = everything before the last '/'; new folder name = the remainder
+    std::string p = path;
+    size_t slash = p.find_last_of('/');
+    std::string parent_path = (slash != std::string::npos) ? p.substr(0, slash) : "/";
+    std::string new_name = (slash != std::string::npos) ? p.substr(slash + 1) : p;
+
+    std::string parent_id = _gdrive.resolve_path(parent_path);
+    if (parent_id.empty())
+        parent_id = "root";
+
+    _last_dir[0] = '\0'; // listing changed
+    RETURN_SUCCESS_IF(!_gdrive.create_folder(parent_id, new_name).empty());
+}
+
+success_is_true FileSystemGDrive::rmdir(const char *path)
+{
+    // A folder is deleted the same way as a file in Drive.
+    return remove(path);
+}
+
+bool FileSystemGDrive::dir_exists(const char *path)
+{
+    return is_dir(path);
+}
+
+success_is_true FileSystemGDrive::dir_open(const char *path, const char *pattern, uint16_t diropts)
+{
+    if (!_started)
+        RETURN_ERROR_AS_FALSE();
+
+    Debug_printf("FileSystemGDrive::dir_open(\"%s\", \"%s\", %u)\n", path ? path : "", pattern ? pattern : "", diropts);
+
+    if (path == nullptr)
+        RETURN_ERROR_AS_FALSE();
+
+    if (strcmp(_last_dir, path) == 0 && !_dircache.empty())
+    {
+        Debug_printf("Use directory cache\n");
+    }
+    else
+    {
+        Debug_printf("Fill directory cache\n");
+
+        _dircache.clear();
+        _last_dir[0] = '\0';
+
+        if (!_gdrive.ensure_access_token())
+        {
+            Debug_println("FileSystemGDrive::dir_open - no access token");
+            RETURN_ERROR_AS_FALSE();
+        }
+
+        // Resolve the path to a folder id ("root" for the Drive root).
+        std::string folder_id = _gdrive.resolve_path(path);
+        if (folder_id.empty())
+            folder_id = "root";
+
+        // List the children of this folder.
+        std::string q = "'" + folder_id + "' in parents and trashed=false";
+        std::string resp = _gdrive.api_get(std::string(GDRIVE_FILES_URL) +
+                                           "?q=" + GoogleDriveClient::url_encode(q) +
+                                           "&fields=files(" GDRIVE_FIELDS ")"
+                                           "&pageSize=1000"
+                                           "&orderBy=folder,name");
+        if (resp.empty())
+        {
+            Debug_println("FileSystemGDrive::dir_open - listing request failed");
+            RETURN_ERROR_AS_FALSE();
+        }
+
+        cJSON *root = cJSON_Parse(resp.c_str());
+        if (!root)
+        {
+            Debug_println("FileSystemGDrive::dir_open - failed to parse listing");
+            RETURN_ERROR_AS_FALSE();
+        }
+
+        // Remember last visited directory
+        strlcpy(_last_dir, path, MAX_PATHLEN);
+
+        cJSON *files = cJSON_GetObjectItemCaseSensitive(root, "files");
+        int count = cJSON_IsArray(files) ? cJSON_GetArraySize(files) : 0;
+        for (int i = 0; i < count; i++)
+        {
+            cJSON *entry = cJSON_GetArrayItem(files, i);
+            if (!entry)
+                continue;
+
+            cJSON *trashed = cJSON_GetObjectItemCaseSensitive(entry, "trashed");
+            if (trashed && cJSON_IsTrue(trashed))
+                continue;
+
+            std::string name = GoogleDriveClient::json_str(entry, "name");
+            std::string mime = GoogleDriveClient::json_str(entry, "mimeType");
+            std::string size_str = GoogleDriveClient::json_str(entry, "size");
+            if (name.empty())
+                continue;
+
+            fsdir_entry *fs_de = &_dircache.new_entry();
+            strlcpy(fs_de->filename, name.c_str(), sizeof(fs_de->filename));
+            fs_de->isDir = (mime == GDRIVE_FOLDER_MIME);
+            fs_de->size = size_str.empty() ? 0 : (uint32_t)atol(size_str.c_str());
+            fs_de->modified_time = 0; // Drive modifiedTime not requested
+
+            Debug_printf(" add entry: \"%s\"\t%s\n", fs_de->filename,
+                         fs_de->isDir ? "DIR" : "");
+        }
+        cJSON_Delete(root);
+    }
+
+    // Apply pattern matching filter and sort entries
+    _dircache.apply_filter(pattern, diropts);
+
+    RETURN_SUCCESS_AS_TRUE();
+}
+
+fsdir_entry *FileSystemGDrive::dir_read()
+{
+    return _dircache.read();
+}
+
+void FileSystemGDrive::dir_close()
+{
+    // Keep the cache populated so repeat dir_open() of the same path is cheap.
+}
+
+uint16_t FileSystemGDrive::dir_tell()
+{
+    return _dircache.tell();
+}
+
+success_is_true FileSystemGDrive::dir_seek(uint16_t pos)
+{
+    return _dircache.seek(pos);
+}

--- a/lib/FileSystem/fnFsGDrive.h
+++ b/lib/FileSystem/fnFsGDrive.h
@@ -4,6 +4,7 @@
 #include <cstddef>
 #include <stdint.h>
 #include <string>
+#include <functional>
 
 #ifdef ESP_PLATFORM
 #include "fnHttpClient.h"
@@ -75,6 +76,18 @@ public:
 
 #ifndef FNIO_IS_STDIO
     FileHandler *cache_file(const char *path, const char *mode);
+#endif
+
+private:
+    // Stream a Drive file's content (?alt=media) for the given file id, passing
+    // each chunk to sink(). sink returns false to abort. Returns true on a
+    // complete, successful download.
+    bool stream_download(const std::string &file_id,
+                         const std::function<bool(const uint8_t *, int)> &sink);
+
+#ifdef FNIO_IS_STDIO
+    // SD-card cache path (relative to SD root) for a Drive file at `path`.
+    std::string cache_file_path(const char *path);
 #endif
 };
 

--- a/lib/FileSystem/fnFsGDrive.h
+++ b/lib/FileSystem/fnFsGDrive.h
@@ -5,6 +5,7 @@
 #include <stdint.h>
 #include <string>
 #include <functional>
+#include <set>
 
 #ifdef ESP_PLATFORM
 #include "fnHttpClient.h"
@@ -39,6 +40,11 @@ private:
     // Host-slot URL string ("GDRIVE:///..."), used as the file-cache host key.
     std::string _rawurl;
 
+    // Paths opened with write intent that may need uploading back to Drive.
+    // Keyed by the (already prefix-resolved) path that file_open() received,
+    // which matches what sync_file() is later called with at unmount.
+    std::set<std::string> _dirty;
+
     // directory cache
     char _last_dir[MAX_PATHLEN];
     DirCache _dircache;
@@ -58,6 +64,10 @@ public:
 #endif
 
     bool exists(const char *path) override;
+
+    // Upload a locally-written/created image back to Google Drive. Only files
+    // that were opened with write intent (tracked in _dirty) are uploaded.
+    success_is_true sync_file(const char *path) override;
 
     success_is_true remove(const char *path) override;
 

--- a/lib/FileSystem/fnFsGDrive.h
+++ b/lib/FileSystem/fnFsGDrive.h
@@ -20,29 +20,20 @@
 #include "fnDirCache.h"
 
 /**
- * FileSystemGDrive
- *
- * Google Drive as a FujiNet *host slot*. A user puts "GDRIVE:///" (optionally
- * with a starting path) in a host slot and can then browse folders and mount
- * media images straight from their Drive.
- *
- * Directory listings come from the Drive REST API; opening a file downloads it
- * in full to the local file cache (memory or SD) and hands back a FileHandler,
- * exactly like the FTP and HTTP host filesystems. All Drive REST + OAuth2 token
- * work is delegated to the shared GoogleDriveClient.
+ * Google Drive as a FujiNet host slot. Listings come from the Drive REST API;
+ * opening a file downloads it to the local cache (memory or SD) and returns a
+ * FileHandler, like the FTP/HTTP host filesystems. Drive REST + OAuth2 work is
+ * delegated to the shared GoogleDriveClient.
  */
 class FileSystemGDrive : public FileSystem
 {
 private:
-    // Shared Google Drive REST + OAuth2 token helper.
     GoogleDriveClient _gdrive;
 
-    // Host-slot URL string ("GDRIVE:///..."), used as the file-cache host key.
+    // Host-slot URL ("GDRIVE:///..."), used as the file-cache host key.
     std::string _rawurl;
 
-    // Paths opened with write intent that may need uploading back to Drive.
-    // Keyed by the (already prefix-resolved) path that file_open() received,
-    // which matches what sync_file() is later called with at unmount.
+    // Paths opened with write intent, to upload back on unmount (sync_file).
     std::set<std::string> _dirty;
 
     // directory cache
@@ -65,8 +56,7 @@ public:
 
     bool exists(const char *path) override;
 
-    // Upload a locally-written/created image back to Google Drive. Only files
-    // that were opened with write intent (tracked in _dirty) are uploaded.
+    // Upload a locally-written image back to Drive (only _dirty paths).
     success_is_true sync_file(const char *path) override;
 
     success_is_true remove(const char *path) override;
@@ -89,20 +79,16 @@ public:
 #endif
 
 private:
-    // Stream a Drive file's content (?alt=media) for the given file id, passing
-    // each chunk to sink(). sink returns false to abort. Returns true on a
-    // complete, successful download.
+    // Stream a Drive file (?alt=media) to sink() (returns false to abort).
     bool stream_download(const std::string &file_id,
                          const std::function<bool(const uint8_t *, int)> &sink);
 
-    // Upload `len` bytes pulled from read_chunk() to Drive at `path` (create or
-    // update), then clear the dirty flag on success. Shared by the stdio (FILE*)
-    // and FileHandler sync_file paths.
+    // Upload `len` bytes from read_chunk() to Drive at `path`, then clear dirty.
     success_is_true upload_path(const char *path, size_t len,
                                 const std::function<int(uint8_t *, int)> &read_chunk);
 
 #ifdef FNIO_IS_STDIO
-    // SD-card cache path (relative to SD root) for a Drive file at `path`.
+    // SD-card cache path for a Drive file at `path`.
     std::string cache_file_path(const char *path);
 #endif
 };

--- a/lib/FileSystem/fnFsGDrive.h
+++ b/lib/FileSystem/fnFsGDrive.h
@@ -95,6 +95,12 @@ private:
     bool stream_download(const std::string &file_id,
                          const std::function<bool(const uint8_t *, int)> &sink);
 
+    // Upload `len` bytes pulled from read_chunk() to Drive at `path` (create or
+    // update), then clear the dirty flag on success. Shared by the stdio (FILE*)
+    // and FileHandler sync_file paths.
+    success_is_true upload_path(const char *path, size_t len,
+                                const std::function<int(uint8_t *, int)> &read_chunk);
+
 #ifdef FNIO_IS_STDIO
     // SD-card cache path (relative to SD root) for a Drive file at `path`.
     std::string cache_file_path(const char *path);

--- a/lib/FileSystem/fnFsGDrive.h
+++ b/lib/FileSystem/fnFsGDrive.h
@@ -1,0 +1,81 @@
+#ifndef FN_FSGDRIVE_H
+#define FN_FSGDRIVE_H
+
+#include <cstddef>
+#include <stdint.h>
+#include <string>
+
+#ifdef ESP_PLATFORM
+#include "fnHttpClient.h"
+#define GDFS_HTTP_CLIENT fnHttpClient
+#else
+#include "mgHttpClient.h"
+#define GDFS_HTTP_CLIENT mgHttpClient
+#endif
+
+#include "GoogleDriveClient.h"
+#include "fnFS.h"
+#include "fnDirCache.h"
+
+/**
+ * FileSystemGDrive
+ *
+ * Google Drive as a FujiNet *host slot*. A user puts "GDRIVE:///" (optionally
+ * with a starting path) in a host slot and can then browse folders and mount
+ * media images straight from their Drive.
+ *
+ * Directory listings come from the Drive REST API; opening a file downloads it
+ * in full to the local file cache (memory or SD) and hands back a FileHandler,
+ * exactly like the FTP and HTTP host filesystems. All Drive REST + OAuth2 token
+ * work is delegated to the shared GoogleDriveClient.
+ */
+class FileSystemGDrive : public FileSystem
+{
+private:
+    // Shared Google Drive REST + OAuth2 token helper.
+    GoogleDriveClient _gdrive;
+
+    // Host-slot URL string ("GDRIVE:///..."), used as the file-cache host key.
+    std::string _rawurl;
+
+    // directory cache
+    char _last_dir[MAX_PATHLEN];
+    DirCache _dircache;
+
+public:
+    FileSystemGDrive();
+    ~FileSystemGDrive();
+
+    success_is_true start(const char *url, const char *user = nullptr, const char *password = nullptr);
+
+    fsType type() override { return FSTYPE_GDRIVE; };
+    const char *typestring() override { return type_to_string(FSTYPE_GDRIVE); };
+
+    FILE *file_open(const char *path, const char *mode = FILE_READ) override;
+#ifndef FNIO_IS_STDIO
+    FileHandler *filehandler_open(const char *path, const char *mode = FILE_READ) override;
+#endif
+
+    bool exists(const char *path) override;
+
+    success_is_true remove(const char *path) override;
+
+    success_is_true rename(const char *pathFrom, const char *pathTo) override;
+
+    bool is_dir(const char *path) override;
+    success_is_true mkdir(const char *path) override;
+    success_is_true rmdir(const char *path) override;
+    bool dir_exists(const char *path) override;
+
+    success_is_true dir_open(const char *path, const char *pattern, uint16_t diropts) override;
+    fsdir_entry *dir_read() override;
+    void dir_close() override;
+    uint16_t dir_tell() override;
+    success_is_true dir_seek(uint16_t pos) override;
+
+#ifndef FNIO_IS_STDIO
+    FileHandler *cache_file(const char *path, const char *mode);
+#endif
+};
+
+#endif // FN_FSGDRIVE_H

--- a/lib/device/adamnet/adamFuji.cpp
+++ b/lib/device/adamnet/adamFuji.cpp
@@ -141,6 +141,15 @@ void adamFuji::adamnet_new_disk()
 
     disk.fileh = host.file_open(disk.filename, disk.filename, sizeof(disk.filename), "w");
 
+    if (disk.fileh == nullptr)
+    {
+        // e.g. read-only host, no SD card, or the host couldn't create the file.
+        // Bail out cleanly rather than fwrite()'ing to a null handle (crash).
+        Debug_printf("adamnet_new_disk: failed to create file %s on host slot %u\n", disk.filename, hs);
+        new_disk_completed = true;
+        return;
+    }
+
     Debug_printf("Creating file %s on host slot %u mounting in disk slot %u numblocks: %lu\n", disk.filename, hs, ds, numBlocks);
 
     disk.disk_dev.write_blank(disk.fileh, numBlocks);

--- a/lib/device/adamnet/adamFuji.cpp
+++ b/lib/device/adamnet/adamFuji.cpp
@@ -156,6 +156,10 @@ void adamFuji::adamnet_new_disk()
 
     fclose(disk.fileh);
 
+    // Push the newly created image back to the host's backing store (e.g. upload
+    // to Google Drive). No-op for hosts that write directly to their storage.
+    host.sync_file(disk.filename);
+
     new_disk_completed = true;
 }
 

--- a/lib/device/adamnet/adamFuji.cpp
+++ b/lib/device/adamnet/adamFuji.cpp
@@ -143,8 +143,7 @@ void adamFuji::adamnet_new_disk()
 
     if (disk.fileh == nullptr)
     {
-        // e.g. read-only host, no SD card, or the host couldn't create the file.
-        // Bail out cleanly rather than fwrite()'ing to a null handle (crash).
+        // Read-only host / no SD / create failed: bail rather than fwrite() null.
         Debug_printf("adamnet_new_disk: failed to create file %s on host slot %u\n", disk.filename, hs);
         new_disk_completed = true;
         return;
@@ -156,8 +155,7 @@ void adamFuji::adamnet_new_disk()
 
     fclose(disk.fileh);
 
-    // Push the newly created image back to the host's backing store (e.g. upload
-    // to Google Drive). No-op for hosts that write directly to their storage.
+    // Push the new image back to the host (e.g. upload to Drive); no-op otherwise.
     host.sync_file(disk.filename);
 
     new_disk_completed = true;

--- a/lib/device/cx16_i2c/cx16Fuji.cpp
+++ b/lib/device/cx16_i2c/cx16Fuji.cpp
@@ -1013,8 +1013,7 @@ void cx16Fuji::new_disk()
         return;
     }
 
-    // Push the newly created image back to the host's backing store (e.g. upload
-    // to Google Drive). No-op for hosts that write directly to their storage.
+    // Push the new image back to the host (e.g. upload to Drive); no-op otherwise.
     host.sync_file(disk.filename);
 
     Debug_print("sio_new_disk succeeded\n");

--- a/lib/device/cx16_i2c/cx16Fuji.cpp
+++ b/lib/device/cx16_i2c/cx16Fuji.cpp
@@ -1013,6 +1013,10 @@ void cx16Fuji::new_disk()
         return;
     }
 
+    // Push the newly created image back to the host's backing store (e.g. upload
+    // to Google Drive). No-op for hosts that write directly to their storage.
+    host.sync_file(disk.filename);
+
     Debug_print("sio_new_disk succeeded\n");
     cx16_complete();
 }

--- a/lib/device/fujiDevice.cpp
+++ b/lib/device/fujiDevice.cpp
@@ -1056,11 +1056,8 @@ success_is_true fujiDevice::fujicore_unmount_disk_image_success(uint8_t deviceSl
     disk_dev = get_disk_dev(deviceSlot);
     disk_dev->unmount();
 
-    // unmount() closed/flushed the (possibly local cache) file, so now push any
-    // locally-written image back to its host's backing store. This is a no-op
-    // for hosts that write directly (SD/TNFS/...) and for read-only mounts; the
-    // host filesystem decides whether there is anything to upload (e.g. Google
-    // Drive uploads images that were opened for writing).
+    // unmount() flushed the file; push any locally-written image back to its
+    // host (no-op for direct-write/read-only hosts, e.g. SD/TNFS).
     {
         fujiDisk &udisk = _fnDisks[deviceSlot];
         if (validate_host_slot(udisk.host_slot) && udisk.filename[0] != '\0')

--- a/lib/device/fujiDevice.cpp
+++ b/lib/device/fujiDevice.cpp
@@ -1055,6 +1055,18 @@ success_is_true fujiDevice::fujicore_unmount_disk_image_success(uint8_t deviceSl
 
     disk_dev = get_disk_dev(deviceSlot);
     disk_dev->unmount();
+
+    // unmount() closed/flushed the (possibly local cache) file, so now push any
+    // locally-written image back to its host's backing store. This is a no-op
+    // for hosts that write directly (SD/TNFS/...) and for read-only mounts; the
+    // host filesystem decides whether there is anything to upload (e.g. Google
+    // Drive uploads images that were opened for writing).
+    {
+        fujiDisk &udisk = _fnDisks[deviceSlot];
+        if (validate_host_slot(udisk.host_slot) && udisk.filename[0] != '\0')
+            _fnHosts[udisk.host_slot].sync_file(udisk.filename);
+    }
+
     _fnDisks[deviceSlot].reset();
 
     RETURN_SUCCESS_AS_TRUE();

--- a/lib/device/iwm/iwmFuji.cpp
+++ b/lib/device/iwm/iwmFuji.cpp
@@ -265,6 +265,10 @@ void iwmFuji::iwm_ctrl_new_disk()
 
         fnio::fclose(disk.fileh);
 
+        // Push the newly created image back to the host's backing store (e.g.
+        // upload to Google Drive). No-op for direct-write hosts.
+        host.sync_file(disk.filename);
+
         // Persist slots
         populate_config_from_slots();
         Config.mark_dirty();

--- a/lib/device/iwm/iwmFuji.cpp
+++ b/lib/device/iwm/iwmFuji.cpp
@@ -265,8 +265,7 @@ void iwmFuji::iwm_ctrl_new_disk()
 
         fnio::fclose(disk.fileh);
 
-        // Push the newly created image back to the host's backing store (e.g.
-        // upload to Google Drive). No-op for direct-write hosts.
+        // Push the new image back to the host (e.g. upload to Drive); no-op otherwise.
         host.sync_file(disk.filename);
 
         // Persist slots

--- a/lib/device/sio/sioFuji.cpp
+++ b/lib/device/sio/sioFuji.cpp
@@ -482,8 +482,7 @@ void sioFuji::sio_new_disk()
         return;
     }
 
-    // Push the newly created image back to the host's backing store (e.g. upload
-    // to Google Drive). No-op for hosts that write directly to their storage.
+    // Push the new image back to the host (e.g. upload to Drive); no-op otherwise.
     host.sync_file(disk.filename);
 
     Debug_print("sio_new_disk succeeded\n");

--- a/lib/device/sio/sioFuji.cpp
+++ b/lib/device/sio/sioFuji.cpp
@@ -482,6 +482,10 @@ void sioFuji::sio_new_disk()
         return;
     }
 
+    // Push the newly created image back to the host's backing store (e.g. upload
+    // to Google Drive). No-op for hosts that write directly to their storage.
+    host.sync_file(disk.filename);
+
     Debug_print("sio_new_disk succeeded\n");
     transaction_complete();
 }

--- a/lib/fuji/fujiHost.cpp
+++ b/lib/fuji/fujiHost.cpp
@@ -260,6 +260,18 @@ fnFile * fujiHost::fnfile_open(const char *path, char *fullpath, int fullpathlen
     return _fs->fnfile_open(fullpath, mode);
 }
 
+/* Push a locally-written file back to the host's backing store.
+ * `path` is already prefix-resolved (fujiDisk::filename), matching what
+ * fnfile_open() handed to the filesystem, so it is passed straight through.
+*/
+success_is_true fujiHost::sync_file(const char *path)
+{
+    if (_fs == nullptr || path == nullptr)
+        RETURN_ERROR_AS_FALSE();
+
+    return _fs->sync_file(path);
+}
+
 /* Remove a file from the host
  * Returns true on error, false on success
 */

--- a/lib/fuji/fujiHost.cpp
+++ b/lib/fuji/fujiHost.cpp
@@ -11,6 +11,7 @@
 #include "fnFsNFS.h"
 #include "fnFsFTP.h"
 #include "fnFsHTTP.h"
+#include "fnFsGDrive.h"
 
 #include "utils.h"
 
@@ -50,6 +51,7 @@ void fujiHost::set_type(fujiHostType type)
     case HOSTTYPE_NFS:
     case HOSTTYPE_FTP:
     case HOSTTYPE_HTTP:
+    case HOSTTYPE_GDRIVE:
         cleanup();
         break;
     }
@@ -114,6 +116,7 @@ uint16_t fujiHost::dir_tell()
     case HOSTTYPE_NFS:
     case HOSTTYPE_FTP:
     case HOSTTYPE_HTTP:
+    case HOSTTYPE_GDRIVE:
         result = _fs->dir_tell();
         break;
     case HOSTTYPE_UNINITIALIZED:
@@ -137,6 +140,7 @@ success_is_true fujiHost::dir_seek(uint16_t pos)
     case HOSTTYPE_NFS:
     case HOSTTYPE_FTP:
     case HOSTTYPE_HTTP:
+    case HOSTTYPE_GDRIVE:
         result = _fs->dir_seek(pos);
         break;
     case HOSTTYPE_UNINITIALIZED:
@@ -170,6 +174,7 @@ success_is_true fujiHost::dir_open(const char *path, const char *pattern, uint16
     case HOSTTYPE_NFS:
     case HOSTTYPE_FTP:
     case HOSTTYPE_HTTP:
+    case HOSTTYPE_GDRIVE:
         result = _fs->dir_open(realpath, pattern, options);
         break;
     case HOSTTYPE_UNINITIALIZED:
@@ -190,6 +195,7 @@ fsdir_entry_t *fujiHost::dir_nextfile()
     case HOSTTYPE_NFS:
     case HOSTTYPE_FTP:
     case HOSTTYPE_HTTP:
+    case HOSTTYPE_GDRIVE:
         return _fs->dir_read();
     case HOSTTYPE_UNINITIALIZED:
         break;
@@ -556,6 +562,46 @@ int fujiHost::mount_http()
     return -1;
 }
 
+int fujiHost::mount_gdrive()
+{
+    Debug_printf("::mount_gdrive {%d:%d} \"%s\"\n", slotid, _type, _hostname);
+
+    // Don't do anything if that's already what's set
+    if (_type == HOSTTYPE_GDRIVE)
+    {
+        if (_fs != nullptr && _fs->running())
+        {
+            Debug_printf("::mount_gdrive Currently connected to \"%s\"\n", _hostname);
+            return 0;
+        }
+        if (_fs != nullptr)
+        {
+            delete _fs;
+            _fs = nullptr;
+        }
+    }
+    else
+        set_type(HOSTTYPE_GDRIVE); // Only start fresh if not HOSTTYPE_GDRIVE
+
+    _fs = new FileSystemGDrive;
+
+    if (_fs == nullptr)
+    {
+        Debug_println("Couldn't create a new FileSystemGDrive in fujiHost::mount_gdrive!");
+    }
+    else
+    {
+        Debug_printf("Starting FileSystemGDrive(\"%s\")\n", _hostname);
+
+        if (((FileSystemGDrive *)_fs)->start(_hostname))
+        {
+            return 0;
+        }
+    }
+
+    return -1;
+}
+
 int fujiHost::unmount_fs()
 {
     Debug_printf("Filesystem (%s) unmounted.\n", _fs != nullptr ? _fs->typestring() : "null");
@@ -575,6 +621,7 @@ int fujiHost::unmount_fs()
 *  "smb://" = SMB share
 *  "ftp://" = FTP server
 *  "http://" or "https://" = Web server with file/dir-like access
+*  "gdrive://" = Google Drive (uses authorized account, host part is ignored)
 *  anything else = TNFS
 */
 success_is_true fujiHost::mount()
@@ -601,6 +648,9 @@ success_is_true fujiHost::mount()
 
     if (0 == strncasecmp("http://", _hostname, 7) || 0 == strncasecmp("https://", _hostname, 8))
         RETURN_SUCCESS_IF(0 == mount_http());
+
+    if (0 == strncasecmp("gdrive://", _hostname, 9))
+        RETURN_SUCCESS_IF(0 == mount_gdrive());
 
     // Try mounting TNFS last
     RETURN_SUCCESS_IF(0 == mount_tnfs());

--- a/lib/fuji/fujiHost.cpp
+++ b/lib/fuji/fujiHost.cpp
@@ -260,10 +260,7 @@ fnFile * fujiHost::fnfile_open(const char *path, char *fullpath, int fullpathlen
     return _fs->fnfile_open(fullpath, mode);
 }
 
-/* Push a locally-written file back to the host's backing store.
- * `path` is already prefix-resolved (fujiDisk::filename), matching what
- * fnfile_open() handed to the filesystem, so it is passed straight through.
-*/
+/* Push a locally-written file back to the host's backing store. */
 success_is_true fujiHost::sync_file(const char *path)
 {
     if (_fs == nullptr || path == nullptr)

--- a/lib/fuji/fujiHost.h
+++ b/lib/fuji/fujiHost.h
@@ -15,6 +15,7 @@ enum fujiHostType
     HOSTTYPE_NFS,
     HOSTTYPE_FTP,
     HOSTTYPE_HTTP,
+    HOSTTYPE_GDRIVE,
 };
 
 class fujiHost
@@ -35,6 +36,7 @@ private:
     int mount_nfs();
     int mount_ftp();
     int mount_http();
+    int mount_gdrive();
 
     int unmount_local();
     int unmount_fs();

--- a/lib/fuji/fujiHost.h
+++ b/lib/fuji/fujiHost.h
@@ -77,8 +77,7 @@ public:
     error_is_true file_remove(char *fullpath);
 
     // Push a locally-written file back to the host's backing store (e.g. upload
-    // to Google Drive). `path` is the already prefix-resolved host path, as
-    // stored in fujiDisk::filename. No-op for hosts that write directly.
+    // to Drive). `path` is the prefix-resolved host path (fujiDisk::filename).
     success_is_true sync_file(const char *path);
 
     // Directory functions

--- a/lib/fuji/fujiHost.h
+++ b/lib/fuji/fujiHost.h
@@ -76,6 +76,11 @@ public:
 
     error_is_true file_remove(char *fullpath);
 
+    // Push a locally-written file back to the host's backing store (e.g. upload
+    // to Google Drive). `path` is the already prefix-resolved host path, as
+    // stored in fujiDisk::filename. No-op for hosts that write directly.
+    success_is_true sync_file(const char *path);
+
     // Directory functions
     success_is_true dir_open(const char *path, const char *pattern, uint16_t options = 0);
     void dir_close();

--- a/lib/http/httpServiceBrowser.cpp
+++ b/lib/http/httpServiceBrowser.cpp
@@ -9,6 +9,7 @@
 #include "fnFsNFS.h"
 #include "fnFsFTP.h"
 #include "fnFsHTTP.h"
+#include "fnFsGDrive.h"
 #include "fnTaskManager.h"
 #include "fnConfig.h"
 #include "fnio.h"
@@ -554,6 +555,11 @@ int fnHttpServiceBrowser::process_browse_get(mg_connection *c, mg_http_message *
         fs = new FileSystemHTTP;
         host_type = HOSTTYPE_HTTP;
     }
+    else if (strncasecmp("gdrive://", hostname, 9) == 0)
+    {
+        fs = new FileSystemGDrive;
+        host_type = HOSTTYPE_GDRIVE;
+    }
     else
     {
         fs = new FileSystemTNFS;
@@ -584,6 +590,9 @@ int fnHttpServiceBrowser::process_browse_get(mg_connection *c, mg_http_message *
         break;
     case HOSTTYPE_HTTP:
         started = ((FileSystemHTTP *)fs)->start(hostname);
+        break;
+    case HOSTTYPE_GDRIVE:
+        started = ((FileSystemGDrive *)fs)->start(hostname);
         break;
     case HOSTTYPE_TNFS:
         started = ((FileSystemTNFS *)fs)->start(hostname);

--- a/lib/network-protocol/GDRIVE.cpp
+++ b/lib/network-protocol/GDRIVE.cpp
@@ -2,6 +2,10 @@
  * NetworkProtocolGDRIVE
  *
  * Google Drive protocol adapter for FujiNet.
+ *
+ * The Drive REST calls and OAuth2 token handling live in the shared
+ * GoogleDriveClient (_gdrive); this class implements the NetworkProtocolFS
+ * surface (open/read/write/dir/del/mkdir/rmdir) on top of it.
  */
 
 #include "GDRIVE.h"
@@ -15,15 +19,6 @@
 #include "../config/fnConfig.h"
 #include "status_error_codes.h"
 #include "utils.h"
-
-
-// Google OAuth2 / Drive API endpoints
-// Token refresh goes through the relay so the client_secret stays server-side.
-#define GDRIVE_RELAY_REFRESH_URL "https://auth.fujinet.online/gdrive-refresh"
-#define GDRIVE_FILES_URL     "https://www.googleapis.com/drive/v3/files"
-#define GDRIVE_UPLOAD_URL    "https://www.googleapis.com/upload/drive/v3/files"
-#define GDRIVE_FIELDS        "id,name,size,mimeType,trashed"
-#define GDRIVE_FOLDER_MIME   "application/vnd.google-apps.folder"
 
 // ─── construction ────────────────────────────────────────────────────────────
 
@@ -49,343 +44,13 @@ NetworkProtocolGDRIVE::~NetworkProtocolGDRIVE()
     }
 }
 
-// ─── helpers ─────────────────────────────────────────────────────────────────
-
-std::string NetworkProtocolGDRIVE::url_encode(const std::string &s)
-{
-    static const char hex[] = "0123456789ABCDEF";
-    std::string out;
-    out.reserve(s.size() * 3);
-    for (unsigned char c : s)
-    {
-        if (isalnum(c) || c == '-' || c == '_' || c == '.' || c == '~')
-            out += (char)c;
-        else
-        {
-            out += '%';
-            out += hex[c >> 4];
-            out += hex[c & 0xF];
-        }
-    }
-    return out;
-}
-
-std::string NetworkProtocolGDRIVE::json_str(cJSON *obj, const char *key)
-{
-    if (!obj) return "";
-    cJSON *item = cJSON_GetObjectItemCaseSensitive(obj, key);
-    if (!item || !cJSON_IsString(item)) return "";
-    return item->valuestring ? item->valuestring : "";
-}
-
-// ─── OAuth2 token management ─────────────────────────────────────────────────
-
-bool NetworkProtocolGDRIVE::refresh_access_token()
-{
-    std::string refresh_token = Config.get_gdrive_refresh_token();
-
-    if (refresh_token.empty())
-    {
-        Debug_printf("GDRIVE: no refresh token — user must re-authorize\r\n");
-        return false;
-    }
-
-    std::string body = "refresh_token=" + url_encode(refresh_token);
-
-    std::string resp = api_post(GDRIVE_RELAY_REFRESH_URL, body,
-                                "application/x-www-form-urlencoded");
-    if (resp.empty())
-        return false;
-
-    cJSON *j = cJSON_Parse(resp.c_str());
-    if (!j)
-    {
-        Debug_printf("GDRIVE: failed to parse token response\r\n");
-        return false;
-    }
-
-    std::string token = json_str(j, "access_token");
-    cJSON *expires_in = cJSON_GetObjectItemCaseSensitive(j, "expires_in");
-    long ttl = (expires_in && cJSON_IsNumber(expires_in))
-                   ? (long)expires_in->valuedouble
-                   : 3600;
-    cJSON_Delete(j);
-
-    if (token.empty())
-    {
-        Debug_printf("GDRIVE: token refresh returned no access_token\r\n");
-        return false;
-    }
-
-    long expiry = (long)time(nullptr) + ttl;
-    Config.store_gdrive_access_token(token);
-    Config.store_gdrive_token_expiry(expiry);
-    Config.save();
-
-    _access_token = token;
-    Debug_printf("GDRIVE: access token refreshed, expires in %ld s\r\n", ttl);
-    return true;
-}
-
-bool NetworkProtocolGDRIVE::ensure_access_token()
-{
-    long now = (long)time(nullptr);
-    // Refresh 60 seconds before actual expiry to avoid clock skew issues
-    if (now >= Config.get_gdrive_token_expiry() - 60)
-        return refresh_access_token();
-
-    _access_token = Config.get_gdrive_access_token();
-    return !_access_token.empty();
-}
-
-// ─── HTTP helpers (ESP32 only) ────────────────────────────────────────────────
-
-#ifdef ESP_PLATFORM
-
-std::string NetworkProtocolGDRIVE::api_get(const std::string &url)
-{
-    esp_http_client_config_t cfg = {};
-    cfg.url        = url.c_str();
-    cfg.timeout_ms = 15000;
-
-    esp_http_client_handle_t h = esp_http_client_init(&cfg);
-    if (!h) return "";
-
-    std::string auth = "Bearer " + _access_token;
-    esp_http_client_set_header(h, "Authorization", auth.c_str());
-
-    if (esp_http_client_open(h, 0) != ESP_OK) {
-        esp_http_client_cleanup(h);
-        Debug_printf("GDRIVE api_get: open failed for %s\r\n", url.c_str());
-        return "";
-    }
-    esp_http_client_fetch_headers(h);
-
-    int status = esp_http_client_get_status_code(h);
-    if (status < 200 || status >= 300) {
-        Debug_printf("GDRIVE api_get: HTTP %d for %s\r\n", status, url.c_str());
-        esp_http_client_close(h);
-        esp_http_client_cleanup(h);
-        return "";
-    }
-
-    std::string body;
-    char buf[512];
-    int n;
-    while ((n = esp_http_client_read(h, buf, sizeof(buf))) > 0)
-        body.append(buf, n);
-
-    esp_http_client_close(h);
-    esp_http_client_cleanup(h);
-    return body;
-}
-
-std::string NetworkProtocolGDRIVE::api_post(const std::string &url,
-                                             const std::string &body,
-                                             const std::string &content_type)
-{
-    esp_http_client_config_t cfg = {};
-    cfg.url        = url.c_str();
-    cfg.timeout_ms = 15000;
-
-    esp_http_client_handle_t h = esp_http_client_init(&cfg);
-    if (!h) return "";
-
-    esp_http_client_set_method(h, HTTP_METHOD_POST);
-    if (!_access_token.empty()) {
-        std::string auth = "Bearer " + _access_token;
-        esp_http_client_set_header(h, "Authorization", auth.c_str());
-    }
-    esp_http_client_set_header(h, "Content-Type", content_type.c_str());
-
-    int wlen = (int)body.size();
-    if (esp_http_client_open(h, wlen) != ESP_OK) {
-        esp_http_client_cleanup(h);
-        Debug_printf("GDRIVE api_post: open failed for %s\r\n", url.c_str());
-        return "";
-    }
-    esp_http_client_write(h, body.c_str(), wlen);
-    esp_http_client_fetch_headers(h);
-
-    int status = esp_http_client_get_status_code(h);
-    if (status < 200 || status >= 300) {
-        Debug_printf("GDRIVE api_post: HTTP %d for %s\r\n", status, url.c_str());
-        esp_http_client_close(h);
-        esp_http_client_cleanup(h);
-        return "";
-    }
-
-    std::string resp;
-    char buf[512];
-    int n;
-    while ((n = esp_http_client_read(h, buf, sizeof(buf))) > 0)
-        resp.append(buf, n);
-
-    esp_http_client_close(h);
-    esp_http_client_cleanup(h);
-    return resp;
-}
-
-bool NetworkProtocolGDRIVE::api_delete(const std::string &url)
-{
-    esp_http_client_config_t cfg = {};
-    cfg.url        = url.c_str();
-    cfg.timeout_ms = 10000;
-
-    esp_http_client_handle_t h = esp_http_client_init(&cfg);
-    if (!h) return false;
-
-    esp_http_client_set_method(h, HTTP_METHOD_DELETE);
-    std::string auth = "Bearer " + _access_token;
-    esp_http_client_set_header(h, "Authorization", auth.c_str());
-
-    if (esp_http_client_open(h, 0) != ESP_OK) {
-        esp_http_client_cleanup(h);
-        return false;
-    }
-    esp_http_client_fetch_headers(h);
-    int status = esp_http_client_get_status_code(h);
-    esp_http_client_close(h);
-    esp_http_client_cleanup(h);
-    return (status == 200 || status == 204);
-}
-
-#else /* !ESP_PLATFORM */
-
-std::string NetworkProtocolGDRIVE::api_get(const std::string &url)
-{
-    mgHttpClient http;
-    if (!http.begin(url)) { Debug_printf("GDRIVE api_get: begin failed for %s\r\n", url.c_str()); return ""; }
-    if (!_access_token.empty())
-        http.set_header("Authorization", ("Bearer " + _access_token).c_str());
-    int status = http.GET();
-    if (status < 200 || status >= 300) { Debug_printf("GDRIVE api_get: HTTP %d for %s\r\n", status, url.c_str()); return ""; }
-    std::string body;
-    uint8_t buf[512]; int n;
-    while ((n = http.read(buf, sizeof(buf))) > 0) body.append((char *)buf, n);
-    return body;
-}
-
-std::string NetworkProtocolGDRIVE::api_post(const std::string &url,
-                                              const std::string &body,
-                                              const std::string &content_type)
-{
-    mgHttpClient http;
-    if (!http.begin(url)) { Debug_printf("GDRIVE api_post: begin failed for %s\r\n", url.c_str()); return ""; }
-    if (!_access_token.empty())
-        http.set_header("Authorization", ("Bearer " + _access_token).c_str());
-    http.set_header("Content-Type", content_type.c_str());
-    int status = http.POST(body.c_str(), (int)body.size());
-    if (status < 200 || status >= 300) { Debug_printf("GDRIVE api_post: HTTP %d for %s\r\n", status, url.c_str()); return ""; }
-    std::string resp;
-    uint8_t buf[512]; int n;
-    while ((n = http.read(buf, sizeof(buf))) > 0) resp.append((char *)buf, n);
-    return resp;
-}
-
-bool NetworkProtocolGDRIVE::api_delete(const std::string &url)
-{
-    mgHttpClient http;
-    if (!http.begin(url)) return false;
-    http.set_header("Authorization", ("Bearer " + _access_token).c_str());
-    int status = http.DELETE();
-    return (status == 200 || status == 204);
-}
-
-#endif /* ESP_PLATFORM */
-
-// ─── path resolution ──────────────────────────────────────────────────────────
-
-std::string NetworkProtocolGDRIVE::find_child(const std::string &folder_id,
-                                               const std::string &name,
-                                               bool is_folder)
-{
-    std::string q = "'" + folder_id + "' in parents"
-                    " and name='" + name + "'"
-                    " and trashed=false";
-    if (is_folder)
-        q += " and mimeType='" GDRIVE_FOLDER_MIME "'";
-
-    std::string url = std::string(GDRIVE_FILES_URL) +
-                      "?q=" + url_encode(q) +
-                      "&fields=files(id,mimeType)&pageSize=1";
-
-    std::string resp = api_get(url);
-    if (resp.empty())
-        return "";
-
-    cJSON *j = cJSON_Parse(resp.c_str());
-    if (!j) return "";
-
-    std::string id;
-    cJSON *files = cJSON_GetObjectItemCaseSensitive(j, "files");
-    if (files && cJSON_IsArray(files) && cJSON_GetArraySize(files) > 0)
-        id = json_str(cJSON_GetArrayItem(files, 0), "id");
-
-    cJSON_Delete(j);
-    return id;
-}
-
-std::string NetworkProtocolGDRIVE::create_folder(const std::string &parent_id,
-                                                   const std::string &name)
-{
-    std::string body = "{\"name\":\"" + name + "\","
-                       "\"mimeType\":\"" GDRIVE_FOLDER_MIME "\","
-                       "\"parents\":[\"" + parent_id + "\"]}";
-
-    std::string resp = api_post(std::string(GDRIVE_FILES_URL) + "?fields=id",
-                                body, "application/json");
-    if (resp.empty()) return "";
-
-    cJSON *j = cJSON_Parse(resp.c_str());
-    if (!j) return "";
-    std::string id = json_str(j, "id");
-    cJSON_Delete(j);
-    return id;
-}
-
-std::string NetworkProtocolGDRIVE::resolve_path(const std::string &path)
-{
-    // Split the path (leading '/' is ignored) into components and walk the tree.
-    std::vector<std::string> parts;
-    std::stringstream ss(path);
-    std::string part;
-    while (std::getline(ss, part, '/'))
-        if (!part.empty()) parts.push_back(part);
-
-    if (parts.empty())
-        return "root";
-
-    std::string current_id = "root";
-    for (size_t i = 0; i < parts.size(); i++)
-    {
-        bool last = (i == parts.size() - 1);
-        // Treat intermediate components as folders; the last one may be a file
-        std::string child = find_child(current_id, parts[i], !last);
-        if (child.empty())
-        {
-            // Try again without the folder restriction in case the last
-            // component is actually a folder (directory open case)
-            if (last)
-                child = find_child(current_id, parts[i], true);
-            if (child.empty())
-            {
-                Debug_printf("GDRIVE: not found: %s\r\n", parts[i].c_str());
-                return "";
-            }
-        }
-        current_id = child;
-    }
-    return current_id;
-}
-
 // ─── NetworkProtocolFS overrides ─────────────────────────────────────────────
 
 fujiError_t NetworkProtocolGDRIVE::mount(PeoplesUrlParser *url)
 {
     Debug_printf("NetworkProtocolGDRIVE::mount(%s)\r\n", url->url.c_str());
 
-    if (!ensure_access_token())
+    if (!_gdrive.ensure_access_token())
     {
         error = NDEV_STATUS::NOT_CONNECTED;
         return FUJI_ERROR::UNSPECIFIED;
@@ -398,13 +63,13 @@ fujiError_t NetworkProtocolGDRIVE::umount()
 {
     _file_id.clear();
     _parent_folder_id.clear();
-    _access_token.clear();
+    _gdrive.clear_token();
     return FUJI_ERROR::NONE;
 }
 
 fujiError_t NetworkProtocolGDRIVE::stat()
 {
-    std::string id = resolve_path(opened_url->path);
+    std::string id = _gdrive.resolve_path(opened_url->path);
     if (id.empty())
     {
         error = NDEV_STATUS::FILE_NOT_FOUND;
@@ -412,7 +77,7 @@ fujiError_t NetworkProtocolGDRIVE::stat()
     }
 
     std::string url = std::string(GDRIVE_FILES_URL) + "/" + id + "?fields=size";
-    std::string resp = api_get(url);
+    std::string resp = _gdrive.api_get(url);
     if (resp.empty())
         return FUJI_ERROR::UNSPECIFIED;
 
@@ -434,19 +99,19 @@ fujiError_t NetworkProtocolGDRIVE::open_file_handle()
     {
         // For writes we buffer everything; resolve the parent folder now.
         std::string parent_path = dir.empty() ? "/" : dir;
-        _parent_folder_id = resolve_path(parent_path);
+        _parent_folder_id = _gdrive.resolve_path(parent_path);
         if (_parent_folder_id.empty())
             _parent_folder_id = "root";
 
         // If appending, locate the existing file and download its current content
         if (streamMode == ACCESS_MODE::APPEND)
         {
-            _file_id = find_child(_parent_folder_id, filename, false);
+            _file_id = _gdrive.find_child(_parent_folder_id, filename, false);
             if (!_file_id.empty())
             {
                 std::string dl_url = std::string(GDRIVE_FILES_URL) + "/" +
                                      _file_id + "?alt=media";
-                std::string existing = api_get(dl_url);
+                std::string existing = _gdrive.api_get(dl_url);
                 _write_buf.assign(existing.begin(), existing.end());
             }
         }
@@ -458,7 +123,7 @@ fujiError_t NetworkProtocolGDRIVE::open_file_handle()
     }
 
     // READ / READWRITE: resolve the file ID and open a streaming GET
-    _file_id = resolve_path(opened_url->path);
+    _file_id = _gdrive.resolve_path(opened_url->path);
     if (_file_id.empty())
     {
         error = NDEV_STATUS::FILE_NOT_FOUND;
@@ -469,7 +134,7 @@ fujiError_t NetworkProtocolGDRIVE::open_file_handle()
     {
         std::string url = std::string(GDRIVE_FILES_URL) + "/" + _file_id +
                           "?fields=size";
-        std::string resp = api_get(url);
+        std::string resp = _gdrive.api_get(url);
         if (!resp.empty())
         {
             cJSON *j = cJSON_Parse(resp.c_str());
@@ -489,7 +154,7 @@ fujiError_t NetworkProtocolGDRIVE::open_file_handle()
         error = NDEV_STATUS::GENERAL;
         return FUJI_ERROR::UNSPECIFIED;
     }
-    _http.set_header("Authorization", ("Bearer " + _access_token).c_str());
+    _http.set_header("Authorization", ("Bearer " + _gdrive.access_token()).c_str());
     int status = _http.GET();
     if (status < 200 || status >= 300)
     {
@@ -574,7 +239,7 @@ fujiError_t NetworkProtocolGDRIVE::close_file_handle()
                   "?uploadType=multipart&fields=id";
         }
 
-        std::string resp = api_post(url, body, ct);
+        std::string resp = _gdrive.api_post(url, body, ct);
         if (resp.empty())
         {
             error = NDEV_STATUS::GENERAL;
@@ -609,7 +274,7 @@ fujiError_t NetworkProtocolGDRIVE::open_dir_handle()
         }
     }
 
-    std::string node_id = resolve_path(dir_path);
+    std::string node_id = _gdrive.resolve_path(dir_path);
     if (node_id.empty())
         node_id = "root";
 
@@ -622,8 +287,8 @@ fujiError_t NetworkProtocolGDRIVE::open_dir_handle()
 
     if (!is_folder)
     {
-        meta_resp = api_get(std::string(GDRIVE_FILES_URL) + "/" + node_id +
-                            "?fields=" GDRIVE_FIELDS);
+        meta_resp = _gdrive.api_get(std::string(GDRIVE_FILES_URL) + "/" + node_id +
+                                    "?fields=" GDRIVE_FIELDS);
         if (meta_resp.empty())
         {
             fserror_to_error();
@@ -632,7 +297,7 @@ fujiError_t NetworkProtocolGDRIVE::open_dir_handle()
         cJSON *meta = cJSON_Parse(meta_resp.c_str());
         if (meta)
         {
-            is_folder = (json_str(meta, "mimeType") == GDRIVE_FOLDER_MIME);
+            is_folder = (GoogleDriveClient::json_str(meta, "mimeType") == GDRIVE_FOLDER_MIME);
             cJSON_Delete(meta);
         }
     }
@@ -644,8 +309,8 @@ fujiError_t NetworkProtocolGDRIVE::open_dir_handle()
     {
         // List the children of this folder.
         std::string q = "'" + node_id + "' in parents and trashed=false";
-        std::string resp = api_get(std::string(GDRIVE_FILES_URL) +
-                                   "?q=" + url_encode(q) +
+        std::string resp = _gdrive.api_get(std::string(GDRIVE_FILES_URL) +
+                                   "?q=" + GoogleDriveClient::url_encode(q) +
                                    "&fields=files(" GDRIVE_FIELDS ")"
                                    "&pageSize=1000"
                                    "&orderBy=name");
@@ -696,9 +361,9 @@ fujiError_t NetworkProtocolGDRIVE::read_dir_entry(char *buf, unsigned short len)
         cJSON *trashed = cJSON_GetObjectItemCaseSensitive(entry, "trashed");
         if (trashed && cJSON_IsTrue(trashed)) continue;
 
-        std::string name = json_str(entry, "name");
-        std::string mime = json_str(entry, "mimeType");
-        std::string size_str = json_str(entry, "size");
+        std::string name = GoogleDriveClient::json_str(entry, "name");
+        std::string mime = GoogleDriveClient::json_str(entry, "mimeType");
+        std::string size_str = GoogleDriveClient::json_str(entry, "size");
 
         strncpy(buf, name.c_str(), len - 1);
         buf[len - 1] = '\0';
@@ -732,14 +397,14 @@ fujiError_t NetworkProtocolGDRIVE::del(PeoplesUrlParser *url)
     if (mount(url) != FUJI_ERROR::NONE)
         return FUJI_ERROR::UNSPECIFIED;
 
-    std::string id = resolve_path(url->path);
+    std::string id = _gdrive.resolve_path(url->path);
     if (id.empty())
     {
         error = NDEV_STATUS::FILE_NOT_FOUND;
         return FUJI_ERROR::UNSPECIFIED;
     }
 
-    bool ok = api_delete(std::string(GDRIVE_FILES_URL) + "/" + id);
+    bool ok = _gdrive.api_delete(std::string(GDRIVE_FILES_URL) + "/" + id);
     umount();
     return ok ? FUJI_ERROR::NONE : FUJI_ERROR::UNSPECIFIED;
 }
@@ -759,10 +424,10 @@ fujiError_t NetworkProtocolGDRIVE::mkdir(PeoplesUrlParser *url)
                                ? path.substr(slash + 1)
                                : path;
 
-    std::string parent_id = resolve_path(parent_path);
+    std::string parent_id = _gdrive.resolve_path(parent_path);
     if (parent_id.empty()) parent_id = "root";
 
-    std::string id = create_folder(parent_id, new_name);
+    std::string id = _gdrive.create_folder(parent_id, new_name);
     umount();
     return id.empty() ? FUJI_ERROR::UNSPECIFIED : FUJI_ERROR::NONE;
 }

--- a/lib/network-protocol/GDRIVE.cpp
+++ b/lib/network-protocol/GDRIVE.cpp
@@ -206,41 +206,18 @@ fujiError_t NetworkProtocolGDRIVE::close_file_handle()
         if (_write_buf.empty())
             return FUJI_ERROR::NONE;
 
-        // Build a multipart/related body
-        const std::string boundary = "fuji_gdrive_boundary";
-        std::string meta = "{\"name\":\"" + filename + "\"";
-        if (!_parent_folder_id.empty() && _file_id.empty())
-            meta += ",\"parents\":[\"" + _parent_folder_id + "\"]";
-        meta += "}";
+        // Upload the buffered bytes via the shared client (streamed).
+        size_t off = 0;
+        std::string id = _gdrive.upload_stream(
+            _parent_folder_id, filename, _file_id, _write_buf.size(),
+            [this, &off](uint8_t *buf, int want) -> int {
+                size_t remaining = _write_buf.size() - off;
+                int n = (int)((remaining < (size_t)want) ? remaining : (size_t)want);
+                if (n > 0) { memcpy(buf, _write_buf.data() + off, n); off += n; }
+                return n;
+            });
 
-        std::string body;
-        body.reserve(256 + _write_buf.size());
-        body += "--" + boundary + "\r\n";
-        body += "Content-Type: application/json; charset=UTF-8\r\n\r\n";
-        body += meta + "\r\n";
-        body += "--" + boundary + "\r\n";
-        body += "Content-Type: application/octet-stream\r\n\r\n";
-        body.append((char *)_write_buf.data(), _write_buf.size());
-        body += "\r\n--" + boundary + "--";
-
-        std::string ct = "multipart/related; boundary=" + boundary;
-
-        std::string url;
-        if (_file_id.empty())
-        {
-            // New file
-            url = std::string(GDRIVE_UPLOAD_URL) +
-                  "?uploadType=multipart&fields=id";
-        }
-        else
-        {
-            // Update existing file
-            url = std::string(GDRIVE_UPLOAD_URL) + "/" + _file_id +
-                  "?uploadType=multipart&fields=id";
-        }
-
-        std::string resp = _gdrive.api_post(url, body, ct);
-        if (resp.empty())
+        if (id.empty())
         {
             error = NDEV_STATUS::GENERAL;
             return FUJI_ERROR::UNSPECIFIED;

--- a/lib/network-protocol/GDRIVE.cpp
+++ b/lib/network-protocol/GDRIVE.cpp
@@ -1,11 +1,8 @@
 /**
  * NetworkProtocolGDRIVE
  *
- * Google Drive protocol adapter for FujiNet.
- *
- * The Drive REST calls and OAuth2 token handling live in the shared
- * GoogleDriveClient (_gdrive); this class implements the NetworkProtocolFS
- * surface (open/read/write/dir/del/mkdir/rmdir) on top of it.
+ * Google Drive protocol adapter. REST + OAuth2 live in the shared
+ * GoogleDriveClient (_gdrive); this implements NetworkProtocolFS on top.
  */
 
 #include "GDRIVE.h"

--- a/lib/network-protocol/GDRIVE.h
+++ b/lib/network-protocol/GDRIVE.h
@@ -7,6 +7,8 @@
 #include <string>
 #include <vector>
 
+#include "GoogleDriveClient.h"
+
 #ifdef ESP_PLATFORM
 #include "../http/fnHttpClient.h"
 #define GDRIVE_HTTP_CLIENT fnHttpClient
@@ -56,12 +58,12 @@ protected:
     fujiError_t stat() override;
 
 private:
+    // Shared Google Drive REST + OAuth2 token helper.
+    GoogleDriveClient _gdrive;
+
     // Resolved Google Drive file/folder IDs for open file/dir
     std::string _file_id;
     std::string _parent_folder_id;
-
-    // Cached access token for this session
-    std::string _access_token;
 
     // Directory listing state
     cJSON *_dir_json = nullptr;
@@ -76,44 +78,6 @@ private:
 
     // Persistent HTTP client used for streaming file downloads
     GDRIVE_HTTP_CLIENT _http;
-
-    // Ensure _access_token is valid, refreshing via refresh_token if needed.
-    bool ensure_access_token();
-
-    // Exchange refresh_token for a new access_token and update fnConfig.
-    bool refresh_access_token();
-
-    // Resolve a path string ("/folder/sub/file.txt") to a Drive file ID.
-    // Returns empty string on failure.
-    std::string resolve_path(const std::string &path);
-
-    // Find a child item (file or folder) by name inside a given folder ID.
-    // Pass is_folder=true to restrict to folders.
-    std::string find_child(const std::string &folder_id,
-                           const std::string &name,
-                           bool is_folder);
-
-    // Create a folder with the given name inside parent_id.
-    std::string create_folder(const std::string &parent_id, const std::string &name);
-
-    // Perform a synchronous GET and return the response body as a string.
-    // Returns empty on HTTP error.
-    std::string api_get(const std::string &url);
-
-    // Perform a synchronous POST with the given body and content-type.
-    // Returns the response body or empty on error.
-    std::string api_post(const std::string &url,
-                         const std::string &body,
-                         const std::string &content_type);
-
-    // Perform a synchronous DELETE. Returns true on success (204).
-    bool api_delete(const std::string &url);
-
-    // URL-encode a string (RFC 3986 unreserved characters are passed through).
-    static std::string url_encode(const std::string &s);
-
-    // Extract a string field from a cJSON object; returns "" if absent.
-    static std::string json_str(cJSON *obj, const char *key);
 
     // Maximum bytes to buffer for a single write operation.
     static constexpr size_t WRITE_BUF_LIMIT = 65536;

--- a/lib/network-protocol/GoogleDriveClient.cpp
+++ b/lib/network-protocol/GoogleDriveClient.cpp
@@ -15,6 +15,11 @@
 #include "../http/fnHttpClient.h"
 #else
 #include "../http/mgHttpClient.h"
+// mongoose.h (via mgHttpClient.h) #defines poll/mkdir as macros on Windows,
+// which then mangle method declarations in headers included below (e.g.
+// NetSIO::poll reached through fnConfig.h). Drop them, matching httpService.h.
+#undef poll
+#undef mkdir
 #endif
 
 #include "../../include/debug.h"

--- a/lib/network-protocol/GoogleDriveClient.cpp
+++ b/lib/network-protocol/GoogleDriveClient.cpp
@@ -1,8 +1,4 @@
-/**
- * GoogleDriveClient
- *
- * Shared Google Drive REST helper. See GoogleDriveClient.h for the rationale.
- */
+// Shared Google Drive REST + OAuth2 helper. See GoogleDriveClient.h.
 
 #include "GoogleDriveClient.h"
 
@@ -15,9 +11,8 @@
 #include "../http/fnHttpClient.h"
 #else
 #include "../http/mgHttpClient.h"
-// mongoose.h (via mgHttpClient.h) #defines poll/mkdir as macros on Windows,
-// which then mangle method declarations in headers included below (e.g.
-// NetSIO::poll reached through fnConfig.h). Drop them, matching httpService.h.
+// mongoose.h #defines poll/mkdir as macros on Windows, mangling declarations in
+// headers included below (e.g. NetSIO::poll). Drop them, matching httpService.h.
 #undef poll
 #undef mkdir
 #endif
@@ -109,7 +104,7 @@ bool GoogleDriveClient::refresh_access_token()
 bool GoogleDriveClient::ensure_access_token()
 {
     long now = (long)time(nullptr);
-    // Refresh 60 seconds before actual expiry to avoid clock skew issues
+    // Refresh 60s early to tolerate clock skew.
     if (now >= Config.get_gdrive_token_expiry() - 60)
         return refresh_access_token();
 
@@ -333,8 +328,7 @@ std::string GoogleDriveClient::upload_stream(const std::string &parent_id,
 {
     const std::string boundary = "fuji_gdrive_boundary";
 
-    // Metadata part. Only set parents when creating a new file (an update keeps
-    // the file in place; Drive rejects parents on a plain media update here).
+    // Only set parents when creating; Drive rejects parents on a media update.
     std::string meta = "{\"name\":\"" + name + "\"";
     if (file_id.empty() && !parent_id.empty())
         meta += ",\"parents\":[\"" + parent_id + "\"]";
@@ -356,8 +350,7 @@ std::string GoogleDriveClient::upload_stream(const std::string &parent_id,
         : std::string(GDRIVE_UPLOAD_URL) + "/" + file_id + "?uploadType=multipart&fields=id";
 
 #ifdef ESP_PLATFORM
-    // Stream the body so we never hold the whole image (which can be hundreds of
-    // KB) in RAM at once.
+    // Stream the body so the whole image is never held in RAM.
     esp_http_client_config_t cfg = {};
     cfg.url        = url.c_str();
     cfg.timeout_ms = 30000;
@@ -414,7 +407,7 @@ std::string GoogleDriveClient::upload_stream(const std::string &parent_id,
     esp_http_client_cleanup(h);
     return id;
 #else
-    // Non-ESP (PC build): buffer the body. Payloads here are small.
+    // PC build: buffer the body (payloads here are small).
     std::string body;
     body.reserve(head.size() + total_len + tail.size());
     body += head;
@@ -443,7 +436,7 @@ std::string GoogleDriveClient::upload_stream(const std::string &parent_id,
 
 std::string GoogleDriveClient::resolve_path(const std::string &path)
 {
-    // Split the path (leading '/' is ignored) into components and walk the tree.
+    // Split into components (leading '/' ignored) and walk the tree.
     std::vector<std::string> parts;
     std::stringstream ss(path);
     std::string part;
@@ -457,12 +450,11 @@ std::string GoogleDriveClient::resolve_path(const std::string &path)
     for (size_t i = 0; i < parts.size(); i++)
     {
         bool last = (i == parts.size() - 1);
-        // Treat intermediate components as folders; the last one may be a file
+        // Intermediate components are folders; the last may be a file.
         std::string child = find_child(current_id, parts[i], !last);
         if (child.empty())
         {
-            // Try again without the folder restriction in case the last
-            // component is actually a folder (directory open case)
+            // Last component might itself be a folder (dir-open case).
             if (last)
                 child = find_child(current_id, parts[i], true);
             if (child.empty())

--- a/lib/network-protocol/GoogleDriveClient.cpp
+++ b/lib/network-protocol/GoogleDriveClient.cpp
@@ -1,0 +1,354 @@
+/**
+ * GoogleDriveClient
+ *
+ * Shared Google Drive REST helper. See GoogleDriveClient.h for the rationale.
+ */
+
+#include "GoogleDriveClient.h"
+
+#include <cctype>
+#include <cstring>
+#include <ctime>
+#include <sstream>
+
+#ifdef ESP_PLATFORM
+#include "../http/fnHttpClient.h"
+#else
+#include "../http/mgHttpClient.h"
+#endif
+
+#include "../../include/debug.h"
+#include "../config/fnConfig.h"
+
+// Token refresh goes through the relay so the client_secret stays server-side.
+#define GDRIVE_RELAY_REFRESH_URL "https://auth.fujinet.online/gdrive-refresh"
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+std::string GoogleDriveClient::url_encode(const std::string &s)
+{
+    static const char hex[] = "0123456789ABCDEF";
+    std::string out;
+    out.reserve(s.size() * 3);
+    for (unsigned char c : s)
+    {
+        if (isalnum(c) || c == '-' || c == '_' || c == '.' || c == '~')
+            out += (char)c;
+        else
+        {
+            out += '%';
+            out += hex[c >> 4];
+            out += hex[c & 0xF];
+        }
+    }
+    return out;
+}
+
+std::string GoogleDriveClient::json_str(cJSON *obj, const char *key)
+{
+    if (!obj) return "";
+    cJSON *item = cJSON_GetObjectItemCaseSensitive(obj, key);
+    if (!item || !cJSON_IsString(item)) return "";
+    return item->valuestring ? item->valuestring : "";
+}
+
+// ─── OAuth2 token management ─────────────────────────────────────────────────
+
+bool GoogleDriveClient::refresh_access_token()
+{
+    std::string refresh_token = Config.get_gdrive_refresh_token();
+
+    if (refresh_token.empty())
+    {
+        Debug_printf("GDRIVE: no refresh token — user must re-authorize\r\n");
+        return false;
+    }
+
+    std::string body = "refresh_token=" + url_encode(refresh_token);
+
+    std::string resp = api_post(GDRIVE_RELAY_REFRESH_URL, body,
+                                "application/x-www-form-urlencoded");
+    if (resp.empty())
+        return false;
+
+    cJSON *j = cJSON_Parse(resp.c_str());
+    if (!j)
+    {
+        Debug_printf("GDRIVE: failed to parse token response\r\n");
+        return false;
+    }
+
+    std::string token = json_str(j, "access_token");
+    cJSON *expires_in = cJSON_GetObjectItemCaseSensitive(j, "expires_in");
+    long ttl = (expires_in && cJSON_IsNumber(expires_in))
+                   ? (long)expires_in->valuedouble
+                   : 3600;
+    cJSON_Delete(j);
+
+    if (token.empty())
+    {
+        Debug_printf("GDRIVE: token refresh returned no access_token\r\n");
+        return false;
+    }
+
+    long expiry = (long)time(nullptr) + ttl;
+    Config.store_gdrive_access_token(token);
+    Config.store_gdrive_token_expiry(expiry);
+    Config.save();
+
+    _access_token = token;
+    Debug_printf("GDRIVE: access token refreshed, expires in %ld s\r\n", ttl);
+    return true;
+}
+
+bool GoogleDriveClient::ensure_access_token()
+{
+    long now = (long)time(nullptr);
+    // Refresh 60 seconds before actual expiry to avoid clock skew issues
+    if (now >= Config.get_gdrive_token_expiry() - 60)
+        return refresh_access_token();
+
+    _access_token = Config.get_gdrive_access_token();
+    return !_access_token.empty();
+}
+
+// ─── HTTP helpers ─────────────────────────────────────────────────────────────
+
+#ifdef ESP_PLATFORM
+
+std::string GoogleDriveClient::api_get(const std::string &url)
+{
+    esp_http_client_config_t cfg = {};
+    cfg.url        = url.c_str();
+    cfg.timeout_ms = 15000;
+
+    esp_http_client_handle_t h = esp_http_client_init(&cfg);
+    if (!h) return "";
+
+    std::string auth = "Bearer " + _access_token;
+    esp_http_client_set_header(h, "Authorization", auth.c_str());
+
+    if (esp_http_client_open(h, 0) != ESP_OK) {
+        esp_http_client_cleanup(h);
+        Debug_printf("GDRIVE api_get: open failed for %s\r\n", url.c_str());
+        return "";
+    }
+    esp_http_client_fetch_headers(h);
+
+    int status = esp_http_client_get_status_code(h);
+    if (status < 200 || status >= 300) {
+        Debug_printf("GDRIVE api_get: HTTP %d for %s\r\n", status, url.c_str());
+        esp_http_client_close(h);
+        esp_http_client_cleanup(h);
+        return "";
+    }
+
+    std::string body;
+    char buf[512];
+    int n;
+    while ((n = esp_http_client_read(h, buf, sizeof(buf))) > 0)
+        body.append(buf, n);
+
+    esp_http_client_close(h);
+    esp_http_client_cleanup(h);
+    return body;
+}
+
+std::string GoogleDriveClient::api_post(const std::string &url,
+                                        const std::string &body,
+                                        const std::string &content_type)
+{
+    esp_http_client_config_t cfg = {};
+    cfg.url        = url.c_str();
+    cfg.timeout_ms = 15000;
+
+    esp_http_client_handle_t h = esp_http_client_init(&cfg);
+    if (!h) return "";
+
+    esp_http_client_set_method(h, HTTP_METHOD_POST);
+    if (!_access_token.empty()) {
+        std::string auth = "Bearer " + _access_token;
+        esp_http_client_set_header(h, "Authorization", auth.c_str());
+    }
+    esp_http_client_set_header(h, "Content-Type", content_type.c_str());
+
+    int wlen = (int)body.size();
+    if (esp_http_client_open(h, wlen) != ESP_OK) {
+        esp_http_client_cleanup(h);
+        Debug_printf("GDRIVE api_post: open failed for %s\r\n", url.c_str());
+        return "";
+    }
+    esp_http_client_write(h, body.c_str(), wlen);
+    esp_http_client_fetch_headers(h);
+
+    int status = esp_http_client_get_status_code(h);
+    if (status < 200 || status >= 300) {
+        Debug_printf("GDRIVE api_post: HTTP %d for %s\r\n", status, url.c_str());
+        esp_http_client_close(h);
+        esp_http_client_cleanup(h);
+        return "";
+    }
+
+    std::string resp;
+    char buf[512];
+    int n;
+    while ((n = esp_http_client_read(h, buf, sizeof(buf))) > 0)
+        resp.append(buf, n);
+
+    esp_http_client_close(h);
+    esp_http_client_cleanup(h);
+    return resp;
+}
+
+bool GoogleDriveClient::api_delete(const std::string &url)
+{
+    esp_http_client_config_t cfg = {};
+    cfg.url        = url.c_str();
+    cfg.timeout_ms = 10000;
+
+    esp_http_client_handle_t h = esp_http_client_init(&cfg);
+    if (!h) return false;
+
+    esp_http_client_set_method(h, HTTP_METHOD_DELETE);
+    std::string auth = "Bearer " + _access_token;
+    esp_http_client_set_header(h, "Authorization", auth.c_str());
+
+    if (esp_http_client_open(h, 0) != ESP_OK) {
+        esp_http_client_cleanup(h);
+        return false;
+    }
+    esp_http_client_fetch_headers(h);
+    int status = esp_http_client_get_status_code(h);
+    esp_http_client_close(h);
+    esp_http_client_cleanup(h);
+    return (status == 200 || status == 204);
+}
+
+#else /* !ESP_PLATFORM */
+
+std::string GoogleDriveClient::api_get(const std::string &url)
+{
+    mgHttpClient http;
+    if (!http.begin(url)) { Debug_printf("GDRIVE api_get: begin failed for %s\r\n", url.c_str()); return ""; }
+    if (!_access_token.empty())
+        http.set_header("Authorization", ("Bearer " + _access_token).c_str());
+    int status = http.GET();
+    if (status < 200 || status >= 300) { Debug_printf("GDRIVE api_get: HTTP %d for %s\r\n", status, url.c_str()); return ""; }
+    std::string body;
+    uint8_t buf[512]; int n;
+    while ((n = http.read(buf, sizeof(buf))) > 0) body.append((char *)buf, n);
+    return body;
+}
+
+std::string GoogleDriveClient::api_post(const std::string &url,
+                                        const std::string &body,
+                                        const std::string &content_type)
+{
+    mgHttpClient http;
+    if (!http.begin(url)) { Debug_printf("GDRIVE api_post: begin failed for %s\r\n", url.c_str()); return ""; }
+    if (!_access_token.empty())
+        http.set_header("Authorization", ("Bearer " + _access_token).c_str());
+    http.set_header("Content-Type", content_type.c_str());
+    int status = http.POST(body.c_str(), (int)body.size());
+    if (status < 200 || status >= 300) { Debug_printf("GDRIVE api_post: HTTP %d for %s\r\n", status, url.c_str()); return ""; }
+    std::string resp;
+    uint8_t buf[512]; int n;
+    while ((n = http.read(buf, sizeof(buf))) > 0) resp.append((char *)buf, n);
+    return resp;
+}
+
+bool GoogleDriveClient::api_delete(const std::string &url)
+{
+    mgHttpClient http;
+    if (!http.begin(url)) return false;
+    http.set_header("Authorization", ("Bearer " + _access_token).c_str());
+    int status = http.DELETE();
+    return (status == 200 || status == 204);
+}
+
+#endif /* ESP_PLATFORM */
+
+// ─── path resolution ──────────────────────────────────────────────────────────
+
+std::string GoogleDriveClient::find_child(const std::string &folder_id,
+                                          const std::string &name,
+                                          bool is_folder)
+{
+    std::string q = "'" + folder_id + "' in parents"
+                    " and name='" + name + "'"
+                    " and trashed=false";
+    if (is_folder)
+        q += " and mimeType='" GDRIVE_FOLDER_MIME "'";
+
+    std::string url = std::string(GDRIVE_FILES_URL) +
+                      "?q=" + url_encode(q) +
+                      "&fields=files(id,mimeType)&pageSize=1";
+
+    std::string resp = api_get(url);
+    if (resp.empty())
+        return "";
+
+    cJSON *j = cJSON_Parse(resp.c_str());
+    if (!j) return "";
+
+    std::string id;
+    cJSON *files = cJSON_GetObjectItemCaseSensitive(j, "files");
+    if (files && cJSON_IsArray(files) && cJSON_GetArraySize(files) > 0)
+        id = json_str(cJSON_GetArrayItem(files, 0), "id");
+
+    cJSON_Delete(j);
+    return id;
+}
+
+std::string GoogleDriveClient::create_folder(const std::string &parent_id,
+                                             const std::string &name)
+{
+    std::string body = "{\"name\":\"" + name + "\","
+                       "\"mimeType\":\"" GDRIVE_FOLDER_MIME "\","
+                       "\"parents\":[\"" + parent_id + "\"]}";
+
+    std::string resp = api_post(std::string(GDRIVE_FILES_URL) + "?fields=id",
+                                body, "application/json");
+    if (resp.empty()) return "";
+
+    cJSON *j = cJSON_Parse(resp.c_str());
+    if (!j) return "";
+    std::string id = json_str(j, "id");
+    cJSON_Delete(j);
+    return id;
+}
+
+std::string GoogleDriveClient::resolve_path(const std::string &path)
+{
+    // Split the path (leading '/' is ignored) into components and walk the tree.
+    std::vector<std::string> parts;
+    std::stringstream ss(path);
+    std::string part;
+    while (std::getline(ss, part, '/'))
+        if (!part.empty()) parts.push_back(part);
+
+    if (parts.empty())
+        return "root";
+
+    std::string current_id = "root";
+    for (size_t i = 0; i < parts.size(); i++)
+    {
+        bool last = (i == parts.size() - 1);
+        // Treat intermediate components as folders; the last one may be a file
+        std::string child = find_child(current_id, parts[i], !last);
+        if (child.empty())
+        {
+            // Try again without the folder restriction in case the last
+            // component is actually a folder (directory open case)
+            if (last)
+                child = find_child(current_id, parts[i], true);
+            if (child.empty())
+            {
+                Debug_printf("GDRIVE: not found: %s\r\n", parts[i].c_str());
+                return "";
+            }
+        }
+        current_id = child;
+    }
+    return current_id;
+}

--- a/lib/network-protocol/GoogleDriveClient.cpp
+++ b/lib/network-protocol/GoogleDriveClient.cpp
@@ -318,6 +318,124 @@ std::string GoogleDriveClient::create_folder(const std::string &parent_id,
     return id;
 }
 
+// ─── upload ───────────────────────────────────────────────────────────────────
+
+std::string GoogleDriveClient::upload_stream(const std::string &parent_id,
+                                             const std::string &name,
+                                             const std::string &file_id,
+                                             size_t total_len,
+                                             const std::function<int(uint8_t *, int)> &read_chunk)
+{
+    const std::string boundary = "fuji_gdrive_boundary";
+
+    // Metadata part. Only set parents when creating a new file (an update keeps
+    // the file in place; Drive rejects parents on a plain media update here).
+    std::string meta = "{\"name\":\"" + name + "\"";
+    if (file_id.empty() && !parent_id.empty())
+        meta += ",\"parents\":[\"" + parent_id + "\"]";
+    meta += "}";
+
+    std::string head;
+    head += "--" + boundary + "\r\n";
+    head += "Content-Type: application/json; charset=UTF-8\r\n\r\n";
+    head += meta + "\r\n";
+    head += "--" + boundary + "\r\n";
+    head += "Content-Type: application/octet-stream\r\n\r\n";
+
+    std::string tail = "\r\n--" + boundary + "--";
+
+    std::string ct = "multipart/related; boundary=" + boundary;
+
+    std::string url = file_id.empty()
+        ? std::string(GDRIVE_UPLOAD_URL) + "?uploadType=multipart&fields=id"
+        : std::string(GDRIVE_UPLOAD_URL) + "/" + file_id + "?uploadType=multipart&fields=id";
+
+#ifdef ESP_PLATFORM
+    // Stream the body so we never hold the whole image (which can be hundreds of
+    // KB) in RAM at once.
+    esp_http_client_config_t cfg = {};
+    cfg.url        = url.c_str();
+    cfg.timeout_ms = 30000;
+
+    esp_http_client_handle_t h = esp_http_client_init(&cfg);
+    if (!h) return "";
+
+    esp_http_client_set_method(h, HTTP_METHOD_POST);
+    if (!_access_token.empty()) {
+        std::string auth = "Bearer " + _access_token;
+        esp_http_client_set_header(h, "Authorization", auth.c_str());
+    }
+    esp_http_client_set_header(h, "Content-Type", ct.c_str());
+
+    int content_length = (int)(head.size() + total_len + tail.size());
+    if (esp_http_client_open(h, content_length) != ESP_OK) {
+        Debug_printf("GDRIVE upload: open failed\r\n");
+        esp_http_client_cleanup(h);
+        return "";
+    }
+
+    bool ok = (esp_http_client_write(h, head.c_str(), head.size()) >= 0);
+    if (ok) {
+        uint8_t buf[1024];
+        size_t remaining = total_len;
+        while (remaining > 0) {
+            int want = (int)((remaining > sizeof(buf)) ? sizeof(buf) : remaining);
+            int n = read_chunk(buf, want);
+            if (n <= 0) { Debug_printf("GDRIVE upload: source read failed\r\n"); ok = false; break; }
+            if (esp_http_client_write(h, (const char *)buf, n) != n) { Debug_printf("GDRIVE upload: write failed\r\n"); ok = false; break; }
+            remaining -= n;
+        }
+    }
+    if (ok)
+        ok = (esp_http_client_write(h, tail.c_str(), tail.size()) >= 0);
+
+    std::string id;
+    if (ok) {
+        esp_http_client_fetch_headers(h);
+        int status = esp_http_client_get_status_code(h);
+        std::string resp;
+        char rbuf[256];
+        int rn;
+        while ((rn = esp_http_client_read(h, rbuf, sizeof(rbuf))) > 0)
+            resp.append(rbuf, rn);
+        if (status >= 200 && status < 300) {
+            cJSON *j = cJSON_Parse(resp.c_str());
+            if (j) { id = json_str(j, "id"); cJSON_Delete(j); }
+        } else {
+            Debug_printf("GDRIVE upload: HTTP %d\r\n", status);
+        }
+    }
+    esp_http_client_close(h);
+    esp_http_client_cleanup(h);
+    return id;
+#else
+    // Non-ESP (PC build): buffer the body. Payloads here are small.
+    std::string body;
+    body.reserve(head.size() + total_len + tail.size());
+    body += head;
+    {
+        uint8_t buf[1024];
+        size_t remaining = total_len;
+        while (remaining > 0) {
+            int want = (int)((remaining > sizeof(buf)) ? sizeof(buf) : remaining);
+            int n = read_chunk(buf, want);
+            if (n <= 0) return "";
+            body.append((const char *)buf, n);
+            remaining -= n;
+        }
+    }
+    body += tail;
+
+    std::string resp = api_post(url, body, ct);
+    if (resp.empty()) return "";
+    cJSON *j = cJSON_Parse(resp.c_str());
+    if (!j) return "";
+    std::string id = json_str(j, "id");
+    cJSON_Delete(j);
+    return id;
+#endif
+}
+
 std::string GoogleDriveClient::resolve_path(const std::string &path)
 {
     // Split the path (leading '/' is ignored) into components and walk the tree.

--- a/lib/network-protocol/GoogleDriveClient.h
+++ b/lib/network-protocol/GoogleDriveClient.h
@@ -4,6 +4,9 @@
 #include <cJSON.h>
 #include <string>
 #include <vector>
+#include <functional>
+#include <cstddef>
+#include <cstdint>
 
 /**
  * GoogleDriveClient
@@ -72,6 +75,18 @@ public:
     // Create a folder with the given name inside parent_id. Returns its id.
     std::string create_folder(const std::string &parent_id,
                               const std::string &name);
+
+    // Upload file content via a multipart/related request, reading the body in
+    // chunks from read_chunk() (returns bytes read, 0 = EOF, <0 = error) so the
+    // whole file never needs to be buffered in RAM. If file_id is non-empty the
+    // existing file is updated; otherwise a new file named `name` is created
+    // under parent_id. total_len must be the exact number of content bytes that
+    // read_chunk will deliver. Returns the resulting Drive file id, or "".
+    std::string upload_stream(const std::string &parent_id,
+                              const std::string &name,
+                              const std::string &file_id,
+                              size_t total_len,
+                              const std::function<int(uint8_t *, int)> &read_chunk);
 
     // URL-encode a string (RFC 3986 unreserved characters pass through).
     static std::string url_encode(const std::string &s);

--- a/lib/network-protocol/GoogleDriveClient.h
+++ b/lib/network-protocol/GoogleDriveClient.h
@@ -9,26 +9,14 @@
 #include <cstdint>
 
 /**
- * GoogleDriveClient
- *
- * Shared Google Drive REST helper used by both the GDRIVE:// network protocol
- * adapter (NetworkProtocolGDRIVE) and the Google Drive host-slot filesystem
- * (FileSystemGDrive).
- *
- * Responsibilities:
- *   - OAuth2 access-token management (refresh via the FujiNet relay so the
- *     client_secret never leaves the server). Tokens are persisted in the
- *     fnConfig [GoogleDrive] section.
- *   - Thin synchronous wrappers over the Drive v3 REST API (GET/POST/DELETE).
- *   - Path -> file-id resolution and folder helpers.
- *
- * Streaming downloads/uploads of file *content* are intentionally left to the
- * caller: each consumer owns its own HTTP client for that (the protocol adapter
- * streams to the bus, the filesystem caches to local storage). Callers set the
- * "Authorization: Bearer <token>" header themselves using access_token().
+ * Shared Google Drive REST + OAuth2 helper, used by both the GDRIVE:// network
+ * protocol adapter and the Google Drive host-slot filesystem. Handles token
+ * refresh (via the relay, keeping client_secret server-side; tokens persist in
+ * fnConfig), the Drive v3 REST verbs, and path->id resolution. Content
+ * streaming is left to each caller via access_token().
  */
 
-// Google Drive v3 REST endpoints, shared by all consumers.
+// Google Drive v3 REST endpoints.
 #define GDRIVE_FILES_URL     "https://www.googleapis.com/drive/v3/files"
 #define GDRIVE_UPLOAD_URL    "https://www.googleapis.com/upload/drive/v3/files"
 #define GDRIVE_FIELDS        "id,name,size,mimeType,trashed"
@@ -39,49 +27,42 @@ class GoogleDriveClient
 public:
     GoogleDriveClient() = default;
 
-    // Ensure _access_token is valid, refreshing via the relay if needed.
-    // Returns true if a usable access token is available.
+    // Ensure a valid access token (refresh via relay if needed).
     bool ensure_access_token();
 
-    // The current cached access token (valid after ensure_access_token()).
+    // Cached access token (valid after ensure_access_token()).
     const std::string &access_token() const { return _access_token; }
 
-    // Forget the cached access token (the persisted refresh token is kept).
+    // Forget the cached access token (refresh token is kept).
     void clear_token() { _access_token.clear(); }
 
-    // Perform a synchronous GET and return the response body as a string.
-    // Returns empty on HTTP error.
+    // Synchronous GET; returns the response body, or "" on error.
     std::string api_get(const std::string &url);
 
-    // Perform a synchronous POST with the given body and content-type.
-    // Returns the response body or empty on error.
+    // Synchronous POST; returns the response body, or "" on error.
     std::string api_post(const std::string &url,
                          const std::string &body,
                          const std::string &content_type);
 
-    // Perform a synchronous DELETE. Returns true on success (200/204).
+    // Synchronous DELETE; true on 200/204.
     bool api_delete(const std::string &url);
 
-    // Resolve a path string ("/folder/sub/file.txt") to a Drive file ID.
-    // Returns empty string on failure. A bare/empty path resolves to "root".
+    // Resolve a path to a Drive file id; "" on failure, "root" if empty.
     std::string resolve_path(const std::string &path);
 
-    // Find a child item (file or folder) by name inside a given folder ID.
-    // Pass is_folder=true to restrict to folders. Returns empty if not found.
+    // Find a child by name in folder_id; is_folder restricts to folders. "" if none.
     std::string find_child(const std::string &folder_id,
                            const std::string &name,
                            bool is_folder);
 
-    // Create a folder with the given name inside parent_id. Returns its id.
+    // Create a folder `name` under parent_id. Returns its id.
     std::string create_folder(const std::string &parent_id,
                               const std::string &name);
 
-    // Upload file content via a multipart/related request, reading the body in
-    // chunks from read_chunk() (returns bytes read, 0 = EOF, <0 = error) so the
-    // whole file never needs to be buffered in RAM. If file_id is non-empty the
-    // existing file is updated; otherwise a new file named `name` is created
-    // under parent_id. total_len must be the exact number of content bytes that
-    // read_chunk will deliver. Returns the resulting Drive file id, or "".
+    // Upload total_len content bytes (pulled in chunks from read_chunk: returns
+    // bytes read, 0=EOF, <0=error) via multipart, without buffering the whole
+    // file. Updates file_id if set, else creates `name` under parent_id.
+    // Returns the new Drive file id, or "".
     std::string upload_stream(const std::string &parent_id,
                               const std::string &name,
                               const std::string &file_id,
@@ -95,11 +76,9 @@ public:
     static std::string json_str(cJSON *obj, const char *key);
 
 private:
-    // Exchange the stored refresh_token for a new access_token (via relay)
-    // and persist it to fnConfig.
+    // Refresh the access token via the relay and persist it.
     bool refresh_access_token();
 
-    // Cached access token for this session.
     std::string _access_token;
 };
 

--- a/lib/network-protocol/GoogleDriveClient.h
+++ b/lib/network-protocol/GoogleDriveClient.h
@@ -1,0 +1,91 @@
+#ifndef GOOGLEDRIVECLIENT_H
+#define GOOGLEDRIVECLIENT_H
+
+#include <cJSON.h>
+#include <string>
+#include <vector>
+
+/**
+ * GoogleDriveClient
+ *
+ * Shared Google Drive REST helper used by both the GDRIVE:// network protocol
+ * adapter (NetworkProtocolGDRIVE) and the Google Drive host-slot filesystem
+ * (FileSystemGDrive).
+ *
+ * Responsibilities:
+ *   - OAuth2 access-token management (refresh via the FujiNet relay so the
+ *     client_secret never leaves the server). Tokens are persisted in the
+ *     fnConfig [GoogleDrive] section.
+ *   - Thin synchronous wrappers over the Drive v3 REST API (GET/POST/DELETE).
+ *   - Path -> file-id resolution and folder helpers.
+ *
+ * Streaming downloads/uploads of file *content* are intentionally left to the
+ * caller: each consumer owns its own HTTP client for that (the protocol adapter
+ * streams to the bus, the filesystem caches to local storage). Callers set the
+ * "Authorization: Bearer <token>" header themselves using access_token().
+ */
+
+// Google Drive v3 REST endpoints, shared by all consumers.
+#define GDRIVE_FILES_URL     "https://www.googleapis.com/drive/v3/files"
+#define GDRIVE_UPLOAD_URL    "https://www.googleapis.com/upload/drive/v3/files"
+#define GDRIVE_FIELDS        "id,name,size,mimeType,trashed"
+#define GDRIVE_FOLDER_MIME   "application/vnd.google-apps.folder"
+
+class GoogleDriveClient
+{
+public:
+    GoogleDriveClient() = default;
+
+    // Ensure _access_token is valid, refreshing via the relay if needed.
+    // Returns true if a usable access token is available.
+    bool ensure_access_token();
+
+    // The current cached access token (valid after ensure_access_token()).
+    const std::string &access_token() const { return _access_token; }
+
+    // Forget the cached access token (the persisted refresh token is kept).
+    void clear_token() { _access_token.clear(); }
+
+    // Perform a synchronous GET and return the response body as a string.
+    // Returns empty on HTTP error.
+    std::string api_get(const std::string &url);
+
+    // Perform a synchronous POST with the given body and content-type.
+    // Returns the response body or empty on error.
+    std::string api_post(const std::string &url,
+                         const std::string &body,
+                         const std::string &content_type);
+
+    // Perform a synchronous DELETE. Returns true on success (200/204).
+    bool api_delete(const std::string &url);
+
+    // Resolve a path string ("/folder/sub/file.txt") to a Drive file ID.
+    // Returns empty string on failure. A bare/empty path resolves to "root".
+    std::string resolve_path(const std::string &path);
+
+    // Find a child item (file or folder) by name inside a given folder ID.
+    // Pass is_folder=true to restrict to folders. Returns empty if not found.
+    std::string find_child(const std::string &folder_id,
+                           const std::string &name,
+                           bool is_folder);
+
+    // Create a folder with the given name inside parent_id. Returns its id.
+    std::string create_folder(const std::string &parent_id,
+                              const std::string &name);
+
+    // URL-encode a string (RFC 3986 unreserved characters pass through).
+    static std::string url_encode(const std::string &s);
+
+    // Extract a string field from a cJSON object; returns "" if absent.
+    static std::string json_str(cJSON *obj, const char *key);
+
+private:
+    // Exchange the stored refresh_token for a new access_token (via relay)
+    // and persist it to fnConfig.
+    bool refresh_access_token();
+
+    // Cached access token for this session.
+    std::string _access_token;
+};
+
+#endif /* GOOGLEDRIVECLIENT_H */


### PR DESCRIPTION
## What

Put `GDRIVE:///` (optionally `GDRIVE:///games/atari`) in a host slot to browse, mount, create, and edit media images from Google Drive. Reuses the OAuth tokens from the existing web UI — no new setup.

## How

Drive REST + OAuth2 logic is extracted from `NetworkProtocolGDRIVE` into a shared **`GoogleDriveClient`** (token refresh via relay, REST verbs, path→id resolution, streaming multipart upload). The `GDRIVE://` protocol adapter now delegates to it.

**`FileSystemGDrive`** adds Drive as a host slot, modeled on the FTP/HTTP hosts. Listings come from the Drive API; opening a file downloads it to the local cache:
- non-stdio (Atari/Apple/CoCo): `filehandler_open` → `FileCache`
- stdio (ADAM/IEC/Lynx): `file_open` → SD cache → `FILE*`

**Write-back:** files opened for writing are uploaded to Drive on disk-image unmount and after `new_disk`, via a new `FileSystem::sync_file` hook (default no-op) wired through `fujiHost`, `fujiDevice`, and the per-bus `new_disk` handlers.

Plus wiring: `FSTYPE_GDRIVE`/`HOSTTYPE_GDRIVE`, `mount_gdrive()`, web file-browser dispatch, PC-build registration, and a null-handle guard in `adamnet_new_disk`.

## Testing

- ✅ ATARI PC build links (FileHandler/FileCache path)
- ✅ stdio paths compile under `-DFNIO_IS_STDIO`
- ✅ ADAM: mount existing image; create disk (no crash)
- ⚠️ Live end-to-end upload round-trip still to confirm on hardware

## Limitations

- Opening downloads the whole file to cache — fine for disk images, RAM/SD-bound for very large files.
- Requires an SD card (cache location) on every target.
- Write-back only on clean unmount / new disk, not on power loss.
- No rename (needs a Drive metadata PATCH).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
