### PR TITLE
[iwm] Use parameter names in iwm_decoded_cmd_t instead of uint8_t array

### DIFF
--- a/lib/bus/iwm/iwm.cpp
+++ b/lib/bus/iwm/iwm.cpp
@@ -56,7 +56,7 @@ https://www.bigmessowires.com/2015/04/09/more-fun-with-apple-iigs-disks/
 //
 // Description: prints packet data for debug purposes to the serial port
 //*****************************************************************************
-void print_packet(uint8_t *data, int bytes)
+void print_packet(void *data, int bytes)
 {
   // int print_len = bytes;
   // if (print_len > 16) print_len = 16;
@@ -67,12 +67,12 @@ void print_packet(uint8_t *data, int bytes)
   // }
 }
 
-void print_packet(uint8_t *data)
+void print_packet(void *data)
 {
   Debug_printf("\n");
 #ifdef DEV_RELAY_SLIP
-  for (int i = 0; i < COMMAND_LEN; i++)
-    Debug_printf("%02x ", data[i]);
+  for (uint8_t *ptr = (uint8_t*)data, *end = ptr + COMMAND_LEN; ptr < end; ptr++)
+    Debug_printf("%02x ", *ptr);
   Debug_printf("\r\n");
 #else
   // Debug_printf("packet: %s\r\n", mstr::toHex(data, 16).c_str());
@@ -256,7 +256,7 @@ void virtualDevice::send_reply_packet(uint8_t status)
 void virtualDevice::iwm_return_badcmd(iwm_decoded_cmd_t cmd)
 {
   //Handle possible data packet to avoid crash extended and non-extended
-  switch(cmd.command)
+  switch(cmd.sp_command)
   {
     case SP_ECMD_WRITEBLOCK:
     case SP_ECMD_CONTROL:
@@ -266,22 +266,21 @@ void virtualDevice::iwm_return_badcmd(iwm_decoded_cmd_t cmd)
     case SP_CMD_WRITE:
       data_len = 512;
       SYSTEM_BUS.iwm_decode_data_packet((uint8_t *)data_buffer, data_len);
-      Debug_printf("\r\nUnit %02x Bad Command with data packet %02x\r\n", id(), cmd.command);
-      print_packet((uint8_t *)data_buffer, data_len);
+      Debug_printf("\r\nUnit %02x Bad Command with data packet %02x\r\n", id(), cmd.sp_command);
+      print_packet(data_buffer, data_len);
       break;
     default: //just send the response and return like before
       send_reply_packet(SP_ERR_BADCMD);
-      Debug_printf("\r\nUnit %02x Bad Command %02x", id(), cmd.command);
+      Debug_printf("\r\nUnit %02x Bad Command %02x", id(), cmd.sp_command);
       return;
   }
 
-  if(cmd.command == SP_CMD_CONTROL) //Decode command control code
+  if(cmd.sp_command == SP_CMD_CONTROL) //Decode command control code
   {
     send_reply_packet(SP_ERR_BADCTL); //we may be required to accept some control commands
                                       // but for now just report bad control if it's a control
                                       // command
-    uint8_t control_code = get_status_code(cmd);
-    Debug_printf("\r\nbad command was a control command with control code %02x",control_code);
+    Debug_printf("\r\nbad command was a control command with control code %02x",cmd.control_status.fuji.command);
   }
   else
   {
@@ -292,7 +291,7 @@ void virtualDevice::iwm_return_badcmd(iwm_decoded_cmd_t cmd)
 void virtualDevice::iwm_return_device_offline(iwm_decoded_cmd_t cmd)
 {
   //Handle possible data packet to avoid crash extended and non-extended
-  switch(cmd.command)
+  switch(cmd.sp_command)
   {
     case SP_ECMD_WRITEBLOCK:
     case SP_ECMD_CONTROL:
@@ -302,20 +301,19 @@ void virtualDevice::iwm_return_device_offline(iwm_decoded_cmd_t cmd)
     case SP_CMD_WRITE:
       data_len = 512;
       SYSTEM_BUS.iwm_decode_data_packet((uint8_t *)data_buffer, data_len);
-      Debug_printf("\r\nUnit %02x Offline, Command with data packet %02x\r\n", id(), cmd.command);
+      Debug_printf("\r\nUnit %02x Offline, Command with data packet %02x\r\n", id(), cmd.sp_command);
       print_packet((uint8_t *)data_buffer, data_len);
       break;
     default: //just send the response and return like before
       send_reply_packet(SP_ERR_OFFLINE);
-      Debug_printf("\r\nUnit %02x Offline, Command %02x", id(), cmd.command);
+      Debug_printf("\r\nUnit %02x Offline, Command %02x", id(), cmd.sp_command);
       return;
   }
 
-  if(cmd.command == SP_CMD_CONTROL) //Decode command control code
+  if(cmd.sp_command == SP_CMD_CONTROL) //Decode command control code
   {
     send_reply_packet(SP_ERR_OFFLINE);
-    uint8_t control_code = get_status_code(cmd);
-    Debug_printf("\r\nOffline command was a control command with control code %02x",control_code);
+    Debug_printf("\r\nOffline command was a control command with control code %02x",cmd.control_status.fuji.command);
   }
   else
   {
@@ -325,7 +323,7 @@ void virtualDevice::iwm_return_device_offline(iwm_decoded_cmd_t cmd)
 
 void virtualDevice::iwm_return_ioerror()
 {
-  // Debug_printf("\r\nUnit %02x Bad Command %02x", id(), cmd.command);
+  // Debug_printf("\r\nUnit %02x Bad Command %02x", id(), cmd.sp_command);
   send_reply_packet(SP_ERR_IOERROR);
 }
 
@@ -336,7 +334,7 @@ void virtualDevice::iwm_return_noerror()
 
 void virtualDevice::iwm_status(iwm_decoded_cmd_t cmd) // override;
 {
-  uint8_t status_code = cmd.params[2];
+  uint8_t status_code = cmd.control_status.code;
 
   if (status_code == SP_CMD_FORMAT)
   {
@@ -533,9 +531,8 @@ bool IRAM_ATTR systemBus::serviceSmartPort()
 
           _activeDev = devicep;
           // handle command
-          memset(command.decoded, 0, sizeof(command.decoded));
-          smartport.decode_data_packet(command_packet.data, command.decoded);
-          print_packet(command.decoded, 9);
+          smartport.decode_data_packet(command_packet.data, &command);
+          print_packet(&command, sizeof(command));
           _activeDev->process(command);
           break; // we don't need to needlessly keep looping once we find it
         }

--- a/lib/bus/iwm/iwm.h
+++ b/lib/bus/iwm/iwm.h
@@ -142,16 +142,39 @@ enum spCode_t : uint8_t {
   SP_STAT_GET_DISKII_SEEN   = 0x08, // iwmFuji
 };
 
-union iwm_decoded_cmd_t
+struct iwm_decoded_cmd_t
 {
-  struct
-  {
-    uint8_t command;
-    uint8_t count;
-    uint8_t params[7];
+  spCommandID_t sp_command;
+  uint8_t param_count;
+  uint8_t sp_dev_id;
+  uint8_t unknown;
+
+  union {
+    struct {
+      union {
+        spCode_t code;
+        struct {
+          fujiCommandID_t command;
+          uint8_t network_unit;
+        } fuji;
+      };
+    } control_status;
+    struct {
+      u24le_t num;
+    } block_rw;
+    struct {
+      u16le_t length;
+      union {
+        u24le_t address;
+        struct {
+          uint8_t network_unit;
+        } fuji;
+      };
+    } char_rw;
+    // format, init, open, close do not have any parameters
   };
-  uint8_t decoded[9];
-};
+} __attribute__((packed));
+static_assert(sizeof(iwm_decoded_cmd_t) == 9, "iwm_decoded_cmd_t must be 9 bytes");
 
 enum class iwm_smartport_type_t
 {
@@ -190,8 +213,8 @@ struct iwm_device_info_block_t
 };
 
 //#ifdef DEBUG
-  void print_packet(uint8_t *data, int bytes);
-  void print_packet(uint8_t* data);
+void print_packet(void *data, int bytes);
+void print_packet(void *data);
 //#endif
 
 class virtualDevice
@@ -232,10 +255,6 @@ protected:
   virtual void iwm_close(iwm_decoded_cmd_t cmd) {};
   virtual void iwm_read(iwm_decoded_cmd_t cmd) {};
   virtual void iwm_write(iwm_decoded_cmd_t cmd) {};
-
-  uint8_t get_status_code(iwm_decoded_cmd_t cmd) {return cmd.params[2];}
-  uint16_t get_numbytes(iwm_decoded_cmd_t cmd) { return cmd.params[2] + (cmd.params[3] << 8); };
-  uint32_t get_address(iwm_decoded_cmd_t cmd) { return cmd.params[4] + (cmd.params[5] << 8) + (cmd.params[6] << 16); }
 
   void iwm_return_badcmd(iwm_decoded_cmd_t cmd);
   void iwm_return_device_offline(iwm_decoded_cmd_t cmd);

--- a/lib/bus/iwm/iwm_ll.cpp
+++ b/lib/bus/iwm/iwm_ll.cpp
@@ -789,13 +789,14 @@ size_t iwm_sp_ll::decode_data_packet(uint8_t* output_data)
   return decode_data_packet(packet_buffer, output_data);
 }
 
-size_t iwm_sp_ll::decode_data_packet(uint8_t* input_data, uint8_t* output_data)
+size_t iwm_sp_ll::decode_data_packet(uint8_t* input_data, void* output_data)
 {
-  int grpbyte, grpcount;
+  unsigned grpbyte, grpcount;
   uint8_t numgrps, numodd;
   size_t numdata;
   uint8_t bit0to6, bit7;
   uint8_t group_buffer[8];
+  uint8_t *out_ptr = (uint8_t*) output_data;
 
   //Handle arbitrary length packets :)
   numodd = input_data[11] & 0x7f;
@@ -804,8 +805,8 @@ size_t iwm_sp_ll::decode_data_packet(uint8_t* input_data, uint8_t* output_data)
   // Debug_printf("\nDecoding %d bytes",numdata);
 
   // decode oddbyte(s), 1 in a 512 data packet
-  for(int i = 0; i < numodd; i++){
-    output_data[i] = ((input_data[13] << (i+1)) & 0x80) | (input_data[14+i] & 0x7f);
+  for(unsigned i = 0; i < numodd; i++){
+    out_ptr[i] = ((input_data[13] << (i+1)) & 0x80) | (input_data[14+i] & 0x7f);
   }
 
   // decode groups of 7, 73 grps of 7 in a 512 byte packet
@@ -817,7 +818,7 @@ size_t iwm_sp_ll::decode_data_packet(uint8_t* input_data, uint8_t* output_data)
     {
       bit7 = (group_buffer[0] << (grpbyte + 1)) & 0x80;
       bit0to6 = (group_buffer[grpbyte + 1]) & 0x7f;
-      output_data[numodd + (grpcount * 7) + grpbyte] = bit7 | bit0to6;
+      out_ptr[numodd + (grpcount * 7) + grpbyte] = bit7 | bit0to6;
     }
   }
 

--- a/lib/bus/iwm/iwm_ll.h
+++ b/lib/bus/iwm/iwm_ll.h
@@ -242,7 +242,7 @@ public:
   int iwm_read_packet_spi(int packet_len);
   void spi_end();
 
-  size_t decode_data_packet(uint8_t* input_data, uint8_t* output_data); //decode smartport data packet
+  size_t decode_data_packet(uint8_t* input_data, void* output_data); //decode smartport data packet
   size_t decode_data_packet(uint8_t* output_data); //decode smartport data packet
   void encode_packet(uint8_t source, iwm_packet_type_t packet_type, uint8_t status, const uint8_t *data, uint16_t num);
 

--- a/lib/bus/iwm/iwm_slip.cpp
+++ b/lib/bus/iwm/iwm_slip.cpp
@@ -231,11 +231,11 @@ size_t iwm_slip::decode_data_packet(uint8_t *output_data)
 	return payload_size;
 }
 
-size_t iwm_slip::decode_data_packet(uint8_t *input_data, uint8_t *output_data)
+size_t iwm_slip::decode_data_packet(uint8_t *input_data, void *output_data)
 {
 	// Used to create the initial "command" for the request into output_data.
 	// We can ignore the input_data, we already have current_request, which can write the appropriate command data to output_data
-	current_request->create_command(output_data);
+	current_request->create_command((uint8_t *) output_data);
 	return 0; // unused
 }
 

--- a/lib/bus/iwm/iwm_slip.h
+++ b/lib/bus/iwm/iwm_slip.h
@@ -72,7 +72,7 @@ public:
 
 	void encode_packet(uint8_t source, iwm_packet_type_t packet_type, uint8_t status, const uint8_t *data, uint16_t num);
 	size_t decode_data_packet(uint8_t *output_data);
-	size_t decode_data_packet(uint8_t *input_data, uint8_t *output_data);
+	size_t decode_data_packet(uint8_t *input_data, void *output_data);
 
 	// void close_connection(int sock, bool report_error);
 	// bool create_connection(in_addr_t host, int port);

--- a/lib/device/iwm/clock.cpp
+++ b/lib/device/iwm/clock.cpp
@@ -68,17 +68,15 @@ void iwmClock::set_alternate_tz()
 
 void iwmClock::iwm_ctrl(iwm_decoded_cmd_t cmd)
 {
-    uint8_t control_code = get_status_code(cmd);
 #ifdef DEBUG
-    auto as_char = (char) control_code;
-    Debug_printf("[CLOCK] Device %02x Control Code %02x('%c')\r\n", id(), control_code, isprint(as_char) ? as_char : '.');
+    Debug_printf("[CLOCK] Device %02x Control Code %02x('%c')\r\n", id(), cmd.control_status.fuji.command, isprint(cmd.control_status.fuji.command) ? (char) cmd.control_status.fuji.command : '.');
 #endif
 
     SYSTEM_BUS.iwm_decode_data_packet((uint8_t *)data_buffer, data_len);
 
     uint8_t err_result = SP_ERR_NOERROR;
 
-    switch (control_code)
+    switch (cmd.control_status.fuji.command)
     {
         case APETIMECMD_SETTZ_ALT2:
             set_tz();
@@ -96,14 +94,13 @@ void iwmClock::iwm_ctrl(iwm_decoded_cmd_t cmd)
 
 void iwmClock::iwm_status(iwm_decoded_cmd_t cmd)
 {
-    uint8_t status_code = get_status_code(cmd);
     bool use_alternate_tz = false;
 
 #ifdef DEBUG
-    auto as_char = (char) status_code;
-    Debug_printf("[CLOCK] Device %02x Status Code %02x('%c')\r\n", id(), status_code, isprint(as_char) ? as_char : '.');
+    Debug_printf("[CLOCK] Device %02x Status Code %02x('%c')\r\n", id(), cmd.control_status.fuji.command, isprint(cmd.control_status.fuji.command) ? (char)cmd.control_status.fuji.command : '.');
 #endif
-    switch (status_code)
+    // FIXME - enums have been mixed&matched, having to cast to int
+    switch (static_cast<int>(cmd.control_status.fuji.command))
     {
     case SP_STAT_DEVICE: // 0x00
         send_status_reply_packet();
@@ -117,7 +114,7 @@ void iwmClock::iwm_status(iwm_decoded_cmd_t cmd)
     // Uppercase = use FN tz, otherwise use alt tz
     case APETIMECMD_SETTZ_ALT2:
     case APETIMECMD_SETTZ_ALT: {
-        use_alternate_tz = status_code == APETIMECMD_SETTZ_ALT;
+        use_alternate_tz = cmd.control_status.fuji.command == APETIMECMD_SETTZ_ALT;
         // Date and time, easy to be used by general programs
         auto simpleTime = Clock::get_current_time_simple(Clock::tz_to_use(use_alternate_tz, alternate_tz, Config.get_general_timezone()));
         std::copy(simpleTime.begin(), simpleTime.end(), data_buffer);
@@ -132,7 +129,7 @@ void iwmClock::iwm_status(iwm_decoded_cmd_t cmd)
     }
     case APETIMECMD_GET_PRODOS:
     case APETIMECMD_GET_PRODOS_ALT: {
-        use_alternate_tz = status_code == APETIMECMD_GET_PRODOS_ALT;
+        use_alternate_tz = cmd.control_status.fuji.command == APETIMECMD_GET_PRODOS_ALT;
         // Date and time, to be used by a ProDOS driver
         auto prodosTime = Clock::get_current_time_prodos(Clock::tz_to_use(use_alternate_tz, alternate_tz, Config.get_general_timezone()));
         std::copy(prodosTime.begin(), prodosTime.end(), data_buffer);
@@ -141,7 +138,7 @@ void iwmClock::iwm_status(iwm_decoded_cmd_t cmd)
     }
     case APETIMECMD_GET_SOS:
     case APETIMECMD_GET_SOS_ALT: {
-        use_alternate_tz = status_code == APETIMECMD_GET_SOS_ALT;
+        use_alternate_tz = cmd.control_status.fuji.command == APETIMECMD_GET_SOS_ALT;
         // Date and time, ASCII string in Apple /// SOS format: YYYYMMDD0HHMMSS000
         std::string sosTime = Clock::get_current_time_sos(Clock::tz_to_use(use_alternate_tz, alternate_tz, Config.get_general_timezone()));
         std::copy(sosTime.begin(), sosTime.end(), data_buffer);
@@ -151,7 +148,7 @@ void iwmClock::iwm_status(iwm_decoded_cmd_t cmd)
     }
     case APETIMECMD_GET_ISO_LOCAL:
     case APETIMECMD_GET_ISO_LOCAL_ALT: {
-        use_alternate_tz = status_code == APETIMECMD_GET_ISO_LOCAL_ALT;
+        use_alternate_tz = cmd.control_status.fuji.command == APETIMECMD_GET_ISO_LOCAL_ALT;
         // Date and time, ASCII string in ISO format
         std::string utcTime = Clock::get_current_time_iso(Clock::tz_to_use(use_alternate_tz, alternate_tz, Config.get_general_timezone()));
         std::copy(utcTime.begin(), utcTime.end(), data_buffer);
@@ -161,7 +158,7 @@ void iwmClock::iwm_status(iwm_decoded_cmd_t cmd)
     }
     case APETIMECMD_GET_ISO_UTC:
     case APETIMECMD_GET_ISO_UTC_ALT: {
-        use_alternate_tz = status_code == APETIMECMD_GET_ISO_UTC_ALT;
+        use_alternate_tz = cmd.control_status.fuji.command == APETIMECMD_GET_ISO_UTC_ALT;
         // utc (zulu)
         std::string isoTime = Clock::get_current_time_iso("UTC+0");
         std::copy(isoTime.begin(), isoTime.end(), data_buffer);
@@ -171,7 +168,7 @@ void iwmClock::iwm_status(iwm_decoded_cmd_t cmd)
     }
     case APETIMECMD_GET_ATARI:
     case APETIMECMD_GET_ATARI_ALT: {
-        use_alternate_tz = status_code == APETIMECMD_GET_ATARI_ALT;
+        use_alternate_tz = cmd.control_status.fuji.command == APETIMECMD_GET_ATARI_ALT;
         // Apetime (Atari, but why not eh?) with TZ
         auto apeTime = Clock::get_current_time_apetime(Clock::tz_to_use(use_alternate_tz, alternate_tz, Config.get_general_timezone()));
         std::copy(apeTime.begin(), apeTime.end(), data_buffer);
@@ -211,7 +208,7 @@ void iwmClock::iwm_close(iwm_decoded_cmd_t cmd)
 void iwmClock::process(iwm_decoded_cmd_t cmd)
 {
     fnLedManager.set(LED_BUS, true);
-    switch (cmd.command)
+    switch (cmd.sp_command)
     {
     case SP_CMD_STATUS:
         Debug_printf("\r\nclock: handling status command\r\n");

--- a/lib/device/iwm/cpm.cpp
+++ b/lib/device/iwm/cpm.cpp
@@ -121,11 +121,11 @@ void iwmCPM::iwm_status(iwm_decoded_cmd_t cmd)
 {
     unsigned short mw;
     // uint8_t source = cmd.dest;                                                // we are the destination and will become the source // packet_buffer[6];
-    uint8_t status_code = get_status_code(cmd); // (cmd.g7byte3 & 0x7f) | ((cmd.grp7msb << 3) & 0x80); // status codes 00-FF
-    Debug_printf("\r\n[CPM] Device %02x Status Code %02x\r\n", id(), status_code);
+    Debug_printf("\r\n[CPM] Device %02x Status Code %02x\r\n", id(), cmd.control_status.fuji.command);
     // Debug_printf("\r\nStatus List is at %02x %02x\n", cmd.g7byte1 & 0x7f, cmd.g7byte2 & 0x7f);
 
-    switch (status_code)
+    // FIXME - enums have been mixed&matched, having to cast to int
+    switch (static_cast<int>(cmd.control_status.code))
     {
     case SP_STAT_DEVICE: // 0x00
         send_status_reply_packet();
@@ -157,6 +157,9 @@ void iwmCPM::iwm_status(iwm_decoded_cmd_t cmd)
         data_len = 1;
         Debug_printf("CPM Task Running? %d %s", data_buffer[0],(data_buffer[0]) ? "=No" : "=Yes");
         break;
+    default:
+        send_reply_packet(SP_ERR_BADCMD);
+        return;
     }
 
     Debug_printf("\r\nStatus code complete, sending response");
@@ -165,27 +168,25 @@ void iwmCPM::iwm_status(iwm_decoded_cmd_t cmd)
 
 void iwmCPM::iwm_read(iwm_decoded_cmd_t cmd)
 {
-    uint16_t numbytes = get_numbytes(cmd); // cmd.g7byte3 & 0x7f) | ((cmd.grp7msb << 3) & 0x80);
-    uint32_t addy = get_address(cmd);      // (cmd.g7byte5 & 0x7f) | ((cmd.grp7msb << 5) & 0x80);
 #ifdef ESP_PLATFORM // OS
     unsigned short mw = uxQueueMessagesWaiting(rxq);
 #else
     unsigned short mw;
 #endif
 
-    Debug_printf("\r\nDevice %02x READ %04x bytes from address %06lx\n", id(), numbytes, addy);
+    Debug_printf("\r\nDevice %02x READ %04x bytes from address %06lx\n", id(), cmd.char_rw.length, cmd.char_rw.address);
 
     memset(data_buffer, 0, sizeof(data_buffer));
 
     if (mw) // check if we really have some bytes waiting
     {
-        if (mw < numbytes) //if there are less than requested, just send what we have
+        if (mw < cmd.char_rw.length) //if there are less than requested, just send what we have
         {
-            numbytes = mw;
+            cmd.char_rw.length = mw;
         }
 
         data_len = 0;
-        for (int i = 0; i < numbytes; i++)
+        for (int i = 0; i < cmd.char_rw.length; i++)
         {
             char b;
 #ifdef ESP_PLATFORM // OS
@@ -208,14 +209,12 @@ void iwmCPM::iwm_read(iwm_decoded_cmd_t cmd)
 
 void iwmCPM::iwm_write(iwm_decoded_cmd_t cmd)
 {
-    uint16_t num_bytes = get_numbytes(cmd); // (cmd.g7byte3 & 0x7f) | ((cmd.grp7msb << 3) & 0x80);
-
-    Debug_printf("\nWRITE %u bytes\n", num_bytes);
+    Debug_printf("\nWRITE %u bytes\n", cmd.char_rw.length);
 
     // get write data packet, keep trying until no timeout
     //  to do - this blows up - check handshaking
 
-    data_len = num_bytes;
+    data_len = cmd.char_rw.length;
     SYSTEM_BUS.iwm_decode_data_packet(data_buffer, data_len); // write data packet now read in ISR
     // if (SYSTEM_BUS.iwm_decode_data_packet(data_buffer, data_len))
     // {
@@ -226,7 +225,7 @@ void iwmCPM::iwm_write(iwm_decoded_cmd_t cmd)
     {
         // DO write
 #ifdef ESP_PLATFORM // OS
-        for (int i = 0; i < num_bytes; i++)
+        for (int i = 0; i < cmd.char_rw.length; i++)
             xQueueSend(txq, &data_buffer[i], portMAX_DELAY);
 #endif
     }
@@ -239,8 +238,7 @@ void iwmCPM::iwm_ctrl(iwm_decoded_cmd_t cmd)
     uint8_t err_result = SP_ERR_NOERROR;
 
     // uint8_t source = cmd.dest;                                                 // we are the destination and will become the source // data_buffer[6];
-    uint8_t control_code = get_status_code(cmd); // (cmd.g7byte3 & 0x7f) | ((cmd.grp7msb << 3) & 0x80); // ctrl codes 00-FF
-    Debug_printf("\r\nCPM Device %02x Control Code %02x", id(), control_code);
+    Debug_printf("\r\nCPM Device %02x Control Code %02x", id(), cmd.control_status.fuji.command);
     // Debug_printf("\r\nControl List is at %02x %02x", cmd.g7byte1 & 0x7f, cmd.g7byte2 & 0x7f);
     data_len = 512;
     SYSTEM_BUS.iwm_decode_data_packet(data_buffer, data_len);
@@ -248,7 +246,7 @@ void iwmCPM::iwm_ctrl(iwm_decoded_cmd_t cmd)
     print_packet(data_buffer);
 
     if (data_len > 0)
-        switch (control_code)
+        switch (cmd.control_status.fuji.command)
         {
         case 'B': // Boot
 #ifdef ESP_PLATFORM // OS
@@ -270,6 +268,9 @@ void iwmCPM::iwm_ctrl(iwm_decoded_cmd_t cmd)
 #endif
             }
             break;
+        default:
+            send_reply_packet(SP_ERR_BADCMD);
+            return;
         }
     else
         err_result = SP_ERR_IOERROR;
@@ -286,7 +287,7 @@ void iwmCPM::process(iwm_decoded_cmd_t cmd)
         return;
     }
 
-    switch (cmd.command)
+    switch (cmd.sp_command)
     {
     case SP_CMD_STATUS:
         Debug_printf("\r\nhandling status command");

--- a/lib/device/iwm/disk.cpp
+++ b/lib/device/iwm/disk.cpp
@@ -213,16 +213,12 @@ void iwmDisk::send_extended_status_dib_reply_packet() //XXX! currently unused
 void iwmDisk::iwm_ctrl(iwm_decoded_cmd_t cmd)
 {
   err_result = SP_ERR_NOERROR;
-  uint8_t control_code = get_status_code(cmd);
-  Debug_printf("\nDisk Device %02x Control Code %02x", id(), control_code);
-  // already called by ISR
-  data_len = 512;
+  Debug_printf("\nDisk Device %02x Control Code %02x", id(), cmd.control_status.fuji.command);
   Debug_printf("\nDecoding Control Data Packet:");
   SYSTEM_BUS.iwm_decode_data_packet((uint8_t *)data_buffer, data_len);
-  // data_len = decode_packet((uint8_t *)data_buffer);
   print_packet((uint8_t *)data_buffer, data_len);
 
-  switch (control_code)
+  switch (cmd.control_status.code)
   {
   case SP_CTRL_EJECT:
     Debug_printf("Handling Eject command\r\n");
@@ -239,15 +235,13 @@ void iwmDisk::iwm_ctrl(iwm_decoded_cmd_t cmd)
 
 void iwmDisk::process(iwm_decoded_cmd_t cmd)
 {
-  uint8_t status_code;
   fnLedManager.set(LED_BUS, true);
-  switch (cmd.command)
+  switch (cmd.sp_command)
   {
   case SP_CMD_STATUS:
     Debug_printf("\r\nhandling status command");
-    status_code = get_status_code(cmd); // (cmd.g7byte3 & 0x7f) | ((cmd.grp7msb << 3) & 0x00); // status codes 00-FF
     // max regular status code is 0x05 to UniDisk
-    if (disk_num == '0' && status_code > 0x05) {
+    if (disk_num == '0' && cmd.control_status.fuji.command > 0x05) {
       // THIS IS AN OLD HACK FOR CALLING STATUS ON THE FUJI DEVICE INSTEAD OF ADDING THE_FUJI AS A DEVICE.
       Debug_printf("\r\nUsing DISK_0 for FUJI device\r\n");
       platformFuji.FujiStatus(cmd);
@@ -268,9 +262,8 @@ void iwmDisk::process(iwm_decoded_cmd_t cmd)
     iwm_return_noerror();
     break;
   case SP_CMD_CONTROL:
-    status_code = get_status_code(cmd); // (cmd.g7byte3 & 0x7f) | ((cmd.grp7msb << 3) & 0x80); // status codes 00-FF
     // max regular control code is 0x0A to 3.5" disk
-    if (disk_num == '0' && status_code > 0x0A) {
+    if (disk_num == '0' && cmd.control_status.fuji.command > 0x0A) {
       // THIS IS AN OLD HACK FOR CALLING CONTROL ON THE FUJI DEVICE INSTEAD OF ADDING THE_FUJI AS A DEVICE.
       Debug_printf("\r\nUsing DISK_0 for FUJI device\r\n");
       platformFuji.FujiControl(cmd);
@@ -287,15 +280,11 @@ void iwmDisk::process(iwm_decoded_cmd_t cmd)
 
 void iwmDisk::iwm_readblock(iwm_decoded_cmd_t cmd)
 {
-  uint32_t block_num;
   uint16_t sdstato;
 
   Debug_printf("\r\nDrive %02x ", id());
 
-
-
-  block_num = get_block_number(cmd);
-  Debug_printf(" Read block %06lx\r\n", block_num);
+  Debug_printf(" Read block %06lx\r\n", cmd.block_rw.num);
   if (!(_disk != nullptr))
   {
     Debug_printf(" - ERROR - No image mounted");
@@ -307,7 +296,7 @@ void iwmDisk::iwm_readblock(iwm_decoded_cmd_t cmd)
     send_reply_packet(SP_ERR_OFFLINE);
     return;
   }
-  if((switched) && (block_num > 2)){
+  if((switched) && (cmd.block_rw.num > 2)){
     Debug_printf("iwm_readblock() returning disk switched error\r\n");
     send_reply_packet(SP_ERR_OFFLINE);
     switched = false;
@@ -317,7 +306,7 @@ void iwmDisk::iwm_readblock(iwm_decoded_cmd_t cmd)
   switched = false; //if we made it here it's ok to reset switched
 
   sdstato = BLOCK_DATA_LEN;
-  if (_disk->read(block_num, &sdstato, data_buffer))
+  if (_disk->read(cmd.block_rw.num, &sdstato, data_buffer))
   {
     Debug_printf("\r\nFile Seek or Read err: %d bytes", sdstato);
     send_reply_packet(SP_ERR_IOERROR);
@@ -336,9 +325,7 @@ void iwmDisk::iwm_writeblock(iwm_decoded_cmd_t cmd)
 
 
   Debug_printf("\r\nDrive %02x ", id());
-  uint32_t block_num = get_block_number(cmd); // (cmd.g7byte3 & 0x7f) | (((unsigned short)cmd.grp7msb << 3) & 0x80);
-  Debug_printf("Write block %06lx", block_num);
-  data_len = BLOCK_DATA_LEN;
+  Debug_printf("Write block %06lx", cmd.block_rw.num);
   if (SYSTEM_BUS.iwm_decode_data_packet((unsigned char *)data_buffer, data_len))
   {
     Debug_printf("\r\nTIMEOUT in read packet!");
@@ -374,7 +361,7 @@ void iwmDisk::iwm_writeblock(iwm_decoded_cmd_t cmd)
       }
 
       uint16_t sdstato = BLOCK_DATA_LEN;
-      _disk->write(block_num, &sdstato, data_buffer);
+      _disk->write(cmd.block_rw.num, &sdstato, data_buffer);
 
       if (sdstato != BLOCK_DATA_LEN)
       {

--- a/lib/device/iwm/disk.h
+++ b/lib/device/iwm/disk.h
@@ -35,7 +35,6 @@ protected:
     void iwm_ctrl(iwm_decoded_cmd_t cmd) override;
     void iwm_readblock(iwm_decoded_cmd_t cmd) override;
     void iwm_writeblock(iwm_decoded_cmd_t cmd) override;
-    uint32_t get_block_number(iwm_decoded_cmd_t cmd) {return cmd.params[2] + (cmd.params[3] << 8) + (cmd.params[4] << 16); };
 
     // void derive_percom_block(uint16_t numSectors);
     // void iwm_read_percom_block();

--- a/lib/device/iwm/iwmFuji.cpp
+++ b/lib/device/iwm/iwmFuji.cpp
@@ -108,16 +108,16 @@ iwmFuji::iwmFuji() : fujiDevice(MAX_A2DISK_DEVICES, IMAGE_EXTENSION, LOBBY_URL)
         { FUJICMD_GET_ADAPTERCONFIG_EXTENDED, [this]() { this->fujicmd_get_adapter_config_extended(); }},      // 0xC4
         { FUJICMD_GET_ADAPTERCONFIG, [this]()          { this->fujicmd_get_adapter_config(); }},               // 0xE8
         { FUJICMD_GET_DEVICE_FULLPATH, [this]()        { this->fujicmd_get_device_filename(data_buffer[0]); }},   // 0xDA
-        { FUJICMD_GET_DEVICE1_FULLPATH, [this]()       { this->fujicmd_get_device_filename(status_code - 160); }},   // 0xA0
-        { FUJICMD_GET_DEVICE2_FULLPATH, [this]()       { this->fujicmd_get_device_filename(status_code - 160); }},   // 0xA1
-        { FUJICMD_GET_DEVICE3_FULLPATH, [this]()       { this->fujicmd_get_device_filename(status_code - 160); }},   // 0xA2
-        { FUJICMD_GET_DEVICE4_FULLPATH, [this]()       { this->fujicmd_get_device_filename(status_code - 160); }},   // 0xA3
-        { FUJICMD_GET_DEVICE5_FULLPATH, [this]()       { this->fujicmd_get_device_filename(status_code - 160); }},   // 0xA4
-        { FUJICMD_GET_DEVICE6_FULLPATH, [this]()       { this->fujicmd_get_device_filename(status_code - 160); }},   // 0xA5
-        { FUJICMD_GET_DEVICE7_FULLPATH, [this]()       { this->fujicmd_get_device_filename(status_code - 160); }},   // 0xA6
-        { FUJICMD_GET_DEVICE8_FULLPATH, [this]()       { this->fujicmd_get_device_filename(status_code - 160); }},   // 0xA7
-        { FUJICMD_GET_DEVICE9_FULLPATH, [this]()       { this->fujicmd_get_device_filename(status_code - 160); }},   // 0xA8
-        { FUJICMD_GET_DEVICE10_FULLPATH, [this]()      { this->fujicmd_get_device_filename(status_code - 160); }},   // 0xA9
+        { FUJICMD_GET_DEVICE1_FULLPATH, [this]()       { this->fujicmd_get_device_filename(active_fuji_command - 160); }},   // 0xA0
+        { FUJICMD_GET_DEVICE2_FULLPATH, [this]()       { this->fujicmd_get_device_filename(active_fuji_command - 160); }},   // 0xA1
+        { FUJICMD_GET_DEVICE3_FULLPATH, [this]()       { this->fujicmd_get_device_filename(active_fuji_command - 160); }},   // 0xA2
+        { FUJICMD_GET_DEVICE4_FULLPATH, [this]()       { this->fujicmd_get_device_filename(active_fuji_command - 160); }},   // 0xA3
+        { FUJICMD_GET_DEVICE5_FULLPATH, [this]()       { this->fujicmd_get_device_filename(active_fuji_command - 160); }},   // 0xA4
+        { FUJICMD_GET_DEVICE6_FULLPATH, [this]()       { this->fujicmd_get_device_filename(active_fuji_command - 160); }},   // 0xA5
+        { FUJICMD_GET_DEVICE7_FULLPATH, [this]()       { this->fujicmd_get_device_filename(active_fuji_command - 160); }},   // 0xA6
+        { FUJICMD_GET_DEVICE8_FULLPATH, [this]()       { this->fujicmd_get_device_filename(active_fuji_command - 160); }},   // 0xA7
+        { FUJICMD_GET_DEVICE9_FULLPATH, [this]()       { this->fujicmd_get_device_filename(active_fuji_command - 160); }},   // 0xA8
+        { FUJICMD_GET_DEVICE10_FULLPATH, [this]()      { this->fujicmd_get_device_filename(active_fuji_command - 160); }},   // 0xA9
         { FUJICMD_GET_DIRECTORY_POSITION, [this]()     { this->fujicmd_get_directory_position(); }},           // 0xE5
         { FUJICMD_GET_HOST_PREFIX, [this]()            { }},                  // 0xE0
         { FUJICMD_GET_SCAN_RESULT, [this]()            { }},                  // 0xFC
@@ -336,16 +336,16 @@ void iwmFuji::iwm_read(iwm_decoded_cmd_t cmd) {}
 
 void iwmFuji::iwm_status(iwm_decoded_cmd_t cmd)
 {
-        status_code = get_status_code(cmd);
         status_completed = false;
+        active_fuji_command = cmd.control_status.fuji.command;
 
-        Debug_printf("\r\n[Fuji] Device %02x Status Code %02x\r\n", id(), status_code);
+        Debug_printf("\r\n[Fuji] Device %02x Status Code %02x\r\n", id(), active_fuji_command);
 
-        auto it = status_handlers.find(status_code);
+        auto it = status_handlers.find(active_fuji_command);
     if (it != status_handlers.end()) {
         it->second();
     } else {
-                Debug_printf("ERROR: Unhandled status code: %02X\n", status_code);
+                Debug_printf("ERROR: Unhandled status code: %02X\n", active_fuji_command);
                 data_len = 0;
     }
 
@@ -357,21 +357,20 @@ void iwmFuji::iwm_status(iwm_decoded_cmd_t cmd)
 
 void iwmFuji::iwm_ctrl(iwm_decoded_cmd_t cmd)
 {
-        uint8_t control_code = get_status_code(cmd);
-        Debug_printf("\ntheFuji Device %02x Control Code %02x", id(), control_code);
+        Debug_printf("\ntheFuji Device %02x Control Code %02x", id(), cmd.control_status.fuji.command);
 
         err_result = SP_ERR_NOERROR;
         data_len = 512;
 
-        Debug_printf("\nDecoding Control Data Packet for code: 0x%02x\r\n", control_code);
+        Debug_printf("\nDecoding Control Data Packet for code: 0x%02x\r\n", cmd.control_status.fuji.command);
         SYSTEM_BUS.iwm_decode_data_packet((uint8_t *)data_buffer, data_len);
         print_packet((uint8_t *)data_buffer, data_len);
 
-        auto it = control_handlers.find(control_code);
+        auto it = control_handlers.find(cmd.control_status.fuji.command);
     if (it != control_handlers.end()) {
         it->second();
     } else {
-                Debug_printf("ERROR: Unhandled control code: %02X\n", control_code);
+                Debug_printf("ERROR: Unhandled control code: %02X\n", cmd.control_status.fuji.command);
         err_result = SP_ERR_BADCTL;
     }
 
@@ -383,12 +382,12 @@ void iwmFuji::process(iwm_decoded_cmd_t cmd)
 {
         fnLedManager.set(LED_BUS, true);
 
-    auto it = command_handlers.find(cmd.command);
-        // Debug_printf("\r\n----- iwmFuji::process handling command: %02X\r\n", cmd.command);
+    auto it = command_handlers.find(cmd.sp_command);
+        // Debug_printf("\r\n----- iwmFuji::process handling command: %02X\r\n", cmd.sp_command);
     if (it != command_handlers.end()) {
         it->second(cmd);
     } else {
-        Debug_printv("\r\nUnknown command: %02x\r\n", cmd.command);
+        Debug_printv("\r\nUnknown command: %02x\r\n", cmd.sp_command);
                 iwm_return_badcmd(cmd);
     }
 

--- a/lib/device/iwm/iwmFuji.h
+++ b/lib/device/iwm/iwmFuji.h
@@ -118,7 +118,7 @@ protected:
 public:
     uint8_t err_result = SP_ERR_NOERROR;
     bool status_completed = false;
-    uint8_t status_code;
+    fujiCommandID_t active_fuji_command;
 
     iwmFuji();
     void setup() override;

--- a/lib/device/iwm/modem.cpp
+++ b/lib/device/iwm/modem.cpp
@@ -1394,20 +1394,20 @@ void iwmModem::iwm_close(iwm_decoded_cmd_t cmd)
 
 void iwmModem::iwm_read(iwm_decoded_cmd_t cmd)
 {
-    uint16_t numbytes = get_numbytes(cmd); // cmd.g7byte3 & 0x7f) | ((cmd.grp7msb << 3) & 0x80);
-    uint32_t addy = get_address(cmd);      // (cmd.g7byte5 & 0x7f) | ((cmd.grp7msb << 5) & 0x80);
 #ifdef ESP_PLATFORM // OS
     unsigned short mw = uxQueueMessagesWaiting(mrxq);
 #else
     unsigned short mw;
 #endif
 
-    Debug_printf("\r\nDevice %02x READ %04x bytes from address %06lx\n", id(), numbytes, addy);
+    Debug_printf("\r\nDevice %02x READ %04x bytes from address %06lx\n", id(), cmd.char_rw.length, cmd.char_rw.address);
 
     memset(data_buffer, 0, sizeof(data_buffer));
 
     if (mw) // check if we really have some bytes waiting
     {
+        size_t numbytes = cmd.char_rw.length;
+
         if (mw < numbytes) //if there are less than requested, just send what we have
         {
             numbytes = mw;  
@@ -1437,20 +1437,17 @@ void iwmModem::iwm_read(iwm_decoded_cmd_t cmd)
 
 void iwmModem::iwm_write(iwm_decoded_cmd_t cmd)
 {
-    uint16_t num_bytes = get_numbytes(cmd); // (cmd.g7byte3 & 0x7f) | ((cmd.grp7msb << 3) & 0x80);
-
-    Debug_printf("\nWRITE %u bytes\n", num_bytes);
+    Debug_printf("\nWRITE %u bytes\n", cmd.char_rw.length);
 
     // get write data packet, keep trying until no timeout
     //  to do - this blows up - check handshaking
 
-    data_len = num_bytes;
     SYSTEM_BUS.iwm_decode_data_packet(data_buffer, data_len);
 
     {
         // DO write
 #ifdef ESP_PLATFORM // OS
-        for (int i = 0; i < num_bytes; i++)
+        for (int i = 0; i < cmd.char_rw.length; i++)
             xQueueSend(mtxq, &data_buffer[i], portMAX_DELAY);
 #endif
     }
@@ -1462,9 +1459,7 @@ void iwmModem::iwm_ctrl(iwm_decoded_cmd_t cmd)
 {
     uint8_t err_result = SP_ERR_NOERROR;
 
-    uint8_t control_code = get_status_code(cmd); // (cmd.g7byte3 & 0x7f) | ((cmd.grp7msb << 3) & 0x80); // ctrl codes 00-FF
-    Debug_printf("\r\nModem Device %02x Control Code %02x", id(), control_code);
-    data_len = 512;
+    Debug_printf("\r\nModem Device %02x Control Code %02x", id(), cmd.control_status.fuji.command);
     SYSTEM_BUS.iwm_decode_data_packet(data_buffer, data_len);
     print_packet(data_buffer,data_len);
 
@@ -1499,11 +1494,11 @@ void iwmModem::iwm_modem_status()
 void iwmModem::iwm_status(iwm_decoded_cmd_t cmd)
 {
     // uint8_t source = cmd.dest;                                                // we are the destination and will become the source // packet_buffer[6];
-    uint8_t status_code = get_status_code(cmd); // (cmd.g7byte3 & 0x7f) | ((cmd.grp7msb << 3) & 0x80); // status codes 00-FF
-    Debug_printf("\r\n[MODEM] Device %02x Status Code %02x\r\n", id(), status_code);
+    Debug_printf("\r\n[MODEM] Device %02x Status Code %02x\r\n", id(), cmd.control_status.fuji.command);
     // Debug_printf("\r\nStatus List is at %02x %02x\n", cmd.g7byte1 & 0x7f, cmd.g7byte2 & 0x7f);
 
-    switch (status_code)
+    // FIXME - enums have been mixed&matched, having to cast to int
+    switch (static_cast<int>(cmd.control_status.code))
     {
     case SP_STAT_DEVICE: // 0x00
         send_status_reply_packet();
@@ -1513,9 +1508,12 @@ void iwmModem::iwm_status(iwm_decoded_cmd_t cmd)
         send_status_dib_reply_packet();
         return;
         break;
-    case 'S': // Status
+    case MODEMCMD_STATUS:
         iwm_modem_status();
         break;
+    default:
+        send_reply_packet(SP_ERR_BADCMD);
+        return;
     }
 
     Debug_printf("\r\nStatus code complete, sending response");
@@ -1524,7 +1522,7 @@ void iwmModem::iwm_status(iwm_decoded_cmd_t cmd)
 
 void iwmModem::process(iwm_decoded_cmd_t cmd)
 {
-    switch (cmd.command)
+    switch (cmd.sp_command)
     {
     case SP_CMD_STATUS:
         Debug_printf("\r\nhandling status command");

--- a/lib/device/iwm/network.cpp
+++ b/lib/device/iwm/network.cpp
@@ -335,24 +335,20 @@ void iwmNetwork::status()
 
 void iwmNetwork::iwm_status(iwm_decoded_cmd_t cmd)
 {
-    uint8_t status_code = get_status_code(cmd); //(cmd.g7byte3 & 0x7f) | ((cmd.grp7msb << 3) & 0x80); // status codes 00-FF
-
     // TODO: remove this in the future when we decide to drop support of the deprecated fujinet-lib (with unit-id support)
     // We have moved to a separate control command that sets the active channel for all subsequent commands
     // fujinet-lib (with unit-id support) sends the count of bytes for a status as 4 to cater for the network unit.
     // Older code sends 3 as the count, so we can detect if the network unit byte is there or not.
-    if (cmd.count == 4) {
-        current_network_unit = cmd.params[3];
+    if (cmd.param_count == 4) {
+        current_network_unit = cmd.control_status.fuji.network_unit;
     }
 
 #ifdef DEBUG
-    char as_char = (char) status_code;
-    Debug_printf("\r\n[NETWORK] Device %02x Status Code %02x('%c') net_unit %02x\r\n", id(), status_code, isprint(as_char) ? as_char : '.', current_network_unit);
+    Debug_printf("\r\n[NETWORK] Device %02x Status Code %02x('%c') net_unit %02x\r\n", id(), cmd.control_status.fuji.command, isprint(cmd.control_status.fuji.command) ? (char) cmd.control_status.fuji.command : '.', current_network_unit);
 #endif
 
-    // auto& current_network_data = network_data_map[current_network_unit];
-
-    switch (status_code)
+    // FIXME - enums have been mixed&matched, having to cast to int
+    switch (static_cast<int>(cmd.control_status.fuji.command))
     {
     case SP_STAT_DEVICE: // 0x00
         send_status_reply_packet();
@@ -373,6 +369,9 @@ void iwmNetwork::iwm_status(iwm_decoded_cmd_t cmd)
     case NETCMD_STATUS:
         status();
         break;
+    default:
+        send_reply_packet(SP_ERR_BADCMD);
+        return;
     }
 
     Debug_printf("\r\nStatus code complete, sending response");
@@ -469,18 +468,17 @@ bool iwmNetwork::write_channel(unsigned short num_bytes)
 void iwmNetwork::iwm_read(iwm_decoded_cmd_t cmd)
 {
     bool error = false;
-    uint16_t numbytes = get_numbytes(cmd);
 
     // TODO: remove this in the future when we decide to drop support of the deprecated fujinet-lib (with unit-id support)
     // We have moved to a separate control command that sets the active channel for all subsequent commands
     // fujinet-lib (with unit-id support) sends the count of bytes for a read as 5 to cater for the network unit.
     // Older code sends 4 as the count, so we can detect if the network unit byte is there or not.
-    if (cmd.count == 5) {
+    if (cmd.param_count == 5) {
         // in a network device, there is no "address" value, this is hijacked by fujinet-lib to pass the network unit in first byte
-        current_network_unit = cmd.params[4];
+        current_network_unit = cmd.char_rw.fuji.network_unit;
     }
 
-    Debug_printf("\r\nDevice %02x Read %04x bytes, net_unit %02x\n", id(), numbytes, current_network_unit);
+    Debug_printf("\r\nDevice %02x Read %04x bytes, net_unit %02x\n", id(), cmd.char_rw.length, current_network_unit);
 
     auto& current_network_data = network_data_map[current_network_unit];
 
@@ -490,10 +488,10 @@ void iwmNetwork::iwm_read(iwm_decoded_cmd_t cmd)
     switch (current_network_data.channelMode)
     {
     case CHANNEL_MODE::PROTOCOL:
-        error = read_channel(numbytes, cmd);
+        error = read_channel(cmd.char_rw.length, cmd);
         break;
     case CHANNEL_MODE::JSON:
-        error = read_channel_json(numbytes, cmd);
+        error = read_channel_json(cmd.char_rw.length, cmd);
         break;
     }
 
@@ -520,18 +518,16 @@ void iwmNetwork::net_write()
 
 void iwmNetwork::iwm_write(iwm_decoded_cmd_t cmd)
 {
-    uint16_t num_bytes = get_numbytes(cmd);
-
     // TODO: remove this in the future when we decide to drop support of the deprecated fujinet-lib (with unit-id support)
     // We have moved to a separate control command that sets the active channel for all subsequent commands
     // fujinet-lib (with unit-id support) sends the count of bytes for a write as 5 to cater for the network unit.
     // Older code sends 4 as the count, so we can detect if the network unit byte is there or not.
-    if (cmd.count == 5) {
+    if (cmd.param_count == 5) {
         // in a network device, there is no "address" value, this is hijacked by fujinet-lib to pass the network unit in first byte
-        current_network_unit = cmd.params[4];
+        current_network_unit = cmd.char_rw.fuji.network_unit;
     }
 
-    Debug_printf("\r\nDevice %02x Write %04x bytes, net_unit %02x\n", id(), num_bytes, current_network_unit);
+    Debug_printf("\r\nDevice %02x Write %04x bytes, net_unit %02x\n", id(), cmd.char_rw.length, current_network_unit);
 
     auto& current_network_data = network_data_map[current_network_unit];
 
@@ -542,8 +538,8 @@ void iwmNetwork::iwm_write(iwm_decoded_cmd_t cmd)
         iwm_return_ioerror();
     else
     {
-        current_network_data.transmitBuffer += string((char *)data_buffer, num_bytes);
-        if (write_channel(num_bytes))
+        current_network_data.transmitBuffer += string((char *)data_buffer, cmd.char_rw.length);
+        if (write_channel(cmd.char_rw.length))
         {
             send_reply_packet(SP_ERR_IOERROR);
         }
@@ -561,14 +557,12 @@ void iwmNetwork::iwm_ctrl(iwm_decoded_cmd_t cmd)
 {
     uint8_t err_result = SP_ERR_NOERROR;
 
-    fujiCommandID_t control_code = (fujiCommandID_t) get_status_code(cmd);
-
     // TODO: remove this in the future when we decide to drop support of the deprecated fujinet-lib (with unit-id support)
     // We have moved to a separate control command that sets the active channel for all subsequent commands
     // fujinet-lib (with unit-id support) sends the count of bytes for a control as 4 to cater for the network unit.
     // Older code sends 3 as the count, so we can detect if the network unit byte is there or not.
-    if (cmd.count == 4) {
-        current_network_unit = cmd.params[3];
+    if (cmd.param_count == 4) {
+        current_network_unit = cmd.control_status.fuji.network_unit;
     }
 
     auto& current_network_data = network_data_map[current_network_unit];
@@ -577,20 +571,19 @@ void iwmNetwork::iwm_ctrl(iwm_decoded_cmd_t cmd)
     print_packet((uint8_t *)data_buffer);
 
 #ifdef DEBUG
-    char as_char = (char) control_code;
-    if (control_code == NETCMD_SET_CHANNEL)
-        Debug_printf("\r\nNet Device %02x Control Code %02x('%c') net_unit %02x", id(), control_code, isprint(as_char) ? as_char : '.', data_buffer[0]);
+    if (cmd.control_status.fuji.command == NETCMD_SET_CHANNEL)
+        Debug_printf("\r\nNet Device %02x Control Code %02x('%c') net_unit %02x", id(), cmd.control_status.fuji.command, isprint(cmd.control_status.fuji.command) ? (char)cmd.control_status.fuji.command : '.', data_buffer[0]);
     else
-        Debug_printf("\r\nNet Device %02x Control Code %02x('%c') net_unit %02x", id(), control_code, isprint(as_char) ? as_char : '.', current_network_unit);
+        Debug_printf("\r\nNet Device %02x Control Code %02x('%c') net_unit %02x", id(), cmd.control_status.fuji.command, isprint(cmd.control_status.fuji.command) ? (char)cmd.control_status.fuji.command : '.', current_network_unit);
 #endif
 
     // Debug_printv("cmd (looking for network_unit in byte 6, i.e. hex[5]):\r\n%s\r\n", mstr::toHex(cmd.decoded, 9).c_str());
 
-    if (control_code != NETCMD_OPEN && current_network_data.json == nullptr) {
+    if (cmd.control_status.fuji.command != NETCMD_OPEN && current_network_data.json == nullptr) {
         Debug_printv("control should not be called on a non-open channel - FN was probably reset");
     }
 
-    switch (control_code)
+    switch (cmd.control_status.fuji.command)
     {
     case NETCMD_SET_CHANNEL:
         current_network_unit = data_buffer[0];
@@ -633,21 +626,21 @@ void iwmNetwork::iwm_ctrl(iwm_decoded_cmd_t cmd)
     case NETCMD_UNLOCK:
     case NETCMD_MKDIR:
     case NETCMD_RMDIR:
-        process_fs(control_code);
+        process_fs(cmd.control_status.fuji.command);
         break;
 
     case NETCMD_CONTROL:
     case NETCMD_CLOSE_CLIENT:
-        process_tcp(control_code);
+        process_tcp(cmd.control_status.fuji.command);
         break;
 
     case NETCMD_UNLISTEN:
-        process_http(control_code);
+        process_http(cmd.control_status.fuji.command);
         break;
 
     case NETCMD_GET_REMOTE:
     case NETCMD_SET_DESTINATION:
-        process_udp(control_code);
+        process_udp(cmd.control_status.fuji.command);
         break;
 
     default:
@@ -667,7 +660,7 @@ void iwmNetwork::iwm_ctrl(iwm_decoded_cmd_t cmd)
 void iwmNetwork::process(iwm_decoded_cmd_t cmd)
 {
     fnLedManager.set(LED_BUS, true);
-    switch (cmd.command)
+    switch (cmd.sp_command)
     {
     case SP_CMD_STATUS:
         Debug_printf("\r\nhandling status command");
@@ -774,7 +767,7 @@ void iwmNetwork::iwmnet_set_timer_rate()
 {
 }
 
-void iwmNetwork::process_fs(fujiCommandID_t control_code)
+void iwmNetwork::process_fs(fujiCommandID_t fuji_command)
 {
     auto& current_network_data = network_data_map[current_network_unit];
     string d;
@@ -795,7 +788,7 @@ void iwmNetwork::process_fs(fujiCommandID_t control_code)
 
     fujiError_t cmd_err;
     auto url = current_network_data.urlParser.get();
-    switch (control_code)
+    switch (fuji_command)
     {
     case NETCMD_RENAME:
         cmd_err = fs->rename(url);
@@ -824,7 +817,7 @@ void iwmNetwork::process_fs(fujiCommandID_t control_code)
         err = SP_ERR_IOERROR;
 }
 
-void iwmNetwork::process_tcp(fujiCommandID_t control_code)
+void iwmNetwork::process_tcp(fujiCommandID_t fuji_command)
 {
     auto& current_network_data = network_data_map[current_network_unit];
     // Make sure this is really a TCP protocol instance
@@ -836,7 +829,7 @@ void iwmNetwork::process_tcp(fujiCommandID_t control_code)
     }
 
     fujiError_t cmd_err;
-    switch (control_code)
+    switch (fuji_command)
     {
     case NETCMD_CONTROL:
         cmd_err = tcp->accept_connection();
@@ -853,7 +846,7 @@ void iwmNetwork::process_tcp(fujiCommandID_t control_code)
         err = SP_ERR_IOERROR;
 }
 
-void iwmNetwork::process_http(fujiCommandID_t control_code)
+void iwmNetwork::process_http(fujiCommandID_t fuji_command)
 {
     auto& current_network_data = network_data_map[current_network_unit];
     // Make sure this is really an HTTP protocol instance
@@ -865,7 +858,7 @@ void iwmNetwork::process_http(fujiCommandID_t control_code)
     }
 
     fujiError_t cmd_err;
-    switch (control_code)
+    switch (fuji_command)
     {
     case NETCMD_UNLISTEN:
         cmd_err = http->set_channel_mode((netProtoHTTPChannelMode_t) cmdFrame.aux2);
@@ -879,7 +872,7 @@ void iwmNetwork::process_http(fujiCommandID_t control_code)
         err = SP_ERR_IOERROR;
 }
 
-void iwmNetwork::process_udp(fujiCommandID_t control_code)
+void iwmNetwork::process_udp(fujiCommandID_t fuji_command)
 {
     auto& current_network_data = network_data_map[current_network_unit];
     // Make sure this is really a UDP protocol instance
@@ -891,7 +884,7 @@ void iwmNetwork::process_udp(fujiCommandID_t control_code)
     }
 
     fujiError_t cmd_err;
-    switch (control_code)
+    switch (fuji_command)
     {
 #ifndef ESP_PLATFORM
     case NETCMD_GET_REMOTE:

--- a/lib/device/iwm/network.h
+++ b/lib/device/iwm/network.h
@@ -102,10 +102,10 @@ public:
     virtual void status();
 
     void process(iwm_decoded_cmd_t cmd) override;
-    void process_fs(fujiCommandID_t control_code);
-    void process_tcp(fujiCommandID_t control_code);
-    void process_http(fujiCommandID_t control_code);
-    void process_udp(fujiCommandID_t control_code);
+    void process_fs(fujiCommandID_t fuji_command);
+    void process_tcp(fujiCommandID_t fuji_command);
+    void process_http(fujiCommandID_t fuji_command);
+    void process_udp(fujiCommandID_t fuji_command);
 
     void iwm_ctrl(iwm_decoded_cmd_t cmd) override;
     void iwm_open(iwm_decoded_cmd_t cmd) override;

--- a/lib/device/iwm/printer.cpp
+++ b/lib/device/iwm/printer.cpp
@@ -61,18 +61,18 @@ void iwmPrinter::send_extended_status_dib_reply_packet()
 
 void iwmPrinter::iwm_status(iwm_decoded_cmd_t cmd)
 {
-    uint8_t status_code = get_status_code(cmd); 
-    Debug_printf("\r\n[PRINTER]: Device: %02x Status Code %02x\r\n", id(), status_code);
-    switch (status_code)
+    Debug_printf("\r\n[PRINTER]: Device: %02x Status Code %02x\r\n", id(), cmd.control_status.fuji.command);
+    switch (cmd.control_status.code)
     {
     case SP_STAT_DEVICE:
         send_status_reply_packet();
-        return;
         break;
     case SP_STAT_DIB:
         send_status_dib_reply_packet();
-        return;
         break;
+    default:
+      send_reply_packet(SP_ERR_BADCMD);
+      break;
     }
 }
 
@@ -90,11 +90,8 @@ void iwmPrinter::iwm_close(iwm_decoded_cmd_t cmd)
 
 void iwmPrinter::iwm_write(iwm_decoded_cmd_t cmd)
 {
-    uint16_t num_bytes = get_numbytes(cmd);
+    Debug_printf("\nPrinter: Write %u bytes\n", cmd.char_rw.length);
 
-    Debug_printf("\nPrinter: Write %u bytes\n", num_bytes);
-
-    data_len = num_bytes;
     SYSTEM_BUS.iwm_decode_data_packet((unsigned char *)data_buffer, data_len);
 
     if (data_len == -1)
@@ -136,7 +133,7 @@ void iwmPrinter::print_from_cpm(uint8_t c)
 void iwmPrinter::process(iwm_decoded_cmd_t cmd)
 {
     fnLedManager.set(LED_BUS, true);
-    switch (cmd.command)
+    switch (cmd.sp_command)
     {
     case SP_CMD_STATUS:
         iwm_status(cmd);
@@ -151,7 +148,7 @@ void iwmPrinter::process(iwm_decoded_cmd_t cmd)
         iwm_write(cmd);
         break;
     default:
-        Debug_printf("\nPrinter: Bad cmd %02X\n", cmd.command);
+        Debug_printf("\nPrinter: Bad cmd %02X\n", cmd.sp_command);
         iwm_return_badcmd(cmd);
         break;
     }


### PR DESCRIPTION
Removed the `uint8_t` arrays in `iwm_decoded_t` using hardcoded indexes and replaced them with explicit parameter names for each command field, grouped by command type. This improves readability and makes the structure more self-documenting, making it clear which fields are being examined and what type of command packet is expected.

Also replaced the 16-bit and 24-bit fields in `iwm_decoded_t` with `u16le_t` and `u24le_t` types so that values can be accessed like regular unsigned integers, with no need to call additional methods to handle decoding.