### PR TITLE
Add option to retrieve google file IDs with a long directory listing

### DIFF
--- a/lib/network-protocol/FS.cpp
+++ b/lib/network-protocol/FS.cpp
@@ -112,6 +112,8 @@ fujiError_t NetworkProtocolFS::open_dir(apple2Flag_t a2flags)
             // Long entry
             if (a2flags == APPLE2_FLAG::IS_80COL) // Apple2 80 col format.
                 dirBuffer += util_long_entry_apple2_80col((char *)entryBuffer.data(), fileSize, is_directory) + lineEnding;
+            else if (a2flags == APPLE2_FLAG::IS_A2_WITH_GDRIVE_ID)
+                dirBuffer += util_long_entry_with_gdrive_id((char *)entryBuffer.data(), fileSize, is_directory, entry_id) + lineEnding;
             else
                 dirBuffer += util_long_entry((char *)entryBuffer.data(), fileSize, is_directory) + lineEnding;
         }
@@ -123,6 +125,7 @@ fujiError_t NetworkProtocolFS::open_dir(apple2Flag_t a2flags)
         fserror_to_error();
 
         // Clearing the buffer for reuse
+        entry_id.clear();
         std::fill(entryBuffer.begin(), entryBuffer.end(), 0); // fenrock was right.
     }
 

--- a/lib/network-protocol/FS.cpp
+++ b/lib/network-protocol/FS.cpp
@@ -47,7 +47,7 @@ fujiError_t NetworkProtocolFS::open(PeoplesUrlParser *urlParser,
         return FUJI_ERROR::UNSPECIFIED;
 
     if (access == ACCESS_MODE::DIRECTORY || access == ACCESS_MODE::DIRECTORY_ALT)
-        return open_dir((apple2Flag_t) translate);
+        return open_dir((dirEntryFormatFlag_t) translate);
 
     return open_file();
 }
@@ -71,7 +71,7 @@ fujiError_t NetworkProtocolFS::open_file()
     return open_file_handle();
 }
 
-fujiError_t NetworkProtocolFS::open_dir(apple2Flag_t a2flags)
+fujiError_t NetworkProtocolFS::open_dir(dirEntryFormatFlag_t fmt)
 {
     streamType = streamType_t::DIR;
 #ifndef BUILD_ATARI
@@ -107,20 +107,20 @@ fujiError_t NetworkProtocolFS::open_dir(apple2Flag_t a2flags)
         if (entryBuffer.at(0) == '.' || entryBuffer.at(0) == '/')
             continue;
 
-        if (a2flags >= APPLE2_FLAG::IS_A2)
+        switch (fmt)
         {
-            // Long entry
-            if (a2flags == APPLE2_FLAG::IS_80COL) // Apple2 80 col format.
-                dirBuffer += util_long_entry_apple2_80col((char *)entryBuffer.data(), fileSize, is_directory) + lineEnding;
-            else if (a2flags == APPLE2_FLAG::IS_A2_WITH_GDRIVE_ID)
-                dirBuffer += util_long_entry_with_gdrive_id((char *)entryBuffer.data(), fileSize, is_directory, entry_id) + lineEnding;
-            else
+        case DIR_ENTRY_FORMAT_FLAG::IS_80COL:
+            dirBuffer += util_long_entry_apple2_80col((char *)entryBuffer.data(), fileSize, is_directory) + lineEnding;
+            break;
+        case DIR_ENTRY_FORMAT_FLAG::IS_80COL_WITH_GDRIVE_ID:
+            dirBuffer += util_long_entry_with_gdrive_id((char *)entryBuffer.data(), fileSize, is_directory, entry_id) + lineEnding;
+            break;
+        default:
+            if (fmt >= DIR_ENTRY_FORMAT_FLAG::IS_LONG_FMT)
                 dirBuffer += util_long_entry((char *)entryBuffer.data(), fileSize, is_directory) + lineEnding;
-        }
-        else
-        {
-            // 8.3 entry
-            dirBuffer += util_entry(util_crunch((char *)entryBuffer.data()), fileSize, is_directory, is_locked) + lineEnding;
+            else
+                dirBuffer += util_entry(util_crunch((char *)entryBuffer.data()), fileSize, is_directory, is_locked) + lineEnding;
+            break;
         }
         fserror_to_error();
 

--- a/lib/network-protocol/FS.cpp
+++ b/lib/network-protocol/FS.cpp
@@ -47,7 +47,7 @@ fujiError_t NetworkProtocolFS::open(PeoplesUrlParser *urlParser,
         return FUJI_ERROR::UNSPECIFIED;
 
     if (access == ACCESS_MODE::DIRECTORY || access == ACCESS_MODE::DIRECTORY_ALT)
-        return open_dir((dirEntryFormatFlag_t) translate);
+        return open_dir((dirFormat_t) translate);
 
     return open_file();
 }
@@ -71,7 +71,7 @@ fujiError_t NetworkProtocolFS::open_file()
     return open_file_handle();
 }
 
