### PR TITLE
Add 16/24/32 bit unsigned types that store their bytes in a specific endianness

### DIFF
--- a/include/fuji_endian.h
+++ b/include/fuji_endian.h
@@ -13,7 +13,7 @@
 
 #endif
 
-#if defined(__linux__) || defined(__CYGWIN__)
+#if defined(__linux__) || defined(__CYGWIN__) || defined(ESP_PLATFORM)
 
 #       include <endian.h>
 

--- a/include/global_types.h
+++ b/include/global_types.h
@@ -5,7 +5,9 @@
 #ifndef GLOBAL_TYPES_H
 #define GLOBAL_TYPES_H
 
-#include <stdint.h>
+#include "fuji_endian.h"
+#include <cstdint>
+#include <cstring>
 
 /**
  * byte array for buffers
@@ -48,5 +50,71 @@ struct error_is_true {
 #define RETURN_ERROR_AS_TRUE()    return error_is_true(true)
 #define RETURN_SUCCESS_AS_FALSE() return error_is_true(false)
 #define RETURN_ERROR_IF(expr)     return error_is_true(expr)
+
+struct u16le_t {
+  uint8_t bytes[2];
+  //u16le_t(uint16_t v = 0) { *this = v; }
+  operator uint16_t() const { uint16_t v; std::memcpy(&v, bytes, 2); return le16toh(v); }
+  u16le_t& operator=(uint16_t v) {
+    uint16_t out = htole16(v); std::memcpy(bytes, &out, 2);
+    return *this;
+  }
+} __attribute__((packed));
+static_assert(sizeof(u16le_t) == 2, "u16le_t must be 2 bytes");
+
+struct u24le_t {
+  uint8_t bytes[3];
+  //u24le_t(uint32_t v = 0) { *this = v; }
+  operator uint32_t() const { return bytes[0] | (bytes[1] << 8) | (bytes[2] << 16); }
+  u24le_t& operator=(uint32_t v) {
+    bytes[0] = v; bytes[1] = v >> 8; bytes[2] = v >> 16;
+    return *this;
+  }
+} __attribute__((packed));
+static_assert(sizeof(u24le_t) == 3, "u24le_t must be 3 bytes");
+
+struct u32le_t {
+  uint8_t bytes[4];
+  //u32le_t(uint32_t v = 0) { *this = v; }
+  operator uint32_t() const { uint32_t v; std::memcpy(&v, bytes, 4); return le32toh(v); }
+  u32le_t& operator=(uint32_t v) {
+    uint32_t out = htole32(v); std::memcpy(bytes, &out, 4);
+    return *this;
+  }
+} __attribute__((packed));
+static_assert(sizeof(u32le_t) == 4, "u32le_t must be 4 bytes");
+
+struct u16be_t {
+  uint8_t bytes[2];
+  //u16be_t(uint16_t v = 0) { *this = v; }
+  operator uint16_t() const { uint16_t v; std::memcpy(&v, bytes, 2); return be16toh(v); }
+  u16be_t& operator=(uint16_t v) {
+    uint16_t out = htobe16(v); std::memcpy(bytes, &out, 2);
+    return *this;
+  }
+} __attribute__((packed));
+static_assert(sizeof(u16be_t) == 2, "u16be_t must be 2 bytes");
+
+struct u24be_t {
+  uint8_t bytes[3];
+  //u24be_t(uint32_t v = 0) { *this = v; }
+  operator uint32_t() const { return (bytes[0] << 16) | (bytes[1] << 8) | bytes[2]; }
+  u24be_t& operator=(uint32_t v) {
+    bytes[0] = v >> 16; bytes[1] = v >> 8; bytes[2] = v;
+    return *this;
+  }
+} __attribute__((packed));
+static_assert(sizeof(u24be_t) == 3, "u24be_t must be 3 bytes");
+
+struct u32be_t {
+  uint8_t bytes[4];
+  //u32be_t(uint32_t v = 0) { *this = v; }
+  operator uint32_t() const { uint32_t v; std::memcpy(&v, bytes, 4); return be32toh(v); }
+  u32be_t& operator=(uint32_t v) {
+    uint32_t out = htobe32(v); std::memcpy(bytes, &out, 4);
+    return *this;
+  }
+} __attribute__((packed));
+static_assert(sizeof(u32be_t) == 4, "u32be_t must be 4 bytes");
 
 #endif


### PR DESCRIPTION
Will be using this with some upcoming changes to Apple II, but I think it will be useful for all "over the bus" data on all platforms. These types can be inserted into a packed struct and can be used where normal unsigned types would work, such as in math or passing into larger integer arguments. They take up the exact number of bytes specified (2, 3, or 4) and are also stored in the struct with matching endianness so no extra steps are required to read/write the values before using or sending to the retro computer.