-fujiError_t NetworkProtocolFS::open_dir(dirEntryFormatFlag_t fmt)
+fujiError_t NetworkProtocolFS::open_dir(dirFormat_t fmt)
 {
     streamType = streamType_t::DIR;
 #ifndef BUILD_ATARI
@@ -109,14 +109,14 @@ fujiError_t NetworkProtocolFS::open_dir(dirEntryFormatFlag_t fmt)
 
         switch (fmt)
         {
-        case DIR_ENTRY_FORMAT_FLAG::IS_80COL:
+        case DIR_FORMAT::A2COL80:
             dirBuffer += util_long_entry_apple2_80col((char *)entryBuffer.data(), fileSize, is_directory) + lineEnding;
             break;
-        case DIR_ENTRY_FORMAT_FLAG::IS_80COL_WITH_GDRIVE_ID:
+        case DIR_FORMAT::GDRIVE:
             dirBuffer += util_long_entry_with_gdrive_id((char *)entryBuffer.data(), fileSize, is_directory, entry_id) + lineEnding;
             break;
         default:
-            if (fmt >= DIR_ENTRY_FORMAT_FLAG::IS_LONG_FMT)
+            if (fmt >= DIR_FORMAT::LONG)
                 dirBuffer += util_long_entry((char *)entryBuffer.data(), fileSize, is_directory) + lineEnding;
             else
                 dirBuffer += util_entry(util_crunch((char *)entryBuffer.data()), fileSize, is_directory, is_locked) + lineEnding;

--- a/lib/network-protocol/FS.h
+++ b/lib/network-protocol/FS.h
@@ -7,11 +7,11 @@
 
 #include "Protocol.h"
 
-typedef enum class DIR_ENTRY_FORMAT_FLAG {
-    IS_LONG_FMT             = 0x80,
-    IS_80COL                = 0x81,
-    IS_80COL_WITH_GDRIVE_ID = 0x82,
-} dirEntryFormatFlag_t;
+typedef enum class DIR_FORMAT {
+    LONG   = 0x80,
+    A2COL80 = 0x81,
+    GDRIVE = 0x82,
+} dirFormat_t;
 
 class NetworkProtocolFS : public NetworkProtocol
 {
@@ -191,7 +191,7 @@ protected:
 
     /**
      * Optional file ID string populated by read_dir_entry() implementations
-     * that support it (e.g. GDRIVE when IS_80COL_WITH_GDRIVE_ID is requested).
+     * that support it (e.g. GDRIVE when DIR_FORMAT::GDRIVE is requested).
      * Reset to empty by open_dir() between entries.
      */
     std::string entry_id;
@@ -212,7 +212,7 @@ protected:
      * @brief Open a Directory via path
      * @return FUJI_ERROR::NONE on success, FUJI_ERROR::UNSPECIFIED on error
      */
-    virtual fujiError_t open_dir(dirEntryFormatFlag_t fmt);
+    virtual fujiError_t open_dir(dirFormat_t fmt);
 
     /**
      * @brief Open directory handle

--- a/lib/network-protocol/FS.h
+++ b/lib/network-protocol/FS.h
@@ -8,8 +8,9 @@
 #include "Protocol.h"
 
 typedef enum class APPLE2_FLAG {
-    IS_A2    = 0x80,
-    IS_80COL = 0x81,
+    IS_A2              = 0x80,
+    IS_80COL           = 0x81,
+    IS_A2_WITH_GDRIVE_ID = 0x82,
 } apple2Flag_t;
 
 class NetworkProtocolFS : public NetworkProtocol
@@ -187,6 +188,13 @@ protected:
      * Is open file locked?
      */
     bool is_locked = false;
+
+    /**
+     * Optional file ID string populated by read_dir_entry() implementations
+     * that support it (e.g. GDRIVE when IS_A2_WITH_GDRIVE_ID is requested).
+     * Reset to empty by open_dir() between entries.
+     */
+    std::string entry_id;
 
     /**
      * @brief Open a file via path.

--- a/lib/network-protocol/FS.h
+++ b/lib/network-protocol/FS.h
@@ -7,11 +7,11 @@
 
 #include "Protocol.h"
 
-typedef enum class APPLE2_FLAG {
-    IS_A2              = 0x80,
-    IS_80COL           = 0x81,
-    IS_A2_WITH_GDRIVE_ID = 0x82,
-} apple2Flag_t;
+typedef enum class DIR_ENTRY_FORMAT_FLAG {
+    IS_LONG_FMT             = 0x80,
+    IS_80COL                = 0x81,
+    IS_80COL_WITH_GDRIVE_ID = 0x82,
+} dirEntryFormatFlag_t;
 
 class NetworkProtocolFS : public NetworkProtocol
 {
@@ -191,7 +191,7 @@ protected:
 
     /**
      * Optional file ID string populated by read_dir_entry() implementations
-     * that support it (e.g. GDRIVE when IS_A2_WITH_GDRIVE_ID is requested).
+     * that support it (e.g. GDRIVE when IS_80COL_WITH_GDRIVE_ID is requested).
      * Reset to empty by open_dir() between entries.
      */
     std::string entry_id;
@@ -212,7 +212,7 @@ protected:
      * @brief Open a Directory via path
      * @return FUJI_ERROR::NONE on success, FUJI_ERROR::UNSPECIFIED on error
      */
-    virtual fujiError_t open_dir(apple2Flag_t a2flags);
+    virtual fujiError_t open_dir(dirEntryFormatFlag_t fmt);
 
     /**
      * @brief Open directory handle

--- a/lib/network-protocol/GDRIVE.cpp
+++ b/lib/network-protocol/GDRIVE.cpp
@@ -676,7 +676,7 @@ fujiError_t NetworkProtocolGDRIVE::open_dir_handle()
     }
 
     _dir_item_idx = 0;
-    _include_file_id = (translation_mode == (netProtoTranslation_t)APPLE2_FLAG::IS_A2_WITH_GDRIVE_ID);
+    _include_file_id = (translation_mode == (netProtoTranslation_t)DIR_ENTRY_FORMAT_FLAG::IS_80COL_WITH_GDRIVE_ID);
     return FUJI_ERROR::NONE;
 }
 

--- a/lib/network-protocol/GDRIVE.cpp
+++ b/lib/network-protocol/GDRIVE.cpp
@@ -676,6 +676,7 @@ fujiError_t NetworkProtocolGDRIVE::open_dir_handle()
     }
 
     _dir_item_idx = 0;
+    _include_file_id = (translation_mode == (netProtoTranslation_t)APPLE2_FLAG::IS_A2_WITH_GDRIVE_ID);
     return FUJI_ERROR::NONE;
 }
 
@@ -706,6 +707,10 @@ fujiError_t NetworkProtocolGDRIVE::read_dir_entry(char *buf, unsigned short len)
         is_directory = (mime == GDRIVE_FOLDER_MIME);
         fileSize = size_str.empty() ? 0 : atoi(size_str.c_str());
         mode = 0755;
+
+        if (_include_file_id)
+            entry_id = json_str(entry, "id");
+
         return FUJI_ERROR::NONE;
     }
 

--- a/lib/network-protocol/GDRIVE.cpp
+++ b/lib/network-protocol/GDRIVE.cpp
@@ -676,7 +676,7 @@ fujiError_t NetworkProtocolGDRIVE::open_dir_handle()
     }
 
     _dir_item_idx = 0;
-    _include_file_id = (translation_mode == (netProtoTranslation_t)DIR_ENTRY_FORMAT_FLAG::IS_80COL_WITH_GDRIVE_ID);
+    _include_file_id = (translation_mode == (netProtoTranslation_t)DIR_FORMAT::GDRIVE);
     return FUJI_ERROR::NONE;
 }
 

--- a/lib/network-protocol/GDRIVE.h
+++ b/lib/network-protocol/GDRIVE.h
@@ -67,7 +67,7 @@ private:
     cJSON *_dir_json = nullptr;
     cJSON *_dir_items = nullptr;
     int _dir_item_idx = 0;
-    bool _include_file_id = false; // set when IS_80COL_WITH_GDRIVE_ID aux2 flag requested
+    bool _include_file_id = false; // set when DIR_FORMAT::GDRIVE aux2 flag requested
 
     // Write buffer – data accumulates here until close_file_handle uploads it
     std::vector<uint8_t> _write_buf;

--- a/lib/network-protocol/GDRIVE.h
+++ b/lib/network-protocol/GDRIVE.h
@@ -67,7 +67,7 @@ private:
     cJSON *_dir_json = nullptr;
     cJSON *_dir_items = nullptr;
     int _dir_item_idx = 0;
-    bool _include_file_id = false; // set when IS_A2_WITH_GDRIVE_ID aux2 flag requested
+    bool _include_file_id = false; // set when IS_80COL_WITH_GDRIVE_ID aux2 flag requested
 
     // Write buffer – data accumulates here until close_file_handle uploads it
     std::vector<uint8_t> _write_buf;

--- a/lib/network-protocol/GDRIVE.h
+++ b/lib/network-protocol/GDRIVE.h
@@ -67,6 +67,7 @@ private:
     cJSON *_dir_json = nullptr;
     cJSON *_dir_items = nullptr;
     int _dir_item_idx = 0;
+    bool _include_file_id = false; // set when IS_A2_WITH_GDRIVE_ID aux2 flag requested
 
     // Write buffer – data accumulates here until close_file_handle uploads it
     std::vector<uint8_t> _write_buf;

--- a/lib/utils/utils.cpp
+++ b/lib/utils/utils.cpp
@@ -413,6 +413,41 @@ std::string util_long_entry_apple2_80col(std::string filename, size_t fileSize, 
     return returned_entry;
 }
 
+// CoCo 80-col directory entry with Google Drive file ID embedded in the middle.
+// Format: NAME(25) + SP + ID(33) + SP + SIZE(4-5) = ~65 chars, fits in 80 columns.
+// First token = filename, last token = size — backward-compatible with old parsers.
+// Middle token = Google Drive file ID — new parsers extract it for Drive URL construction.
+std::string util_long_entry_with_gdrive_id(std::string filename, size_t fileSize, bool is_dir, const std::string &file_id)
+{
+    char size_tmp[12];
+
+    if (is_dir)
+        filename += "/";
+
+    // Filename field: exactly 25 chars
+    if (filename.length() > 25)
+        filename = filename.substr(0, 25);
+    while (filename.length() < 25)
+        filename += ' ';
+
+    // File ID field: exactly 33 chars (Google Drive IDs are typically 28-33 chars)
+    std::string id = file_id;
+    if (id.length() > 33)
+        id = id.substr(0, 33);
+    while (id.length() < 33)
+        id += ' ';
+
+    // Size field
+    if (fileSize > 1048576)
+        snprintf(size_tmp, sizeof(size_tmp), "%.1fM", (float)fileSize / 1048576.0f);
+    else if (fileSize > 1024)
+        snprintf(size_tmp, sizeof(size_tmp), "%4uK", (unsigned int)(fileSize >> 10));
+    else
+        snprintf(size_tmp, sizeof(size_tmp), "%4u", (unsigned int)fileSize);
+
+    return filename + ' ' + id + ' ' + std::string(size_tmp);
+}
+
 /* Shortens the source string by splitting it in to shorter halves connected by "..." if it won't fit in the destination buffer.
    Returns number of bytes copied into buffer.
 */

--- a/lib/utils/utils.h
+++ b/lib/utils/utils.h
@@ -59,6 +59,7 @@ std::string util_crunch(std::string filename);
 std::string util_entry(std::string crunched, size_t fileSize, bool is_dir, bool is_locked);
 std::string util_long_entry(std::string filename, size_t fileSize, bool is_dir);
 std::string util_long_entry_apple2_80col(std::string filename, size_t fileSize, bool is_dir);
+std::string util_long_entry_with_gdrive_id(std::string filename, size_t fileSize, bool is_dir, const std::string &file_id);
 int util_ellipsize(const char* src, char *dst, int dstsize);
 std::string util_ellipsize_string(const std::string& src, size_t maxSize);
 bool util_wildcard_match(const char *str, const char *pattern);


### PR DESCRIPTION
This makes it so if you open a Google drive with aux1 = 6 (OPEN_MODE_DIR) and aux2 - 0x82 (OPEN_TRANS_LONG_DIR_WITH_ID), you get a directory listing with the full (long) file name, the Google file ID for the file, and the approximate file size.

The constants need to be added to fujinet-lib and fujinet-lib-experimental headers so we can remember what they do!

There are 0x80 and 0x81 values that do varieties of DIR formats as well. They probably need to be added.
