### PR TITLE
RunCPM 6.9: single shared core, N:CPM telnet console (:8677), RSX bar commands

### DIFF
--- a/fujinet_pc.cmake
+++ b/fujinet_pc.cmake
@@ -245,6 +245,10 @@ set(SOURCES src/main.cpp
     lib/network-protocol/Protocol.h lib/network-protocol/Protocol.cpp
     lib/network-protocol/ProtocolParser.h lib/network-protocol/ProtocolParser.cpp
     lib/network-protocol/CPM.h lib/network-protocol/CPM.cpp
+    # Single shared RunCPM core (one Z80/CP/M state + engine).  Compiled on every
+    # target because the N:CPM:// device (CPM.cpp, above) is available on all of
+    # them; the SIO 'G' and telnet transports that also drive it are ATARI-only.
+    lib/runcpm/runcpm_session.h lib/runcpm/runcpm_core.cpp
     lib/network-protocol/GDRIVE.h lib/network-protocol/GDRIVE.cpp
     lib/network-protocol/Test.h lib/network-protocol/Test.cpp
     lib/network-protocol/TCP.h lib/network-protocol/TCP.cpp
@@ -303,6 +307,8 @@ if(FUJINET_TARGET STREQUAL "ATARI")
     lib/device/sio/voice.h lib/device/sio/voice.cpp
     lib/device/sio/clock.h lib/device/sio/clock.cpp
     lib/device/sio/siocpm.h lib/device/sio/siocpm.cpp
+    lib/device/sio/vm_telnet.h lib/device/sio/vm_telnet.cpp
+    lib/device/sio/vm_bar.h lib/device/sio/vm_bar.cpp
     lib/device/sio/pclink.h lib/device/sio/pclink.cpp
     lib/device/sio/modem.h lib/device/sio/modem.cpp
 

--- a/lib/device/drivewire/cpm.cpp
+++ b/lib/device/drivewire/cpm.cpp
@@ -2,7 +2,16 @@
 
 #ifdef ESP_PLATFORM
 
-#define CCP_INTERNAL
+/*
+ * drivewire/cpm.cpp — CoCo DriveWire CP/M transport, now a thin console
+ * back-end.
+ *
+ * The RunCPM engine + state live once in lib/runcpm/runcpm_core.cpp.  This file
+ * no longer includes the RunCPM header chain (which, since RunCPM 6.9, defines
+ * the `Command` struct and the `CPM` macro that collide with the FujiNet bus
+ * headers); it only supplies a queue-based console back-end (runcpm_console_ops)
+ * over the DriveWire rx/tx queues and asks the shared core to run a session.
+ */
 
 #include "cpm.h"
 
@@ -12,38 +21,70 @@
 #include "fnFS.h"
 #include "fnFsSD.h"
 
-#include "../runcpm/globals.h"
-#include "../runcpm/abstraction_fujinet_apple2.h"
-#include "../runcpm/ram.h"     // ram.h - Implements the RAM
-#include "../runcpm/console.h" // console.h - implements console.
-#include "../runcpm/cpu.h"     // cpu.h - Implements the emulated CPU
-#include "../runcpm/disk.h"    // disk.h - Defines all the disk access abstraction functions
-#include "../runcpm/host.h"    // host.h - Custom host-specific BDOS call
-#include "../runcpm/cpm.h"     // cpm.h - Defines the CPM structures and calls
-#ifdef CCP_INTERNAL
-# include "../runcpm/ccp.h" // ccp.h - Defines a simple internal CCP
-#endif
+#include "../runcpm/runcpm_session.h"
+
+/*
+ * DriveWire console queues (this TU owns them).
+ *   rxq : CP/M stdout -> host read  (putch pushes; read() pops)
+ *   txq : host write  -> CP/M stdin (write() pushes; getch pops)
+ */
+static QueueHandle_t rxq = nullptr;
+static QueueHandle_t txq = nullptr;
+
+/* ----- console back-end (runcpm_console_ops) ----- */
+
+static int cpm_kbhit(void)
+{
+    return txq ? (int)uxQueueMessagesWaiting(txq) : 0;
+}
+
+static int cpm_getch(void)
+{
+    uint8_t c = 0;
+    if (txq)
+        xQueueReceive(txq, &c, portMAX_DELAY);
+    return c;
+}
+
+static int cpm_getche(void)
+{
+    uint8_t c = (uint8_t)cpm_getch();
+    if (rxq)
+        xQueueSend(rxq, &c, portMAX_DELAY);
+    return c;
+}
+
+static void cpm_putch(uint8_t ch)
+{
+    if (rxq)
+        xQueueSend(rxq, &ch, portMAX_DELAY);
+}
+
+static void cpm_clrscr(void)
+{
+    /* VT100 cursor-home + clear-screen */
+    static const uint8_t seq[] = {0x1B, '[', '1', ';', '1', 'H',
+                                  0x1B, '[', '2', 'J'};
+    for (size_t i = 0; i < sizeof(seq); i++)
+        cpm_putch(seq[i]);
+}
+
+static const runcpm_console_ops cpm_console_ops = {
+    cpm_getch,
+    cpm_getche,
+    cpm_kbhit,
+    cpm_putch,
+    cpm_clrscr,
+};
 
 static void cpmTask(void *arg)
 {
+    (void)arg;
     Debug_printf("cpmTask()\n");
+    // The shared core owns the CCP + warm-boot loop; keep re-running it so the
+    // DriveWire console behaves like the original always-on task.
     while (1)
-    {
-        Status = Debug = 0;
-        Break = Step = -1;
-        RAM = (uint8_t *)malloc(MEMSIZE);
-        memset(RAM, 0, MEMSIZE);
-        memset(filename, 0, sizeof(filename));
-        memset(newname, 0, sizeof(newname));
-        memset(fcbname, 0, sizeof(fcbname));
-        memset(pattern, 0, sizeof(pattern));
-#ifdef ESP_PLATFORM // OS
-        vTaskDelay(100);
-#endif
-        _puts(CCPHEAD);
-        _PatchCPM();
-        _ccp();
-    }
+        runcpm_session_run(&cpm_console_ops);
 }
 
 drivewireCPM::drivewireCPM()

--- a/lib/device/iwm/cpm.cpp
+++ b/lib/device/iwm/cpm.cpp
@@ -1,5 +1,15 @@
 #ifdef BUILD_APPLE
-#define CCP_INTERNAL
+
+/*
+ * iwm/cpm.cpp — Apple II SmartPort CP/M transport, now a thin console back-end.
+ *
+ * The RunCPM engine + state live once in lib/runcpm/runcpm_core.cpp.  This file
+ * no longer includes the RunCPM header chain (which, since RunCPM 6.9, defines
+ * the `Command` struct and the `CPM` macro that collide with the Apple-II bus
+ * headers, e.g. devrelay/types/Command.h and improv.h); it only supplies a
+ * queue-based console back-end (runcpm_console_ops) over the SmartPort rx/tx
+ * queues and asks the shared core to run a session.
+ */
 
 #include "cpm.h"
 
@@ -13,39 +23,91 @@
 
 #include "../hardware/led.h"
 
-#include "../runcpm/abstraction_fujinet_apple2.h"
-
-#include "../runcpm/globals.h"
-#include "../runcpm/ram.h"     // ram.h - Implements the RAM
-#include "../runcpm/console.h" // console.h - implements console.
-#include "../runcpm/cpu.h"     // cpu.h - Implements the emulated CPU
-#include "../runcpm/disk.h"    // disk.h - Defines all the disk access abstraction functions
-#include "../runcpm/host.h"    // host.h - Custom host-specific BDOS call
-#include "../runcpm/cpm.h"     // cpm.h - Defines the CPM structures and calls
-#ifdef CCP_INTERNAL
-#include "../runcpm/ccp.h" // ccp.h - Defines a simple internal CCP
-#endif
+#include "../runcpm/runcpm_session.h"
 
 #define CPM_TASK_PRIORITY 10
 
+/*
+ * SmartPort console queues (this TU owns them).
+ *   rxq : CP/M stdout -> host read  (putch pushes; iwm_read pops)
+ *   txq : host write  -> CP/M stdin (iwm_write pushes; getch pops)
+ * They are FreeRTOS queues, so they only exist on the ESP target; on
+ * FujiNet-PC the Apple-II CP/M console is inert (as it was before).
+ */
+#ifdef ESP_PLATFORM // OS
+static QueueHandle_t rxq = nullptr;
+static QueueHandle_t txq = nullptr;
+#endif
+
+/* ----- console back-end (runcpm_console_ops) ----- */
+
+static int cpm_kbhit(void)
+{
+#ifdef ESP_PLATFORM // OS
+    return txq ? (int)uxQueueMessagesWaiting(txq) : 0;
+#else
+    return 0;
+#endif
+}
+
+static int cpm_getch(void)
+{
+    uint8_t c = 0;
+#ifdef ESP_PLATFORM // OS
+    if (txq)
+        xQueueReceive(txq, &c, portMAX_DELAY);
+#endif
+    return c;
+}
+
+static int cpm_getche(void)
+{
+    uint8_t c = (uint8_t)cpm_getch();
+#ifdef ESP_PLATFORM // OS
+    if (rxq)
+        xQueueSend(rxq, &c, portMAX_DELAY);
+#endif
+    return c;
+}
+
+static void cpm_putch(uint8_t ch)
+{
+#ifdef ESP_PLATFORM // OS
+    if (rxq)
+        xQueueSend(rxq, &ch, portMAX_DELAY);
+#else
+    (void)ch;
+#endif
+}
+
+static void cpm_clrscr(void)
+{
+    /* VT100 cursor-home + clear-screen */
+    static const uint8_t seq[] = {0x1B, '[', '1', ';', '1', 'H',
+                                  0x1B, '[', '2', 'J'};
+    for (size_t i = 0; i < sizeof(seq); i++)
+        cpm_putch(seq[i]);
+}
+
+static const runcpm_console_ops cpm_console_ops = {
+    cpm_getch,
+    cpm_getche,
+    cpm_kbhit,
+    cpm_putch,
+    cpm_clrscr,
+};
+
+#ifdef ESP_PLATFORM // OS
 static void cpmTask(void *arg)
 {
+    (void)arg;
     Debug_printf("cpmTask()\n");
+    // The shared core owns the CCP + warm-boot loop; keep re-running it so the
+    // SmartPort console behaves like the original always-on task.
     while (1)
-    {
-        Status = Debug = 0;
-        Break = Step = -1;
-        RAM = (uint8_t *)malloc(MEMSIZE);
-        memset(RAM, 0, MEMSIZE);
-        memset(filename, 0, sizeof(filename));
-        memset(newname, 0, sizeof(newname));
-        memset(fcbname, 0, sizeof(fcbname));
-        memset(pattern, 0, sizeof(pattern));
-        _puts(CCPHEAD);
-        _PatchCPM();
-        _ccp();
-    }
+        runcpm_session_run(&cpm_console_ops);
 }
+#endif
 
 iwmCPM::iwmCPM()
 {

--- a/lib/device/rc2014/rc2014cpm.cpp
+++ b/lib/device/rc2014/rc2014cpm.cpp
@@ -1,27 +1,72 @@
 #ifdef BUILD_RC2014
 
-#define CCP_INTERNAL
+/*
+ * rc2014cpm.cpp — RC2014 CP/M transport, now a thin console back-end.
+ *
+ * The RunCPM engine + state live once in lib/runcpm/runcpm_core.cpp.  This file
+ * no longer includes the RunCPM header chain (which, since RunCPM 6.9, defines
+ * the `Command` struct and the `CPM` macro that collide with the FujiNet bus
+ * headers); it only supplies an RC2014 console back-end (runcpm_console_ops)
+ * and asks the shared core to run a session.  The RC2014 bus has no
+ * character-stream console, so the back-end is a no-op stub (see below).
+ */
 
 #include "rc2014cpm.h"
 
+#include <string.h>
+
 #include "fnSystem.h"
-#include "fnWiFi.h"
-#include "fujiDevice.h"
-#include "fnFS.h"
-#include "fnFsSD.h"
 
-#include "../runcpm/globals.h"
-#include "../runcpm/abstraction_fujinet.h"
-#include "../runcpm/ram.h"     // ram.h - Implements the RAM
-#include "../runcpm/console.h" // console.h - implements console.
-#include "../runcpm/cpu.h"     // cpu.h - Implements the emulated CPU
-#include "../runcpm/disk.h"    // disk.h - Defines all the disk access abstraction functions
-#include "../runcpm/host.h"    // host.h - Custom host-specific BDOS call
-#include "../runcpm/cpm.h"     // cpm.h - Defines the CPM structures and calls
-#ifdef CCP_INTERNAL
-# include "../runcpm/ccp.h" // ccp.h - Defines a simple internal CCP
-#endif
+#include "../runcpm/runcpm_session.h"
 
+/* ----- console back-end (runcpm_console_ops) -----
+ *
+ * The RC2014 systemBus exposes a block/transaction API (busTxBuffer /
+ * busRxBuffer / busTxAvail), not a character-stream console (read / write /
+ * available).  Historically the RC2014 CP/M console went through
+ * abstraction_fujinet.h, whose console was only wired to the bus when
+ * BYPASS_BUS was defined — and BYPASS_BUS is defined *only* for BUILD_ATARI.
+ * For RC2014 the console was therefore a no-op stub (and _getch busy-looped
+ * forever), so RC2014 CP/M has never had a working interactive console.
+ *
+ * To preserve that "no console transport" reality while compiling against the
+ * shared core, these ops are clean no-ops.  getch returns CP/M EOF (^Z) instead
+ * of busy-looping, so the session ends gracefully rather than hanging.
+ */
+
+static int rc2014_kbhit(void)
+{
+    return 0;
+}
+
+static int rc2014_getch(void)
+{
+    return 0x1a; /* ^Z / CP/M EOF */
+}
+
+static int rc2014_getche(void)
+{
+    return rc2014_getch();
+}
+
+static void rc2014_putch(uint8_t ch)
+{
+    (void)ch;
+}
+
+static void rc2014_clrscr(void)
+{
+}
+
+static const runcpm_console_ops rc2014_console_ops = {
+    rc2014_getch,
+    rc2014_getche,
+    rc2014_kbhit,
+    rc2014_putch,
+    rc2014_clrscr,
+};
+
+/* =========================== rc2014CPM device ========================== */
 
 void rc2014CPM::rc2014_status()
 {
@@ -31,41 +76,18 @@ void rc2014CPM::rc2014_status()
 
 void rc2014CPM::rc2014_handle_cpm()
 {
-    _puts(CCPHEAD);
-    _PatchCPM();
-    Status = 0;
-#ifdef CCP_INTERNAL
-    _ccp();
-#else
-    if (!_sys_exists((uint8 *)CCPname))
-    {
-        _puts("Unable to load CP/M CCP.\r\nCPU halted.\r\n");
-        break;
-    }
-    _RamLoad((uint8 *)CCPname, CCPaddr);    // Loads the CCP binary file into memory
-    Z80reset();                             // Resets the Z80 CPU
-    SET_LOW_REGISTER(BC, _RamRead(0x0004)); // Sets C to the current drive/user
-    PC = CCPaddr;                           // Sets CP/M application jump point
-    Z80run();                               // Starts simulation
-#endif
-    if (Status == 1) // This is set by a call to BIOS 0 - ends CP/M
-    {
-        cpmActive = false;
-        free(RAM);
-    }
+    // Run a full CP/M session on the shared core using the RC2014 console.
+    // Blocks until the session ends; the bus service loop then stops calling
+    // us because cpmActive is cleared.
+    runcpm_session_run(&rc2014_console_ops);
+    cpmActive = false;
 }
 
 void rc2014CPM::init_cpm(int baud)
 {
-    // fnUartBUS.set_baudrate(baud); // RC2014 SPI bus does not use UART
-    Status = Debug = 0;
-    Break = Step = -1;
-    RAM = (uint8_t *)malloc(MEMSIZE);
-    memset(RAM, 0, MEMSIZE);
-    memset(filename, 0, sizeof(filename));
-    memset(newname, 0, sizeof(newname));
-    memset(fcbname, 0, sizeof(fcbname));
-    memset(pattern, 0, sizeof(pattern));
+    // RAM/globals are owned by the shared core now; the RC2014 SPI bus does not
+    // use a UART baud rate, so nothing transport-specific to set up here.
+    (void)baud;
 }
 
 void rc2014CPM::rc2014_process(uint32_t commanddata, uint8_t checksum)

--- a/lib/device/rs232/rs232cpm.cpp
+++ b/lib/device/rs232/rs232cpm.cpp
@@ -1,27 +1,74 @@
 #ifdef BUILD_RS232
 
-#define CCP_INTERNAL
+/*
+ * rs232cpm.cpp — RS232 CP/M transport, now a thin console back-end.
+ *
+ * The RunCPM engine + state live once in lib/runcpm/runcpm_core.cpp.  This file
+ * no longer includes the RunCPM header chain (which, since RunCPM 6.9, defines
+ * the `Command` struct and the `CPM` macro that collide with the FujiNet bus
+ * headers); it only supplies an RS232 console back-end (runcpm_console_ops) and
+ * asks the shared core to run a session.  The RS232 bus has no character-stream
+ * console, so the back-end is a no-op stub (see below).
+ */
 
 #include "rs232cpm.h"
 
+#include <string.h>
+
 #include "fnSystem.h"
-#include "fnWiFi.h"
-#include "rs232Fuji.h"
-#include "fnFS.h"
-#include "fnFsSD.h"
 
-#include "../runcpm/globals.h"
-#include "../runcpm/abstraction_fujinet.h"
-#include "../runcpm/ram.h"     // ram.h - Implements the RAM
-#include "../runcpm/console.h" // console.h - implements console.
-#include "../runcpm/cpu.h"     // cpu.h - Implements the emulated CPU
-#include "../runcpm/disk.h"    // disk.h - Defines all the disk access abstraction functions
-#include "../runcpm/host.h"    // host.h - Custom host-specific BDOS call
-#include "../runcpm/cpm.h"     // cpm.h - Defines the CPM structures and calls
-#ifdef CCP_INTERNAL
-# include "../runcpm/ccp.h" // ccp.h - Defines a simple internal CCP
-#endif
+#include "../runcpm/runcpm_session.h"
 
+/*
+ * ----- console back-end (runcpm_console_ops) -----
+ *
+ * The RS232 systemBus does not expose a character-stream console API
+ * (read/write/available); it is a transaction-based bus.  Historically the
+ * RS232 CP/M console went through abstraction_fujinet.h, whose console was only
+ * wired to the bus when BYPASS_BUS was defined — and BYPASS_BUS is defined
+ * *only* for BUILD_ATARI.  For RS232 the console was therefore a no-op stub
+ * (and _getch actually busy-looped forever), so RS232 CP/M has never had a
+ * working interactive console.
+ *
+ * To preserve that "no console transport" reality while still compiling against
+ * the shared core, these ops are clean no-ops.  getch returns CP/M EOF (^Z)
+ * instead of busy-looping, so the session terminates gracefully rather than
+ * hanging the bus service loop as the old code did.
+ */
+
+static int rs232_kbhit(void)
+{
+    return 0;
+}
+
+static int rs232_getch(void)
+{
+    return 0x1a; /* ^Z / CP/M EOF */
+}
+
+static int rs232_getche(void)
+{
+    return rs232_getch();
+}
+
+static void rs232_putch(uint8_t ch)
+{
+    (void)ch;
+}
+
+static void rs232_clrscr(void)
+{
+}
+
+static const runcpm_console_ops rs232_console_ops = {
+    rs232_getch,
+    rs232_getche,
+    rs232_kbhit,
+    rs232_putch,
+    rs232_clrscr,
+};
+
+/* ============================ rs232CPM device =========================== */
 
 void rs232CPM::rs232_status(FujiStatusReq reqType)
 {
@@ -31,43 +78,18 @@ void rs232CPM::rs232_status(FujiStatusReq reqType)
 
 void rs232CPM::rs232_handle_cpm()
 {
-    _puts(CCPHEAD);
-    _PatchCPM();
-    Status = 0;
-#ifdef CCP_INTERNAL
-    _ccp();
-#else
-    if (!_sys_exists((uint8 *)CCPname))
-    {
-        _puts("Unable to load CP/M CCP.\r\nCPU halted.\r\n");
-        break;
-    }
-    _RamLoad((uint8 *)CCPname, CCPaddr);    // Loads the CCP binary file into memory
-    Z80reset();                             // Resets the Z80 CPU
-    SET_LOW_REGISTER(BC, _RamRead(0x0004)); // Sets C to the current drive/user
-    PC = CCPaddr;                           // Sets CP/M application jump point
-    Z80run();                               // Starts simulation
-#endif
-    if (Status == 1) // This is set by a call to BIOS 0 - ends CP/M
-    {
-        cpmActive = false;
-        free(RAM);
-    }
+    // Run a full CP/M session on the shared core using the RS232 console.
+    // Blocks until the session ends; the bus service loop then stops calling
+    // us because cpmActive is cleared.
+    runcpm_session_run(&rs232_console_ops);
+    cpmActive = false;
 }
 
 void rs232CPM::init_cpm(int baud)
 {
-#ifdef OBSOLETE
-    SYSTEM_BUS.setBaudrate(baud);
-#endif /* OBSOLETE */
-    Status = Debug = 0;
-    Break = Step = -1;
-    RAM = (uint8_t *)malloc(MEMSIZE);
-    memset(RAM, 0, MEMSIZE);
-    memset(filename, 0, sizeof(filename));
-    memset(newname, 0, sizeof(newname));
-    memset(fcbname, 0, sizeof(fcbname));
-    memset(pattern, 0, sizeof(pattern));
+    // RAM/globals are owned by the shared core now; nothing transport-specific
+    // to set up here (the RS232 link rate is managed elsewhere).
+    (void)baud;
 }
 
 void rs232CPM::rs232_process(FujiBusPacket &packet)

--- a/lib/device/sio/siocpm.cpp
+++ b/lib/device/sio/siocpm.cpp
@@ -1,27 +1,215 @@
 #ifdef BUILD_ATARI
 
-#define CCP_INTERNAL
+/*
+ * siocpm.cpp — SIO 'G' (R:) CP/M transport, now a thin console back-end.
+ *
+ * The RunCPM engine + state live once in lib/runcpm/runcpm_core.cpp.  This file
+ * no longer includes the RunCPM header chain; it only supplies an SIO console
+ * back-end (runcpm_console_ops) and asks the shared core to run a session.
+ *
+ * The SIO console primitives (the batched _cpm_txbuf writer and the tee-mode
+ * TCP mirror) moved here verbatim from the old abstraction_fujinet.h, because
+ * they are specific to the SIO serial link (SYSTEM_BUS) and the optional TCP
+ * tee — they are not part of the shared, transport-agnostic core.
+ */
 
 #include "siocpm.h"
+
+#include <errno.h>
+#include <string.h>
 
 #include "fnSystem.h"
 #include "fnWiFi.h"
 #include "fujiDevice.h"
 #include "fnFS.h"
 #include "fnFsSD.h"
+#include "fnTcpServer.h"
+#include "fnTcpClient.h"
 
-#include "../runcpm/globals.h"
-#include "../runcpm/abstraction_fujinet.h" // FN_CPM_LINK defined here (one of fnUartBUS, fnSioCom)
-#include "../runcpm/ram.h"     // ram.h - Implements the RAM
-#include "../runcpm/console.h" // console.h - implements console.
-#include "../runcpm/cpu.h"     // cpu.h - Implements the emulated CPU
-#include "../runcpm/disk.h"    // disk.h - Defines all the disk access abstraction functions
-#include "../runcpm/host.h"    // host.h - Custom host-specific BDOS call
-#include "../runcpm/cpm.h"     // cpm.h - Defines the CPM structures and calls
-#ifdef CCP_INTERNAL
-# include "../runcpm/ccp.h" // ccp.h - Defines a simple internal CCP
-#endif
+#include "../runcpm/runcpm_session.h"
 
+// Why is CP/M writing directly to the SYSTEM_BUS?
+#define FN_CPM_LINK SYSTEM_BUS
+
+/* Optional TCP tee mirror of the SIO console (dormant: enabled only by
+   bios_tcpTeeAccept(), which the current CCP never calls — preserved for
+   parity with the historical abstraction). */
+static fnTcpClient client;
+static fnTcpServer *server = nullptr;
+static bool teeMode = false;
+static unsigned short portActive = 0;
+
+/*
+ * CP/M console output batching (FujiNet, 2026-06-21)
+ *
+ * BUG / SYMPTOM:
+ *   The RunCPM console was painfully slow on the Atari client (~500 char/s,
+ *   ~2 s to print 1000 characters, DIR/TYPE crawling) even though the serial
+ *   link is configured for 111861 bit/s (~11 kB/s).  The SSH (N:) examples on
+ *   the very same link are fast.
+ *
+ * ROOT CAUSE:
+ *   The Z80 BDOS console calls (_putch -> _cwrite) wrote ONE byte per call
+ *   straight to the bus: SYSTEM_BUS.write(ch) -> IOChannel::write(int) ->
+ *   dataOut(buf, 1).  Each dataOut() call pays a fixed cost (a pre-write
+ *   select(), the ::write(), and a post-write select() that waits for the TTY
+ *   to be writable again - TTYChannel.cpp).  For block transfers (how the N:
+ *   device sends a whole SIO frame) that cost is amortised over the frame; for
+ *   the per-character console stream it was paid for every single byte, so the
+ *   per-call overhead - not the bit rate - dominated.
+ *
+ * FIX:
+ *   Accumulate console output in a small buffer and emit it as a block with
+ *   SYSTEM_BUS.write(buffer, length), exactly like the fast N:/SIO frame path.
+ *   The buffer is flushed (a) when it fills and (b) whenever CP/M polls for
+ *   keyboard input (kbhit) - interactive CP/M always polls/reads input right
+ *   after emitting a prompt or output, so the user never sees stale output.
+ */
+#define CPM_TX_BUFSZ 512
+static uint8_t _cpm_txbuf[CPM_TX_BUFSZ];
+static size_t _cpm_txlen = 0;
+
+static inline void _cflush(void)
+{
+    if (_cpm_txlen)
+    {
+        SYSTEM_BUS.write(_cpm_txbuf, _cpm_txlen);
+        _cpm_txlen = 0;
+    }
+}
+
+static inline void _cput(uint8_t ch)
+{
+    if (_cpm_txlen >= CPM_TX_BUFSZ)
+        _cflush();
+    _cpm_txbuf[_cpm_txlen++] = ch;
+}
+
+/* ----- console back-end (runcpm_console_ops) ----- */
+
+// kbhit flushes any pending console output before reporting input
+// availability, so buffered output is always on screen before CP/M blocks
+// waiting for a key.
+static int sio_kbhit(void)
+{
+    _cflush();
+    return SYSTEM_BUS.available();
+}
+
+static int sio_getch(void)
+{
+    if (teeMode == true)
+    {
+        while (sio_kbhit() > 0)
+        {
+            if (client.available())
+            {
+                uint8_t ch;
+                client.read(&ch, 1);
+                return ch & 0x7F;
+            }
+        }
+        return SYSTEM_BUS.read() & 0x7F;
+    }
+    else
+    {
+        while (sio_kbhit() <= 0)
+        {
+        }
+        return SYSTEM_BUS.read() & 0x7f;
+    }
+}
+
+static int sio_getche(void)
+{
+    uint8_t ch = sio_getch() & 0x7f;
+    _cput(ch);
+    if (teeMode == true)
+        client.write(ch);
+    return ch;
+}
+
+static void sio_putch(uint8_t ch)
+{
+    _cput(ch & 0x7f);
+    if (teeMode == true)
+        client.write(ch);
+}
+
+static void sio_clrscr(void)
+{
+}
+
+static const runcpm_console_ops sio_console_ops = {
+    sio_getch,
+    sio_getche,
+    sio_kbhit,
+    sio_putch,
+    sio_clrscr,
+};
+
+/* ----- optional TCP tee BIOS helpers (dormant; preserved for parity) ----- */
+
+uint8_t bios_tcpListen(uint16_t port)
+{
+    Debug_printf("Do we get here?\r\n");
+
+    if (client.connected())
+        client.stop();
+
+    if (server != nullptr && port != portActive)
+    {
+        server->stop();
+        delete server;
+    }
+
+    server = new fnTcpServer(port, 1);
+
+    int res = server->begin(port);
+    if (res == 0)
+    {
+        Debug_printf("bios_tcpListen - failed to open port %u\nError (%d): %s\r\n", port, errno, strerror(errno));
+        return true;
+    }
+    else
+    {
+        Debug_printf("bios_tcpListen - Now listening on port %u\r\n", port);
+        return false;
+    }
+}
+
+uint8_t bios_tcpAvailable(void)
+{
+    if (server == nullptr)
+        return 0;
+
+    return server->hasClient();
+}
+
+uint8_t bios_tcpTeeAccept(void)
+{
+    if (server == nullptr)
+        return false;
+
+    if (server->hasClient())
+        client = server->accept();
+
+    teeMode = true;
+
+    return client.connected();
+}
+
+uint8_t bios_tcpDrop(void)
+{
+    if (server == nullptr)
+        return false;
+
+    client.stop();
+
+    return true;
+}
+
+/* ============================ sioCPM device ============================== */
 
 void sioCPM::sio_status()
 {
@@ -31,41 +219,18 @@ void sioCPM::sio_status()
 
 void sioCPM::sio_handle_cpm()
 {
-    _puts(CCPHEAD);
-    _PatchCPM();
-    Status = 0;
-#ifdef CCP_INTERNAL
-    _ccp();
-#else
-    if (!_sys_exists((uint8 *)CCPname))
-    {
-        _puts("Unable to load CP/M CCP.\r\nCPU halted.\r\n");
-        break;
-    }
-    _RamLoad((uint8 *)CCPname, CCPaddr);    // Loads the CCP binary file into memory
-    Z80reset();                             // Resets the Z80 CPU
-    SET_LOW_REGISTER(BC, _RamRead(0x0004)); // Sets C to the current drive/user
-    PC = CCPaddr;                           // Sets CP/M application jump point
-    Z80run();                               // Starts simulation
-#endif
-    if (Status == 1) // This is set by a call to BIOS 0 - ends CP/M
-    {
-        cpmActive = false;
-        free(RAM);
-    }
+    // Run a full CP/M session on the shared core using the SIO console.
+    // Blocks until the session ends; the bus service loop then stops calling
+    // us because cpmActive is cleared.
+    runcpm_session_run(&sio_console_ops);
+    cpmActive = false;
 }
 
 void sioCPM::init_cpm(int baud)
 {
+    // RAM/globals are owned by the shared core now; only the serial link rate
+    // is an SIO-transport concern.
     SYSTEM_BUS.setBaudrate(baud);
-    Status = Debug = 0;
-    Break = Step = -1;
-    RAM = (uint8_t *)malloc(MEMSIZE);
-    memset(RAM, 0, MEMSIZE);
-    memset(filename, 0, sizeof(filename));
-    memset(newname, 0, sizeof(newname));
-    memset(fcbname, 0, sizeof(fcbname));
-    memset(pattern, 0, sizeof(pattern));
 }
 
 void sioCPM::sio_process(uint32_t commanddata, uint8_t checksum)

--- a/lib/device/sio/vm_bar.cpp
+++ b/lib/device/sio/vm_bar.cpp
@@ -1,0 +1,1333 @@
+// vm_bar.cpp — RSX-style "bar command" gate between RunCPM and FujiNet.
+//
+// FEATURE (RunCPM RSX / Amstrad-CPC "bar commands"):
+//   At the CP/M prompt, a line whose first non-space character is '|' is not a
+//   CP/M command — RunCPM's CCP (lib/runcpm/ccp.h) routes the rest of the line
+//   to vm_bar_command() below.  This lets the Atari trigger host-side FujiNet
+//   actions (download a file, etc.) from inside CP/M without a .COM program and
+//   without leaving the session.
+//
+//   Mechanism / trust boundary:
+//     - The CCP hook is the ONLY caller.  It passes a plain NUL-terminated
+//       command string (a host pointer into the Z80 RAM array, read-only here),
+//       the destination directory prefix the calling RunCPM instance uses for
+//       its CP/M files (already ending in '/'), and an output buffer.
+//     - This gate performs the action and writes back a short status string;
+//       the CCP prints it.  The gate never touches Z80 RAM, the console queues,
+//       or RunCPM's Status flag, so the same code serves all three RunCPM
+//       instances (SIO 'G'/R:, N:CPM://, telnet console).
+//     - |wget fetches arbitrary user-supplied URLs into the SD /CPM area.  This
+//       is intentional: FujiNet is a network peripheral and the user issuing
+//       the command is the operator of the machine.
+//
+//   New verbs are added by extending the kVerbs[] dispatch table.
+
+#ifdef BUILD_ATARI
+
+#include "vm_bar.h"
+
+#include "../../include/debug.h"
+
+#ifdef ESP_PLATFORM
+#include "fnHttpClient.h"
+#define HTTP_CLIENT_CLASS fnHttpClient
+#else
+#include "mgHttpClient.h"
+#define HTTP_CLIENT_CLASS mgHttpClient
+#endif
+
+#include "fnFsSD.h"
+#include "fnSystem.h"
+#include "peoples_url_parser.h"
+
+#include "fnConfig.h" // Config: read-only host/mount slot accessors for |fn mounts
+
+#include "fnFTP.h" // existing FujiNet FTP client, reused by |ftp (no new stack)
+
+#include <ctype.h>
+#include <stdio.h>
+#include <string.h>
+#include <string>
+#include <vector>
+
+namespace
+{
+
+// ---------------------------------------------------------------------------
+// Small helpers
+// ---------------------------------------------------------------------------
+
+// Skip leading spaces/tabs.
+const char *skip_spaces(const char *p)
+{
+    while (*p == ' ' || *p == '\t')
+        ++p;
+    return p;
+}
+
+// Copy the next whitespace-delimited token from *pp into tok (NUL-terminated,
+// at most toksize-1 chars).  Advances *pp past the token.  Returns the token
+// length (0 if no token remains).
+int next_token(const char **pp, char *tok, int toksize)
+{
+    const char *p = skip_spaces(*pp);
+    int n = 0;
+    while (*p && *p != ' ' && *p != '\t')
+    {
+        if (n < toksize - 1)
+            tok[n] = *p;
+        ++n;
+        ++p;
+    }
+    if (n > toksize - 1)
+        n = toksize - 1;
+    tok[n] = '\0';
+    *pp = p;
+    return n;
+}
+
+// Build an uppercase CP/M 8.3 filename (NAME.EXT, name<=8, ext<=3) from a
+// source filename, dropping path separators and characters illegal in a CP/M
+// FCB.  Returns false if nothing usable remains.
+bool to_cpm_83(const char *src, char *out, int outsize)
+{
+    // Keep only the basename (strip any path the URL parser left in).
+    const char *base = src;
+    for (const char *q = src; *q; ++q)
+        if (*q == '/' || *q == '\\' || *q == ':')
+            base = q + 1;
+
+    char name[9] = {0};
+    char ext[4] = {0};
+    int ni = 0, ei = 0;
+    bool in_ext = false;
+
+    for (const char *q = base; *q; ++q)
+    {
+        char c = *q;
+        if (c == '.')
+        {
+            // Last dot starts the extension; treat earlier dots as name chars
+            // by restarting the extension capture.
+            in_ext = true;
+            ei = 0;
+            continue;
+        }
+        // CP/M FCB illegal characters; replace with '_' rather than drop so the
+        // result stays a single recognisable token.
+        if (c <= ' ' || strchr("<>.,;:=?*[]/\\|", c))
+            c = '_';
+        c = (char)toupper((unsigned char)c);
+        if (!in_ext)
+        {
+            if (ni < 8)
+                name[ni++] = c;
+        }
+        else
+        {
+            if (ei < 3)
+                ext[ei++] = c;
+        }
+    }
+
+    if (ni == 0)
+        return false;
+
+    int w = 0;
+    for (int i = 0; i < ni && w < outsize - 1; ++i)
+        out[w++] = name[i];
+    if (ei > 0 && w < outsize - 1)
+    {
+        out[w++] = '.';
+        for (int i = 0; i < ei && w < outsize - 1; ++i)
+            out[w++] = ext[i];
+    }
+    out[w] = '\0';
+    return w > 0;
+}
+
+// Write a buffer to f converting line endings to CP/M's CRLF convention.  Any
+// of LF (Unix), CR (classic Mac), or CRLF (DOS) in the input is normalised to a
+// single CRLF, so files fetched from Unix hosts display correctly under CP/M
+// TYPE (which expects CR before each LF).  *pending_cr carries a CR seen at the
+// very end of the previous buffer, whose matching LF may begin this one (CRLF
+// can straddle the 1 KB read boundary).  Returns the number of bytes written,
+// or -1 on a write error.
+long write_text(FILE *f, const uint8_t *buf, int len, bool *pending_cr)
+{
+    long w = 0;
+    for (int i = 0; i < len; ++i)
+    {
+        uint8_t c = buf[i];
+        if (*pending_cr)
+        {
+            // A CR was buffered last time; emit the CRLF it represents now.
+            if (fputc('\r', f) == EOF || fputc('\n', f) == EOF)
+                return -1;
+            w += 2;
+            *pending_cr = false;
+            if (c == '\n')
+                continue; // CRLF pair: this LF was already accounted for
+            if (c == '\r')
+            {
+                *pending_cr = true; // another bare CR; decide on the next byte
+                continue;
+            }
+            if (fputc(c, f) == EOF)
+                return -1;
+            ++w;
+        }
+        else if (c == '\r')
+        {
+            *pending_cr = true; // could be a lone CR or the CR of a CRLF
+        }
+        else if (c == '\n')
+        {
+            if (fputc('\r', f) == EOF || fputc('\n', f) == EOF)
+                return -1;
+            w += 2; // bare LF -> CRLF
+        }
+        else
+        {
+            if (fputc(c, f) == EOF)
+                return -1;
+            ++w;
+        }
+    }
+    return w;
+}
+
+// Pad a freshly-written CP/M file up to the next 128-byte record boundary with
+// the soft-EOF byte 0x1A (^Z).  RunCPM's disk layer (_sys_readseq in the
+// abstraction) reads whole 128-byte records only, so a file whose length is not
+// a multiple of 128 would have its final partial record dropped, and a
+// zero-length file would read as immediate EOF.  This is the single source of
+// truth for that convention: both |wget and |ftp call it so their on-disk
+// layout is identical.  128 == RunCPM BlkSZ.  Returns bytes padded, or -1 on a
+// write error.
+long pad_cpm_record(FILE *f, long written)
+{
+    long pad = (128 - (written % 128)) % 128;
+    if (written == 0)
+        pad = 128; // never leave a zero-length (unreadable) CP/M file
+    for (long i = 0; i < pad; ++i)
+        if (fputc(0x1A, f) == EOF)
+            return -1;
+    return pad;
+}
+
+// ---------------------------------------------------------------------------
+// Verb: wget
+// ---------------------------------------------------------------------------
+
+int do_wget(const char *args, const char *dir_prefix, char *outmsg,
+            int outmsg_size, const vm_bar_io *io)
+{
+    (void)io; // wget is non-interactive
+
+    // Options precede the URL: any whitespace-delimited token starting with '-'.
+    // Currently only -a (ASCII/text mode: convert line endings to CP/M CRLF).
+    bool ascii = false;
+    char url[256];
+    url[0] = '\0';
+    for (;;)
+    {
+        char t[256];
+        if (next_token(&args, t, sizeof(t)) == 0)
+            break; // ran out of tokens without finding a URL
+        if (t[0] == '-' && t[1] != '\0')
+        {
+            for (const char *o = t + 1; *o; ++o)
+            {
+                if (*o == 'a' || *o == 'A')
+                    ascii = true;
+                else
+                {
+                    snprintf(outmsg, outmsg_size, "wget: unknown option -%c\r\n", *o);
+                    return 1;
+                }
+            }
+            continue; // keep scanning for more options / the URL
+        }
+        snprintf(url, sizeof(url), "%s", t); // first non-option token = URL
+        break;
+    }
+    if (url[0] == '\0')
+    {
+        snprintf(outmsg, outmsg_size, "wget: usage: |wget [-a] URL [DEST]\r\n");
+        return 1;
+    }
+
+    char destarg[64];
+    next_token(&args, destarg, sizeof(destarg)); // optional explicit destination
+
+    // Decide the CP/M 8.3 destination filename.
+    char dest83[16];
+    if (destarg[0] != '\0')
+    {
+        if (!to_cpm_83(destarg, dest83, sizeof(dest83)))
+        {
+            snprintf(outmsg, outmsg_size, "wget: bad dest name\r\n");
+            return 1;
+        }
+    }
+    else
+    {
+        std::unique_ptr<PeoplesUrlParser> up = PeoplesUrlParser::parseURL(url);
+        const std::string &nm = up ? up->name : std::string();
+        if (nm.empty() || !to_cpm_83(nm.c_str(), dest83, sizeof(dest83)))
+        {
+            snprintf(outmsg, outmsg_size, "wget: cannot derive name, give DEST\r\n");
+            return 1;
+        }
+    }
+
+    // Full host path = directory prefix (ends in '/') + 8.3 name.
+    char path[160];
+    snprintf(path, sizeof(path), "%s%s", dir_prefix, dest83);
+
+    // Ensure the CP/M drive/user directory exists (create_path wants the
+    // directory path without a trailing slash).
+    char dir[160];
+    snprintf(dir, sizeof(dir), "%s", dir_prefix);
+    size_t dlen = strlen(dir);
+    if (dlen > 1 && dir[dlen - 1] == '/')
+        dir[dlen - 1] = '\0';
+    fnSDFAT.create_path(dir);
+
+    FILE *f = fnSDFAT.file_open(path, "w");
+    if (!f)
+    {
+        snprintf(outmsg, outmsg_size, "wget: open failed: %s\r\n", dest83);
+        return 1;
+    }
+
+    HTTP_CLIENT_CLASS http;
+    if (!http.begin(std::string(url)))
+    {
+        fclose(f);
+        fnSDFAT.remove(path);
+        snprintf(outmsg, outmsg_size, "wget: begin failed\r\n");
+        return 1;
+    }
+
+    int code = http.GET();
+    if (code < 200 || code >= 300)
+    {
+        http.close();
+        fclose(f);
+        fnSDFAT.remove(path);
+        snprintf(outmsg, outmsg_size, "wget: HTTP %d\r\n", code);
+        return 1;
+    }
+
+    // Drain the response body to the file (mirrors lib/network-protocol/HTTP.cpp).
+    // total   = raw bytes received from the server.
+    // written = bytes actually placed in the file (differs from total in ASCII
+    //           mode, where each line ending may grow from 1 byte to 2).
+    uint8_t buf[1024];
+    long total = 0;
+    long written = 0;
+    bool pending_cr = false; // ASCII mode: a CR awaiting its possible LF
+    bool ok = true;
+    while (!http.is_transaction_done() || http.available() > 0)
+    {
+        int len = http.available();
+        if (len > 0)
+        {
+            if (len > (int)sizeof(buf))
+                len = (int)sizeof(buf);
+            int got = http.read(buf, len);
+            if (got <= 0)
+            {
+                ok = false;
+                break;
+            }
+            if (ascii)
+            {
+                long w = write_text(f, buf, got, &pending_cr);
+                if (w < 0)
+                {
+                    ok = false;
+                    break;
+                }
+                written += w;
+            }
+            else
+            {
+                if ((int)fwrite(buf, 1, got, f) != got)
+                {
+                    ok = false;
+                    break;
+                }
+                written += got;
+            }
+            total += got;
+        }
+        else if (len == 0)
+        {
+            fnSystem.delay(10); // wait for more body data
+        }
+        else // len < 0
+        {
+            ok = false;
+            break;
+        }
+    }
+
+    http.close();
+
+    // ASCII mode: a stream ending on a bare CR leaves a pending CRLF to emit.
+    if (ok && ascii && pending_cr)
+    {
+        if (fputc('\r', f) == EOF || fputc('\n', f) == EOF)
+            ok = false;
+        else
+            written += 2;
+    }
+
+    // Pad up to the next 128-byte CP/M record boundary so TYPE and other tools
+    // can read back exactly what was written (see pad_cpm_record).
+    if (ok && pad_cpm_record(f, written) < 0)
+        ok = false;
+
+    fclose(f);
+
+    if (!ok)
+    {
+        fnSDFAT.remove(path);
+        snprintf(outmsg, outmsg_size, "wget: read error after %ld bytes\r\n", total);
+        return 1;
+    }
+
+    snprintf(outmsg, outmsg_size, "Saved %s (%ld bytes)\r\n", dest83, written);
+    return 0;
+}
+
+// ---------------------------------------------------------------------------
+// Verb: fn  (FujiNet info subcommands)
+// ---------------------------------------------------------------------------
+
+// Append src to outmsg at *off, never exceeding outmsg_size.  Returns false
+// (and stops the caller) once the buffer is full so a long listing degrades
+// gracefully instead of overflowing.
+bool append_msg(char *outmsg, int outmsg_size, int *off, const char *src)
+{
+    int avail = outmsg_size - *off;
+    if (avail <= 1)
+        return false;
+    int n = snprintf(outmsg + *off, avail, "%s", src);
+    if (n < 0)
+        return false;
+    if (n >= avail)
+    {
+        *off = outmsg_size - 1; // truncated; no room for more
+        return false;
+    }
+    *off += n;
+    return true;
+}
+
+// |fn mounts — read-only listing of the FujiNet drive slots D1-D8, mirroring
+// the host:path (mode) column of the web/config UI (httpServiceBrowser.cpp
+// browse_listdrives()).  Uses only Config getters, so it performs no mount,
+// eject, write, reconnect, WiFi, SD-card, or network side effects.
+int do_fn_mounts(char *outmsg, int outmsg_size)
+{
+    outmsg[0] = '\0';
+    int off = 0;
+
+    for (int slot = 0; slot < MAX_MOUNT_SLOTS && slot < 8; ++slot)
+    {
+        int host_slot = Config.get_mount_host_slot(slot);
+        std::string path = Config.get_mount_path(slot);
+
+        char line[320];
+        if (host_slot == HOST_SLOT_INVALID && path.empty())
+        {
+            // Nothing configured for this slot.
+            snprintf(line, sizeof(line), "D%d: <empty>\r\n", slot + 1);
+        }
+        else
+        {
+            // Host name from the referenced host slot; fall back safely if the
+            // slot index is invalid/unknown but a path is still present.
+            std::string host = (host_slot != HOST_SLOT_INVALID)
+                                   ? Config.get_host_name((uint8_t)host_slot)
+                                   : std::string();
+            const char *hoststr = host.empty() ? "<unknown-host>" : host.c_str();
+
+            fnConfig::mount_mode_t m = Config.get_mount_mode(slot);
+            const char *modestr =
+                (m == fnConfig::mount_modes::MOUNTMODE_READ)    ? "R"
+                : (m == fnConfig::mount_modes::MOUNTMODE_WRITE) ? "W"
+                                                                : "?";
+
+            snprintf(line, sizeof(line), "D%d: %s:%s (%s)\r\n",
+                     slot + 1, hoststr, path.c_str(), modestr);
+        }
+
+        if (!append_msg(outmsg, outmsg_size, &off, line))
+            break;
+    }
+    return 0;
+}
+
+int do_fn(const char *args, const char *dir_prefix, char *outmsg,
+          int outmsg_size, const vm_bar_io *io)
+{
+    (void)dir_prefix;
+    (void)io; // fn is non-interactive
+
+    char sub[16];
+    next_token(&args, sub, sizeof(sub));
+    for (char *s = sub; *s; ++s)
+        *s = (char)tolower((unsigned char)*s);
+
+    // No subcommand, or an explicit help request -> list the |fn subcommands.
+    if (sub[0] == '\0' || strcmp(sub, "help") == 0 || strcmp(sub, "--help") == 0)
+    {
+        snprintf(outmsg, outmsg_size,
+                 "FNC Bar Commands:\r\n"
+                 "|fn mounts - show mounted FujiNet drive slots D1-D8\r\n"
+                 "|fn help   - this list\r\n");
+        return 0;
+    }
+
+    if (strcmp(sub, "mounts") == 0)
+    {
+        // Per-command help: |fn mounts --help (or -h / help).
+        char opt[16];
+        next_token(&args, opt, sizeof(opt));
+        for (char *o = opt; *o; ++o)
+            *o = (char)tolower((unsigned char)*o);
+        if (strcmp(opt, "--help") == 0 || strcmp(opt, "-h") == 0 ||
+            strcmp(opt, "help") == 0)
+        {
+            snprintf(outmsg, outmsg_size,
+                     "|fn mounts - show currently mounted FujiNet drive slots "
+                     "D1-D8\r\n");
+            return 0;
+        }
+        // Any other extra arguments are ignored (as |wget ignores trailing
+        // tokens) since the listing takes no parameters.
+        return do_fn_mounts(outmsg, outmsg_size);
+    }
+
+    snprintf(outmsg, outmsg_size, "?fn: %s (try |fn help)\r\n", sub);
+    return 1;
+}
+
+// ---------------------------------------------------------------------------
+// Verb: help
+// ---------------------------------------------------------------------------
+
+int do_help(const char *args, const char *dir_prefix, char *outmsg,
+            int outmsg_size, const vm_bar_io *io)
+{
+    (void)args;
+    (void)dir_prefix;
+    (void)io; // help is non-interactive
+    snprintf(outmsg, outmsg_size,
+             "Bar commands:\r\n"
+             "|wget [-a] URL [DEST] - download URL to current dir\r\n"
+             "                       (-a: convert text to CP/M CRLF)\r\n"
+             "|ftp HOST             - interactive anonymous FTP client\r\n"
+             "|fn                   - FujiNet Network Configuration Tools\r\n"
+             "|apt                  - Advanced Packaging Tool\r\n"
+             "|help                 - this list\r\n");
+    return 0;
+}
+
+// ---------------------------------------------------------------------------
+// Verb: ftp  (interactive anonymous FTP client)
+// ---------------------------------------------------------------------------
+//
+// Unlike the other verbs, |ftp is INTERACTIVE: it opens a small shell that
+// reads commands from, and prints results to, the CP/M terminal through the
+// vm_bar_io callbacks the CCP hook supplies.  It reuses the existing FujiNet
+// FTP client (fnFTP) for all networking and fnSDFAT for SD writes — no new FTP
+// stack and no new file I/O.  Scope is deliberately small: anonymous login,
+// browse (ls/cd/pwd), and download (get).  There is no put, no remote mutation,
+// and no credential handling.
+
+// Map a CP/M user number (0..15) to RunCPM's directory hex character ('0'..'9',
+// 'A'..'F'), matching ccp.h's tohex()/toupper() so |ftp writes to the same
+// /CPM/<drive>/<user>/ folder DIR and TYPE read from.
+char ftp_hexuser(int u) { return (char)(u < 10 ? '0' + u : 'A' + (u - 10)); }
+
+// Interactive FTP session state.
+struct FtpState
+{
+    std::string remote_cwd; // current remote directory, absolute, starts '/'
+    std::string root;       // local CP/M host root prefix, e.g. "/CPM/"
+    char drive;             // local CP/M drive letter A..P
+    int user;               // local CP/M user number 0..15
+    bool binary;            // true = binary (default), false = ASCII text
+};
+
+// Build the host directory for the current local CP/M drive/user, ending in '/'
+// (e.g. root "/CPM/" + drive 'B' + user 3 -> "/CPM/B/3/").
+std::string ftp_local_dir(const FtpState &st)
+{
+    std::string d = st.root;
+    d += st.drive;
+    d += '/';
+    d += ftp_hexuser(st.user);
+    d += '/';
+    return d;
+}
+
+// Parse a CP/M drive/user spec like "A", "A:", "A0", "A0:", "A15:".  Drive must
+// be A..P; user (when present) must be 0..15 and defaults to 0.  Returns false
+// on a bad drive letter, an out-of-range user, or trailing garbage.
+bool parse_lcd(const char *tok, char *drive, int *user)
+{
+    if (!tok || !tok[0])
+        return false;
+    char d = (char)toupper((unsigned char)tok[0]);
+    if (d < 'A' || d > 'P')
+        return false;
+    const char *p = tok + 1;
+    int u = 0;
+    bool has_digit = false;
+    while (*p >= '0' && *p <= '9')
+    {
+        u = u * 10 + (*p - '0');
+        if (u > 15)
+            return false;
+        has_digit = true;
+        ++p;
+    }
+    if (*p == ':')
+        ++p;
+    if (*p != '\0')
+        return false; // trailing junk (e.g. "A0X")
+    *drive = d;
+    *user = has_digit ? u : 0;
+    return true;
+}
+
+// Resolve an FTP path argument against the current remote working directory.
+// Absolute args (leading '/') replace cwd; relative args extend it.  '.', '..'
+// and duplicate slashes collapse.  The result always begins with '/'.
+std::string ftp_resolve(const std::string &cwd, const std::string &arg)
+{
+    std::string in = (!arg.empty() && arg[0] == '/') ? arg : (cwd + "/" + arg);
+    std::vector<std::string> parts;
+    size_t i = 0;
+    while (i < in.size())
+    {
+        size_t j = in.find('/', i);
+        if (j == std::string::npos)
+            j = in.size();
+        std::string seg = in.substr(i, j - i);
+        if (seg.empty() || seg == ".")
+        {
+            // skip
+        }
+        else if (seg == "..")
+        {
+            if (!parts.empty())
+                parts.pop_back();
+        }
+        else
+        {
+            parts.push_back(seg);
+        }
+        i = j + 1;
+    }
+    std::string out = "/";
+    for (size_t k = 0; k < parts.size(); ++k)
+    {
+        out += parts[k];
+        if (k + 1 < parts.size())
+            out += "/";
+    }
+    return out;
+}
+
+// Read one line from the interactive terminal into buf (NUL-terminated, at most
+// bufsize-1 chars).  Echoes printable input through io, supports BS/DEL line
+// editing, and treats Ctrl-C as "cancel this line".  CR or LF ends the line.
+// Returns the line length, or -1 if cancelled with Ctrl-C.
+int ftp_readline(const vm_bar_io *io, char *buf, int bufsize)
+{
+    int n = 0;
+    for (;;)
+    {
+        int c = io->getch() & 0xFF;
+        if (c == 0x03) // Ctrl-C
+        {
+            io->puts_("^C\r\n");
+            return -1;
+        }
+        if (c == '\r' || c == '\n')
+        {
+            io->puts_("\r\n");
+            break;
+        }
+        if (c == 0x08 || c == 0x7F) // BS / DEL
+        {
+            if (n > 0)
+            {
+                --n;
+                io->puts_("\b \b");
+            }
+            continue;
+        }
+        if (c < 0x20) // ignore other control characters
+            continue;
+        if (n < bufsize - 1)
+        {
+            buf[n++] = (char)c;
+            io->putch(c); // echo
+        }
+    }
+    buf[n] = '\0';
+    return n;
+}
+
+// |ftp 'get' — RETR a remote file into the current local CP/M directory using a
+// safe temp-then-rename sequence.  All status is printed through io.
+void do_ftp_get(fnFTP &ftp, FtpState &st, const char *args, const vm_bar_io *io)
+{
+    bool use_ascii = !st.binary; // per-transfer mode starts from the session's
+    bool force = false;
+    char remote[256];
+    remote[0] = '\0';
+    char localarg[64];
+    localarg[0] = '\0';
+
+    // Options (-a ascii, -b binary, -f force) precede the remote name.
+    const char *q = args;
+    for (;;)
+    {
+        char t[256];
+        if (next_token(&q, t, sizeof(t)) == 0)
+            break;
+        if (t[0] == '-' && t[1] != '\0')
+        {
+            for (const char *o = t + 1; *o; ++o)
+            {
+                if (*o == 'a' || *o == 'A')
+                    use_ascii = true;
+                else if (*o == 'b' || *o == 'B')
+                    use_ascii = false;
+                else if (*o == 'f' || *o == 'F')
+                    force = true;
+                else
+                {
+                    io->puts_("?get: unknown option\r\n");
+                    return;
+                }
+            }
+            continue;
+        }
+        snprintf(remote, sizeof(remote), "%s", t);
+        break;
+    }
+    if (remote[0] == '\0')
+    {
+        io->puts_("?USAGE: get [-a|-b|-f] remote [local]\r\n");
+        return;
+    }
+    next_token(&q, localarg, sizeof(localarg)); // optional explicit local name
+
+    std::string rpath = ftp_resolve(st.remote_cwd, remote);
+
+    // Derive the CP/M 8.3 local name (explicit arg wins, else the remote
+    // basename).  No silent truncation — reject a name that won't fit.
+    char name83[16];
+    const char *src = localarg[0] ? localarg : rpath.c_str();
+    if (!to_cpm_83(src, name83, sizeof(name83)))
+    {
+        io->puts_("?BAD CP/M NAME - USE: get remote-file LOCAL.EXT\r\n");
+        return;
+    }
+
+    std::string dir = ftp_local_dir(st);
+    std::string finalpath = dir + name83;
+    std::string tmp = dir + "$FTPTEMP.$$$";
+
+    if (fnSDFAT.exists(finalpath.c_str()) && !force)
+    {
+        io->puts_("?FILE EXISTS\r\n");
+        return;
+    }
+
+    // Ensure the CP/M drive/user directory exists (create_path wants no trailing
+    // slash).
+    std::string dirNoSlash = dir;
+    if (dirNoSlash.size() > 1 && dirNoSlash.back() == '/')
+        dirNoSlash.pop_back();
+    fnSDFAT.create_path(dirNoSlash.c_str());
+
+    FILE *f = fnSDFAT.file_open(tmp.c_str(), "w");
+    if (!f)
+    {
+        io->puts_("?SD WRITE ERROR\r\n");
+        return;
+    }
+
+    if (ftp.open_file(rpath, false) != FUJI_ERROR::NONE)
+    {
+        fclose(f);
+        fnSDFAT.remove(tmp.c_str());
+        io->puts_("?NO SUCH FILE\r\n");
+        return;
+    }
+
+    // Drain the data connection.  Mirrors lib/FileSystem/fnFsFTP.cpp
+    // cache_file(): read whatever the data socket has buffered, clamped to what
+    // fnFTP::read_file() can satisfy in one call, until the server closes the
+    // data connection (data_connected() == NONE).
+    uint8_t buf[1024];
+    long total = 0;
+    long written = 0;
+    bool pending_cr = false; // ASCII: a CR awaiting its possible LF
+    int last_raw = -1;       // last raw byte received (ASCII soft-EOF decision)
+    bool ok = true;
+    bool done = false;
+    while (!done)
+    {
+        int available = ftp.data_available();
+        if (ftp.data_connected() == FUJI_ERROR::NONE) // transfer complete
+            break;
+        if (available == 0)
+        {
+            fnSystem.delay(10); // server still sending; wait for the next burst
+            continue;
+        }
+        if (available < 0)
+        {
+            ok = false;
+            break;
+        }
+        while (available > 0)
+        {
+            if (ftp.data_connected() == FUJI_ERROR::NONE)
+            {
+                done = true;
+                break;
+            }
+            int to_read = available > (int)sizeof(buf) ? (int)sizeof(buf) : available;
+            if (ftp.read_file(buf, (unsigned short)to_read) != FUJI_ERROR::NONE)
+            {
+                ok = false;
+                break;
+            }
+            last_raw = buf[to_read - 1];
+            if (use_ascii)
+            {
+                long w = write_text(f, buf, to_read, &pending_cr);
+                if (w < 0)
+                {
+                    ok = false;
+                    break;
+                }
+                written += w;
+            }
+            else
+            {
+                if ((int)fwrite(buf, 1, to_read, f) != to_read)
+                {
+                    ok = false;
+                    break;
+                }
+                written += to_read;
+            }
+            total += to_read;
+            available = ftp.data_available();
+        }
+        if (!ok)
+            break;
+    }
+
+    ftp.close();
+
+    // ASCII: flush a trailing bare CR, then guarantee a CP/M soft-EOF (^Z),
+    // appending one only if the text doesn't already end with it.
+    if (ok && use_ascii && pending_cr)
+    {
+        if (fputc('\r', f) == EOF || fputc('\n', f) == EOF)
+            ok = false;
+        else
+            written += 2;
+    }
+    if (ok && use_ascii && last_raw != 0x1A)
+    {
+        if (fputc(0x1A, f) == EOF)
+            ok = false;
+        else
+            ++written;
+    }
+
+    // Pad to the next 128-byte CP/M record boundary (same convention as |wget).
+    if (ok && pad_cpm_record(f, written) < 0)
+        ok = false;
+
+    fclose(f);
+
+    if (!ok)
+    {
+        fnSDFAT.remove(tmp.c_str()); // never leave a partial/corrupt file
+        io->puts_("?TRANSFER FAILED\r\n");
+        return;
+    }
+
+    // Safe publish: the temp is closed; only now remove the old final (when
+    // forcing) and rename temp -> final.  On rename failure the temp is removed
+    // and the existing final is left untouched.
+    if (force && fnSDFAT.exists(finalpath.c_str()))
+        fnSDFAT.remove(finalpath.c_str());
+    if (!fnSDFAT.rename(tmp.c_str(), finalpath.c_str()))
+    {
+        fnSDFAT.remove(tmp.c_str());
+        io->puts_("?SD WRITE ERROR\r\n");
+        return;
+    }
+
+    char line[64];
+    snprintf(line, sizeof(line), "Got %s (%ld bytes)\r\n", name83, written);
+    io->puts_(line);
+    (void)total;
+}
+
+int do_ftp(const char *args, const char *dir_prefix, char *outmsg,
+           int outmsg_size, const vm_bar_io *io)
+{
+    // |ftp is interactive and needs the terminal-I/O callbacks.  A
+    // non-interactive caller (no io) gets a clear refusal instead of a crash.
+    if (!io || !io->getch || !io->putch || !io->puts_)
+    {
+        snprintf(outmsg, outmsg_size, "?INTERACTIVE I/O UNAVAILABLE\r\n");
+        return 1;
+    }
+    outmsg[0] = '\0'; // the shell prints everything through io itself
+
+    char host[128];
+    if (next_token(&args, host, sizeof(host)) == 0)
+    {
+        io->puts_("?USAGE: |ftp HOST\r\n");
+        return 1;
+    }
+
+    // Initialise session state.  Parse dir_prefix ("/CPM/A/0/") into the local
+    // root, drive letter and user number so 'get' lands where DIR/TYPE look.
+    FtpState st;
+    st.remote_cwd = "/";
+    st.binary = true; // binary is the default transfer mode
+    st.drive = 'A';
+    st.user = 0;
+    st.root = "/CPM/";
+    {
+        std::string dp = dir_prefix ? dir_prefix : "/CPM/A/0/";
+        if (!dp.empty() && dp.back() == '/')
+            dp.pop_back(); // "/CPM/A/0"
+        size_t s2 = dp.find_last_of('/');
+        if (s2 != std::string::npos && s2 > 0)
+        {
+            std::string useg = dp.substr(s2 + 1);
+            std::string rest = dp.substr(0, s2);
+            size_t s1 = rest.find_last_of('/');
+            if (s1 != std::string::npos && !useg.empty())
+            {
+                std::string dseg = rest.substr(s1 + 1);
+                char u = (char)toupper((unsigned char)useg[0]);
+                int un = (u >= '0' && u <= '9')   ? (u - '0')
+                         : (u >= 'A' && u <= 'F') ? (10 + u - 'A')
+                                                  : -1;
+                if (!dseg.empty())
+                {
+                    char d = (char)toupper((unsigned char)dseg[0]);
+                    if (d >= 'A' && d <= 'P' && un >= 0)
+                    {
+                        st.drive = d;
+                        st.user = un;
+                        st.root = rest.substr(0, s1 + 1); // "/CPM/"
+                    }
+                }
+            }
+        }
+    }
+
+    // Connect + anonymous login.  Reuses the codebase default anonymous
+    // credentials; there is no user/password prompt and nothing is stored.
+    fnFTP ftp;
+    if (ftp.login("anonymous", "fujinet@fujinet.online", std::string(host)) !=
+        FUJI_ERROR::NONE)
+    {
+        io->puts_("?LOGIN FAILED\r\n");
+        return 1;
+    }
+
+    {
+        char banner[200];
+        snprintf(banner, sizeof(banner),
+                 "\r\nConnected to %s (anonymous).\r\n"
+                 "Type 'help' for commands, 'bye' to quit.\r\n",
+                 host);
+        io->puts_(banner);
+    }
+
+    for (;;)
+    {
+        io->puts_("ftp> ");
+        char line[256];
+        int n = ftp_readline(io, line, sizeof(line));
+        if (n < 0)
+            continue; // Ctrl-C cancels the current line
+
+        const char *p = line;
+        char cmd[16];
+        if (next_token(&p, cmd, sizeof(cmd)) == 0)
+            continue;
+        for (char *c = cmd; *c; ++c)
+            *c = (char)tolower((unsigned char)*c);
+
+        if (strcmp(cmd, "bye") == 0 || strcmp(cmd, "quit") == 0)
+        {
+            ftp.logout();
+            break;
+        }
+        else if (strcmp(cmd, "help") == 0 || strcmp(cmd, "?") == 0)
+        {
+            io->puts_(
+                "Commands:\r\n"
+                "  ls [path]    list remote dir     cd path  change remote dir\r\n"
+                "  pwd          show remote dir      lcd D[u] set local CP/M dir\r\n"
+                "  lpwd         show local dir       type     show transfer mode\r\n"
+                "  ascii        text mode (CRLF+^Z)  binary   binary mode\r\n"
+                "  get [-a|-b|-f] remote [local]     bye      quit\r\n");
+        }
+        else if (strcmp(cmd, "pwd") == 0)
+        {
+            char b[280];
+            snprintf(b, sizeof(b), "%s\r\n", st.remote_cwd.c_str());
+            io->puts_(b);
+        }
+        else if (strcmp(cmd, "lpwd") == 0)
+        {
+            char b[16];
+            snprintf(b, sizeof(b), "%c%c:\r\n", st.drive, ftp_hexuser(st.user));
+            io->puts_(b);
+        }
+        else if (strcmp(cmd, "type") == 0)
+        {
+            io->puts_(st.binary ? "binary\r\n" : "ascii\r\n");
+        }
+        else if (strcmp(cmd, "binary") == 0)
+        {
+            st.binary = true;
+            io->puts_("binary\r\n");
+        }
+        else if (strcmp(cmd, "ascii") == 0)
+        {
+            st.binary = false;
+            io->puts_("ascii\r\n");
+        }
+        else if (strcmp(cmd, "lcd") == 0)
+        {
+            char arg[32];
+            if (next_token(&p, arg, sizeof(arg)) == 0)
+            {
+                char b[16];
+                snprintf(b, sizeof(b), "%c%c:\r\n", st.drive, ftp_hexuser(st.user));
+                io->puts_(b);
+            }
+            else
+            {
+                char d;
+                int u;
+                if (parse_lcd(arg, &d, &u))
+                {
+                    st.drive = d;
+                    st.user = u;
+                }
+                else
+                {
+                    io->puts_("?BAD LOCAL NAME\r\n");
+                }
+            }
+        }
+        else if (strcmp(cmd, "cd") == 0)
+        {
+            char arg[256];
+            if (next_token(&p, arg, sizeof(arg)) == 0)
+            {
+                io->puts_("?USAGE: cd PATH\r\n");
+            }
+            else
+            {
+                std::string target = ftp_resolve(st.remote_cwd, arg);
+                // Validate by listing; open_directory stops its own data socket,
+                // so no extra cleanup is needed here.
+                if (ftp.open_directory(target, "") != FUJI_ERROR::NONE)
+                    io->puts_("?NO SUCH FILE\r\n");
+                else
+                    st.remote_cwd = target;
+            }
+        }
+        else if (strcmp(cmd, "ls") == 0 || strcmp(cmd, "dir") == 0)
+        {
+            char arg[256];
+            std::string target = st.remote_cwd;
+            if (next_token(&p, arg, sizeof(arg)) != 0)
+                target = ftp_resolve(st.remote_cwd, arg);
+            if (ftp.open_directory(target, "") != FUJI_ERROR::NONE)
+            {
+                io->puts_("?NO SUCH FILE\r\n");
+            }
+            else
+            {
+                // read_directory ends iteration on a non-NONE result OR an empty
+                // name (the "no more entries" sentinel); the last real entry may
+                // still arrive together with the terminating non-NONE.
+                for (;;)
+                {
+                    std::string name;
+                    long sz = 0;
+                    bool isdir = false;
+                    fujiError_t r = ftp.read_directory(name, sz, isdir);
+                    if (!name.empty())
+                    {
+                        io->puts_(name.c_str());
+                        if (isdir)
+                            io->puts_("/");
+                        io->puts_("\r\n");
+                    }
+                    if (r != FUJI_ERROR::NONE || name.empty())
+                        break;
+                }
+            }
+        }
+        else if (strcmp(cmd, "get") == 0)
+        {
+            do_ftp_get(ftp, st, p, io);
+        }
+        else
+        {
+            char b[48];
+            snprintf(b, sizeof(b), "?%s\r\n", cmd);
+            io->puts_(b);
+        }
+    }
+
+    return 0;
+}
+
+// ---------------------------------------------------------------------------
+// Verb: apt  (Advanced Packaging Tool — STUB / scaffolding only)
+// ---------------------------------------------------------------------------
+//
+// This is intentionally a command-dispatch SKELETON for a future package
+// manager.  It parses the apt subcommand and its arguments, validates the
+// usage shape, and prints "to be implemented" for every recognized command.
+// It performs NO package management: no network access, no SD writes, no
+// downloads, no archive extraction, no package database, and the
+// "to=<destination>" option (valid only for `install`) is parsed but not
+// acted upon.  All real functionality is deferred to a later stage.
+//
+// Recognized subcommands:
+//   update                              refresh package index   (stub)
+//   install <package> [to=<dest>]       install a package       (stub)
+//   upgrade                             upgrade everything       (stub)
+//   remove  <package>                   remove a package         (stub)
+//   list                                list packages            (stub)
+//   search  <text>                      search packages          (stub)
+//   info    <package>                   show package details     (stub)
+int do_apt(const char *args, const char *dir_prefix, char *outmsg,
+           int outmsg_size, const vm_bar_io *io)
+{
+    (void)dir_prefix;
+    (void)io; // non-interactive stub
+
+    const char *p = skip_spaces(args);
+    char sub[16];
+    next_token(&p, sub, sizeof(sub));
+
+    // Subcommand match is case-insensitive.
+    for (char *s = sub; *s; ++s)
+        *s = (char)tolower((unsigned char)*s);
+
+    // No subcommand, or explicit help -> print the apt usage banner.
+    if (sub[0] == '\0' || strcmp(sub, "help") == 0 ||
+        strcmp(sub, "--help") == 0)
+    {
+        snprintf(outmsg, outmsg_size,
+                 "APT Bar Commands:\r\n"
+                 "\r\n"
+                 "usage:\r\n"
+                 "  |apt update\r\n"
+                 "  |apt install <package> [to=<destination>]\r\n"
+                 "  |apt upgrade\r\n"
+                 "  |apt remove <package>\r\n"
+                 "  |apt list\r\n"
+                 "  |apt search <text>\r\n"
+                 "  |apt info <package>\r\n"
+                 "\r\n"
+                 "examples:\r\n"
+                 "  |apt install aztec-c\r\n"
+                 "  |apt install aztec-c to=A1:\r\n");
+        return 0;
+    }
+
+    // Commands that take NO arguments.
+    if (strcmp(sub, "update") == 0 || strcmp(sub, "upgrade") == 0 ||
+        strcmp(sub, "list") == 0)
+    {
+        char extra[64];
+        next_token(&p, extra, sizeof(extra));
+        if (extra[0] != '\0')
+        {
+            snprintf(outmsg, outmsg_size, "USE: |apt %s\r\n", sub);
+            return 1;
+        }
+        snprintf(outmsg, outmsg_size, "to be implemented\r\n");
+        return 0;
+    }
+
+    // install <package> [to=<destination>]
+    if (strcmp(sub, "install") == 0)
+    {
+        char pkg[64];
+        next_token(&p, pkg, sizeof(pkg));
+        if (pkg[0] == '\0')
+        {
+            snprintf(outmsg, outmsg_size,
+                     "USE: |apt install <package> [to=<destination>]\r\n");
+            return 1;
+        }
+        // Optional second token must be "to=<destination>".
+        char opt[80];
+        next_token(&p, opt, sizeof(opt));
+        if (opt[0] != '\0')
+        {
+            if (strncmp(opt, "to=", 3) != 0 || opt[3] == '\0')
+            {
+                snprintf(outmsg, outmsg_size,
+                         "USE: |apt install <package> [to=<destination>]\r\n");
+                return 1;
+            }
+            // Reject anything after the to= token.
+            char trailing[16];
+            next_token(&p, trailing, sizeof(trailing));
+            if (trailing[0] != '\0')
+            {
+                snprintf(outmsg, outmsg_size,
+                         "USE: |apt install <package> [to=<destination>]\r\n");
+                return 1;
+            }
+            // "to=<destination>" is parsed but not acted upon (stub).
+        }
+        snprintf(outmsg, outmsg_size, "to be implemented\r\n");
+        return 0;
+    }
+
+    // remove <package> / info <package> — exactly one argument; no to=.
+    if (strcmp(sub, "remove") == 0 || strcmp(sub, "info") == 0)
+    {
+        char pkg[64];
+        next_token(&p, pkg, sizeof(pkg));
+        if (pkg[0] == '\0')
+        {
+            snprintf(outmsg, outmsg_size, "USE: |apt %s <package>\r\n", sub);
+            return 1;
+        }
+        char extra[64];
+        next_token(&p, extra, sizeof(extra));
+        if (extra[0] != '\0')
+        {
+            // Trailing tokens (e.g. a stray to=) are malformed here:
+            // to=<destination> is only valid for `install`.
+            snprintf(outmsg, outmsg_size, "USE: |apt %s <package>\r\n", sub);
+            return 1;
+        }
+        snprintf(outmsg, outmsg_size, "to be implemented\r\n");
+        return 0;
+    }
+
+    // search <text> — requires a search term.
+    if (strcmp(sub, "search") == 0)
+    {
+        char term[64];
+        next_token(&p, term, sizeof(term));
+        if (term[0] == '\0')
+        {
+            snprintf(outmsg, outmsg_size, "USE: |apt search <text>\r\n");
+            return 1;
+        }
+        snprintf(outmsg, outmsg_size, "to be implemented\r\n");
+        return 0;
+    }
+
+    snprintf(outmsg, outmsg_size, "?UNKNOWN APT COMMAND\r\nUSE: |apt help\r\n");
+    return 1;
+}
+
+// ---------------------------------------------------------------------------
+// Dispatch table (extension point for new verbs)
+// ---------------------------------------------------------------------------
+
+struct BarVerb
+{
+    const char *name;
+    int (*handler)(const char *args, const char *dir_prefix, char *outmsg,
+                   int outmsg_size, const vm_bar_io *io);
+};
+
+const BarVerb kVerbs[] = {
+    {"wget", do_wget},
+    {"ftp", do_ftp},
+    {"fn", do_fn},
+    {"apt", do_apt},
+    {"help", do_help},
+};
+
+} // namespace
+
+// ---------------------------------------------------------------------------
+// Gate entry point
+// ---------------------------------------------------------------------------
+
+extern "C" int vm_bar_command(const char *cmd, const char *dir_prefix,
+                               char *outmsg, int outmsg_size,
+                               const vm_bar_io *io)
+{
+    if (!outmsg || outmsg_size <= 0)
+        return 1;
+    outmsg[0] = '\0';
+
+    if (!cmd)
+    {
+        snprintf(outmsg, outmsg_size, "?bar\r\n");
+        return 1;
+    }
+
+    const char *p = skip_spaces(cmd);
+    char verb[16];
+    next_token(&p, verb, sizeof(verb));
+    if (verb[0] == '\0')
+    {
+        snprintf(outmsg, outmsg_size, "?bar (try |help)\r\n");
+        return 1;
+    }
+
+    // Verb match is case-insensitive.
+    for (char *v = verb; *v; ++v)
+        *v = (char)tolower((unsigned char)*v);
+
+    const char *prefix = dir_prefix ? dir_prefix : "/CPM/";
+
+    for (size_t i = 0; i < sizeof(kVerbs) / sizeof(kVerbs[0]); ++i)
+    {
+        if (strcmp(verb, kVerbs[i].name) == 0)
+            return kVerbs[i].handler(p, prefix, outmsg, outmsg_size, io);
+    }
+
+    snprintf(outmsg, outmsg_size, "?bar: %s (try |help)\r\n", verb);
+    return 1;
+}
+
+#endif // BUILD_ATARI

--- a/lib/device/sio/vm_bar.cpp
+++ b/lib/device/sio/vm_bar.cpp
@@ -28,14 +28,6 @@
 
 #include "../../include/debug.h"
 
-#ifdef ESP_PLATFORM
-#include "fnHttpClient.h"
-#define HTTP_CLIENT_CLASS fnHttpClient
-#else
-#include "mgHttpClient.h"
-#define HTTP_CLIENT_CLASS mgHttpClient
-#endif
-
 #include "fnFsSD.h"
 #include "fnSystem.h"
 #include "peoples_url_parser.h"
@@ -43,6 +35,21 @@
 #include "fnConfig.h" // Config: read-only host/mount slot accessors for |fn mounts
 
 #include "fnFTP.h" // existing FujiNet FTP client, reused by |ftp (no new stack)
+
+// NOTE: the HTTP client header MUST come after the FujiNet bus headers above.
+// On Windows/FujiNet-PC, mgHttpClient.h pulls in mongoose.h, which does
+// `#define poll(a,b,c) WSAPoll(...)`.  bus headers (fnSystem.h -> bus.h ->
+// NetSIO.h) declare a method `bool poll(int ms);` — if mongoose's macro is
+// already active, that declaration fails with "too few arguments provided to
+// function-like macro invocation".  Including the bus headers first lets
+// NetSIO.h parse cleanly before the macro is defined.
+#ifdef ESP_PLATFORM
+#include "fnHttpClient.h"
+#define HTTP_CLIENT_CLASS fnHttpClient
+#else
+#include "mgHttpClient.h"
+#define HTTP_CLIENT_CLASS mgHttpClient
+#endif
 
 #include <ctype.h>
 #include <stdio.h>

--- a/lib/device/sio/vm_bar.cpp
+++ b/lib/device/sio/vm_bar.cpp
@@ -36,6 +36,8 @@
 
 #include "fnFTP.h" // existing FujiNet FTP client, reused by |ftp (no new stack)
 
+#include "utils.h" // util_sam_say(): SAM text-to-speech out the SIO AUDIO line, used by |say
+
 // NOTE: the HTTP client header MUST come after the FujiNet bus headers above.
 // On Windows/FujiNet-PC, mgHttpClient.h pulls in mongoose.h, which does
 // `#define poll(a,b,c) WSAPoll(...)`.  bus headers (fnSystem.h -> bus.h ->
@@ -526,6 +528,42 @@ int do_fn(const char *args, const char *dir_prefix, char *outmsg,
 }
 
 // ---------------------------------------------------------------------------
+// Verb: say  (speak text via the SAM voice synth, out the SIO AUDIO line)
+// ---------------------------------------------------------------------------
+//
+// Reuses the firmware's built-in SAM (Software Automatic Mouth) synthesizer via
+// util_sam_say() (lib/utils/utils.cpp) — the same engine that announces disk
+// swaps.  The synthesized 8-bit/22050 Hz PCM is played out the FujiNet DAC onto
+// the Atari SIO AUDIO IN line.  util_sam_say() copies the text into SAM's own
+// buffer, so this never writes back into Z80 RAM (the gate's contract holds).
+// Playback is synchronous (it blocks the CP/M worker task for the speech
+// duration, exactly like the disk-swap announcements).
+
+int do_say(const char *args, const char *dir_prefix, char *outmsg,
+           int outmsg_size, const vm_bar_io *io)
+{
+    (void)dir_prefix;
+    (void)io; // non-interactive: speech is hardware audio, not console I/O
+
+    const char *text = skip_spaces(args);
+
+    if (text[0] == '\0' || strcmp(text, "help") == 0 ||
+        strcmp(text, "--help") == 0)
+    {
+        snprintf(outmsg, outmsg_size,
+                 "|say <text> - speak text aloud via the SAM voice synth\r\n"
+                 "              (audio out the Atari SIO AUDIO line)\r\n");
+        return text[0] == '\0' ? 1 : 0;
+    }
+
+    // English text -> SAM's reciter converts it to phonemes (phonetic=false).
+    util_sam_say(text);
+
+    snprintf(outmsg, outmsg_size, "OK\r\n");
+    return 0;
+}
+
+// ---------------------------------------------------------------------------
 // Verb: help
 // ---------------------------------------------------------------------------
 
@@ -542,6 +580,7 @@ int do_help(const char *args, const char *dir_prefix, char *outmsg,
              "|ftp HOST             - interactive anonymous FTP client\r\n"
              "|fn                   - FujiNet Network Configuration Tools\r\n"
              "|apt                  - Advanced Packaging Tool\r\n"
+             "|say <text>           - Speak aloud using SAM voice\r\n"
              "|help                 - this list\r\n");
     return 0;
 }
@@ -1289,6 +1328,7 @@ const BarVerb kVerbs[] = {
     {"ftp", do_ftp},
     {"fn", do_fn},
     {"apt", do_apt},
+    {"say", do_say},
     {"help", do_help},
 };
 

--- a/lib/device/sio/vm_bar.h
+++ b/lib/device/sio/vm_bar.h
@@ -1,0 +1,58 @@
+#ifndef VM_BAR_H
+#define VM_BAR_H
+
+#ifdef BUILD_ATARI
+
+/**
+ * vm_bar — RSX-style "bar command" gate between the VM (RunCPM) and FujiNet
+ * firmware.
+ *
+ * Amstrad-CPC inspired: when an Atari at the CP/M prompt types a line whose
+ * first non-space character is '|', the RunCPM CCP (lib/runcpm/ccp.h) hands
+ * the remainder of the line off to this single firmware-side gate instead of
+ * trying to load a .COM program.  The gate parses a verb (e.g. "wget"),
+ * performs a host-side action (download a URL, etc.) and returns a short
+ * status message which the CCP prints with its own console primitive.
+ *
+ * This is the ONE place where CP/M reaches out to the firmware.  The gate is
+ * deliberately decoupled from RunCPM internals: it receives a plain
+ * NUL-terminated command string plus the destination directory prefix that
+ * the calling RunCPM instance uses for its CP/M files, and writes back a
+ * status string.  It never touches Z80 RAM, the console queues, or RunCPM's
+ * Status flag, so the same gate works for all three RunCPM instances
+ * (SIO 'G'/R:, N:CPM://, and the loopback telnet console).
+ *
+ * Most verbs are "one string in, one string out": they perform their action
+ * and return a status line in outmsg which the CCP prints.  A few verbs are
+ * INTERACTIVE (currently |ftp): they run a sub-shell that needs continuous
+ * terminal I/O.  The CCP's console primitives (_getch/_putch/_puts) are
+ * per-translation-unit statics, so the once-compiled gate cannot call them
+ * directly; instead the CCP hook passes them in via the vm_bar_io callback
+ * struct below.  Interactive verbs print through io and leave outmsg empty;
+ * non-interactive verbs ignore io.
+ */
+struct vm_bar_io
+{
+    int (*getch)(void);          // blocking read of one char (0..255), no echo
+    void (*putch)(int c);        // write one char to the terminal
+    void (*puts_)(const char *s);// write a NUL-terminated string to the terminal
+};
+
+/**
+ * @param cmd         remainder of the command line after the leading '|'
+ *                    (NUL-terminated, host pointer into the Z80 RAM array)
+ * @param dir_prefix  host filesystem prefix for the active CP/M directory,
+ *                    already ending in '/'  (e.g. "/CPM/A/0/")
+ * @param outmsg      caller-provided buffer for a status/result message
+ * @param outmsg_size size of outmsg in bytes
+ * @param io          terminal I/O callbacks for interactive verbs (may be NULL
+ *                    for non-interactive callers; interactive verbs require it)
+ * @return 0 on success, non-zero on error (the message is in outmsg either way)
+ */
+extern "C" int vm_bar_command(const char *cmd, const char *dir_prefix,
+                              char *outmsg, int outmsg_size,
+                              const struct vm_bar_io *io);
+
+#endif /* BUILD_ATARI */
+
+#endif /* VM_BAR_H */

--- a/lib/device/sio/vm_telnet.cpp
+++ b/lib/device/sio/vm_telnet.cpp
@@ -1,0 +1,599 @@
+/**
+ * vm_telnet — loopback TELNET console for the shared VM (currently RunCPM).
+ *
+ * Reachable by an Atari that does N:TELNET://127.0.0.1:8677.  It is one of the
+ * thin console back-ends to the single shared RunCPM core
+ * (lib/runcpm/runcpm_core.cpp), alongside:
+ *   - siocpm.cpp                       (SIO 'G' / R: / 9600)
+ *   - lib/network-protocol/CPM.cpp     (N:CPM://)
+ *
+ * This TU no longer includes the RunCPM header chain.  It owns its own console
+ * queues (_vm_txq / _vm_rxq), exposes them to the core as a runcpm_console_ops,
+ * and asks the core to run a session:
+ *   _vm_txq : user -> VM stdin   (pump pushes; getch pops)
+ *   _vm_rxq : VM stdout -> user  (putch pushes; pump drains)
+ *
+ * Transport: a loopback TCP listen socket (127.0.0.1:8677) bridged through
+ * libtelnet.  One live session at a time (one Z80, one shared SD CP/M drive);
+ * additional connections wait in the listen backlog.
+ *
+ * Named vm_ (not cpm_) because the gate is VM-generic: future non-CP/M VMs can
+ * reuse the same telnet console plumbing.
+ */
+
+#ifdef BUILD_ATARI
+
+#include "vm_telnet.h"
+
+#include "../runcpm/runcpm_session.h"
+
+#include <string.h>
+
+#include "libtelnet.h"
+#include "compat_inet.h"
+#include "fnConfig.h"
+#include "fnSystem.h"
+#include "../../include/debug.h"
+
+#ifdef ESP_PLATFORM
+#include "freertos/FreeRTOS.h"
+#include "freertos/queue.h"
+#include "freertos/task.h"
+#include "fnWiFi.h" // wait for the STA to obtain an IP before bind()/listen()
+#else
+#include <queue>
+#include <mutex>
+#include <condition_variable>
+#include <thread>
+#include <atomic>
+#include <cstdlib> // atexit
+#endif
+
+/* -------------------------------------------------------------------------
+ * Console queue storage (this TU owns the telnet console queues).
+ *
+ * _vm_txq : user -> VM stdin   (pump pushes; getch pops)
+ * _vm_rxq : VM stdout -> user  (putch pushes; pump drains)
+ * ------------------------------------------------------------------------- */
+#ifdef ESP_PLATFORM
+static QueueHandle_t _vm_rxq = nullptr;
+static QueueHandle_t _vm_txq = nullptr;
+#else
+static std::queue<uint8_t> _vm_rxq;
+static std::queue<uint8_t> _vm_txq;
+static std::mutex _vm_rxmtx;
+static std::mutex _vm_txmtx;
+static std::condition_variable _vm_txcv;
+#endif
+
+/* Set by _vm_run() when the session ends (CCP exited, or teardown requested).
+ * Polled by the pump/teardown to know the worker has unwound. */
+static volatile bool _vm_session_ended = false;
+
+/* Shutdown plumbing (PC build only).  The acceptor runs on its own thread and,
+ * while a session is live, the VM worker thread parks on the queue mutex /
+ * condition-variable below.  vm_telnet_stop() (called from main() before
+ * teardown) sets _vm_telnet_quit, which both the accept loop and the session
+ * pump poll, then joins the acceptor thread so every telnet thread is gone
+ * while the mutexes are still valid. */
+#ifndef ESP_PLATFORM
+static std::atomic<bool> _vm_telnet_quit{false};
+static std::thread       _vm_acceptor_thread;
+#endif
+
+/* TCP listen endpoint — loopback only, non-privileged port.
+ * 127.0.0.1 avoids the macOS lo0-alias issue of 127.0.0.2; :8677 avoids the
+ * privileged-port issue of :23. */
+#define VM_TELNET_BIND_ADDR "127.0.0.1"
+#define VM_TELNET_PORT      8677
+
+/* TEST-ONLY: bind the console to all interfaces (0.0.0.0) instead of loopback,
+ * so it can be reached from another machine on the LAN for testing.  WARNING:
+ * this exposes an UNAUTHENTICATED CP/M shell (with |wget/|ftp host-side file
+ * access) to the network.  Keep this 0 for any committed/upstream build; only
+ * flip to 1 on a trusted test network. */
+#define VM_TELNET_BIND_ANY  0
+
+/* -------------------------------------------------------------------------
+ * Console back-end (runcpm_console_ops) — bridges the core's console I/O to
+ * the per-TU queues.
+ * ------------------------------------------------------------------------- */
+static int _vm_kbhit(void)
+{
+#ifdef ESP_PLATFORM
+    if (_vm_txq == nullptr) return 0;
+    return (int)uxQueueMessagesWaiting(_vm_txq);
+#else
+    std::lock_guard<std::mutex> lk(_vm_txmtx);
+    return (int)_vm_txq.size();
+#endif
+}
+
+static int _vm_getch(void)
+{
+    uint8_t c = 0;
+#ifdef ESP_PLATFORM
+    if (_vm_txq != nullptr)
+        xQueueReceive(_vm_txq, &c, portMAX_DELAY);
+#else
+    std::unique_lock<std::mutex> lk(_vm_txmtx);
+    _vm_txcv.wait(lk, [] { return !_vm_txq.empty(); });
+    c = _vm_txq.front();
+    _vm_txq.pop();
+#endif
+    return c;
+}
+
+static void _vm_push_rx(uint8_t c)
+{
+#ifdef ESP_PLATFORM
+    if (_vm_rxq != nullptr)
+        xQueueSend(_vm_rxq, &c, portMAX_DELAY);
+#else
+    {
+        std::lock_guard<std::mutex> lk(_vm_rxmtx);
+        _vm_rxq.push(c);
+    }
+#endif
+}
+
+static int _vm_getche(void)
+{
+    uint8_t c = (uint8_t)_vm_getch();
+    /* echo back through rxq so the terminal sees it */
+    _vm_push_rx(c);
+    return c;
+}
+
+static void _vm_putch(uint8_t ch)
+{
+    _vm_push_rx(ch);
+}
+
+static void _vm_clrscr(void)
+{
+    /* VT100 cursor-home + clear-screen */
+    _vm_push_rx(0x1B); _vm_push_rx('['); _vm_push_rx('1'); _vm_push_rx(';');
+    _vm_push_rx('1');  _vm_push_rx('H'); _vm_push_rx(0x1B); _vm_push_rx('[');
+    _vm_push_rx('2');  _vm_push_rx('J');
+}
+
+static const runcpm_console_ops vm_console_ops = {
+    _vm_getch,
+    _vm_getche,
+    _vm_kbhit,
+    _vm_putch,
+    _vm_clrscr,
+};
+
+/* -------------------------------------------------------------------------
+ * VM session worker — run a full session on the shared core, then signal end.
+ * ------------------------------------------------------------------------- */
+static void _vm_run(void)
+{
+    runcpm_session_run(&vm_console_ops);
+    _vm_session_ended = true;
+}
+
+#ifdef ESP_PLATFORM
+static void _vm_task_entry(void *arg)
+{
+    (void)arg;
+    _vm_run();
+    vTaskDelete(nullptr);
+}
+#endif
+
+/* -------------------------------------------------------------------------
+ * Queue helpers — bridge the socket pump to the console queues.
+ * ------------------------------------------------------------------------- */
+static void _push_stdin(uint8_t c)
+{
+#ifdef ESP_PLATFORM
+    if (_vm_txq != nullptr)
+        xQueueSend(_vm_txq, &c, portMAX_DELAY);
+#else
+    {
+        std::lock_guard<std::mutex> lk(_vm_txmtx);
+        _vm_txq.push(c);
+    }
+    _vm_txcv.notify_one();
+#endif
+}
+
+static bool _pop_stdout(uint8_t &c)
+{
+#ifdef ESP_PLATFORM
+    if (_vm_rxq == nullptr)
+        return false;
+    return xQueueReceive(_vm_rxq, &c, 0) == pdTRUE;
+#else
+    std::lock_guard<std::mutex> lk(_vm_rxmtx);
+    if (_vm_rxq.empty())
+        return false;
+    c = _vm_rxq.front();
+    _vm_rxq.pop();
+    return true;
+#endif
+}
+
+#ifndef ESP_PLATFORM
+static void _drain_queues(void)
+{
+    {
+        std::lock_guard<std::mutex> lk(_vm_txmtx);
+        std::queue<uint8_t> empty;
+        std::swap(_vm_txq, empty);
+    }
+    {
+        std::lock_guard<std::mutex> lk(_vm_rxmtx);
+        std::queue<uint8_t> empty;
+        std::swap(_vm_rxq, empty);
+    }
+}
+#endif
+
+/* -------------------------------------------------------------------------
+ * libtelnet server side
+ * ------------------------------------------------------------------------- */
+struct vm_telnet_ctx
+{
+    int fd;
+};
+
+/* Server echoes (the core's getche provides the single echo) and runs
+ * character-at-a-time.  Matches the N: client telopts in Telnet.cpp
+ * ({ECHO, WONT, DO} / {SGA, WONT, DO}): server WILL ECHO + WILL SGA. */
+static const telnet_telopt_t srv_telopts[] = {
+    {TELNET_TELOPT_ECHO, TELNET_WILL, TELNET_DONT},
+    {TELNET_TELOPT_SGA,  TELNET_WILL, TELNET_DONT},
+    {-1, 0, 0}
+};
+
+static void _telnet_evt(telnet_t *tn, telnet_event_t *ev, void *user)
+{
+    (void)tn;
+    vm_telnet_ctx *ctx = (vm_telnet_ctx *)user;
+
+    switch (ev->type)
+    {
+    case TELNET_EV_DATA:
+        /* Decoded input from the client -> VM stdin.
+         * Normalise line endings to a single CR (0x0D): pass CR through, drop
+         * bare LF (0x0A, the second byte of CR-LF) and NUL (the second byte of
+         * CR-NUL). */
+        for (size_t i = 0; i < ev->data.size; ++i)
+        {
+            uint8_t c = (uint8_t)ev->data.buffer[i];
+            if (c == 0x0A || c == 0x00)
+                continue;
+            _push_stdin(c);
+        }
+        break;
+
+    case TELNET_EV_SEND:
+        /* libtelnet wants raw bytes written to the socket. */
+        {
+            const char *p = ev->data.buffer;
+            size_t left = ev->data.size;
+            while (left > 0)
+            {
+                int n = (int)send(ctx->fd, p, left, 0);
+                if (n <= 0)
+                    break;
+                p += n;
+                left -= (size_t)n;
+            }
+        }
+        break;
+
+    default:
+        break;
+    }
+}
+
+/* True if a recv() returning < 0 just means "no data right now". */
+static bool _recv_would_block(int err)
+{
+#if defined(_WIN32)
+    return err == WSAEWOULDBLOCK;
+#else
+    return err == EWOULDBLOCK || err == EAGAIN || err == EINTR;
+#endif
+}
+
+/* -------------------------------------------------------------------------
+ * One telnet session: bridge the accepted socket to a fresh VM session.
+ * ------------------------------------------------------------------------- */
+static void _handle_session(int cfd)
+{
+    Debug_printf("vm_telnet: session start (fd %d)\r\n", cfd);
+
+    _vm_session_ended = false;
+
+#ifdef ESP_PLATFORM
+    _vm_rxq = xQueueCreate(2048, sizeof(uint8_t));
+    _vm_txq = xQueueCreate(2048, sizeof(uint8_t));
+#else
+    _drain_queues();
+#endif
+
+    compat_socket_set_nonblocking(cfd);
+
+    vm_telnet_ctx ctx;
+    ctx.fd = cfd;
+
+    telnet_t *tn = telnet_init(srv_telopts, _telnet_evt, 0, &ctx);
+    if (tn == nullptr)
+    {
+        Debug_printf("vm_telnet: telnet_init failed\r\n");
+#ifdef ESP_PLATFORM
+        if (_vm_rxq) { vQueueDelete(_vm_rxq); _vm_rxq = nullptr; }
+        if (_vm_txq) { vQueueDelete(_vm_txq); _vm_txq = nullptr; }
+#endif
+        return;
+    }
+
+    /* Drive option negotiation so the client disables local echo. */
+    telnet_negotiate(tn, TELNET_WILL, TELNET_TELOPT_ECHO);
+    telnet_negotiate(tn, TELNET_WILL, TELNET_TELOPT_SGA);
+
+    /* Launch the VM worker (it blocks in getch waiting on _vm_txq). */
+#ifdef ESP_PLATFORM
+    TaskHandle_t vmTask = nullptr;
+    xTaskCreatePinnedToCore(_vm_task_entry,
+                            "cpmtel",
+#ifdef BUILD_APPLE
+                            4096,
+#else
+                            32768,
+#endif
+                            nullptr,
+                            20,
+                            &vmTask,
+                            1);
+#else
+    std::thread vmThread(_vm_run);
+#endif
+
+    /* Pump: socket -> telnet_recv (-> _vm_txq via EV_DATA);
+     *       _vm_rxq -> telnet_send (-> socket via EV_SEND). */
+    char rbuf[256];
+    char obuf[256];
+    bool peer_closed = false;
+
+    while (!_vm_session_ended && !peer_closed
+#ifndef ESP_PLATFORM
+           && !_vm_telnet_quit
+#endif
+          )
+    {
+        int n = (int)recv(cfd, rbuf, sizeof(rbuf), 0);
+        if (n == 0)
+        {
+            peer_closed = true; /* peer performed orderly shutdown */
+        }
+        else if (n > 0)
+        {
+            telnet_recv(tn, rbuf, (size_t)n);
+        }
+        else /* n < 0 */
+        {
+            if (!_recv_would_block(compat_getsockerr()))
+            {
+                peer_closed = true;
+            }
+        }
+
+        /* Drain VM stdout to the client. */
+        int oi = 0;
+        uint8_t c;
+        while (_pop_stdout(c))
+        {
+            obuf[oi++] = (char)c;
+            if (oi == (int)sizeof(obuf))
+            {
+                telnet_send(tn, obuf, (size_t)oi);
+                oi = 0;
+            }
+        }
+        if (oi > 0)
+            telnet_send(tn, obuf, (size_t)oi);
+
+        fnSystem.delay(2);
+    }
+
+    /* Teardown.  Ask the core's CCP loop (and any running Z80 program, via
+     * Z80run's `while(!Status)`) to stop, then feed CR bytes to unblock the
+     * blocking console read (BDOS C_READSTR -> getch).
+     *
+     * We deliberately do NOT send CTRL-C (0x03): at column 0 the CCP treats ^C
+     * as a warm boot (Status=STATUS_RESTART), which makes the session loop
+     * re-enter and reset Status to STATUS_RUNNING — the worker then blocks in
+     * getch forever and the join below hangs, stalling the acceptor so no
+     * further connection is served.  A CR just completes an empty command line;
+     * the CCP loop then observes the exit request and returns cleanly. */
+    runcpm_session_request_exit();
+    for (int i = 0; i < 100 && !_vm_session_ended; ++i)
+    {
+        _push_stdin('\r');
+        fnSystem.delay(20);
+    }
+
+#ifdef ESP_PLATFORM
+    /* Task self-deletes when _vm_run returns; ensure it has unwound. */
+    if (!_vm_session_ended)
+        vTaskDelay(pdMS_TO_TICKS(300));
+    (void)vmTask;
+    if (_vm_rxq) { vQueueDelete(_vm_rxq); _vm_rxq = nullptr; }
+    if (_vm_txq) { vQueueDelete(_vm_txq); _vm_txq = nullptr; }
+#else
+    if (vmThread.joinable())
+        vmThread.join();
+#endif
+
+    telnet_free(tn);
+    Debug_printf("vm_telnet: session end (fd %d)\r\n", cfd);
+}
+
+/* -------------------------------------------------------------------------
+ * Acceptor loop — owns the listen socket and serves one session at a time.
+ * ------------------------------------------------------------------------- */
+static void _acceptor_loop(void)
+{
+#ifdef ESP_PLATFORM
+    /* Wait for the STA to actually obtain an IP before we bind/listen.  On
+     * ESP-IDF lwIP the listen socket must be created once the network stack is
+     * fully up; binding INADDR_ANY while the STA interface is still
+     * address-less leaves the listener unable to accept on the eventual STA
+     * address (the SYN is answered at the PCB level — so the port looks "open"
+     * to a probe — but accept() never yields a usable session).  fnWiFi.start()
+     * has already run esp_netif_init() (so socket() is safe here); we just hold
+     * off the bind until IP_EVENT_STA_GOT_IP has set fnWiFi.connected().  This
+     * mirrors the firmware's documented async-WiFi bring-up pattern. */
+    while (!fnWiFi.connected())
+        vTaskDelay(pdMS_TO_TICKS(250));
+#endif
+
+    int lfd = (int)socket(AF_INET, SOCK_STREAM, 0);
+    if (lfd < 0)
+    {
+        Debug_printf("vm_telnet: socket() failed, err %d\r\n", compat_getsockerr());
+        return;
+    }
+
+    int enable = 1;
+#if defined(_WIN32)
+    setsockopt(lfd, SOL_SOCKET, SO_EXCLUSIVEADDRUSE, (char *)&enable, sizeof(enable));
+#else
+    setsockopt(lfd, SOL_SOCKET, SO_REUSEADDR, &enable, sizeof(enable));
+#endif
+
+    struct sockaddr_in srv;
+    memset(&srv, 0, sizeof(srv));
+    srv.sin_family = AF_INET;
+    srv.sin_port = htons(VM_TELNET_PORT);
+#if VM_TELNET_BIND_ANY
+    srv.sin_addr.s_addr = htonl(INADDR_ANY); /* TEST-ONLY: all interfaces */
+#else
+    srv.sin_addr.s_addr = inet_addr(VM_TELNET_BIND_ADDR);
+#endif
+
+    if (bind(lfd, (struct sockaddr *)&srv, sizeof(srv)) < 0)
+    {
+        Debug_printf("vm_telnet: bind(%s:%d) failed, err %d\r\n",
+                     VM_TELNET_BIND_ADDR, VM_TELNET_PORT, compat_getsockerr());
+        closesocket(lfd);
+        return;
+    }
+
+    if (listen(lfd, 1) < 0)
+    {
+        Debug_printf("vm_telnet: listen() failed, err %d\r\n", compat_getsockerr());
+        closesocket(lfd);
+        return;
+    }
+
+    Debug_printf("vm_telnet: CP/M telnet server listening on %s:%d\r\n",
+#if VM_TELNET_BIND_ANY
+                 "0.0.0.0",
+#else
+                 VM_TELNET_BIND_ADDR,
+#endif
+                 VM_TELNET_PORT);
+
+    /* PC build: make accept() non-blocking so the loop can poll the shutdown
+     * flag and exit cleanly at process teardown.  (ESP runs forever and reboots
+     * the chip, so it keeps the original blocking accept.) */
+#ifndef ESP_PLATFORM
+    compat_socket_set_nonblocking(lfd);
+#endif
+
+    while (true)
+    {
+#ifndef ESP_PLATFORM
+        if (_vm_telnet_quit)
+            break;
+#endif
+        struct sockaddr_in cli;
+        socklen_t cl = sizeof(cli);
+        int cfd = (int)accept(lfd, (struct sockaddr *)&cli, &cl);
+        if (cfd < 0)
+        {
+            fnSystem.delay(100);
+            continue;
+        }
+
+        _handle_session(cfd);
+        closesocket(cfd);
+    }
+
+#ifndef ESP_PLATFORM
+    closesocket(lfd);
+#endif
+}
+
+#ifdef ESP_PLATFORM
+static void _acceptor_task_entry(void *arg)
+{
+    (void)arg;
+    _acceptor_loop();
+    vTaskDelete(nullptr);
+}
+#endif
+
+/* -------------------------------------------------------------------------
+ * Public entry — spawn the acceptor once at boot.
+ * ------------------------------------------------------------------------- */
+void vm_telnet_start()
+{
+    static bool started = false;
+    if (started)
+        return;
+    started = true;
+
+#ifdef ESP_PLATFORM
+    /* Pin the acceptor to CORE 0, NOT core 1.  fn_service_loop ("fnLoop", the
+     * SIO bus pump) runs at priority 17 pinned to core 1 in a tight
+     * non-blocking loop (SYSTEM_BUS.service() + taskYIELD()).  taskYIELD() only
+     * yields to ready tasks of EQUAL OR HIGHER priority, so a priority-10
+     * acceptor on core 1 would be permanently starved: its blocking accept()
+     * wakeup could never get CPU and no telnet session would ever start (the
+     * port still listens, but connecting produced no CP/M banner).  Core 0 is
+     * where the WiFi / lwIP tcpip thread lives; those idle-sleep when there is
+     * no traffic, so the acceptor gets scheduled there. */
+    xTaskCreatePinnedToCore(_acceptor_task_entry, "cpmtelsrv", 8192,
+                            nullptr, 10, nullptr, 0);
+#else
+    /* Keep the thread joinable (not detached) so vm_telnet_stop() can wind it
+     * down before the global queue mutexes are destroyed at process exit. */
+    _vm_acceptor_thread = std::thread(_acceptor_loop);
+
+    /* Safety net: not every shutdown returns through main() — some paths call
+     * exit() directly (e.g. SystemManager::reboot()).  Register vm_telnet_stop
+     * with atexit so the acceptor is always joined before the C++ runtime
+     * destroys the global queue mutexes AND before this std::thread's own
+     * destructor runs (which would std::terminate() on a still-joinable
+     * thread).  atexit handlers registered here (after static init) run before
+     * those static destructors; on _exit() no destructors run at all, so
+     * skipping it there is harmless.  vm_telnet_stop() is idempotent. */
+    atexit(vm_telnet_stop);
+#endif
+}
+
+void vm_telnet_stop()
+{
+#ifndef ESP_PLATFORM
+    if (!_vm_acceptor_thread.joinable())
+        return;
+
+    /* Ask the accept loop and the live-session pump to exit, then join.  The
+     * pump runs on this same acceptor thread, so its existing teardown (request
+     * exit, feed CR, join the VM worker) runs first; the loop then sees
+     * _vm_telnet_quit and returns, closing the listen socket. */
+    _vm_telnet_quit = true;
+    _vm_acceptor_thread.join();
+#endif
+}
+
+#endif /* BUILD_ATARI */

--- a/lib/device/sio/vm_telnet.cpp
+++ b/lib/device/sio/vm_telnet.cpp
@@ -412,9 +412,11 @@ static void _handle_session(int cfd)
 
         /* Drain VM stdout to the client. */
         int oi = 0;
+        bool produced = false;
         uint8_t c;
         while (_pop_stdout(c))
         {
+            produced = true;
             obuf[oi++] = (char)c;
             if (oi == (int)sizeof(obuf))
             {
@@ -425,7 +427,31 @@ static void _handle_session(int cfd)
         if (oi > 0)
             telnet_send(tn, obuf, (size_t)oi);
 
+#ifdef ESP_PLATFORM
+        /* Yield core 0 to lower-priority tasks when this iteration had no
+         * socket input and produced no console output.
+         *
+         * This pump runs on the "cpmtelsrv" task (core 0, priority 10) and the
+         * accepted socket is non-blocking, so an idle CP/M prompt spins this
+         * loop at 100%.  fnSystem.delay(2) maps to vTaskDelay(2/portTICK)==
+         * vTaskDelay(0) at the firmware's 100 Hz tick (portTICK_PERIOD_MS=10),
+         * which only yields to EQUAL-or-higher-priority READY tasks on this
+         * core.  The safe-reset button poller ("fnKeys") runs at priority 1, so
+         * it could never get core 0 while a session was connected (core 1 is
+         * likewise saturated by the priority-17 SIO "fnLoop").  Net effect: the
+         * physical reset button was dead for the entire telnet session and only
+         * worked again once the client disconnected.  A real one-tick block
+         * (~10 ms) deschedules the pump so the priority-1 button task (and the
+         * idle/watchdog task) actually run — giving the reset button priority
+         * over the session as expected.  When there IS traffic we only
+         * taskYIELD() to keep terminal latency low. */
+        if (n <= 0 && !produced)
+            vTaskDelay(1);
+        else
+            taskYIELD();
+#else
         fnSystem.delay(2);
+#endif
     }
 
     /* Teardown.  Ask the core's CCP loop (and any running Z80 program, via

--- a/lib/device/sio/vm_telnet.cpp
+++ b/lib/device/sio/vm_telnet.cpp
@@ -102,7 +102,32 @@ static int _vm_kbhit(void)
 {
 #ifdef ESP_PLATFORM
     if (_vm_txq == nullptr) return 0;
-    return (int)uxQueueMessagesWaiting(_vm_txq);
+    UBaseType_t waiting = uxQueueMessagesWaiting(_vm_txq);
+    if (waiting == 0)
+    {
+        /* No input pending — yield core 1 back to the SIO loop and idle task.
+         *
+         * The VM worker (this task) is pinned to core 1 at priority 20, ABOVE
+         * fn_service_loop ("fnLoop", the SIO bus pump, priority 17, also core 1)
+         * and IDLE1 (priority 0).  CP/M full-screen programs (vi, etc.) poll
+         * console status (BDOS 6/11 -> _kbhit) in a tight loop while waiting for
+         * a keypress.  If we returned immediately the worker would never block,
+         * so fnLoop would never run (every SIO command — including the Atari's
+         * own N:TELNET reads back into this console — times out) and IDLE1 would
+         * never run (the task watchdog is never fed and deleted tasks are never
+         * reaped), wedging the device into an unrecoverable hang where even the
+         * safe-reset button stops responding.  taskYIELD() cannot fix this: it
+         * only yields to ready tasks of EQUAL OR HIGHER priority, and this
+         * worker is the highest-priority task on core 1.  Block for one tick so
+         * the lower-priority SIO loop and idle task get the core back.
+         *
+         * Cost is latency on the idle path only: real Z80 computation does not
+         * poll kbhit, and a screen redraw polls it once after many putch calls,
+         * so throughput is unaffected. */
+        vTaskDelay(1);
+        return 0;
+    }
+    return (int)waiting;
 #else
     std::lock_guard<std::mutex> lk(_vm_txmtx);
     return (int)_vm_txq.size();

--- a/lib/device/sio/vm_telnet.h
+++ b/lib/device/sio/vm_telnet.h
@@ -1,0 +1,40 @@
+#ifndef VM_TELNET_H
+#define VM_TELNET_H
+
+#ifdef BUILD_ATARI
+
+/**
+ * vm_telnet — loopback TELNET console for the shared VM (currently RunCPM).
+ *
+ * Starts a TCP server bound to 127.0.0.1:8677.  An Atari client that does
+ * N:TELNET://127.0.0.1:8677 lands directly in a CP/M session — no ATCPM,
+ * no SIO takeover, at whatever speed the N: device is configured for.
+ *
+ * This is one of the thin console back-ends to the single shared RunCPM core
+ * (lib/runcpm/runcpm_core.cpp), alongside the SIO 'G' R:/9600 path in
+ * siocpm.cpp and the N:CPM:// path in lib/network-protocol/CPM.cpp.  It bridges
+ * a socket <-> libtelnet <-> its own stdin/stdout queues, exposes those queues
+ * to the core as a runcpm_console_ops, and asks the core to run a session.
+ *
+ * Named vm_ (not cpm_) because the gate is VM-generic: future non-CP/M VMs can
+ * reuse the same telnet console plumbing.
+ *
+ * Call vm_telnet_start() once at boot (gated on Config.get_cpm_enabled()).
+ */
+void vm_telnet_start();
+
+/**
+ * vm_telnet_stop() — stop the acceptor (and any live session) and join its
+ * thread.  Call this at process shutdown, BEFORE the global CP/M queue
+ * mutexes/condition-variable are destroyed.
+ *
+ * Without it the detached acceptor/CP/M threads outlive those static globals
+ * during exit and abort the process with "mutex lock failed: Invalid argument"
+ * (pthread_mutex_lock returns EINVAL on a destroyed mutex).  No-op on ESP32,
+ * where the whole chip reboots instead of unwinding.
+ */
+void vm_telnet_stop();
+
+#endif /* BUILD_ATARI */
+
+#endif /* VM_TELNET_H */

--- a/lib/network-protocol/CPM.cpp
+++ b/lib/network-protocol/CPM.cpp
@@ -1,71 +1,131 @@
 /**
  * NetworkProtocolCPM — CP/M emulator as a network protocol adapter.
  *
- * IMPORTANT: RUNCPM_STATIC_IMPL must be defined before any RunCPM header so
- * that every RunCPM symbol in this TU gets static (internal) linkage.  This
- * lets the network-protocol CPM adapter and any bus-device CPM adapter (sio,
- * drivewire, iwm, …) coexist in the same binary without linker conflicts.
+ * This TU no longer includes the RunCPM header chain.  The Z80/CP/M engine +
+ * state live once in lib/runcpm/runcpm_core.cpp; this adapter is a thin console
+ * back-end.  It owns its own stdin/stdout queues, exposes them to the shared
+ * core as a runcpm_console_ops, and asks the core to run a session:
+ *   _cpm_txq : host write() -> CPM stdin   (write() pushes; getch pops)
+ *   _cpm_rxq : CPM stdout  -> host read()  (putch pushes; read() pops)
  */
-
-#define RUNCPM_STATIC_IMPL
-#define CCP_INTERNAL
 
 #include "CPM.h"
 #include "../../include/debug.h"
 #include "status_error_codes.h"
 
-/* The network-protocol abstraction defines the static queue variables
- * (_cpm_rxq / _cpm_txq) and the _kbhit / _getch / _putch / _clrscr
- * functions.  It must come before the RunCPM headers that use them. */
-#include "../runcpm/abstraction_network_protocol.h"
+#include "../runcpm/runcpm_session.h"
 
-/* Standard RunCPM header chain */
-#include "../runcpm/globals.h"
-#include "../runcpm/ram.h"
-#include "../runcpm/console.h"
-#include "../runcpm/cpu.h"
-#include "../runcpm/disk.h"
-#include "../runcpm/host.h"
-#include "../runcpm/cpm.h"
-#include "../runcpm/ccp.h"
+#ifdef ESP_PLATFORM
+#include "freertos/FreeRTOS.h"
+#include "freertos/queue.h"
+#include "freertos/task.h"
+#else
+#include <queue>
+#include <mutex>
+#include <condition_variable>
+#endif
 
 /* -------------------------------------------------------------------------
- * CPM task / thread entry point
+ * Console queue storage (this TU owns the N:CPM:// console queues).
  *
- * Runs the CCP in a loop.  Status == 1 is the conventional "exit" signal
- * set by the CCP itself on a warm-boot, or by stopCPM() on close().
- * The outer loop re-boots CP/M (as a real machine would on warm-boot)
- * unless a clean exit was requested.
+ * _cpm_txq : host write() -> CPM stdin   (write() pushes; getch pops)
+ * _cpm_rxq : CPM stdout  -> host read()  (putch pushes; read() pops)
+ * ------------------------------------------------------------------------- */
+#ifdef ESP_PLATFORM
+static QueueHandle_t _cpm_rxq = nullptr;
+static QueueHandle_t _cpm_txq = nullptr;
+#else
+static std::queue<uint8_t> _cpm_rxq;
+static std::queue<uint8_t> _cpm_txq;
+static std::mutex _cpm_rxmtx;
+static std::mutex _cpm_txmtx;
+static std::condition_variable _cpm_txcv;
+#endif
+
+/* Set by _cpm_run() when the session ends (CCP exited of its own accord, e.g.
+ * user typed EXIT, or stopCPM() requested teardown).  Polled by status() to
+ * drive EOF back to the host. */
+static volatile bool _cpm_session_ended = false;
+
+/* -------------------------------------------------------------------------
+ * Console back-end (runcpm_console_ops) — bridges the core's console I/O to
+ * the per-TU queues.
+ * ------------------------------------------------------------------------- */
+static int _cpm_kbhit(void)
+{
+#ifdef ESP_PLATFORM
+    if (_cpm_txq == nullptr) return 0;
+    return (int)uxQueueMessagesWaiting(_cpm_txq);
+#else
+    std::lock_guard<std::mutex> lk(_cpm_txmtx);
+    return (int)_cpm_txq.size();
+#endif
+}
+
+static int _cpm_getch(void)
+{
+    uint8_t c = 0;
+#ifdef ESP_PLATFORM
+    if (_cpm_txq != nullptr)
+        xQueueReceive(_cpm_txq, &c, portMAX_DELAY);
+#else
+    std::unique_lock<std::mutex> lk(_cpm_txmtx);
+    _cpm_txcv.wait(lk, [] { return !_cpm_txq.empty(); });
+    c = _cpm_txq.front();
+    _cpm_txq.pop();
+#endif
+    return c;
+}
+
+static void _cpm_push_rx(uint8_t c)
+{
+#ifdef ESP_PLATFORM
+    if (_cpm_rxq != nullptr)
+        xQueueSend(_cpm_rxq, &c, portMAX_DELAY);
+#else
+    {
+        std::lock_guard<std::mutex> lk(_cpm_rxmtx);
+        _cpm_rxq.push(c);
+    }
+#endif
+}
+
+static int _cpm_getche(void)
+{
+    uint8_t c = (uint8_t)_cpm_getch();
+    /* echo back through rxq so the terminal sees it */
+    _cpm_push_rx(c);
+    return c;
+}
+
+static void _cpm_putch(uint8_t ch)
+{
+    _cpm_push_rx(ch);
+}
+
+static void _cpm_clrscr(void)
+{
+    /* VT100 cursor-home + clear-screen */
+    _cpm_push_rx(0x1B); _cpm_push_rx('['); _cpm_push_rx('1'); _cpm_push_rx(';');
+    _cpm_push_rx('1');  _cpm_push_rx('H'); _cpm_push_rx(0x1B); _cpm_push_rx('[');
+    _cpm_push_rx('2');  _cpm_push_rx('J');
+}
+
+static const runcpm_console_ops cpm_console_ops = {
+    _cpm_getch,
+    _cpm_getche,
+    _cpm_kbhit,
+    _cpm_putch,
+    _cpm_clrscr,
+};
+
+/* -------------------------------------------------------------------------
+ * CPM task / thread entry point — run a full session on the shared core, then
+ * signal end.  The core's runcpm_session_run() owns the CCP + warm-boot loop.
  * ------------------------------------------------------------------------- */
 static void _cpm_run(void)
 {
-    while (true)
-    {
-        Status = Debug = 0;
-        Break = Step = Watch = -1;
-
-        RAM = (uint8_t *)malloc(MEMSIZE);
-        if (!RAM)
-            break;
-
-        memset(RAM,      0, MEMSIZE);
-        memset(filename, 0, sizeof(filename));
-        memset(newname,  0, sizeof(newname));
-        memset(fcbname,  0, sizeof(fcbname));
-        memset(pattern,  0, sizeof(pattern));
-
-        _puts(CCPHEAD);
-        _PatchCPM();
-        _ccp();
-
-        free(RAM);
-        RAM = nullptr;
-
-        /* Status == 1: clean exit requested — stop looping */
-        if (Status == 1)
-            break;
-        /* Status == 2: warm-boot — re-enter the CCP loop */
-    }
+    runcpm_session_run(&cpm_console_ops);
 
     /* Notify the protocol object that the session ended from the CP/M side. */
     _cpm_session_ended = true;
@@ -74,6 +134,7 @@ static void _cpm_run(void)
 #ifdef ESP_PLATFORM
 static void _cpm_task_entry(void *arg)
 {
+    (void)arg;
     _cpm_run();
     vTaskDelete(nullptr);
 }
@@ -147,16 +208,16 @@ void NetworkProtocolCPM::stopCPM()
     if (!running) return;
     running = false;
 
-    /* Signal the CCP to stop re-booting */
-    Status = 1;
+    /* Ask the shared core's CCP to stop re-booting and end the session. */
+    runcpm_session_request_exit();
 
-    /* Unblock any _getch() call waiting for user input */
+    /* Unblock any getch() call waiting for user input */
     uint8_t sentinel = 0x03;  // CTRL-C
 #ifdef ESP_PLATFORM
     if (_cpm_txq != nullptr)
         xQueueSend(_cpm_txq, &sentinel, pdMS_TO_TICKS(200));
 
-    /* Give the FreeRTOS task time to notice Status==1 and self-delete */
+    /* Give the FreeRTOS task time to notice the exit request and self-delete */
     vTaskDelay(pdMS_TO_TICKS(300));
 
     if (_cpm_rxq != nullptr) { vQueueDelete(_cpm_rxq); _cpm_rxq = nullptr; }

--- a/lib/runcpm/abstraction_fujinet.h
+++ b/lib/runcpm/abstraction_fujinet.h
@@ -29,6 +29,22 @@
 
 #define HostOS 0x07 // FUJINET
 
+/* FujiNet vendoring: RunCPM 6.9 disk.h::_mockupDirEntry references FILEBASE
+   (the host path prefix) to optionally strip it from enumerated names. FujiNet
+   stores bare filenames (no prefix) and always calls _mockupDirEntry(0), so
+   define FILEBASE empty to satisfy compilation with zero-length prefix. */
+#ifndef FILEBASE
+#define FILEBASE ""
+#endif
+
+/* FujiNet vendoring: RunCPM 6.9 calls millis() unconditionally (CPU throttle in
+   cpu.h, Z80estimateClock in cpu_mhz.h, BDOS F_UPTIME C=248 in cpm.h). In 5.8
+   millis() was only used under #ifdef PROFILE (never compiled). Map it to the
+   FujiNet system uptime clock, mirroring upstream's macro abstraction. */
+#ifndef millis
+#define millis() ((uint32)fnSystem.millis())
+#endif
+
 typedef struct
 {
     uint8_t dr;
@@ -81,27 +97,26 @@ uint32 _HardwareIn(const uint32 Port)
 
 /* Memory abstraction functions */
 /*===============================================================================*/
-bool _RamLoad(char *fn, uint16_t address)
+/* FujiNet vendoring: RunCPM 6.9 changed _RamLoad to
+   `uint16 _RamLoad(uint8 *filename, uint16 address, uint16 maxsize)` returning
+   the number of bytes read (maxsize == 0 means "no limit"). ccp.h's AUTOEXEC
+   path relies on the byte count, so honor maxsize and return the count. */
+uint16 _RamLoad(uint8 *filename, uint16 address, uint16 maxsize)
 {
-    FILE *f = fnSDFAT.file_open(full_path(fn), "r");
-    bool result = false;
+    FILE *f = fnSDFAT.file_open(full_path((char *)filename), "r");
+    uint16 count = 0;
     uint8_t b;
 
     if (f)
     {
-        while (!feof(f))
+        while ((!maxsize || count < maxsize) && fread(&b, sizeof(uint8_t), 1, f) == 1)
         {
-            if (fread(&b, sizeof(uint8_t), 1, f) == 1)
-            {
-                _RamWrite(address++, b);
-                result = true;
-            }
-            else
-                result = false;
+            _RamWrite(address++, b);
+            count++;
         }
         fclose(f);
     }
-    return (result);
+    return (count);
 }
 
 /* filesystem (disk) abstraction fuctions */
@@ -245,7 +260,20 @@ uint8_t _sys_readseq(uint8_t *fn, long fpos)
         {
             // set DMA buffer to EOF
             memset(dmabuf, 0x1a, BlkSZ);
-            bytesread = fread(&dmabuf[0], BlkSZ, sizeof(uint8_t), f);
+            // BUG FIX (2026-06-21): this was fread(dmabuf, BlkSZ, 1, f), i.e.
+            // size=128, nmemb=1.  fread() returns the number of *complete*
+            // elements read, so a final PARTIAL record (file size not a
+            // multiple of 128) made it return 0: the bytes that WERE read were
+            // discarded (the `if (bytesread)` memcpy was skipped) and result
+            // was reported as 0x01 (EOF).  Symptom: TYPE / ASM / LOAD / PIP
+            // silently dropped the last partial 128-byte record of every file
+            // whose length was not a multiple of 128 -- a 127-byte file showed
+            // nothing at all, a 202-byte file was truncated at exactly 128
+            // bytes.  Fix: read byte-wise (size=1, nmemb=BlkSZ) so fread
+            // returns the byte count (1..128) for partial records too; dmabuf
+            // is already pre-filled with 0x1a so the short record is padded
+            // with CP/M EOF markers as the BDOS sequential read expects.
+            bytesread = fread(&dmabuf[0], sizeof(uint8_t), BlkSZ, f);
             if (bytesread)
                 memcpy((uint8_t *)&RAM[dmaAddr], dmabuf, BlkSZ);
             result = bytesread ? 0x00 : 0x01;
@@ -303,7 +331,12 @@ uint8_t _sys_readrand(uint8_t *fn, long fpos)
         if (fseek(f, fpos, SEEK_SET) == 0)
         {
             memset(dmabuf, 0x1A, BlkSZ);
-            bytesread = fread(&dmabuf[0], BlkSZ, sizeof(uint8_t), f);
+            // BUG FIX (2026-06-21): same partial-record fread bug as
+            // _sys_readseq above -- fread(dmabuf, BlkSZ, 1, f) returns 0 for a
+            // final record shorter than 128 bytes, dropping its data and
+            // signalling premature EOF.  Read byte-wise so the count (1..128)
+            // is returned; dmabuf is pre-filled with 0x1A as EOF padding.
+            bytesread = fread(&dmabuf[0], sizeof(uint8_t), BlkSZ, f);
             if (bytesread)
                 memcpy((uint8_t *)&RAM[dmaAddr], dmabuf, BlkSZ);
             result = bytesread ? 0x00 : 0x01;
@@ -382,7 +415,7 @@ uint8_t _findnext(uint8_t isdir)
 
     if (allExtents && fileRecords)
     {
-        _mockupDirEntry();
+        _mockupDirEntry(0); // FujiNet vendoring: mode 0 = bare filename (no FILEBASE prefix)
         result = 0;
     }
     else
@@ -409,7 +442,7 @@ uint8_t _findnext(uint8_t isdir)
                     fileExtents = fileRecords / BlkEX + ((fileRecords & (BlkEX - 1)) ? 1 : 0);
                     fileExtentsUsed = 0;
                     firstFreeAllocBlock = firstBlockAfterDir;
-                    _mockupDirEntry();
+                    _mockupDirEntry(0); // FujiNet vendoring: mode 0 = bare filename (no FILEBASE prefix)
                 }
                 else
                 {
@@ -515,9 +548,59 @@ uint8_t _sys_makedisk(uint8_t drive)
 
 
 #ifdef BYPASS_BUS
-#define _kbhit() SYSTEM_BUS.available()
+
+/*
+ * CP/M console output batching (FujiNet, 2026-06-21)
+ *
+ * BUG / SYMPTOM:
+ *   The RunCPM console was painfully slow on the Atari client (~500 char/s,
+ *   ~2 s to print 1000 characters, DIR/TYPE crawling) even though the serial
+ *   link is configured for 111861 bit/s (~11 kB/s).  The SSH (N:) examples on
+ *   the very same link are fast.
+ *
+ * ROOT CAUSE:
+ *   The Z80 BDOS console calls (_putch -> _cwrite) wrote ONE byte per call
+ *   straight to the bus: SYSTEM_BUS.write(ch) -> IOChannel::write(int) ->
+ *   dataOut(buf, 1).  Each dataOut() call pays a fixed cost (a pre-write
+ *   select(), the ::write(), and a post-write select() that waits for the TTY
+ *   to be writable again - TTYChannel.cpp).  For block transfers (how the N:
+ *   device sends a whole SIO frame) that cost is amortised over the frame; for
+ *   the per-character console stream it was paid for every single byte, so the
+ *   per-call overhead - not the bit rate - dominated.
+ *
+ * FIX:
+ *   Accumulate console output in a small buffer and emit it as a block with
+ *   SYSTEM_BUS.write(buffer, length), exactly like the fast N:/SIO frame path.
+ *   The buffer is flushed (a) when it fills and (b) whenever CP/M polls for
+ *   keyboard input (_kbhit) - interactive CP/M always polls/reads input right
+ *   after emitting a prompt or output, so the user never sees stale output.
+ */
+#define CPM_TX_BUFSZ 512
+static uint8_t _cpm_txbuf[CPM_TX_BUFSZ];
+static size_t _cpm_txlen = 0;
+
+static inline void _cflush(void)
+{
+    if (_cpm_txlen)
+    {
+        SYSTEM_BUS.write(_cpm_txbuf, _cpm_txlen);
+        _cpm_txlen = 0;
+    }
+}
+
+static inline void _cput(uint8_t ch)
+{
+    if (_cpm_txlen >= CPM_TX_BUFSZ)
+        _cflush();
+    _cpm_txbuf[_cpm_txlen++] = ch;
+}
+
+// _kbhit flushes any pending console output before reporting input
+// availability, so buffered output is always on screen before CP/M blocks
+// waiting for a key.
+#define _kbhit() (_cflush(), SYSTEM_BUS.available())
 #define _cread() SYSTEM_BUS.read()
-#define _cwrite(ch) SYSTEM_BUS.write(ch)
+#define _cwrite(ch) _cput((uint8_t)(ch))
 #else
 #define _kbhit() 0
 #define _cread() 0

--- a/lib/runcpm/abstraction_fujinet_apple2.h
+++ b/lib/runcpm/abstraction_fujinet_apple2.h
@@ -24,6 +24,18 @@
 
 #define HostOS 0x07 // FUJINET
 
+/* FujiNet vendoring: see abstraction_fujinet.h — 6.9 disk.h needs FILEBASE;
+   FujiNet uses bare filenames and always calls _mockupDirEntry(0). */
+#ifndef FILEBASE
+#define FILEBASE ""
+#endif
+
+/* FujiNet vendoring: see abstraction_fujinet.h — 6.9 calls millis()
+   unconditionally; map it to the FujiNet system uptime clock. */
+#ifndef millis
+#define millis() ((uint32)fnSystem.millis())
+#endif
+
 #ifdef BUILD_COCO
 // This file says "apple2" right in the name so CoCo should follow apple2 convention, right?
 #include "drivewire/drivewireFuji.h"
@@ -75,28 +87,25 @@ char *full_path(char *fn)
 
 /* Memory abstraction functions */
 /*===============================================================================*/
-bool _RamLoad(char *fn, uint16_t address)
+/* FujiNet vendoring: RunCPM 6.9 _RamLoad signature returns bytes read and
+   honors maxsize (0 == no limit). See abstraction_fujinet.h for rationale. */
+uint16 _RamLoad(uint8 *filename, uint16 address, uint16 maxsize)
 {
-        FILE *f = fnSDFAT.file_open(full_path(fn), "r");
-        bool result = false;
+        FILE *f = fnSDFAT.file_open(full_path((char *)filename), "r");
+        uint16 count = 0;
         uint8_t b;
 
         if (f)
         {
-                while (!feof(f))
+                while ((!maxsize || count < maxsize) && fread(&b, sizeof(uint8_t), 1, f) == 1)
                 {
-                        if (fread(&b, sizeof(uint8_t), 1, f) == 1)
-                        {
-                                _RamWrite(address++, b);
-                                result = true;
-                        }
-                        else
-                                result = false;
+                        _RamWrite(address++, b);
+                        count++;
                 }
                 fclose(f);
         }
         Debug_printf("CCP last address: %04x\r\n",address);
-        return (result);
+        return (count);
 }
 
 //
@@ -389,7 +398,7 @@ uint8_t _findnext(uint8_t isdir)
 
         if (allExtents && fileRecords)
         {
-                _mockupDirEntry();
+                _mockupDirEntry(0); // FujiNet vendoring: mode 0 = bare filename (no FILEBASE prefix)
                 result = 0;
         }
         else
@@ -416,7 +425,7 @@ uint8_t _findnext(uint8_t isdir)
                                         fileExtents = fileRecords / BlkEX + ((fileRecords & (BlkEX - 1)) ? 1 : 0);
                                         fileExtentsUsed = 0;
                                         firstFreeAllocBlock = firstBlockAfterDir;
-                                        _mockupDirEntry();
+                                        _mockupDirEntry(0); // FujiNet vendoring: mode 0 = bare filename (no FILEBASE prefix)
                                 }
                                 else
                                 {

--- a/lib/runcpm/abstraction_fujinet_core.h
+++ b/lib/runcpm/abstraction_fujinet_core.h
@@ -98,6 +98,62 @@ char *full_path(char *fn)
     return full_filename;
 }
 
+/* ---------------------------------------------------------------------------
+ * Read file-handle cache (FujiNet vendoring, 2026-06-23).
+ *
+ * RunCPM's host abstraction keeps no persistent FILE* per FCB: the stock
+ * _sys_readseq / _sys_readrand re-derived the host path from the FCB and
+ * performed a full open / seek / read(128) / close for EVERY 128-byte CP/M
+ * record.  Loading a 39 KB .COM is ~310 records, and on the FujiNet SD card
+ * each fnSDFAT.file_open() costs ~11 ms, so a program took several SECONDS just
+ * to load -- and an editor reading a file by random access paid the same toll
+ * (the serial log shows hundreds of consecutive "fopen ... ok" lines for the
+ * same file).
+ *
+ * Only one CP/M session runs at a time (the core's g_busy interlock) and the
+ * BDOS read loops hit the same file back-to-back, so we keep the
+ * most-recently-read file open and reuse the handle when the next read --
+ * sequential OR random -- targets the same path, turning ~310 opens into 1.
+ *
+ * The cached handle is opened read-only ("r").  Both read primitives only
+ * *read* here (writes go through _sys_writeseq / _sys_writerand on their own
+ * "r+" handle), so a shared read-only handle serves both -- and keeping it
+ * read-only means we never hold a writable handle that FatFs FF_FS_LOCK would
+ * have to arbitrate, and a transient read-only probe open of the same file is
+ * compatible with it.
+ *
+ * Coherency: the cached handle is closed/invalidated
+ *   - when a different file is read (path change in _sys_readseq/_sys_readrand),
+ *   - before any create / write / delete / rename / extend touches a file (so
+ *     subsequent reads always observe fresh on-disk data, and we never hold a
+ *     read handle while FatFs wants exclusive write access),
+ *   - and at session boundaries in runcpm_core.cpp (so a file replaced between
+ *     sessions is never read through a stale handle).
+ * Read-only probes (_sys_filesize / _sys_openfile / _sys_exists) do NOT touch
+ * the cache: they never interleave inside the record-read loop and a second
+ * read-only open of the same file is harmless.
+ * ------------------------------------------------------------------------- */
+static FILE *seq_cache_fp = nullptr;
+static char  seq_cache_path[sizeof(full_filename)] = {0};
+
+static void _seq_cache_close(void)
+{
+    if (seq_cache_fp)
+    {
+        fclose(seq_cache_fp);
+        seq_cache_fp = nullptr;
+    }
+    seq_cache_path[0] = '\0';
+}
+
+/* Drop the cached handle if it refers to `path` (already built via full_path).
+   Called by the mutating ops so the next read reopens with fresh contents. */
+static void _seq_cache_invalidate(const char *path)
+{
+    if (seq_cache_fp && strcmp(seq_cache_path, path) == 0)
+        _seq_cache_close();
+}
+
 
 //
 // Hardware functions, new in 5.x
@@ -195,6 +251,7 @@ int _sys_openfile(uint8_t *fn)
 
 int _sys_makefile(uint8_t *fn)
 {
+    _seq_cache_invalidate(full_path((char *)fn));
     FILE *fp = fnSDFAT.file_open(full_path((char *)fn), "w");
     if (fp)
     {
@@ -207,6 +264,7 @@ int _sys_makefile(uint8_t *fn)
 
 int _sys_deletefile(uint8_t *fn)
 {
+    _seq_cache_invalidate(full_path((char *)fn));
     return fnSDFAT.remove(full_path((char *)fn));
 }
 
@@ -216,6 +274,11 @@ int _sys_renamefile(uint8_t *fn, uint8_t *newname)
 
     from = std::string(full_path((char *)fn));
     to = std::string(full_path((char *)newname));
+
+    /* Invalidate both endpoints: the source is moving, and a stale handle on
+       the destination path (if any) must not survive the rename. */
+    _seq_cache_invalidate(from.c_str());
+    _seq_cache_invalidate(to.c_str());
 
     return fnSDFAT.rename(from.c_str(), to.c_str());
 }
@@ -227,6 +290,7 @@ void _sys_logbuffer(uint8_t *buffer)
 
 bool _sys_extendfile(char *fn, unsigned long fpos)
 {
+    _seq_cache_invalidate(full_path((char *)fn));
     FILE *fp = fnSDFAT.file_open(full_path((char *)fn), "a");
 
     if (!fp)
@@ -259,48 +323,61 @@ uint8_t _sys_readseq(uint8_t *fn, long fpos)
     uint8_t dmabuf[BlkSZ];
     int seekErr;
 
-    f = fnSDFAT.file_open(full_path((char *)fn), "r");
-    if (!f)
+    const char *path = full_path((char *)fn);
+
+    /* Reuse the cached handle when this record is from the same file as the
+       previous sequential read; otherwise (re)open and cache it.  This is the
+       optimization that collapses a ~310-open .COM load into a single open --
+       see the _seq_cache_* block above. */
+    if (seq_cache_fp && strcmp(seq_cache_path, path) == 0)
     {
-        result = 0x10;
-        return result;
-    }
-    seekErr = fseek(f, fpos, SEEK_SET);
-    if (f)
-    {
-        if (fpos > 0 && seekErr != 0)
-        {
-            // EOF
-            result = 0x01;
-        }
-        else
-        {
-            // set DMA buffer to EOF
-            memset(dmabuf, 0x1a, BlkSZ);
-            // BUG FIX (2026-06-21): this was fread(dmabuf, BlkSZ, 1, f), i.e.
-            // size=128, nmemb=1.  fread() returns the number of *complete*
-            // elements read, so a final PARTIAL record (file size not a
-            // multiple of 128) made it return 0: the bytes that WERE read were
-            // discarded (the `if (bytesread)` memcpy was skipped) and result
-            // was reported as 0x01 (EOF).  Symptom: TYPE / ASM / LOAD / PIP
-            // silently dropped the last partial 128-byte record of every file
-            // whose length was not a multiple of 128 -- a 127-byte file showed
-            // nothing at all, a 202-byte file was truncated at exactly 128
-            // bytes.  Fix: read byte-wise (size=1, nmemb=BlkSZ) so fread
-            // returns the byte count (1..128) for partial records too; dmabuf
-            // is already pre-filled with 0x1a so the short record is padded
-            // with CP/M EOF markers as the BDOS sequential read expects.
-            bytesread = fread(&dmabuf[0], sizeof(uint8_t), BlkSZ, f);
-            if (bytesread)
-                memcpy((uint8_t *)&RAM[dmaAddr], dmabuf, BlkSZ);
-            result = bytesread ? 0x00 : 0x01;
-        }
+        f = seq_cache_fp;
     }
     else
     {
-        result = 0x10;
+        _seq_cache_close();
+        f = fnSDFAT.file_open(path, "r");
+        if (!f)
+        {
+            result = 0x10;
+            return result;
+        }
+        seq_cache_fp = f;
+        strncpy(seq_cache_path, path, sizeof(seq_cache_path) - 1);
+        seq_cache_path[sizeof(seq_cache_path) - 1] = '\0';
     }
-    fclose(f);
+
+    seekErr = fseek(f, fpos, SEEK_SET);
+    if (fpos > 0 && seekErr != 0)
+    {
+        // EOF
+        result = 0x01;
+    }
+    else
+    {
+        // set DMA buffer to EOF
+        memset(dmabuf, 0x1a, BlkSZ);
+        // BUG FIX (2026-06-21): this was fread(dmabuf, BlkSZ, 1, f), i.e.
+        // size=128, nmemb=1.  fread() returns the number of *complete*
+        // elements read, so a final PARTIAL record (file size not a
+        // multiple of 128) made it return 0: the bytes that WERE read were
+        // discarded (the `if (bytesread)` memcpy was skipped) and result
+        // was reported as 0x01 (EOF).  Symptom: TYPE / ASM / LOAD / PIP
+        // silently dropped the last partial 128-byte record of every file
+        // whose length was not a multiple of 128 -- a 127-byte file showed
+        // nothing at all, a 202-byte file was truncated at exactly 128
+        // bytes.  Fix: read byte-wise (size=1, nmemb=BlkSZ) so fread
+        // returns the byte count (1..128) for partial records too; dmabuf
+        // is already pre-filled with 0x1a so the short record is padded
+        // with CP/M EOF markers as the BDOS sequential read expects.
+        bytesread = fread(&dmabuf[0], sizeof(uint8_t), BlkSZ, f);
+        if (bytesread)
+            memcpy((uint8_t *)&RAM[dmaAddr], dmabuf, BlkSZ);
+        result = bytesread ? 0x00 : 0x01;
+    }
+    /* Handle intentionally left open and cached for the next record; closed by
+       _seq_cache_close()/_seq_cache_invalidate() on file change, mutation, or
+       session end. */
     return (result);
 }
 
@@ -309,6 +386,7 @@ uint8_t _sys_writeseq(uint8_t *fn, long fpos)
     uint8_t result = 0xff;
     FILE *f;
 
+    _seq_cache_invalidate(full_path((char *)fn));
     if (_sys_extendfile((char *)fn, fpos))
         f = fnSDFAT.file_open(full_path((char *)fn), "r+");
     else
@@ -342,7 +420,30 @@ uint8_t _sys_readrand(uint8_t *fn, long fpos)
     uint8 dmabuf[BlkSZ];
     long extSize;
 
-    f = fnSDFAT.file_open(full_path((char *)fn), "r+");
+    const char *path = full_path((char *)fn);
+
+    /* Reuse the shared read-handle cache (see the _seq_cache_* block above).
+       Random access is a pure read here -- random writes go through
+       _sys_writerand on their own "r+" handle -- so the read-only cached "r"
+       handle serves it too.  This collapses an editor's per-record random reads
+       (a 39 KB file is ~310 reopens) into a single open, exactly as for the
+       sequential .COM-load path. */
+    if (seq_cache_fp && strcmp(seq_cache_path, path) == 0)
+    {
+        f = seq_cache_fp;
+    }
+    else
+    {
+        _seq_cache_close();
+        f = fnSDFAT.file_open(path, "r");
+        if (f)
+        {
+            seq_cache_fp = f;
+            strncpy(seq_cache_path, path, sizeof(seq_cache_path) - 1);
+            seq_cache_path[sizeof(seq_cache_path) - 1] = '\0';
+        }
+    }
+
     if (f)
     {
         if (fseek(f, fpos, SEEK_SET) == 0)
@@ -381,7 +482,9 @@ uint8_t _sys_readrand(uint8_t *fn, long fpos)
     {
         result = 0x10;
     }
-    fclose(f);
+    /* Handle intentionally left open and cached for the next read; closed by
+       _seq_cache_close()/_seq_cache_invalidate() on file change, mutation, or
+       session end. */
     return (result);
 }
 
@@ -390,6 +493,7 @@ uint8_t _sys_writerand(uint8_t *fn, long fpos)
     uint8 result = 0xff;
     FILE *f;
 
+    _seq_cache_invalidate(full_path((char *)fn));
     if (_sys_extendfile((char *)fn, fpos))
     {
         f = fnSDFAT.file_open(full_path((char *)fn), "r+");

--- a/lib/runcpm/abstraction_fujinet_core.h
+++ b/lib/runcpm/abstraction_fujinet_core.h
@@ -1,0 +1,591 @@
+/**
+ * Abstraction functions for #FujiNet — SHARED CORE variant.
+ *
+ * This is the disk/SD + BDOS-helper section of abstraction_fujinet.h, made
+ * console-transport-agnostic so it can be compiled EXACTLY ONCE inside the
+ * single shared RunCPM core (lib/runcpm/runcpm_core.cpp).
+ *
+ * Differences from abstraction_fujinet.h:
+ *   - The SIO-specific console section (the _cpm_txbuf batched writer, the
+ *     teeMode/client/server mirror, and the direct SYSTEM_BUS _getch/_getche/
+ *     _putch) is REPLACED by thin indirection shims that dispatch through the
+ *     active transport's runcpm_console_ops (g_runcpm_console).  Each transport
+ *     (SIO 'G', N:CPM://, telnet console) supplies its own ops.
+ *   - The TCP/tee BIOS helpers (bios_tcpListen/Available/TeeAccept/Drop) and
+ *     their client/server/teeMode/portActive globals live in the SIO transport
+ *     (siocpm.cpp), not here, because they are SIO-console specific.
+ *   - The Atari-only bdos_* config helpers (networkConfig/readHostSlots/
+ *     readDeviceSlots) are dropped: they have no callers anywhere in the tree
+ *     and were the only thing tying this core to theFuji/fujiDevice.h/fnWiFi,
+ *     which would have prevented the shared core from compiling on the non-Atari
+ *     FujiNet targets that also expose the N:CPM:// device.
+ *
+ * The disk/SD family is byte-for-byte identical to abstraction_fujinet.h; only
+ * one copy now exists in the firmware image.
+ */
+
+#ifndef ABSTRACTION_FUJINET_CORE_H
+#define ABSTRACTION_FUJINET_CORE_H
+
+#include <string.h>
+#include <errno.h>
+#include "compat_string.h"
+
+#include "globals.h"
+
+#include "../../include/debug.h"
+
+#include "fnSystem.h"
+#include "fnFsSD.h"
+
+#include "runcpm_session.h"
+
+#define HostOS 0x07 // FUJINET
+
+/* FujiNet vendoring: the per-transport CP/M headers (siocpm.h, the network
+   abstraction, etc.) used to define FOLDERCHAR for the chain.  Now that the
+   chain is compiled once here in the shared core, define it locally.  FujiNet
+   stores CP/M disks under "/CPM/<drive>/<user>/" on the SD card, so the path
+   separator is the POSIX forward slash. */
+#ifndef FOLDERCHAR
+#define FOLDERCHAR '/'
+#endif
+
+/* FujiNet vendoring: RunCPM 6.9 disk.h::_mockupDirEntry references FILEBASE
+   (the host path prefix) to optionally strip it from enumerated names. FujiNet
+   stores bare filenames (no prefix) and always calls _mockupDirEntry(0), so
+   define FILEBASE empty to satisfy compilation with zero-length prefix. */
+#ifndef FILEBASE
+#define FILEBASE ""
+#endif
+
+/* FujiNet vendoring: RunCPM 6.9 calls millis() unconditionally (CPU throttle in
+   cpu.h, Z80estimateClock in cpu_mhz.h, BDOS F_UPTIME C=248 in cpm.h). In 5.8
+   millis() was only used under #ifdef PROFILE (never compiled). Map it to the
+   FujiNet system uptime clock, mirroring upstream's macro abstraction. */
+#ifndef millis
+#define millis() ((uint32)fnSystem.millis())
+#endif
+
+typedef struct
+{
+    uint8_t dr;
+    uint8_t fn[8];
+    uint8_t tp[3];
+    uint8_t ex, s1, s2, rc;
+    uint8_t al[16];
+    uint8_t cr, r0, r1, r2;
+} CPM_FCB;
+
+typedef struct
+{
+    uint8_t dr;
+    uint8_t fn[8];
+    uint8_t tp[3];
+    uint8_t ex, s1, s2, rc;
+    uint8_t al[16];
+} CPM_DIRENTRY;
+
+int dirPos;
+
+char full_filename[128];
+
+char *full_path(char *fn)
+{
+    memset(full_filename, 0, sizeof(full_filename));
+    strcpy(full_filename, "/CPM/");
+    strcat(full_filename, fn);
+    return full_filename;
+}
+
+
+//
+// Hardware functions, new in 5.x
+//
+void _HardwareOut(const uint32 Port, const uint32 Value)
+{
+
+}
+
+uint32 _HardwareIn(const uint32 Port)
+{
+    return 0;
+}
+
+/* Memory abstraction functions */
+/*===============================================================================*/
+/* FujiNet vendoring: RunCPM 6.9 changed _RamLoad to
+   `uint16 _RamLoad(uint8 *filename, uint16 address, uint16 maxsize)` returning
+   the number of bytes read (maxsize == 0 means "no limit"). ccp.h's AUTOEXEC
+   path relies on the byte count, so honor maxsize and return the count. */
+uint16 _RamLoad(uint8 *filename, uint16 address, uint16 maxsize)
+{
+    FILE *f = fnSDFAT.file_open(full_path((char *)filename), "r");
+    uint16 count = 0;
+    uint8_t b;
+
+    if (f)
+    {
+        while ((!maxsize || count < maxsize) && fread(&b, sizeof(uint8_t), 1, f) == 1)
+        {
+            _RamWrite(address++, b);
+            count++;
+        }
+        fclose(f);
+    }
+    return (count);
+}
+
+/* filesystem (disk) abstraction fuctions */
+/*===============================================================================*/
+FILE *rootdir;
+FILE *userdir;
+
+bool _sys_exists(uint8* filename)
+{
+    return fnSDFAT.exists(full_path((char *)filename));
+}
+
+int _sys_fputc(uint8_t ch, FILE *f)
+{
+    return fputc(ch, f);
+}
+
+void _sys_fflush(FILE *f)
+{
+    fflush(f);
+}
+
+void _sys_fclose(FILE *f)
+{
+    fclose(f);
+}
+
+int _sys_select(uint8_t *disk)
+{
+    return fnSDFAT.exists(full_path((char *)disk));
+}
+
+long _sys_filesize(uint8_t *fn)
+{
+    unsigned long fs = -1;
+    FILE *fp = fnSDFAT.file_open(full_path((char *)fn), "r");
+
+    if (fp)
+    {
+        fseek(fp, 0L, SEEK_END);
+        fs = ftell(fp);
+    }
+
+    fclose(fp);
+    return fs;
+}
+
+int _sys_openfile(uint8_t *fn)
+{
+    FILE *fp = fnSDFAT.file_open(full_path((char *)fn), "r");
+    if (fp)
+    {
+        fclose(fp);
+        return 1;
+    }
+    else
+        return 0;
+}
+
+int _sys_makefile(uint8_t *fn)
+{
+    FILE *fp = fnSDFAT.file_open(full_path((char *)fn), "w");
+    if (fp)
+    {
+        fclose(fp);
+        return true;
+    }
+    else
+        return false;
+}
+
+int _sys_deletefile(uint8_t *fn)
+{
+    return fnSDFAT.remove(full_path((char *)fn));
+}
+
+int _sys_renamefile(uint8_t *fn, uint8_t *newname)
+{
+    std::string from, to;
+
+    from = std::string(full_path((char *)fn));
+    to = std::string(full_path((char *)newname));
+
+    return fnSDFAT.rename(from.c_str(), to.c_str());
+}
+
+void _sys_logbuffer(uint8_t *buffer)
+{
+    // not implemented at present.
+}
+
+bool _sys_extendfile(char *fn, unsigned long fpos)
+{
+    FILE *fp = fnSDFAT.file_open(full_path((char *)fn), "a");
+
+    if (!fp)
+        return false;
+
+    long origSize = fnSDFAT.filesize(full_path(fn));
+
+    // This was patterned after the arduino abstraction, and I do not like how this works.
+
+    if (fpos > origSize)
+    {
+        for (long i = 0; i < (origSize - fpos); ++i)
+        {
+            if (fwrite("\0", sizeof(uint8_t), 1, fp) != 1)
+            {
+                fclose(fp);
+                return false;
+            }
+        }
+    }
+    fclose(fp);
+    return true;
+}
+
+uint8_t _sys_readseq(uint8_t *fn, long fpos)
+{
+    uint8_t result = 0xff;
+    FILE *f;
+    uint8_t bytesread;
+    uint8_t dmabuf[BlkSZ];
+    int seekErr;
+
+    f = fnSDFAT.file_open(full_path((char *)fn), "r");
+    if (!f)
+    {
+        result = 0x10;
+        return result;
+    }
+    seekErr = fseek(f, fpos, SEEK_SET);
+    if (f)
+    {
+        if (fpos > 0 && seekErr != 0)
+        {
+            // EOF
+            result = 0x01;
+        }
+        else
+        {
+            // set DMA buffer to EOF
+            memset(dmabuf, 0x1a, BlkSZ);
+            // BUG FIX (2026-06-21): this was fread(dmabuf, BlkSZ, 1, f), i.e.
+            // size=128, nmemb=1.  fread() returns the number of *complete*
+            // elements read, so a final PARTIAL record (file size not a
+            // multiple of 128) made it return 0: the bytes that WERE read were
+            // discarded (the `if (bytesread)` memcpy was skipped) and result
+            // was reported as 0x01 (EOF).  Symptom: TYPE / ASM / LOAD / PIP
+            // silently dropped the last partial 128-byte record of every file
+            // whose length was not a multiple of 128 -- a 127-byte file showed
+            // nothing at all, a 202-byte file was truncated at exactly 128
+            // bytes.  Fix: read byte-wise (size=1, nmemb=BlkSZ) so fread
+            // returns the byte count (1..128) for partial records too; dmabuf
+            // is already pre-filled with 0x1a so the short record is padded
+            // with CP/M EOF markers as the BDOS sequential read expects.
+            bytesread = fread(&dmabuf[0], sizeof(uint8_t), BlkSZ, f);
+            if (bytesread)
+                memcpy((uint8_t *)&RAM[dmaAddr], dmabuf, BlkSZ);
+            result = bytesread ? 0x00 : 0x01;
+        }
+    }
+    else
+    {
+        result = 0x10;
+    }
+    fclose(f);
+    return (result);
+}
+
+uint8_t _sys_writeseq(uint8_t *fn, long fpos)
+{
+    uint8_t result = 0xff;
+    FILE *f;
+
+    if (_sys_extendfile((char *)fn, fpos))
+        f = fnSDFAT.file_open(full_path((char *)fn), "r+");
+    else
+        return result;
+
+    if (f)
+    {
+        if (fseek(f, fpos, SEEK_SET) == 0)
+        {
+            if (fwrite(_RamSysAddr(dmaAddr), BlkSZ, sizeof(uint8_t), f))
+                result = 0x00;
+        }
+        else
+        {
+            result = 0x01;
+        }
+    }
+    else
+    {
+        result = 0x10;
+    }
+    fclose(f);
+    return (result);
+}
+
+uint8_t _sys_readrand(uint8_t *fn, long fpos)
+{
+    uint8 result = 0xff;
+    FILE *f;
+    uint8 bytesread;
+    uint8 dmabuf[BlkSZ];
+    long extSize;
+
+    f = fnSDFAT.file_open(full_path((char *)fn), "r+");
+    if (f)
+    {
+        if (fseek(f, fpos, SEEK_SET) == 0)
+        {
+            memset(dmabuf, 0x1A, BlkSZ);
+            // BUG FIX (2026-06-21): same partial-record fread bug as
+            // _sys_readseq above -- fread(dmabuf, BlkSZ, 1, f) returns 0 for a
+            // final record shorter than 128 bytes, dropping its data and
+            // signalling premature EOF.  Read byte-wise so the count (1..128)
+            // is returned; dmabuf is pre-filled with 0x1A as EOF padding.
+            bytesread = fread(&dmabuf[0], sizeof(uint8_t), BlkSZ, f);
+            if (bytesread)
+                memcpy((uint8_t *)&RAM[dmaAddr], dmabuf, BlkSZ);
+            result = bytesread ? 0x00 : 0x01;
+        }
+        else
+        {
+            if (fpos >= 65536L * BlkSZ)
+            {
+                result = 0x06; // seek past 8MB (largest file size in CP/M)
+            }
+            else
+            {
+                extSize = _sys_filesize((uint8_t *)full_path((char *)fn));
+
+                // round file size up to next full logical extent
+                extSize = ExtSZ * ((extSize / ExtSZ) + ((extSize % ExtSZ) ? 1 : 0));
+                if (fpos < extSize)
+                    result = 0x01; // reading unwritten data
+                else
+                    result = 0x04; // seek to unwritten extent
+            }
+        }
+    }
+    else
+    {
+        result = 0x10;
+    }
+    fclose(f);
+    return (result);
+}
+
+uint8_t _sys_writerand(uint8_t *fn, long fpos)
+{
+    uint8 result = 0xff;
+    FILE *f;
+
+    if (_sys_extendfile((char *)fn, fpos))
+    {
+        f = fnSDFAT.file_open(full_path((char *)fn), "r+");
+    }
+    else
+        return result;
+
+    if (f)
+    {
+        if (fseek(f, fpos, SEEK_SET) == 0)
+        {
+            if (fwrite(_RamSysAddr(dmaAddr), BlkSZ, sizeof(uint8_t), f))
+                result = 0x00;
+        }
+        else
+        {
+            result = 0x06;
+        }
+    }
+    else
+    {
+        result = 0x10;
+    }
+    fclose(f);
+    return (result);
+}
+
+uint8_t findNextDirName[17];
+uint16_t fileRecords = 0;
+uint16_t fileExtents = 0;
+uint16_t fileExtentsUsed = 0;
+uint16_t firstFreeAllocBlock;
+
+uint8_t _findnext(uint8_t isdir)
+{
+    uint8 result = 0xff;
+    bool isfile;
+    uint32 bytes;
+    fsdir_entry *entry;
+
+    if (allExtents && fileRecords)
+    {
+        _mockupDirEntry(0); // FujiNet vendoring: mode 0 = bare filename (no FILEBASE prefix)
+        result = 0;
+    }
+    else
+    {
+        while ((entry = fnSDFAT.dir_read()))
+        {
+            strcpy((char *)findNextDirName, entry->filename); // careful watch for string overflow!
+            isfile = !entry->isDir;
+            bytes = entry->size;
+            if (!isfile)
+                continue;
+            _HostnameToFCBname(findNextDirName, fcbname);
+            if (match(fcbname, pattern))
+            {
+                if (isdir)
+                {
+                    // account for host files that aren't multiples of the block size
+                    // by rounding their bytes up to the next multiple of blocks
+                    if (bytes & (BlkSZ - 1))
+                    {
+                        bytes = (bytes & ~(BlkSZ - 1)) + BlkSZ;
+                    }
+                    fileRecords = bytes / BlkSZ;
+                    fileExtents = fileRecords / BlkEX + ((fileRecords & (BlkEX - 1)) ? 1 : 0);
+                    fileExtentsUsed = 0;
+                    firstFreeAllocBlock = firstBlockAfterDir;
+                    _mockupDirEntry(0); // FujiNet vendoring: mode 0 = bare filename (no FILEBASE prefix)
+                }
+                else
+                {
+                    fileRecords = 0;
+                    fileExtents = 0;
+                    fileExtentsUsed = 0;
+                    firstFreeAllocBlock = firstBlockAfterDir;
+                }
+                _RamWrite(tmpFCB, filename[0] - '@');
+                _HostnameToFCB(tmpFCB, findNextDirName);
+                result = 0x00;
+                break;
+            }
+        }
+    }
+    return (result);
+}
+
+uint8_t _findfirst(uint8_t isdir)
+{
+    uint8 path[4] = {'?', FOLDERCHAR, '?', 0};
+    path[0] = filename[0];
+    path[2] = filename[2];
+    fnSDFAT.dir_close();
+    fnSDFAT.dir_open(full_path((char *)path), "*", 0);
+    _HostnameToFCBname(filename, pattern);
+    fileRecords = 0;
+    fileExtents = 0;
+    fileExtentsUsed = 0;
+    return (_findnext(isdir));
+}
+
+uint8_t _findnextallusers(uint8_t isdir)
+{
+    return _findnext(isdir);
+}
+
+uint8_t _findfirstallusers(uint8_t isdir)
+{
+    dirPos = 0;
+    strcpy((char *)pattern, "???????????");
+    fileRecords = 0;
+    fileExtents = 0;
+    fileExtentsUsed = 0;
+    return (_findnextallusers(isdir));
+}
+
+uint8_t _Truncate(char *fn, uint8_t rc)
+{
+    // Implement some other way.
+    return 0;
+}
+
+void _MakeUserDir()
+{
+    uint8 dFolder = cDrive + 'A';
+    uint8 uFolder = toupper(tohex(userCode));
+
+    uint8 path[4] = {dFolder, FOLDERCHAR, uFolder, 0};
+
+    if (fnSDFAT.exists(full_path((char *)path)))
+    {
+        return;
+    }
+
+    fnSDFAT.create_path(full_path((char *)path));
+}
+
+uint8_t _sys_makedisk(uint8_t drive)
+{
+    uint8 result = 0;
+    if (drive < 1 || drive > 16)
+    {
+        result = 0xff;
+    }
+    else
+    {
+        uint8 dFolder = drive + '@';
+        uint8 disk[2] = {dFolder, 0};
+
+        if (fnSDFAT.exists(full_path((char *)disk)))
+            return 0;
+
+        if (!fnSDFAT.create_path(full_path((char *)disk)))
+        {
+            result = 0xfe;
+        }
+        else
+        {
+            uint8 path[4] = {dFolder, FOLDERCHAR, '0', 0};
+            fnSDFAT.create_path(full_path((char *)path));
+        }
+    }
+    return (result);
+}
+
+/* Console abstraction functions */
+/*===============================================================================*/
+/*
+ * Transport-agnostic console: every console primitive the RunCPM chain
+ * (console.h, cpm.h, ccp.h) calls is dispatched through the active transport's
+ * runcpm_console_ops, installed by runcpm_session_run() before the CCP starts.
+ * g_runcpm_console is defined in runcpm_core.cpp.
+ */
+extern "C" runcpm_console_ops g_runcpm_console;
+
+#define _kbhit() (g_runcpm_console.kbhit())
+
+static inline uint8 _getch(void)
+{
+    return (uint8)g_runcpm_console.getch();
+}
+
+static inline uint8 _getche(void)
+{
+    return (uint8)g_runcpm_console.getche();
+}
+
+static inline void _putch(uint8 ch)
+{
+    g_runcpm_console.putch(ch);
+}
+
+static inline void _clrscr(void)
+{
+    g_runcpm_console.clrscr();
+}
+
+#endif /* ABSTRACTION_FUJINET_CORE_H */

--- a/lib/runcpm/abstraction_network_protocol.h
+++ b/lib/runcpm/abstraction_network_protocol.h
@@ -18,9 +18,22 @@
 #include "globals.h"
 #include "../../include/debug.h"
 #include "fnFsSD.h"
+#include "fnSystem.h" // FujiNet vendoring: provides fnSystem.millis() for the millis() macro below
 
 #define FOLDERCHAR '/'
 #define HostOS 0x07  // FUJINET
+
+/* FujiNet vendoring: see abstraction_fujinet.h — 6.9 disk.h needs FILEBASE;
+   FujiNet uses bare filenames and always calls _mockupDirEntry(0). */
+#ifndef FILEBASE
+#define FILEBASE ""
+#endif
+
+/* FujiNet vendoring: see abstraction_fujinet.h — 6.9 calls millis()
+   unconditionally; map it to the FujiNet system uptime clock. */
+#ifndef millis
+#define millis() ((uint32)fnSystem.millis())
+#endif
 
 typedef struct
 {
@@ -89,28 +102,26 @@ static uint32 _HardwareIn(const uint32 Port) { (void)Port; return 0; }
 /* -------------------------------------------------------------------------
  * Memory abstraction
  * ------------------------------------------------------------------------- */
-static bool _RamLoad(char *fn, uint16_t address)
+/* FujiNet vendoring: RunCPM 6.9 _RamLoad signature returns bytes read and
+   honors maxsize (0 == no limit). Kept `static` for the RUNCPM_STATIC_IMPL TU.
+   See abstraction_fujinet.h for rationale. */
+static uint16 _RamLoad(uint8 *filename, uint16 address, uint16 maxsize)
 {
-    FILE *f = fnSDFAT.file_open(full_path(fn), "r");
-    bool result = false;
+    FILE *f = fnSDFAT.file_open(full_path((char *)filename), "r");
+    uint16 count = 0;
     uint8_t b;
 
     if (f)
     {
-        while (!feof(f))
+        while ((!maxsize || count < maxsize) && fread(&b, sizeof(uint8_t), 1, f) == 1)
         {
-            if (fread(&b, sizeof(uint8_t), 1, f) == 1)
-            {
-                _RamWrite(address++, b);
-                result = true;
-            }
-            else
-                result = false;
+            _RamWrite(address++, b);
+            count++;
         }
         fclose(f);
     }
     Debug_printf("CCP last address: %04x\r\n", address);
-    return result;
+    return count;
 }
 
 /* -------------------------------------------------------------------------
@@ -322,7 +333,7 @@ static uint8_t _findnext(uint8_t isdir)
 
     if (allExtents && fileRecords)
     {
-        _mockupDirEntry();
+        _mockupDirEntry(0); // FujiNet vendoring: mode 0 = bare filename (no FILEBASE prefix)
         return 0;
     }
 
@@ -342,7 +353,7 @@ static uint8_t _findnext(uint8_t isdir)
                 fileExtents       = fileRecords / BlkEX + ((fileRecords & (BlkEX - 1)) ? 1 : 0);
                 fileExtentsUsed   = 0;
                 firstFreeAllocBlock = firstBlockAfterDir;
-                _mockupDirEntry();
+                _mockupDirEntry(0); // FujiNet vendoring: mode 0 = bare filename (no FILEBASE prefix)
             }
             else
             {

--- a/lib/runcpm/ccp.h
+++ b/lib/runcpm/ccp.h
@@ -49,10 +49,14 @@ RUNCPM_DECL uint8 prompt[PROMPT_SIZE] = "\r\n  >";  // Command prompt
 RUNCPM_DECL uint16 cmdBufferPtr, errorPtr;          // Pointer to the command buffer, and error position
 RUNCPM_DECL uint8 bufferLen = 0;                    // Actual size of the typed command line
 
+/* FujiNet vendoring: renamed from RunCPM's `Command` to `CcpCommand` to avoid a
+   name collision with FujiNet's `class Command` (lib/devrelay/types/Command.h),
+   which is pulled into the shared RunCPM core TU (runcpm_core.cpp) via the bus
+   headers on the APPLE/COCO targets. */
 typedef struct {
     const char *name;
     uint8 (*handler)(void);
-} Command;
+} CcpCommand;
 
 // Used to call BIOS from inside the CCP
 RUNCPM_DECL void _ccp_bios(uint8 function) {
@@ -1146,7 +1150,7 @@ RUNCPM_DECL uint8 _ccp_hlp(void) {
 }
 
 // List of CCP commands
-static const Command Commands[] = {
+static const CcpCommand Commands[] = {
 #ifdef Internals
     // Standard CP/M commands
     {"DIR", _ccp_dir},
@@ -1177,7 +1181,7 @@ static const Command Commands[] = {
 };
 
 // Gets the command pointer
-RUNCPM_DECL const Command *_ccp_cnum(void) {
+RUNCPM_DECL const CcpCommand *_ccp_cnum(void) {
     uint8 command[9];
     uint8 i = 0;
 
@@ -1665,7 +1669,7 @@ RUNCPM_DECL void _ccp(void) {
 
             i = FALSE; // Checks if the command is valid and executes
 
-            const Command *cmd = _ccp_cnum();
+            const CcpCommand *cmd = _ccp_cnum();
             if (cmd) {
                 i = cmd->handler();
             } else {

--- a/lib/runcpm/ccp.h
+++ b/lib/runcpm/ccp.h
@@ -8,115 +8,174 @@
 // CP/M BDOS calls
 #include "cpm.h"
 
-#define CmdFCB	(BatchFCB + 36)							// FCB for use by internal commands
-#define ParFCB	0x005C									// FCB for use by line parameters
-#define SecFCB	0x006C									// Secondary part of FCB for renaming files
-#define Trampoline (CmdFCB + 36)						// Trampoline for running external commands
+// Memory Layout Definitions
+#define CmdFCB      (BatchFCB + 48)     // FCB for use by internal commands
+#define ParFCB      0x005C              // FCB for use by line parameters
+#define SecFCB      0x006C              // Secondary part of FCB for renaming files
+#define Trampoline  (CmdFCB + 36)       // Trampoline for running external commands
 
-#define inBuf	(BDOSjmppage - 256)						// Input buffer location
-#define cmdLen	125										// Maximum size of a command line (sz+rd+cmd+\0)
+#define inBuf       (BDOSjmppage - 256) // Input buffer location
+#define cmdLen      125                 // Maximum size of a command line (sz+rd+cmd+\0)
 
-#define defDMA	0x0080									// Default DMA address
-#define defLoad	0x0100									// Default load address
+#define defDMA      0x0080              // Default DMA address
+#define defLoad     0x0100              // Default load address
+
+#define Internals                       // Define to have internal commands
+
+// CCP Configuration and State
+#define DEFAULT_PAGE_SIZE 22
+#define PROMPT_SIZE       8
+#define FCB_SIZE          36
+#define SEC_SIZE          128
+#define MAX_USER          15
 
 // CCP global variables
-RUNCPM_DECL uint8 pgSize = 22;  // for TYPE
-RUNCPM_DECL uint8 curDrive = 0; // 0 -> 15 = A -> P	.. Current drive for the CCP (same as RAM[DSKByte])
-RUNCPM_DECL uint8 parDrive = 0; // 0 -> 15 = A -> P .. Drive for the first file parameter
-RUNCPM_DECL uint8 curUser = 0;  // 0 -> 15			.. Current user area to access
-RUNCPM_DECL bool sFlag = FALSE; // Submit Flag
-RUNCPM_DECL uint8 sRecs = 0;    // Number of records on the Submit file
-RUNCPM_DECL uint8 prompt[8] = "\r\n  >";
-RUNCPM_DECL uint16 pbuf, perr;
-RUNCPM_DECL uint8 blen; // Actual size of the typed command line (size of the buffer)
+RUNCPM_DECL uint8 pageSize = DEFAULT_PAGE_SIZE;     // for TYPE
+RUNCPM_DECL uint8 currentDrive = 0;                 // 0 -> 15 = A -> P (Current drive for the CCP)
+RUNCPM_DECL uint8 paramDrive = 0;                   // 0 -> 15 = A -> P (Drive for the first file parameter)
+RUNCPM_DECL uint8 currentUser = 0;                  // 0 -> 15 (Current user area to access)
+RUNCPM_DECL bool submitFlag = FALSE;                // Submit Flag
+RUNCPM_DECL uint8 submitRecords = 0;                // Number of records on the Submit file
+RUNCPM_DECL uint8 prompt[PROMPT_SIZE] = "\r\n  >";  // Command prompt
+RUNCPM_DECL uint16 cmdBufferPtr, errorPtr;          // Pointer to the command buffer, and error position
+RUNCPM_DECL uint8 bufferLen = 0;                    // Actual size of the typed command line
 
-static const char *Commands[] =
-{
-    // Standard CP/M commands
-    "DIR",
-    "ERA",
-    "TYPE",
-    "SAVE",
-    "REN",
-    "USER",
-    
-    // Extra CCP commands
-    "CLS",
-    "DEL",
-    "EXIT",
-    "PAGE",
-    "VOL",
-    NULL
-};
+typedef struct {
+    const char *name;
+    uint8 (*handler)(void);
+} Command;
+
+// Used to call BIOS from inside the CCP
+RUNCPM_DECL void _ccp_bios(uint8 function) {
+    SET_LOW_REGISTER(PCX, function);
+    _Bios();
+} // _ccp_bios
 
 // Used to call BDOS from inside the CCP
 RUNCPM_DECL uint16 _ccp_bdos(uint8 function, uint16 de) {
     SET_LOW_REGISTER(BC, function);
     DE = de;
     _Bdos();
-    
+
     return (HL & 0xffff);
 } // _ccp_bdos
 
+// --- New Helper Functions for Printing ---
+
+// Helper to print a byte in Hex
+RUNCPM_DECL void _ccp_printHex8(uint8 v) {
+    uint8 nibble = v >> 4;
+    _ccp_bdos(C_WRITE, nibble > 9 ? nibble + 55 : nibble + 48);
+    nibble = v & 0x0F;
+    _ccp_bdos(C_WRITE, nibble > 9 ? nibble + 55 : nibble + 48);
+}
+
+// Helper to print a word in Hex
+RUNCPM_DECL void _ccp_printHex16(uint16 v) {
+    _ccp_printHex8(v >> 8);
+    _ccp_printHex8(v & 0xFF);
+}
+
+// Helper to print a number in Decimal
+RUNCPM_DECL void _ccp_printDec(uint32 v) {
+    char buf[10];
+    uint8 i = 0;
+    if (v == 0) {
+        _ccp_bdos(C_WRITE, '0');
+        return;
+    }
+    while (v) {
+        buf[i++] = (v % 10) + '0';
+        v /= 10;
+    }
+    while (i) {
+        _ccp_bdos(C_WRITE, buf[--i]);
+    }
+}
+
+#ifdef CPM3
+// Helper to print a 2-digit zero-padded decimal value
+RUNCPM_DECL void _ccp_print2(uint8 v) {
+    _ccp_bdos(C_WRITE, '0' + (v / 10) % 10);
+    _ccp_bdos(C_WRITE, '0' + v % 10);
+}
+
+// Prints a CP/M 3 date stamp (4 bytes at 'stamp': day word, hour BCD,
+// minute BCD) as MM/DD/YYYY HH:MM. Day 1 = 1978-01-01.
+RUNCPM_DECL void _ccp_printFileDate(uint16 stamp) {
+    uint16 days = _RamRead(stamp) | (_RamRead(stamp + 1) << 8);
+    uint8 bh = _RamRead(stamp + 2);
+    uint8 bm = _RamRead(stamp + 3);
+    uint16 year = 1978;
+    uint8 month;
+    static const uint8 mlen[12] = {31, 28, 31, 30, 31, 30,
+                                   31, 31, 30, 31, 30, 31};
+
+    if (days == 0) { // no stamp recorded
+        _puts("       --       ");
+        return;
+    }
+    days -= 1; // days since 1978-01-01
+    for (;;) {
+        uint16 ylen =
+            (year % 4 == 0 && (year % 100 != 0 || year % 400 == 0)) ? 366 : 365;
+        if (days < ylen)
+            break;
+        days -= ylen;
+        ++year;
+    }
+    for (month = 0; month < 12; ++month) {
+        uint8 dm = mlen[month];
+        if (month == 1 &&
+            (year % 4 == 0 && (year % 100 != 0 || year % 400 == 0)))
+            dm = 29;
+        if (days < dm)
+            break;
+        days -= dm;
+    }
+    _ccp_print2(month + 1);
+    _ccp_bdos(C_WRITE, '/');
+    _ccp_print2((uint8)days + 1);
+    _ccp_bdos(C_WRITE, '/');
+    _ccp_printDec(year);
+    _ccp_bdos(C_WRITE, ' ');
+    _ccp_print2(((bh >> 4) & 0x0F) * 10 + (bh & 0x0F));
+    _ccp_bdos(C_WRITE, ':');
+    _ccp_print2(((bm >> 4) & 0x0F) * 10 + (bm & 0x0F));
+}
+#endif
+
 // Compares two strings (Atmel doesn't like strcmp)
-RUNCPM_DECL uint8 _ccp_strcmp(char *stra, char *strb) {
+RUNCPM_DECL uint8 _ccp_strEqual(const char *stra, const char *strb) {
     while (*stra && *strb && (*stra == *strb)) {
         ++stra;
         ++strb;
     }
     return (*stra == *strb);
-} // _ccp_strcmp
+} // _ccp_strEqual
 
-// Gets the command ID number
-RUNCPM_DECL uint8 _ccp_cnum(void) {
-    uint8 result = 255;
-    uint8 command[9];
-    uint8 i = 0;
-    
-    if (!_RamRead(CmdFCB)) {    // If a drive was set, then the command is external
-        while (i < 8 && _RamRead(CmdFCB + i + 1) != ' ') {
-            command[i] = _RamRead(CmdFCB + i + 1);
-            ++i;
-        }
-        command[i] = 0;
-        
-        i = 0;
-        
-        while (Commands[i]) {
-            if (_ccp_strcmp((char *)command, (char *)Commands[i])) {
-                result = i;
-                perr = defDMA + 2;
-                break;
-            }
-            ++i;
-        }
-    }
-    return (result);
-} // _ccp_cnum
-
-// Returns true if character is a separator
+// Returns true if character is a delimiter
 RUNCPM_DECL uint8 _ccp_delim(uint8 ch) {
-    return (ch == 0 || ch == ' ' || ch == '=' || ch == '.' || ch == ':' || ch == ';' || ch == '<' || ch == '>');
+    return (ch == 0 || ch == ' ' || ch == '=' || ch == '.' || ch == ':' ||
+            ch == ';' || ch == '<' || ch == '>');
 }
 
 // Prints the FCB filename
 RUNCPM_DECL void _ccp_printfcb(uint16 fcb, uint8 compact) {
     uint8 i, ch;
-    
+
     ch = _RamRead(fcb);
     if (ch && compact) {
-        _ccp_bdos(	C_WRITE,	ch + '@');
-        _ccp_bdos(	C_WRITE,	':');
+        _ccp_bdos(C_WRITE, ch + '@');
+        _ccp_bdos(C_WRITE, ':');
     }
-    
+
     for (i = 1; i < 12; ++i) {
         ch = _RamRead(fcb + i);
-        if ((ch == ' ') && compact) {
+        if ((ch == ' ') && compact)
             continue;
-        }
-        if (i == 9) {
+        if (i == 9)
             _ccp_bdos(C_WRITE, compact ? '.' : ' ');
-        }
         _ccp_bdos(C_WRITE, ch);
     }
 } // _ccp_printfcb
@@ -124,85 +183,84 @@ RUNCPM_DECL void _ccp_printfcb(uint16 fcb, uint8 compact) {
 // Initializes the FCB
 RUNCPM_DECL void _ccp_initFCB(uint16 address, uint8 size) {
     uint8 i;
-    
-    for (i = 0; i < size; ++i) {
+
+    for (i = 0; i < size; ++i)
         _RamWrite(address + i, 0x00);
-    }
-    
-    for (i = 0; i < 11; ++i) {
+
+    for (i = 0; i < 11; ++i)
         _RamWrite(address + 1 + i, 0x20);
-    }
 } // _ccp_initFCB
 
 // Name to FCB
+// Parses a filename from the command buffer into an FCB
+// Handles drive specifiers (A:), wildcards (*, ?), and extensions
 RUNCPM_DECL uint8 _ccp_nameToFCB(uint16 fcb) {
     uint8 pad, plen, ch, n = 0;
-    
+
     // Checks for a drive and places it on the Command FCB
-    if (_RamRead(pbuf + 1) == ':') {
-        ch = toupper(_RamRead(pbuf++));
-        _RamWrite(fcb, ch - '@');   // Makes the drive 0x1-0xF for A-P
-        ++pbuf;                     // Points pbuf past the :
-        blen -= 2;
+    if (_RamRead(cmdBufferPtr + 1) == ':') {
+        ch = toupper(_RamRead(cmdBufferPtr++));
+        _RamWrite(fcb, ch - '@'); // Makes the drive 0x1-0xF for A-P
+        ++cmdBufferPtr;           // Points cmdBufferPtr past the :
+        bufferLen -= 2;
     }
-    if (blen) {
+    if (bufferLen) {
         ++fcb;
-        
+
+        // Parse filename (up to 8 chars)
         plen = 8;
         pad = ' ';
-        ch = toupper(_RamRead(pbuf));
-        
-        while (blen && plen) {
-            if (_ccp_delim(ch)) {
+        ch = toupper(_RamRead(cmdBufferPtr));
+
+        while (bufferLen && plen) {
+            if (_ccp_delim(ch))
                 break;
-            }
-            ++pbuf;
-            --blen;
-            if (ch == '*') {
+            ++cmdBufferPtr;
+            --bufferLen;
+            if (ch == '*')
                 pad = '?';
-            }
             if (pad == '?') {
                 ch = pad;
-                n = n | 0x80;   // Name is not unique
+                n = n | 0x80; // Name is not unique
             }
             --plen;
             ++n;
             _RamWrite(fcb++, ch);
-            ch = toupper(_RamRead(pbuf));
+            ch = toupper(_RamRead(cmdBufferPtr));
         }
-        
-        while (plen--) {
+
+        // Pad remaining filename with spaces
+        while (plen--)
             _RamWrite(fcb++, pad);
-        }
+        
+        // Parse extension (up to 3 chars)
         plen = 3;
         pad = ' ';
         if (ch == '.') {
-            ++pbuf;
-            --blen;
+            ++cmdBufferPtr;
+            --bufferLen;
         }
-        
-        while (blen && plen) {
-            ch = toupper(_RamRead(pbuf));
-            if (_ccp_delim(ch)) {
+
+        while (bufferLen && plen) {
+            ch = toupper(_RamRead(cmdBufferPtr));
+            if (_ccp_delim(ch))
                 break;
-            }
-            ++pbuf;
-            --blen;
-            if (ch == '*') {
+            ++cmdBufferPtr;
+            --bufferLen;
+            if (ch == '*')
                 pad = '?';
-            }
             if (pad == '?') {
                 ch = pad;
-                n = n | 0x80;   // Name is not unique
+                n = n | 0x80; // Name is not unique
             }
             --plen;
             ++n;
             _RamWrite(fcb++, ch);
         }
-        
-        while (plen--) {
+
+        // Pad remaining extension with spaces
+        while (plen--)
             _RamWrite(fcb++, pad);
-        }
     }
     return (n);
 } // _ccp_nameToFCB
@@ -212,7 +270,7 @@ RUNCPM_DECL uint16 _ccp_fcbtonum() {
     uint8 ch;
     uint16 n = 0;
     uint8 pos = ParFCB + 1;
-    
+
     while (TRUE) {
         ch = _RamRead(pos++);
         if ((ch < '0') || (ch > '9')) {
@@ -223,108 +281,241 @@ RUNCPM_DECL uint16 _ccp_fcbtonum() {
     return (n);
 } // _ccp_fcbtonum
 
-// DIR command
-RUNCPM_DECL void _ccp_dir(void) {
+// Asks for a key to continue, used by TYPE and LDIR
+RUNCPM_DECL void _ccp_askForKey(void) {
+    _puts("-- Press any key, ^C to quit --");
+    _ccp_bios(B_CONIN);
+    _puts("\r");
+    _puts("                               \r");
+}
+
+#ifdef Internals
+// DIR command - standard directory listing
+RUNCPM_DECL uint8 _ccp_dir(void) {
     uint8 i;
     uint8 dirHead[6] = "A: ";
     uint8 dirSep[6] = "  |  ";
-    uint32 fcount = 0;  // Number of files printed
-    uint32 ccount = 0;  // Number of columns printed
-    
-    if (_RamRead(ParFCB + 1) == ' ') {
-        for (i = 1; i < 12; ++i) {
+    uint32 ccount = 0; // Number of columns printed
+
+    if (_RamRead(ParFCB + 1) == ' ')
+        for (i = 1; i < 12; ++i)
             _RamWrite(ParFCB + i, '?');
-        }
-    }
     dirHead[0] = _RamRead(ParFCB) ? _RamRead(ParFCB) + '@' : prompt[2];
-    
+
     _puts("\r\n");
     if (!_SearchFirst(ParFCB, TRUE)) {
         _puts((char *)dirHead);
         _ccp_printfcb(tmpFCB, FALSE);
-        ++fcount;
         ++ccount;
-        
+
         while (!_SearchNext(ParFCB, TRUE)) {
             if (!ccount) {
-                _puts(	"\r\n");
-                _puts(	(char *)dirHead);
+                _puts("\r\n");
+                _puts((char *)dirHead);
             } else {
                 _puts((char *)dirSep);
             }
             _ccp_printfcb(tmpFCB, FALSE);
-            ++fcount;
             ++ccount;
-            if (ccount > 3) {
+            if (ccount > 3)
                 ccount = 0;
-            }
         }
     } else {
         _puts("No file");
     }
+    return 0;
 } // _ccp_dir
 
-// ERA command
-RUNCPM_DECL void _ccp_era(void) {
-    if (_ccp_bdos(F_DELETE, ParFCB)) {
-        _puts("\r\nNo file");
+// LDIR command (Long DIR) - directory listing with file sizes and optional
+// checksum
+RUNCPM_DECL uint8 _ccp_ldir(void) {
+    uint8 checksumOption = 0;
+    uint8 l = 0;
+
+    // Check for /C option in ParFCB or SecFCB
+    if ((_RamRead(ParFCB + 1) == '/' && _RamRead(ParFCB + 2) == 'C') ||
+        (_RamRead(SecFCB + 1) == '/' && _RamRead(SecFCB + 2) == 'C')) {
+        checksumOption = 1;
     }
+
+    // If ParFCB has /C, set it to list all files
+    if (_RamRead(ParFCB + 1) == '/' && _RamRead(ParFCB + 2) == 'C') {
+        for (uint8 i = 1; i < 12; ++i)
+            _RamWrite(ParFCB + i, '?');
+    } else if (_RamRead(ParFCB + 1) == ' ') {
+        // If no pattern specified, list all files
+        for (uint8 i = 1; i < 12; ++i)
+            _RamWrite(ParFCB + i, '?');
+    }
+
+    _puts("\r\n");
+    if (!_SearchFirst(ParFCB, TRUE)) {
+        do {
+            _ccp_printfcb(tmpFCB, TRUE);
+            // Calculate length of printed filename for alignment
+            uint8 len = 2; // drive:
+            for (uint8 i = 1; i <= 8; ++i) {
+                uint8 ch = _RamRead(tmpFCB + i);
+                if (ch != ' ')
+                    len++;
+                else
+                    break;
+            }
+            len++; // .
+            for (uint8 i = 9; i <= 11; ++i) {
+                uint8 ch = _RamRead(tmpFCB + i);
+                if (ch != ' ')
+                    len++;
+                else
+                    break;
+            }
+            // Align to column 20
+            uint8 target = 20;
+            while (len < target) {
+                _ccp_bdos(C_WRITE, ' ');
+                len++;
+            }
+            // Get file size
+#ifdef CPM3
+            // CP/M 3: obtain the size strictly through BDOS. F_SIZE (function
+            // 35) sets the random-record field to the number of 128-byte
+            // records, which is the file size CP/M actually tracks.
+            _ccp_bdos(F_SIZE, tmpFCB);
+            uint32 size = ((uint32)_RamRead(tmpFCB + 33) |
+                           ((uint32)_RamRead(tmpFCB + 34) << 8) |
+                           ((uint32)_RamRead(tmpFCB + 35) << 16)) * 128;
+#else
+            long fsize = _FileSize(tmpFCB);
+            uint32 size = (fsize == -1) ? 0 : (uint32)fsize;
+#endif
+
+            // Print size in bytes, padded to 7 digits
+            // Optimized to remove sprintf
+            uint32 temp = size;
+            uint8 digits = 0;
+            if (temp == 0) digits = 1;
+            else {
+                while (temp > 0) { temp /= 10; digits++; }
+            }
+            
+            uint8 padding = 7 - digits;
+            while (padding > 0) {
+                _ccp_bdos(C_WRITE, ' ');
+                padding--;
+            }
+            _ccp_printDec(size);
+            _puts(" bytes");
+
+#ifdef CPM3
+            // CP/M 3: append the read/write status and date stamp, obtained
+            // strictly through BDOS function 102 (Read File Date Stamps).
+            if (!_ccp_bdos(F_TIMEDATE, tmpFCB)) {
+                _puts((_RamRead(tmpFCB + 9) & 0x80) ? "  R/O  " : "  R/W  ");
+                _ccp_printFileDate(tmpFCB + 28); // update stamp at FCB+28
+            } else {
+                _puts("  R/W  ");
+                _puts("       --       ");
+            }
+#endif
+
+            if (checksumOption) {
+                // Compute checksum
+                uint16 checksum = 0;
+                CPM_FCB *F = (CPM_FCB *)_RamSysAddr(tmpFCB);
+                F->ex = 0;
+                F->cr = 0;
+                if (!_ccp_bdos(F_OPEN, tmpFCB)) {
+                    // Optimization: Use direct pointer if available for checksum
+                    uint8* dmaPtr = (uint8*)_RamSysAddr(dmaAddr);
+                    while (!_ccp_bdos(F_READ, tmpFCB)) {
+                        for (uint8 i = 0; i < 128; ++i) {
+                            checksum += dmaPtr[i];
+                        }
+                    }
+                    _ccp_bdos(F_CLOSE, tmpFCB);
+                }
+                // Print checksum
+                _puts("  ");
+                _ccp_printHex16(checksum);
+                _puts("h");
+            }
+
+            _puts("\r\n");
+            l++;
+            if (pageSize && (l == pageSize)) {
+                l = 0;
+                _ccp_askForKey();
+                if (HIGH_REGISTER(AF) == 3)
+                    break;
+            }
+        } while (!_SearchNext(ParFCB, TRUE));
+    } else {
+        _puts("No file");
+    }
+    return 0;
+} // _ccp_ldir
+
+// ERA command - erases files
+RUNCPM_DECL uint8 _ccp_era(void) {
+    if (_ccp_bdos(F_DELETE, ParFCB))
+        _puts("\r\nNo file");
+    return 0;
 } // _ccp_era
 
-// TYPE command
+// TYPE command - types a file to the console
 RUNCPM_DECL uint8 _ccp_type(void) {
-    uint8 i, c, l = 0, error = TRUE;
-    uint16 a, p = 0;
-    
+    uint8 i, c, l = 0, p = 0;
+    uint16 a = 0;
+
+    _puts("\r\n");
     if (!_ccp_bdos(F_OPEN, ParFCB)) {
-        _puts("\r\n");
-        
+
         while (!_ccp_bdos(F_READ, ParFCB)) {
             i = 128;
             a = dmaAddr;
-            
+
             while (i) {
                 c = _RamRead(a);
-                if (c == 0x1a) {
+                if (c == 0x1a)
                     break;
-                }
                 _ccp_bdos(C_WRITE, c);
                 if (c == 0x0a) {
                     ++l;
-                    if (pgSize && (l == pgSize)) {
+                    if (pageSize && (l == pageSize)) {
                         l = 0;
-                        p = _ccp_bdos(C_READ, 0x0000);
-                        if (p == 3) {
+                        _ccp_askForKey();
+                        p = HIGH_REGISTER(AF);
+                        if (p == 3)
                             break;
-                        }
                     }
                 }
                 --i;
                 ++a;
             }
-            if (p == 3) {
+            if (p == 3)
                 break;
-            }
         }
-        error = FALSE;
+    } else {
+        _puts("No file");
     }
-    return (error);
+    return 0;
 } // _ccp_type
 
-// SAVE command
+// SAVE command - saves memory pages to a file
 RUNCPM_DECL uint8 _ccp_save(void) {
     uint8 error = TRUE;
     uint16 pages = _ccp_fcbtonum();
     uint16 i, dma;
-    
-    if (pages < 256) {
+
+    if (pages > 0 && pages < 256) {
         error = FALSE;
-        
-        while (_RamRead(pbuf) == ' ' && blen) { // Skips any leading spaces
-            ++pbuf;
-            --blen;
+
+        while (_RamRead(cmdBufferPtr) == ' ' && bufferLen) { // Skips any leading spaces
+            ++cmdBufferPtr;
+            --bufferLen;
         }
         _ccp_nameToFCB(SecFCB); // Loads file name onto the ParFCB
+        _puts("\r\n");
         if (_ccp_bdos(F_MAKE, SecFCB)) {
             _puts("Err: create");
         } else {
@@ -333,13 +524,13 @@ RUNCPM_DECL uint8 _ccp_save(void) {
             } else {
                 pages *= 2; // Calculates the number of CP/M blocks to write
                 dma = defLoad;
-                _puts("\r\n");
-                
+
                 for (i = 0; i < pages; i++) {
-                    _ccp_bdos(	F_DMAOFF,	dma);
-                    _ccp_bdos(	F_WRITE,	SecFCB);
+                    _ccp_bdos(F_DMAOFF, dma);
+                    _ccp_bdos(F_WRITE, SecFCB);
                     dma += 128;
-                    _ccp_bdos(	C_WRITE,	'.');
+                    if (i % 2)
+                        _ccp_bdos(C_WRITE, '.');
                 }
                 _ccp_bdos(F_CLOSE, SecFCB);
             }
@@ -348,61 +539,206 @@ RUNCPM_DECL uint8 _ccp_save(void) {
     return (error);
 } // _ccp_save
 
-// REN command
-RUNCPM_DECL void _ccp_ren(void) {
+// REN command - renames a file
+RUNCPM_DECL uint8 _ccp_ren(void) {
     uint8 ch, i;
-    
-    ++pbuf;
-    
+
+    ++cmdBufferPtr;
+    --bufferLen;
+
     _ccp_nameToFCB(SecFCB);
-    
-    for (i = 0; i < 12; ++i) {  // Swap the filenames on the fcb
+
+    for (i = 0; i < 12; ++i) { // Swap the filenames on the fcb
         ch = _RamRead(ParFCB + i);
-        _RamWrite(	ParFCB + i, _RamRead(SecFCB + i));
-        _RamWrite(	SecFCB + i, ch);
+        _RamWrite(ParFCB + i, _RamRead(SecFCB + i));
+        _RamWrite(SecFCB + i, ch);
     }
-    if (_ccp_bdos(F_RENAME, ParFCB)) {
+    if (_ccp_bdos(F_RENAME, ParFCB))
         _puts("\r\nNo file");
-    }
+    return 0;
 } // _ccp_ren
 
-// USER command
+// USER command - changes user area
 RUNCPM_DECL uint8 _ccp_user(void) {
     uint8 error = TRUE;
-    
-    curUser = (uint8)_ccp_fcbtonum();
-    if (curUser < 16) {
-        _ccp_bdos(F_USERNUM, curUser);
+
+    currentUser = (uint8)_ccp_fcbtonum();
+    if (currentUser < 16) {
+        _ccp_bdos(F_USERNUM, currentUser);
         error = FALSE;
     }
     return (error);
 } // _ccp_user
 
-// PAGE command
+// CLS command - clears the screen
+RUNCPM_DECL uint8 _ccp_cls(void) {
+    _clrscr();
+    return (FALSE);
+} // _ccp_cls
+
+// EXIT command - terminates RunCPM
+RUNCPM_DECL uint8 _ccp_exit(void) {
+    _puts("\r\nTerminating RunCPM.");
+    _puts("\r\nCPU Halted.");
+    Status = STATUS_EXIT;
+    return (FALSE);
+} // _ccp_exit
+
+// PAGE command - sets the paging size for TYPE and LDIR
 RUNCPM_DECL uint8 _ccp_page(void) {
     uint8 error = TRUE;
     uint16 r = _ccp_fcbtonum();
-    
+
     if (r < 256) {
-        pgSize = (uint8)r;
+        pageSize = (uint8)r;
+        _puts("\r\nPage size set to ");
+        _ccp_printDec(pageSize);
+        _puts(" lines");
+        _puts("\r\n");
         error = FALSE;
     }
     return (error);
 } // _ccp_page
 
-// VOL command
+// VER command - displays the CCP version
+RUNCPM_DECL uint8 _ccp_ver(void) {
+    _puts(CCPHEAD);
+    return (FALSE);
+}
+
+// DUMP command - dump memory or file in hex+ASCII, 128 bytes per screen, stop
+// on ESC
+RUNCPM_DECL uint8 _ccp_dump(void) {
+    uint8 param[17];
+    uint8 i = 0, c;
+    uint16 addr = 0;
+    uint8 isHex = 1;
+    uint8 done = 0;
+
+    // Extract parameter from ParFCB (filename or address)
+    for (i = 1; i < 13; ++i) {
+        c = _RamRead(ParFCB + i);
+        if (c == ' ' || c == 0)
+            break;
+        param[i - 1] = c;
+    }
+    param[i - 1] = 0;
+
+    // Check if parameter is exactly 4 hex digits
+    if (i == 5) {
+        for (uint8 j = 0; j < 4; ++j) {
+            c = param[j];
+            if (!((c >= '0' && c <= '9') || (c >= 'A' && c <= 'F') ||
+                  (c >= 'a' && c <= 'f'))) {
+                isHex = 0;
+                break;
+            }
+        }
+    } else {
+        isHex = 0;
+    }
+
+    if (isHex) {
+        // Parse hex address
+        addr = 0;
+        for (uint8 j = 0; j < 4; ++j) {
+            c = param[j];
+            addr <<= 4;
+            if (c >= '0' && c <= '9')
+                addr += c - '0';
+            else if (c >= 'A' && c <= 'F')
+                addr += c - 'A' + 10;
+            else if (c >= 'a' && c <= 'f')
+                addr += c - 'a' + 10;
+        }
+        // Dump memory
+        _puts("\r\n");
+        while (!done) {
+            // Print address
+            _ccp_printHex16(addr);
+            _puts(": ");
+
+            // Print hex bytes
+            // Optimization: Use direct pointer if available
+            uint8* ptr = (uint8*)_RamSysAddr(addr);
+            for (i = 0; i < 16; ++i) {
+                _ccp_printHex8(ptr[i]);
+                _ccp_bdos(C_WRITE, ' ');
+            }
+            _puts(" ");
+            // Print ASCII
+            for (i = 0; i < 16; ++i) {
+                uint8 b = ptr[i];
+                _ccp_bdos(C_WRITE, (b >= 32 && b < 127) ? b : '.');
+            }
+            _puts("\r\n");
+            addr += 16;
+            if ((addr & 0x7F) == 0) { // Every 128 bytes, pause
+                _ccp_askForKey();
+                if (HIGH_REGISTER(AF) == 3) // ^C
+                    done = 1;
+            }
+        }
+        return 0;
+    } else {
+        // Assume file, try to open
+        if (_ccp_bdos(F_OPEN, ParFCB)) {
+            _puts("\r\nNo file");
+            return 0;
+        }
+        _puts("\r\n");
+        uint32 faddr = 0;
+        done = 0;
+        while (!done) {
+            // Read 128 bytes
+            if (_ccp_bdos(F_READ, ParFCB))
+                break;
+            // Print 8 lines of 16 bytes
+            // Optimization: Use direct pointer to DMA buffer
+            uint8* dmaPtr = (uint8*)_RamSysAddr(dmaAddr);
+            for (uint8 l = 0; l < 8; ++l) {
+                // Print file offset (24-bit)
+                _ccp_printHex8((faddr >> 16) & 0xFF);
+                _ccp_printHex16(faddr & 0xFFFF);
+                _puts(": ");
+                
+                // Print hex
+                for (i = 0; i < 16; ++i) {
+                    _ccp_printHex8(dmaPtr[l * 16 + i]);
+                    _ccp_bdos(C_WRITE, ' ');
+                }
+                _puts(" ");
+                // Print ASCII
+                for (i = 0; i < 16; ++i) {
+                    uint8 b = dmaPtr[l * 16 + i];
+                    _ccp_bdos(C_WRITE, (b >= 32 && b < 127) ? b : '.');
+                }
+                _puts("\r\n");
+                faddr += 16;
+            }
+            // Pause every 128 bytes
+            _ccp_askForKey();
+            if (HIGH_REGISTER(AF) == 3) // ^C
+                done = 1;
+        }
+        return 0;
+    }
+} // _ccp_dump
+
+// VOL command - shows the volume INFO.TXT information
 RUNCPM_DECL uint8 _ccp_vol(void) {
     uint8 error = FALSE;
-    uint8 letter = _RamRead(ParFCB) ? '@' + _RamRead(ParFCB) : 'A' + curDrive;
+    uint8 letter = _RamRead(ParFCB) ? '@' + _RamRead(ParFCB) : 'A' + currentDrive;
     uint8 folder[5] = {letter, FOLDERCHAR, '0', FOLDERCHAR, 0};
-    uint8 filename[13] = {letter, FOLDERCHAR, '0', FOLDERCHAR, 'I', 'N', 'F', 'O', '.', 'T', 'X', 'T', 0};
+    uint8 filename[13] = {letter, FOLDERCHAR, '0', FOLDERCHAR, 'I', 'N', 'F',
+                          'O', '.', 'T', 'X', 'T', 0};
     uint8 bytesread;
     uint8 i, j;
-    
+
     _puts("\r\nVolumes on ");
     _putcon(folder[0]);
     _puts(":\r\n");
-    
+
     for (i = 0; i < 16; ++i) {
         folder[2] = i < 10 ? i + 48 : i + 55;
         if (_sys_exists(folder)) {
@@ -413,9 +749,9 @@ RUNCPM_DECL uint8 _ccp_vol(void) {
             bytesread = (uint8)_sys_readseq(filename, 0);
             if (!bytesread) {
                 for (j = 0; j < 128; ++j) {
-                    if ((_RamRead(dmaAddr + j) < 32) || (_RamRead(dmaAddr + j) > 126)) {
+                    if ((_RamRead(dmaAddr + j) < 32) ||
+                        (_RamRead(dmaAddr + j) > 126))
                         break;
-                    }
                     _putcon(_RamRead(dmaAddr + j));
                 }
             }
@@ -425,56 +761,434 @@ RUNCPM_DECL uint8 _ccp_vol(void) {
     return (error);
 } // _ccp_vol
 
-#ifdef HASLUA
+// COPY command - copies a file
+// Usage: COPY <src> <dest>
+RUNCPM_DECL uint8 _ccp_copy(void) {
+    if (_RamRead(ParFCB + 1) == ' ') {
+        _puts("\r\nNo source");
+        return 0;
+    }
+    if (_RamRead(SecFCB + 1) == ' ') {
+        _puts("\r\nNo dest");
+        return 0;
+    }
 
-// External (.LUA) command
-RUNCPM_DECL uint8 _ccp_lua(void) {
-    uint8 error = TRUE;
-    uint8 found, drive, user = 0;
-    uint16 loadAddr = defLoad;
+    // Move SecFCB to CmdFCB to avoid corruption when opening ParFCB
+    // ParFCB (0x5C) overlaps SecFCB (0x6C) when used as a full FCB
+    for (uint8 i = 0; i < 16; ++i) {
+        _RamWrite(CmdFCB + i, _RamRead(SecFCB + i));
+    }
+    // Initialize the rest of CmdFCB
+    for (uint8 i = 16; i < 36; ++i) {
+        _RamWrite(CmdFCB + i, 0);
+    }
+
+    if (_ccp_bdos(F_OPEN, ParFCB) == 255) {
+        _puts("\r\nSource not found");
+        return 0;
+    }
     
-    _RamWrite(	CmdFCB + 9,		'L');
-    _RamWrite(	CmdFCB + 10,	'U');
-    _RamWrite(	CmdFCB + 11,	'A');
+    _ccp_bdos(F_DELETE, CmdFCB); // Delete dest if exists
     
-    drive = _RamRead(CmdFCB);
-    found = !_ccp_bdos(F_OPEN, CmdFCB); // Look for the program on the FCB drive, current or specified
-    if (!found) {                       // If not found
-        if (!drive) {                   // and the search was on the default drive
-            _RamWrite(CmdFCB, 0x01);    // Then look on drive A: user 0
-            if (curUser) {
-                user = curUser;                 // Save the current user
-                _ccp_bdos(F_USERNUM, 0x0000);   // then set it to 0
-            }
-            found = !_ccp_bdos(F_OPEN, CmdFCB);
-            if (!found) {                               // If still not found then
-                if (curUser) {                          // If current user not = 0
-                    _RamWrite(CmdFCB, 0x00);            // look on current drive user 0
-                    found = !_ccp_bdos(F_OPEN, CmdFCB); // and try again
-                }
-            }
+    if (_ccp_bdos(F_MAKE, CmdFCB) == 255) {
+        _puts("\r\nDir full");
+        return 0;
+    }
+    
+    if (_ccp_bdos(F_OPEN, CmdFCB) == 255) {
+        _puts("\r\nErr open dest");
+        return 0;
+    }
+    
+    _puts("\r\nCopying...");
+    
+    // Use 128 byte buffer at defDMA
+    while(TRUE) {
+        _ccp_bdos(F_DMAOFF, defDMA);
+        if (_ccp_bdos(F_READ, ParFCB) != 0) break; // EOF (or error, assumed EOF for now)
+        if (_ccp_bdos(F_WRITE, CmdFCB) != 0) {
+            _puts("\r\nDisk full");
+            break;
         }
     }
-    if (found) {
+    
+    _ccp_bdos(F_CLOSE, CmdFCB);
+    _puts(" Done.");
+    return 0;
+} // _ccp_copy
+
+// ECHO command - prints text to console
+// Usage: ECHO <text>
+RUNCPM_DECL uint8 _ccp_echo(void) {
+    // Find the start of the arguments in the input buffer
+    // inBuf + 2 is the start of the command line
+    uint16 ptr = inBuf + 2;
+    
+    // Skip leading spaces
+    while (_RamRead(ptr) == ' ') ptr++;
+    
+    // Skip the command itself (ECHO)
+    while (_RamRead(ptr) != ' ' && _RamRead(ptr) != 0) ptr++;
+    
+    // Skip spaces after command
+    while (_RamRead(ptr) == ' ') ptr++;
+    
+    _puts("\r\n");
+    
+    // Print the rest
+    while (_RamRead(ptr) != 0) {
+        _ccp_bdos(C_WRITE, _RamRead(ptr++));
+    }
+    
+    return 0;
+} // _ccp_echo
+
+// POKE command - writes a byte to memory
+// Usage: POKE <addr> <val> (hex)
+RUNCPM_DECL uint8 _ccp_poke(void) {
+    uint16 addr = 0;
+    uint16 val = 0;
+    uint8 c, i;
+    
+    // Parse Address from ParFCB (first argument)
+    for (i = 1; i <= 4; ++i) {
+        c = _RamRead(ParFCB + i);
+        if (c == ' ') break;
+        addr <<= 4;
+        if (c >= '0' && c <= '9') addr += (c - '0');
+        else if (c >= 'A' && c <= 'F') addr += (c - 'A' + 10);
+        else if (c >= 'a' && c <= 'f') addr += (c - 'a' + 10);
+    }
+    
+    // Parse Value from SecFCB (second argument)
+    for (i = 1; i <= 2; ++i) {
+        c = _RamRead(SecFCB + i);
+        if (c == ' ') break;
+        val <<= 4;
+        if (c >= '0' && c <= '9') val += (c - '0');
+        else if (c >= 'A' && c <= 'F') val += (c - 'A' + 10);
+        else if (c >= 'a' && c <= 'f') val += (c - 'a' + 10);
+    }
+    
+    _RamWrite(addr, (uint8)val);
+    _puts("\r\nOK");
+    return 0;
+} // _ccp_poke
+
+#ifdef CPM3
+// --- DATE command (CP/M 3 only) ------------------------------------------
+// Displays and sets the system date and time. All date/time access goes
+// strictly through BDOS T_GET (105) and T_SET (104).
+
+static const char *_ccp_wday[7] = {"Sun", "Mon", "Tue", "Wed",
+                                   "Thu", "Fri", "Sat"};
+static const uint8 _ccp_dmlen[12] = {31, 28, 31, 30, 31, 30,
+                                     31, 31, 30, 31, 30, 31};
+
+static uint8 _ccp_isleap(uint16 y) {
+    return (y % 4 == 0 && (y % 100 != 0 || y % 400 == 0));
+}
+
+// Converts a day count (1 = 1978-01-01) into year/month/day
+static void _ccp_dayToYMD(uint16 days, uint16 *year, uint8 *month, uint8 *day) {
+    uint16 y = 1978;
+    uint8 m;
+    days -= 1;
+    for (;;) {
+        uint16 yl = _ccp_isleap(y) ? 366 : 365;
+        if (days < yl)
+            break;
+        days -= yl;
+        ++y;
+    }
+    for (m = 0; m < 12; ++m) {
+        uint8 dm = _ccp_dmlen[m];
+        if (m == 1 && _ccp_isleap(y))
+            dm = 29;
+        if (days < dm)
+            break;
+        days -= dm;
+    }
+    *year = y;
+    *month = m + 1;
+    *day = (uint8)days + 1;
+}
+
+// Converts year/month/day into a day count (1 = 1978-01-01)
+static uint16 _ccp_ymdToDay(uint16 year, uint8 month, uint8 day) {
+    uint32 days = 0;
+    uint16 yy;
+    uint8 mm;
+    for (yy = 1978; yy < year; ++yy)
+        days += _ccp_isleap(yy) ? 366 : 365;
+    for (mm = 1; mm < month; ++mm) {
+        days += _ccp_dmlen[mm - 1];
+        if (mm == 2 && _ccp_isleap(year))
+            days += 1;
+    }
+    days += day - 1;
+    return ((uint16)(days + 1));
+}
+
+// Prints a packed-BCD byte as two decimal digits
+static void _ccp_printBCD(uint8 b) {
+    _ccp_bdos(C_WRITE, '0' + ((b >> 4) & 0x0F));
+    _ccp_bdos(C_WRITE, '0' + (b & 0x0F));
+}
+
+// Reads the current date/time via BDOS and prints "Ddd MM/DD/YY HH:MM:SS"
+static void _ccp_dateShow(void) {
+    uint16 dat = defDMA; // scratch DAT buffer in the DMA page
+    uint16 days, year;
+    uint8 month, day;
+
+    _ccp_bdos(T_GET, dat);
+    days = _RamRead(dat) | (_RamRead(dat + 1) << 8);
+    _ccp_dayToYMD(days, &year, &month, &day);
+    _puts((char *)_ccp_wday[(days - 1) % 7]); // 1978-01-01 was a Sunday
+    _ccp_bdos(C_WRITE, ' ');
+    _ccp_print2(month);
+    _ccp_bdos(C_WRITE, '/');
+    _ccp_print2(day);
+    _ccp_bdos(C_WRITE, '/');
+    _ccp_print2(year % 100);
+    _ccp_bdos(C_WRITE, ' ');
+    _ccp_printBCD(_RamRead(dat + 2)); // hour
+    _ccp_bdos(C_WRITE, ':');
+    _ccp_printBCD(_RamRead(dat + 3)); // minute
+    _ccp_bdos(C_WRITE, ':');
+    _ccp_printBCD(_RamRead(dat + 4)); // second
+}
+
+// Extracts up to 'max' decimal numbers from string s into out[]
+static uint8 _ccp_parseNums(const char *s, uint8 *out, uint8 max) {
+    uint8 n = 0;
+    while (*s && n < max) {
+        if (*s >= '0' && *s <= '9') {
+            uint16 v = 0;
+            while (*s >= '0' && *s <= '9') {
+                v = v * 10 + (*s - '0');
+                ++s;
+            }
+            out[n++] = (uint8)v;
+        } else {
+            ++s;
+        }
+    }
+    return (n);
+}
+
+// Validates and sets the date/time via BDOS T_SET. Returns 0 on success.
+static uint8 _ccp_dateSet(uint8 mo, uint8 dy, uint8 yr, uint8 hh, uint8 mi,
+                          uint8 ss) {
+    uint16 dat = defDMA;
+    uint16 year, days;
+
+    if (mo < 1 || mo > 12 || dy < 1 || dy > 31 || hh > 23 || mi > 59 ||
+        ss > 59)
+        return (1);
+    year = (yr >= 78) ? (1900 + yr) : (2000 + yr);
+    days = _ccp_ymdToDay(year, mo, dy);
+    _RamWrite(dat, days & 0xFF);
+    _RamWrite(dat + 1, (days >> 8) & 0xFF);
+    _RamWrite(dat + 2, ((hh / 10) << 4) | (hh % 10));
+    _RamWrite(dat + 3, ((mi / 10) << 4) | (mi % 10));
+    _RamWrite(dat + 4, ((ss / 10) << 4) | (ss % 10));
+    // Per the manual, wait for a keystroke so the time can be set precisely
+    _puts("\r\nPress any key to set time");
+    _ccp_bios(B_CONIN);
+    _ccp_bdos(T_SET, dat);
+    return (0);
+}
+
+// Reads a line from the console into buf (NUL-terminated)
+static void _ccp_readLine(char *buf, uint8 maxlen) {
+    uint8 n, k;
+    _RamWrite(inBuf, maxlen);
+    _ccp_bdos(C_READSTR, inBuf);
+    n = _RamRead(inBuf + 1);
+    for (k = 0; k < n && k < maxlen; ++k)
+        buf[k] = _RamRead(inBuf + 2 + k);
+    buf[k] = 0;
+}
+
+// DATE command
+RUNCPM_DECL uint8 _ccp_date(void) {
+    char arg[64];
+    uint8 len = _RamRead(defDMA);
+    uint8 i = 0, j = 0;
+    uint8 nums[6];
+
+    // defDMA holds the command tail (the command word is already stripped),
+    // uppercased. Skip the leading spaces and copy the remaining argument.
+    while (i < len && _RamRead(defDMA + 1 + i) == ' ')
+        ++i;
+    while (i < len && j < (uint8)(sizeof(arg) - 1))
+        arg[j++] = _RamRead(defDMA + 1 + i++);
+    arg[j] = 0;
+
+    _puts("\r\n");
+
+    if (j == 0) { // DATE -> display once
+        _ccp_dateShow();
+        return (0);
+    }
+
+    if (arg[0] == 'C') { // DATE C / CONTINUOUS -> display until a key is pressed
+        uint8 lastSec = 0xFF;
+        while (!_ccp_bdos(C_STAT, 0)) {
+            _ccp_bdos(T_GET, defDMA);
+            uint8 sec = _RamRead(defDMA + 4);
+            if (sec != lastSec) {
+                lastSec = sec;
+                _ccp_bdos(C_WRITE, '\r');
+                _ccp_dateShow();
+            }
+        }
+        _ccp_bios(B_CONIN); // consume the key
+        return (0);
+    }
+
+    if (arg[0] == 'S' && arg[1] == 'E' && arg[2] == 'T') { // DATE SET
+        uint16 year;
+        uint8 mo, dy;
+        uint8 cd[3], ct[3];
+        // Preload the current values so empty entries keep them
+        _ccp_bdos(T_GET, defDMA);
+        _ccp_dayToYMD(_RamRead(defDMA) | (_RamRead(defDMA + 1) << 8), &year,
+                      &mo, &dy);
+        cd[0] = mo;
+        cd[1] = dy;
+        cd[2] = (uint8)(year % 100);
+        ct[0] = ((_RamRead(defDMA + 2) >> 4) & 0x0F) * 10 +
+                (_RamRead(defDMA + 2) & 0x0F);
+        ct[1] = ((_RamRead(defDMA + 3) >> 4) & 0x0F) * 10 +
+                (_RamRead(defDMA + 3) & 0x0F);
+        ct[2] = ((_RamRead(defDMA + 4) >> 4) & 0x0F) * 10 +
+                (_RamRead(defDMA + 4) & 0x0F);
+        _puts("Enter today's date (MM/DD/YY): ");
+        _ccp_readLine(arg, 20);
+        if (_ccp_parseNums(arg, nums, 3) >= 3) {
+            cd[0] = nums[0];
+            cd[1] = nums[1];
+            cd[2] = nums[2];
+        }
+        _puts("\r\nEnter the time (HH:MM:SS): ");
+        _ccp_readLine(arg, 20);
+        if (_ccp_parseNums(arg, nums, 3) >= 3) {
+            ct[0] = nums[0];
+            ct[1] = nums[1];
+            ct[2] = nums[2];
+        }
+        if (_ccp_dateSet(cd[0], cd[1], cd[2], ct[0], ct[1], ct[2])) {
+            _puts("\r\nInvalid date or time");
+            return (0);
+        }
         _puts("\r\n");
-        
-        _ccp_bdos(F_RUNLUA, CmdFCB);
-        if (user) {                         // If a user was selected
-            _ccp_bdos(F_USERNUM, curUser);  // Set it back
-            user = 0;
+        _ccp_dateShow();
+        return (0);
+    }
+
+    // Otherwise treat the tail as a time-specification MM/DD/YY HH:MM:SS
+    if (_ccp_parseNums(arg, nums, 6) < 6) {
+        _puts("Invalid date or time");
+        return (0);
+    }
+    if (_ccp_dateSet(nums[0], nums[1], nums[2], nums[3], nums[4], nums[5])) {
+        _puts("\r\nInvalid date or time");
+        return (0);
+    }
+    _puts("\r\n");
+    _ccp_dateShow();
+    return (0);
+} // _ccp_date
+#endif // CPM3
+
+#endif // Internals
+
+// ?/Help command
+RUNCPM_DECL uint8 _ccp_hlp(void) {
+    _puts("\r\nCCP Commands:\r\n");
+    _puts(" ?                  - Shows this list of commands\r\n");
+    _puts(" CLS                - Clears the screen\r\n");
+    _puts(" COPY <src> <dst>   - Copies a file\r\n");
+#ifdef CPM3
+    _puts(" DATE [spec|C|SET]  - Shows or sets date/time (MM/DD/YY HH:MM:SS)\r\n");
+#endif
+    _puts(" DEL [<patt>]       - Alias to ERA\r\n");
+    _puts(" DIR [<patt>]       - Lists file directory\r\n");
+    _puts(" DUMP <addr|file>   - Hex+ASCII dump of memory or file\r\n");
+    _puts("                      addr = 4 hex digits\r\n");
+    _puts(" ECHO <text>        - Prints text to console\r\n");
+    _puts(" ERA [<patt>]       - Erases files\r\n");
+    _puts(" EXIT               - Terminates RunCPM\r\n");
+    _puts(" LDIR [<patt>] [/C] - Lists file directory with sizes\r\n");
+    _puts("                      /C option includes 16 bit checksum\r\n");
+    _puts(" PAGE [<n>]         - Sets the paging size for TYPE and LDIR\r\n");
+    _puts("                      n = 0 to 255, 0 disables paging\r\n");
+    _puts(" POKE <addr> <val>  - Writes a byte to memory (hex)\r\n");
+    _puts(" REN <new>=<old>    - Renames files\r\n");
+    _puts(" SAVE <n> <file>    - Saves memory pages (256 bytes) to file\r\n");
+    _puts(" TYPE <file>        - Displays file contents\r\n");
+    _puts(" USER <n>           - Changes user area\r\n");
+    _puts(" VER                - Displays the current CCP version\r\n");
+    _puts(" VOL [<drv>]        - Shows the volume INFO.TXT information\r\n");
+    return (FALSE);
+}
+
+// List of CCP commands
+static const Command Commands[] = {
+#ifdef Internals
+    // Standard CP/M commands
+    {"DIR", _ccp_dir},
+    {"ERA", _ccp_era},
+    {"TYPE", _ccp_type},
+    {"SAVE", _ccp_save},
+    {"REN", _ccp_ren},
+    {"USER", _ccp_user},
+
+    // Extra CCP commands
+    {"CLS", _ccp_cls},
+    {"COPY", _ccp_copy},
+    {"LDIR", _ccp_ldir},
+    {"DEL", _ccp_era},
+    {"ECHO", _ccp_echo},
+    {"EXIT", _ccp_exit},
+    {"PAGE", _ccp_page},
+    {"POKE", _ccp_poke},
+    {"VER", _ccp_ver},
+    {"DUMP", _ccp_dump},
+    {"VOL", _ccp_vol},
+#ifdef CPM3
+    {"DATE", _ccp_date},
+#endif
+#endif
+    {"?", _ccp_hlp},
+    {NULL, NULL} // Sentinel
+};
+
+// Gets the command pointer
+RUNCPM_DECL const Command *_ccp_cnum(void) {
+    uint8 command[9];
+    uint8 i = 0;
+
+    if (!_RamRead(CmdFCB)) { // If a drive was set, then the command is external
+        while (i < 8 && _RamRead(CmdFCB + i + 1) != ' ') {
+            command[i] = _RamRead(CmdFCB + i + 1);
+            ++i;
         }
-        _RamWrite(CmdFCB, drive);           // Set the command FCB drive back to what it was
-        cDrive = oDrive;                    // And restore cDrive
-        error = FALSE;
+        command[i] = 0;
+        i = 0;
+        while (Commands[i].name) {
+            if (_ccp_strEqual((char *)command, Commands[i].name)) {
+                errorPtr = defDMA + 2;
+                return &Commands[i];
+            }
+            ++i;
+        }
     }
-    if (user) {                             // If a user was selected
-        _ccp_bdos(F_USERNUM, curUser);      // Set it back
-    }
-    _RamWrite(CmdFCB, drive);               // Set the command FCB drive back to what it was
-    
-    return (error);
-} // _ccp_lua
-#endif // ifdef HASLUA
+    return NULL; // External command
+} // _ccp_cnum
 
 // External (.COM) command
 RUNCPM_DECL uint8 _ccp_ext(void) {
@@ -483,32 +1197,30 @@ RUNCPM_DECL uint8 _ccp_ext(void) {
     uint16 loadAddr = defLoad;
 
     bool wasBlank = (_RamRead(CmdFCB + 9) == ' ');
-    //printf("\n\rwasBlank: %s", wasBlank ? "True" : "False");
-    bool wasSUB = ((_RamRead(CmdFCB + 9) == 'S') &&
-                   (_RamRead(CmdFCB + 10) == 'U') &&
-                   (_RamRead(CmdFCB + 11) == 'B'));
-    //printf("\r\nwasSUB: %s", wasSUB ? "True" : "False");
+    bool wasSUB =
+        ((_RamRead(CmdFCB + 9) == 'S') && (_RamRead(CmdFCB + 10) == 'U') &&
+         (_RamRead(CmdFCB + 11) == 'B'));
 
     if (!wasSUB) {
         if (wasBlank) {
-            //first look for a .COM file
-            _RamWrite(CmdFCB + 9, 'C');
+            _RamWrite(CmdFCB + 9, 'C'); // first look for a .COM file
             _RamWrite(CmdFCB + 10, 'O');
             _RamWrite(CmdFCB + 11, 'M');
         }
 
-        drive = _RamRead(CmdFCB);                           // Get the drive from the command FCB
-        found = !_ccp_bdos(F_OPEN, CmdFCB);                 // Look for the program on the FCB drive, current or specified
-        if (!found) {                                       // If not found
-            if (!drive) {                                   // and the search was on the default drive
-                _RamWrite(CmdFCB, 0x01);                    // Then look on drive A: user 0
-                if (curUser) {
-                    user = curUser;                         // Save the current user
-                    _ccp_bdos(F_USERNUM, 0x0000);           // then set it to 0
+        drive = _RamRead(CmdFCB);           // Get the drive from the command FCB
+        found = !_ccp_bdos(F_OPEN, CmdFCB); // Look for the program on the FCB
+                                            // drive, current or specified
+        if (!found) {                       // If not found
+            if (!drive) {                   // and the search was on the default drive
+                _RamWrite(CmdFCB, 0x01);    // Then look on drive A: user 0
+                if (currentUser) {
+                    user = currentUser;           // Save the current user
+                    _ccp_bdos(F_USERNUM, 0x0000); // then set it to 0
                 }
                 found = !_ccp_bdos(F_OPEN, CmdFCB);
                 if (!found) {                               // If still not found then
-                    if (curUser) {                          // If current user not = 0
+                    if (currentUser) {                      // If current user not = 0
                         _RamWrite(CmdFCB, 0x00);            // look on current drive user 0
                         found = !_ccp_bdos(F_OPEN, CmdFCB); // and try again
                     }
@@ -516,31 +1228,31 @@ RUNCPM_DECL uint8 _ccp_ext(void) {
             }
         }
         if (!found) {
-            _RamWrite(CmdFCB, drive);       // restore previous drive
-            _ccp_bdos(F_USERNUM, curUser);  // restore to previous user
+            _RamWrite(CmdFCB, drive);      // restore previous drive
+            _ccp_bdos(F_USERNUM, currentUser); // restore to previous user
         }
     }
 
-    //if .COM not found then look for a .SUB file
-    if ((wasBlank || wasSUB) && !found && !sFlag) {    //don't auto-submit while executing a submit file
-        //_puts("\n\rLooking for .SUB file");
-        
+    // if .COM not found then look for a .SUB file
+    if ((wasBlank || wasSUB) && !found &&
+        !submitFlag) { // don't auto-submit while executing a submit file
         _RamWrite(CmdFCB + 9, 'S');
         _RamWrite(CmdFCB + 10, 'U');
         _RamWrite(CmdFCB + 11, 'B');
-        
-        drive = _RamRead(CmdFCB);                           // Get the drive from the command FCB
-        found = !_ccp_bdos(F_OPEN, CmdFCB);                 // Look for the program on the FCB drive, current or specified
-        if (!found) {                                       // If not found
-            if (!drive) {                                   // and the search was on the default drive
-                _RamWrite(CmdFCB, 0x01);                    // Then look on drive A: user 0
-                if (curUser) {
-                    user = curUser;                         // Save the current user
-                    _ccp_bdos(F_USERNUM, 0x0000);           // then set it to 0
+
+        drive = _RamRead(CmdFCB);           // Get the drive from the command FCB
+        found = !_ccp_bdos(F_OPEN, CmdFCB); // Look for the program on the FCB
+                                            // drive, current or specified
+        if (!found) {                       // If not found
+            if (!drive) {                   // and the search was on the default drive
+                _RamWrite(CmdFCB, 0x01);    // Then look on drive A: user 0
+                if (currentUser) {
+                    user = currentUser;           // Save the current user
+                    _ccp_bdos(F_USERNUM, 0x0000); // then set it to 0
                 }
                 found = !_ccp_bdos(F_OPEN, CmdFCB);
                 if (!found) {                               // If still not found then
-                    if (curUser) {                          // If current user not = 0
+                    if (currentUser) {                      // If current user not = 0
                         _RamWrite(CmdFCB, 0x00);            // look on current drive user 0
                         found = !_ccp_bdos(F_OPEN, CmdFCB); // and try again
                     }
@@ -548,107 +1260,134 @@ RUNCPM_DECL uint8 _ccp_ext(void) {
             }
         }
         if (!found) {
-            _RamWrite(CmdFCB, drive);       // restore previous drive
-            _ccp_bdos(F_USERNUM, curUser);  // restore to previous user
+            _RamWrite(CmdFCB, drive);      // restore previous drive
+            _ccp_bdos(F_USERNUM, currentUser); // restore to previous user
         }
 
         if (found) {
-            //_puts(".SUB file found!\r\n");
+            //_puts(".SUB file found!\n");
+            int i;
+
+            // move FCB's (CmdFCB --> ParFCB --> SecFCB)
+            // Optimization: Use direct pointers for FCB copying
+            uint8* secPtr = (uint8*)_RamSysAddr(SecFCB);
+            uint8* parPtr = (uint8*)_RamSysAddr(ParFCB);
+            uint8* cmdPtr = (uint8*)_RamSysAddr(CmdFCB);
             
-            //move FCB's (CmdFCB --> ParFCB --> SecFCB)
-            for (int i = 0; i < 16; i++) {
-                //ParFCB to SecFCB
-                _RamWrite(SecFCB + i, _RamRead(ParFCB + i));
-                //CmdFCB to ParFCB
-                _RamWrite(ParFCB + i, _RamRead(CmdFCB + i));
+            for (i = 0; i < 16; i++) {
+                // ParFCB to SecFCB
+                secPtr[i] = parPtr[i];
+                // CmdFCB to ParFCB
+                parPtr[i] = cmdPtr[i];
             }
             // (Re)Initialize the CmdFCB
             _ccp_initFCB(CmdFCB, 36);
-            
-            //put 'SUBMIT.COM' in CmdFCB
+
+            // put 'SUBMIT.COM' in CmdFCB
             const char *str = "SUBMIT  COM";
             int s = (int)strlen(str);
-            for (int i = 0; i < s; i++) {
+            for (i = 0; i < s; i++)
                 _RamWrite(CmdFCB + i + 1, str[i]);
-            }
-            
-            //now try to find SUBMIT.COM file
-            found = !_ccp_bdos(F_OPEN, CmdFCB);                 // Look for the program on the FCB drive, current or specified
-            if (!found) {                                       // If not found
-                if (!drive) {                                   // and the search was on the default drive
-                    _RamWrite(CmdFCB, 0x01);                    // Then look on drive A: user 0
-                    if (curUser) {
-                        user = curUser;                         // Save the current user
-                        _ccp_bdos(F_USERNUM, 0x0000);           // then set it to 0
+
+            // now try to find SUBMIT.COM file
+            found =
+                !_ccp_bdos(F_OPEN, CmdFCB);  // Look for the program on the FCB
+                                             // drive, current or specified
+            if (!found) {                    // If not found
+                if (!drive) {                // and the search was on the default drive
+                    _RamWrite(CmdFCB, 0x01); // Then look on drive A: user 0
+                    if (currentUser) {
+                        user = currentUser;           // Save the current user
+                        _ccp_bdos(F_USERNUM, 0x0000); // then set it to 0
                     }
                     found = !_ccp_bdos(F_OPEN, CmdFCB);
-                    if (!found) {                               // If still not found then
-                        if (curUser) {                          // If current user not = 0
-                            _RamWrite(CmdFCB, 0x00);            // look on current drive user 0
+                    if (!found) {      // If still not found then
+                        if (currentUser) { // If current user not = 0
+                            _RamWrite(CmdFCB,
+                                      0x00);                    // look on current drive user 0
                             found = !_ccp_bdos(F_OPEN, CmdFCB); // and try again
                         }
                     }
                 }
             }
+            if (found) {
+                // insert "@" into command buffer
+                // note: this is so the rest will be parsed correctly
+                bufferLen = _RamRead(defDMA);
+                if (bufferLen < cmdLen) {
+                    bufferLen++;
+                    _RamWrite(defDMA, bufferLen);
+                }
+                uint8 lc = '@';
+                for (i = 0; i < bufferLen; i++) {
+                    uint8 nc = _RamRead(defDMA + 1 + i);
+                    _RamWrite(defDMA + 1 + i, lc);
+                    lc = nc;
+                }
+            }
         }
     }
-    
-    if (found) {										// Program was found somewhere
+
+    if (found) { // Program was found somewhere
         _puts("\r\n");
-        _ccp_bdos(F_DMAOFF, loadAddr);					// Sets the DMA address for the loading
-        while (!_ccp_bdos(F_READ, CmdFCB)) {			// Loads the program into memory
+        _ccp_bdos(F_DMAOFF, loadAddr);       // Sets the DMA address for the loading
+        while (!_ccp_bdos(F_READ, CmdFCB)) { // Loads the program into memory
             loadAddr += 128;
-            if (loadAddr == BDOSjmppage) {				// Breaks if it reaches the end of TPA
+            if (loadAddr ==
+                BDOSjmppage) { // Breaks if it reaches the end of TPA
                 _puts("\r\nNo Memory");
                 break;
             }
-            _ccp_bdos(F_DMAOFF, loadAddr);				// Points the DMA offset to the next loadAddr
+            _ccp_bdos(F_DMAOFF,
+                      loadAddr); // Points the DMA offset to the next loadAddr
         }
-        _ccp_bdos(F_DMAOFF, defDMA);					// Points the DMA offset back to the default
-        
-        if (user) {										// If a user was selected
-            _ccp_bdos(F_USERNUM, curUser);				// Set it back
+        _ccp_bdos(F_DMAOFF,
+                  defDMA); // Points the DMA offset back to the default
+
+        if (user) {                        // If a user was selected
+            _ccp_bdos(F_USERNUM, currentUser); // Set it back
             user = 0;
         }
-        _RamWrite(CmdFCB, drive);						// Set the command FCB drive back to what it was
-        cDrive = oDrive;								// And restore cDrive
-        
+        _RamWrite(CmdFCB,
+                  drive); // Set the command FCB drive back to what it was
+        cDrive = oDrive;  // And restore cDrive
+
         // Place a trampoline to call the external command
         // as it may return using RET instead of JP 0000h
         loadAddr = Trampoline;
-        _RamWrite(loadAddr, CALL);						// CALL 0100h
+        _RamWrite(loadAddr, CALL); // CALL 0100h
         _RamWrite16(loadAddr + 1, defLoad);
-        _RamWrite(loadAddr + 3, JP);					// JP RETTOCCP
-        _RamWrite16(loadAddr + 4, BIOSjmppage + 0x33);
-        
-        Z80reset();										// Resets the Z80 CPU
-        SET_LOW_REGISTER(BC, _RamRead(DSKByte));		// Sets C to the current drive/user
-        PC = loadAddr;									// Sets CP/M application jump point
-        SP = BDOSjmppage;								// Sets the stack to the top of the TPA
-        
-        Z80run();										// Starts Z80 simulation
-        
+        _RamWrite(loadAddr + 3, JP); // JP USERF
+        _RamWrite16(loadAddr + 4, BIOSjmppage + B_USERF);
+
+        Z80reset(); // Resets the Z80 CPU
+        SET_LOW_REGISTER(BC,
+                         _RamRead(DSKByte)); // Sets C to the current drive/user
+        PC = loadAddr;                       // Sets CP/M application jump point
+        SP = BDOSjmppage;                    // Sets the stack to the top of the TPA
+
+        Z80run(cpuDelayInstructions); // Starts Z80 simulation
+        PC = 0;   // Resets the PC/SP after command execution
+        SP = 0;
+
         error = FALSE;
     }
-    
-    if (user) {											// If a user was selected
-        _ccp_bdos(F_USERNUM, curUser);					// Set it back
-    }
-    _RamWrite(CmdFCB, drive);							// Set the command FCB drive back to what it was
-    
-    return(error);
+
+    if (user)                          // If a user was selected
+        _ccp_bdos(F_USERNUM, currentUser); // Set it back
+    _RamWrite(CmdFCB, drive);          // Set the command FCB drive back to what it was
+
+    return (error);
 } // _ccp_ext
 
 // Prints a command error
 RUNCPM_DECL void _ccp_cmdError() {
     uint8 ch;
-    
+
     _puts("\r\n");
-    
-    while ((ch = _RamRead(perr++))) {
-        if (ch == ' ') {
+    while ((ch = _RamRead(errorPtr++))) {
+        if (ch == ' ')
             break;
-        }
         _ccp_bdos(C_WRITE, toupper(ch));
     }
     _puts("?\r\n");
@@ -658,240 +1397,233 @@ RUNCPM_DECL void _ccp_cmdError() {
 RUNCPM_DECL void _ccp_readInput(void) {
     uint8 i;
     uint8 chars;
-    
-    if (sFlag) {                                // Are we running a submit?
-        if (!sRecs) {                           // Are we already counting?
-            _ccp_bdos(F_OPEN, BatchFCB);        // Open the batch file
-            sRecs = _RamRead(BatchFCB + 15);    // Gets its record count
+
+    if (submitFlag) {                             // Are we running a submit?
+        if (!submitRecords) {                        // Are we already counting?
+            _ccp_bdos(F_OPEN, BatchFCB);     // Open the batch file
+            submitRecords = _RamRead(BatchFCB + 15); // Gets its record count
         }
-        --sRecs;                            // Counts one less
-        _RamWrite(BatchFCB + 32, sRecs);    // And sets to be the next read
-        _ccp_bdos(	F_DMAOFF,	defDMA);    // Reset current DMA
-        _ccp_bdos(	F_READ,		BatchFCB);  // And reads the last sector
-        chars = _RamRead(defDMA);           // Then moves it to the input buffer
-        
-        for (i = 0; i <= chars; ++i) {
+        --submitRecords;                         // Counts one less
+        _RamWrite(BatchFCB + 32, submitRecords); // And sets to be the next read
+        _ccp_bdos(F_DMAOFF, defDMA);     // Reset current DMA
+        _ccp_bdos(F_READ, BatchFCB);     // And reads the last sector
+        chars = _RamRead(defDMA);        // Then moves it to the input buffer
+
+        for (i = 0; i <= chars; ++i)
             _RamWrite(inBuf + i + 1, _RamRead(defDMA + i));
-        }
         _RamWrite(inBuf + i + 1, 0);
         _puts((char *)_RamSysAddr(inBuf + 2));
-        if (!sRecs) {
-            _ccp_bdos(F_DELETE, BatchFCB);  // Deletes the submit file
-            sFlag = FALSE;                  // and clears the submit flag
+        if (!submitRecords) {
+            _ccp_bdos(F_DELETE, BatchFCB); // Deletes the submit file
+            submitFlag = FALSE;                 // and clears the submit flag
         }
     } else {
-        _ccp_bdos(C_READSTR, inBuf);    // Reads the command line from console
+        _ccp_bdos(C_READSTR, inBuf); // Reads the command line from console
+        if (Debug)
+            Z80run(cpuDelayInstructions);
     }
 } // _ccp_readInput
+
+// Parses the command line for drive/user changes (e.g., A:, 0:, A0:)
+// Returns TRUE if a drive/user change was processed, FALSE otherwise
+// Sets errorFlag if an invalid user was specified
+RUNCPM_DECL bool _ccp_parseDriveUser(bool *errorFlag) {
+    uint8 i;
+    uint8 ch, tDrive = 0, tUser = currentUser, u = 0;
+
+    *errorFlag = FALSE;
+
+    for (i = 0; i < bufferLen; i++) {
+        ch = toupper(_RamRead(cmdBufferPtr + i));
+        if ((ch >= 'A') && (ch <= 'P')) {
+            if (tDrive) { // if we've already specified a new drive
+                return FALSE; // not a DU: command
+            } else {
+                tDrive = ch - '@';
+            }
+        } else if ((ch >= '0') && (ch <= '9')) {
+            tUser = u = (u * 10) + (ch - '0');
+        } else if (ch == ':') {
+            if (i == bufferLen - 1) {   // if we at the end of the command line
+                if (tUser >= 16) { // if invalid user
+                    *errorFlag = TRUE;
+                    return FALSE;
+                }
+                if (tDrive != 0) {
+                    cDrive = oDrive = tDrive - 1;
+                    _RamWrite(DSKByte,
+                              (_RamRead(DSKByte) & 0xf0) | cDrive);
+                    _ccp_bdos(DRV_SET, cDrive);
+                    if (Status)
+                        currentDrive = 0;
+                }
+                if (tUser != currentUser) {
+                    currentUser = tUser;
+                    _ccp_bdos(F_USERNUM, currentUser);
+                }
+                return TRUE;
+            }
+            return FALSE;
+        } else {   // invalid character
+            return FALSE; // don't error; may be valid (non-DU:) command
+        }
+    }
+    return FALSE;
+}
 
 // Main CCP code
 RUNCPM_DECL void _ccp(void) {
     uint8 i;
-    
-    sFlag = (bool)_ccp_bdos(DRV_ALLRESET, 0x0000);
-    _ccp_bdos(DRV_SET, curDrive);
-    
+
+    submitFlag = (bool)_ccp_bdos(DRV_ALLRESET, 0x0000);
+    _ccp_bdos(DRV_SET, currentDrive);
+
     for (i = 0; i < 36; ++i) {
         _RamWrite(BatchFCB + i, _RamRead(tmpFCB + i));
     }
-    
+
+    // Loads an autoexec file if it exists and this is the first boot
+    // The file contents are loaded at ccpAddr+8 up to 126 bytes then the size
+    // loaded is stored at ccpAddr+7
+#ifdef CPM3
+    if (chainLoad) {
+        // A program chained to a command via BDOS 47 (Chain To Program).
+        // Run that command before anything else.
+        uint16 cmd = inBuf + 2;
+        bufferLen = 0;
+        while (chainCmd[bufferLen] && bufferLen < 125) {
+            _RamWrite(cmd + bufferLen, chainCmd[bufferLen]);
+            ++bufferLen;
+        }
+        _RamWrite(cmd + bufferLen, 0x00);
+        _RamWrite(inBuf, cmdLen);
+        _RamWrite(inBuf + 1, bufferLen);
+        chainLoad = 0;
+    } else
+#endif
+    if (firstBoot && !submitFlag) {
+        if (_sys_exists((uint8 *)AUTOEXEC)) {
+            uint16 cmd = inBuf + 2;
+            uint8 bytesread = (uint8)_RamLoad((uint8 *)AUTOEXEC, cmd, 125);
+            bufferLen = 0;
+            while (bufferLen < bytesread && _RamRead(cmd + bufferLen) > 31)
+                bufferLen++;
+            _RamWrite(cmd + bufferLen, 0x00);
+            _RamWrite(--cmd, bufferLen);
+        } else {
+            bufferLen = 0;
+        }
+        if (BOOTONLY)
+            firstBoot = FALSE;
+    } else {
+        _RamWrite(inBuf, 0);     // Clears the buffer
+        _RamWrite(inBuf + 1, 0); // Clears the buffer
+        bufferLen = 0;
+    }
+
     while (TRUE) {
-        curDrive = (uint8)_ccp_bdos(DRV_GET, 0x0000);   // Get current drive
-        curUser = (uint8)_ccp_bdos(F_USERNUM, 0x00FF);  // Get current user
-        _RamWrite(DSKByte, (curUser << 4) + curDrive);  // Set user/drive on addr DSKByte
-        
-        parDrive = curDrive;    // Initially the parameter drive is the same as the current drive
-        
-        snprintf((char *) prompt, sizeof(prompt), "\r\n%c%u%c", 'A' + curDrive, curUser, sFlag ? '$' : '>');
-        _puts((char *)prompt);
-        
-        _RamWrite(inBuf, cmdLen);   // Sets the buffer size to read the command line
-        _ccp_readInput();
-        
-        blen = _RamRead(inBuf + 1); // Obtains the number of bytes read
-        
-        _ccp_bdos(F_DMAOFF, defDMA);    // Reset current DMA
-        if (blen) {
-            _RamWrite(inBuf + 2 + blen, 0); // "Closes" the read buffer with a \0
-            pbuf = inBuf + 2;               // Points pbuf to the first command character
-            
-            while (_RamRead(pbuf) == ' ' && blen) { // Skips any leading spaces
-                ++pbuf;
-                --blen;
+        currentDrive = (uint8)_ccp_bdos(DRV_GET, 0x0000);  // Get current drive
+        currentUser = (uint8)_ccp_bdos(F_USERNUM, 0x00FF); // Get current user
+        _RamWrite(DSKByte,
+                  (currentUser << 4) + currentDrive); // Set user/drive on addr DSKByte
+
+        paramDrive = currentDrive; // Initially the parameter drive is the same as the
+                             // current drive
+
+        sprintf((char *)prompt, "\r\n%c%u%c", 'A' + currentDrive, currentUser,
+                submitFlag ? '$' : '>');
+        if (!bufferLen) {
+            _puts((char *)prompt);
+
+            _RamWrite(inBuf,
+                      cmdLen); // Sets the buffer size to read the command line
+            _ccp_readInput();
+            if (Status == STATUS_RETURN)
+                Status = STATUS_RUNNING;
+            bufferLen = _RamRead(inBuf + 1); // Obtains the number of bytes read
+        }
+
+        _ccp_bdos(F_DMAOFF, defDMA); // Reset current DMA
+        if (bufferLen) {
+            _RamWrite(inBuf + 2 + bufferLen,
+                      0);     // "Closes" the read buffer with a \0
+            cmdBufferPtr = inBuf + 2; // Points cmdBufferPtr to the first command character
+
+            while (_RamRead(cmdBufferPtr) == ' ' && bufferLen) { // Skips any leading spaces
+                ++cmdBufferPtr;
+                --bufferLen;
             }
-            if (!blen) {    // There were only spaces
+            if (!bufferLen) // There were only spaces
+                continue;
+            if (_RamRead(cmdBufferPtr) == ';') { // Found a comment line
+                bufferLen = 0;                // Ignore the rest of the line
                 continue;
             }
-            if (_RamRead(pbuf) == ';') {    // Found a comment line
-                continue;
-            }
-            
+
             // parse for DU: command line shortcut
-            bool errorFlag = FALSE, continueFlag = FALSE;
-            uint8 ch, tDrive = 0, tUser = curUser, u = 0;
-            
-            for (i = 0; i < blen; i++) {
-                ch = toupper(_RamRead(pbuf + i));
-                if ((ch >= 'A') && (ch <= 'P')) {
-                    if (tDrive) {   // if we've already specified a new drive
-                        break;      // not a DU: command
-                    } else {
-                        tDrive = ch - '@';
-                    }
-                } else if ((ch >= '0') && (ch <= '9')) {
-                    tUser = u = (u * 10) + (ch - '0');
-                } else if (ch == ':') {
-                    if (i == blen - 1) {    // if we at the end of the command line
-                        if (tUser >= 16) {  // if invalid user
-                            errorFlag = TRUE;
-                            break;
-                        }
-                        if (tDrive != 0) {
-                            cDrive = oDrive = tDrive - 1;
-                            _RamWrite(DSKByte, (_RamRead(DSKByte) & 0xf0) | cDrive);
-                            _ccp_bdos(DRV_SET, cDrive);
-                            if (Status) {
-                                curDrive = 0;
-                            }
-                        }
-                        if (tUser != curUser) {
-                            curUser = tUser;
-                            _ccp_bdos(F_USERNUM, curUser);
-                        }
-                        continueFlag = TRUE;
-                    }
-                    break;
-                } else {    // invalid character
-                    break;  // don't error; may be valid (non-DU:) command
-                }
+            bool errorFlag = FALSE;
+            if (_ccp_parseDriveUser(&errorFlag)) {
+                bufferLen = 0; // ignore the rest of the line
+                continue;
             }
             if (errorFlag) {
-                _ccp_cmdError();    // print command error
+                _ccp_cmdError(); // print command error
+                bufferLen = 0;        // ignore the rest of the line
                 continue;
             }
-            if (continueFlag) {
+
+            _ccp_initFCB(CmdFCB, 36); // Initializes the command FCB
+
+            errorPtr = cmdBufferPtr; // Saves the pointer in case there's an error
+            if (_ccp_nameToFCB(CmdFCB) >
+                8) {             // Extracts the command from the buffer
+                _ccp_cmdError(); // Command name cannot be non-unique or have an
+                                 // extension
+                bufferLen = 0;        // ignore the rest of the line
                 continue;
             }
-            _ccp_initFCB(CmdFCB, 36);   // Initializes the command FCB
-            
-            perr = pbuf;                        // Saves the pointer in case there's an error
-            if (_ccp_nameToFCB(CmdFCB) > 8) {   // Extracts the command from the buffer
-                _ccp_cmdError();                // Command name cannot be non-unique or have an extension
-                continue;
-            }
-            _RamWrite(defDMA, blen);    // Move the command line at this point to 0x0080
-            
-            for (i = 0; i < blen; ++i) {
-                _RamWrite(defDMA + i + 1, toupper(_RamRead(pbuf + i)));
-            }
-            
-            while (i++ < 127) { // "Zero" the rest of the DMA buffer
+            _RamWrite(defDMA,
+                      bufferLen); // Move the command line at this point to 0x0080
+
+            for (i = 0; i < bufferLen; ++i)
+                _RamWrite(defDMA + i + 1, toupper(_RamRead(cmdBufferPtr + i)));
+            while (i++ < 127) // "Zero" the rest of the DMA buffer
                 _RamWrite(defDMA + i, 0);
+            _ccp_initFCB(ParFCB, 18); // Initializes the parameter FCB
+            _ccp_initFCB(SecFCB, 18); // Initializes the secondary FCB
+
+            while (_RamRead(cmdBufferPtr) == ' ' && bufferLen) { // Skips any leading spaces
+                ++cmdBufferPtr;
+                --bufferLen;
             }
-            _ccp_initFCB(	ParFCB, 18);    // Initializes the parameter FCB
-            _ccp_initFCB(	SecFCB, 18);    // Initializes the secondary FCB
-            
-            while (_RamRead(pbuf) == ' ' && blen) { // Skips any leading spaces
-                ++pbuf;
-                --blen;
+            _ccp_nameToFCB(
+                ParFCB); // Loads the next file parameter onto the parameter FCB
+
+            while (_RamRead(cmdBufferPtr) == ' ' && bufferLen) { // Skips any leading spaces
+                ++cmdBufferPtr;
+                --bufferLen;
             }
-            _ccp_nameToFCB(ParFCB); // Loads the next file parameter onto the parameter FCB
-            
-            while (_RamRead(pbuf) == ' ' && blen) { // Skips any leading spaces
-                ++pbuf;
-                --blen;
+            _ccp_nameToFCB(
+                SecFCB); // Loads the next file parameter onto the secondary FCB
+
+            i = FALSE; // Checks if the command is valid and executes
+
+            const Command *cmd = _ccp_cnum();
+            if (cmd) {
+                i = cmd->handler();
+            } else {
+                i = _ccp_ext();
             }
-            _ccp_nameToFCB(SecFCB); // Loads the next file parameter onto the secondary FCB
-            
-            i = FALSE;  // Checks if the command is valid and executes
-            
-            switch (_ccp_cnum()) {
-                    // Standard CP/M commands
-                case 0: {   // DIR
-                    _ccp_dir();
-                    break;
-                }
-                    
-                case 1: {   // ERA
-                    _ccp_era();
-                    break;
-                }
-                    
-                case 2: {   // TYPE
-                    i = _ccp_type();
-                    break;
-                }
-                    
-                case 3: {   // SAVE
-                    i = _ccp_save();
-                    break;
-                }
-                    
-                case 4: {   // REN
-                    _ccp_ren();
-                    break;
-                }
-                    
-                case 5: {   // USER
-                    i = _ccp_user();
-                    break;
-                }
-                    
-                    // Extra CCP commands
-                case 6: {   // CLS
-                    _clrscr();
-                    break;
-                }
-                    
-                case 7: {   // DEL is an alias to ERA
-                    _ccp_era();
-                    break;
-                }
-                    
-                case 8: {   // EXIT
-                    _puts(	"Terminating RunCPM.\r\n");
-                    _puts(	"CPU Halted.\r\n");
-                    Status = 1;
-                    break;
-                }
-                    
-                case 9: {   // PAGE
-                    i = _ccp_page();
-                    break;
-                }
-                    
-                case 10: {  // VOL
-                    i = _ccp_vol();
-                    break;
-                }
-                    
-                    // External/Lua commands
-                case 255: { // It is an external command
-                    i = _ccp_ext();
-#ifdef HASLUA
-                    if (i) {
-                        i = _ccp_lua();
-                    }
-#endif // ifdef HASLUA
-                    break;
-                }
-                    
-                default: {
-                    i = TRUE;
-                    break;
-                }
-            } // switch
-            cDrive = oDrive = curDrive; // Restore cDrive and oDrive
-            if (i) {
+
+            cDrive = oDrive = currentDrive; // Restore cDrive and oDrive
+            if (i)
                 _ccp_cmdError();
-            }
         }
-        if ((Status == 1) || (Status == 2)) {
+        bufferLen = 0;
+        if ((Status == STATUS_EXIT) || (Status == STATUS_RESTART))
             break;
-        }
     }
     _puts("\r\n");
 } // _ccp
 
 #endif // ifndef CCP_H
-

--- a/lib/runcpm/ccp.h
+++ b/lib/runcpm/ccp.h
@@ -8,6 +8,15 @@
 // CP/M BDOS calls
 #include "cpm.h"
 
+#ifdef BUILD_ATARI
+// RSX-style "bar command" gate into the FujiNet firmware.  Defined once in
+// lib/device/sio/vm_bar.cpp and shared by every RunCPM instance.  The header
+// declares the gate (at namespace scope, as the linkage specification
+// requires) plus the vm_bar_io callback struct used by interactive verbs.
+// See vm_bar.h for the full contract.
+#include "../device/sio/vm_bar.h"
+#endif
+
 // Memory Layout Definitions
 #define CmdFCB      (BatchFCB + 48)     // FCB for use by internal commands
 #define ParFCB      0x005C              // FCB for use by line parameters
@@ -1559,6 +1568,54 @@ RUNCPM_DECL void _ccp(void) {
                 bufferLen = 0;                // Ignore the rest of the line
                 continue;
             }
+
+#ifdef BUILD_ATARI
+            // RSX-style "bar command" (Amstrad-CPC inspired): a line whose first
+            // non-space character is '|' is not a CP/M command.  Hand the rest of
+            // the line to the FujiNet firmware gate (lib/device/sio/vm_bar.cpp),
+            // which performs a host-side action (e.g. |wget URL) and returns a
+            // status string we print here.  The gate is decoupled from RunCPM
+            // internals, so this works for every RunCPM instance (R:, N:CPM:,
+            // telnet).  See vm_bar.h for the gate contract.
+            if (_RamRead(cmdBufferPtr) == '|') {
+                // Sized for multi-line replies such as "|fn mounts" (8 drive
+                // slots) and "|help"; the gate bounds its output to this size.
+                char _barmsg[640];
+                _barmsg[0] = 0;
+                // Build the host directory prefix for the current drive/user the
+                // same way RunCPM maps CP/M files: full_path("<drive>/<user>/")
+                // -> "/CPM/A/0/".  Uses cDrive/userCode (what _FCBtoHostname in
+                // disk.h uses) so downloads land where DIR/TYPE look for them.
+                char _bardir[6];
+                _bardir[0] = cDrive + 'A';
+                _bardir[1] = FOLDERCHAR;
+                _bardir[2] = (char)toupper(tohex(userCode));
+                _bardir[3] = FOLDERCHAR;
+                _bardir[4] = '\0';
+                // Terminal-I/O callbacks for interactive verbs (e.g. |ftp).
+                // Captureless lambdas convert to plain function pointers and
+                // bind to THIS translation unit's console primitives, so the
+                // single shared gate can drive the right console for whichever
+                // RunCPM instance (R:, N:CPM:, telnet) is running.
+                vm_bar_io _bario;
+                _bario.getch = []() -> int { return (int)_getch(); };
+                _bario.putch = [](int c) { _putch((uint8_t)c); };
+                _bario.puts_ = [](const char *s) { _puts((char *)s); };
+                vm_bar_command((const char *)_RamSysAddr(cmdBufferPtr + 1),
+                                full_path(_bardir), _barmsg,
+                                (int)sizeof(_barmsg), &_bario);
+                // C_READSTR leaves the cursor at the end of the echoed
+                // command line, so start the reply on a fresh line (same
+                // convention as _ccp_cmdError() above) to avoid overwriting
+                // the "A0>|verb" the user just typed.
+                if (_barmsg[0]) {
+                    _puts("\r\n");
+                    _puts(_barmsg);
+                }
+                bufferLen = 0; // ignore the rest of the line
+                continue;
+            }
+#endif
 
             // parse for DU: command line shortcut
             bool errorFlag = FALSE;

--- a/lib/runcpm/console.h
+++ b/lib/runcpm/console.h
@@ -1,50 +1,126 @@
 #ifndef CONSOLE_H
 #define CONSOLE_H
 
-/* see main.c for definition */
-
 #ifndef RUNCPM_DECL
 #define RUNCPM_DECL
 #endif
 
-RUNCPM_DECL uint8 mask8bit = 0x7f;		// TO be used for masking 8 bit characters (XMODEM related)
-										// If set to 0x7f, RunCPM masks the 8th bit of characters sent
-										// to the console. This is the standard CP/M behavior.
-										// If set to 0xff, RunCPM passes 8 bit characters. This is
-										// required for XMODEM to work.
-										// Use the CONSOLE7 and CONSOLE8 programs to change this on the fly.
+/* see main.c for definition */
 
-RUNCPM_DECL uint8 _chready(void)		// Checks if there's a character ready for input
+RUNCPM_DECL uint8 mask8bit = 0x7f; // TO be used for masking 8 bit characters (XMODEM related)
+                       // If set to 0x7f, RunCPM masks the 8th bit of characters sent
+                       // to the console. This is the standard CP/M behavior.
+                       // If set to 0xff, RunCPM passes 8 bit characters. This is
+                       // required for XMODEM to work.
+                       // Use the CONSOLE7 and CONSOLE8 programs to change this on the fly.
+
+RUNCPM_DECL void _putcon(uint8 ch) // Puts a character
 {
-	return(_kbhit() ? 0xff : 0x00);
+#ifdef STREAMIO
+    if (consoleOutputActive)
+        _putch(ch & mask8bit);
+    if (streamOutputFile)
+        fputc(ch & mask8bit, streamOutputFile);
+#else
+    _putch(ch & mask8bit);
+#endif
 }
 
-RUNCPM_DECL uint8 _getchNB(void)		// Gets a character, non-blocking, no echo
+RUNCPM_DECL void _puts(const char *str) // Puts a \0 terminated string
 {
-	return(_kbhit() ? _getch() : 0x00);
+    while (*str)
+        _putcon(*(str++));
 }
 
-RUNCPM_DECL void _putcon(uint8 ch)		// Puts a character
+RUNCPM_DECL void _puthex8(uint8 c) // Puts a HH hex string
 {
-	_putch(ch & mask8bit);
+    _putcon(tohex(c >> 4));
+    _putcon(tohex(c & 0x0f));
 }
 
-RUNCPM_DECL void _puts(const char* str)	// Puts a \0 terminated string
+RUNCPM_DECL void _puthex16(uint16 w) // puts a HHHH hex string
 {
-	while (*str)
-		_putcon(*(str++));
+    _puthex8(w >> 8);
+    _puthex8(w & 0x00ff);
 }
 
-RUNCPM_DECL void _puthex8(uint8 c)		// Puts a HH hex string
-{
-	_putcon(tohex(c >> 4));
-	_putcon(tohex(c & 0x0f));
+#ifdef STREAMIO
+RUNCPM_DECL int _nextStreamInChar;
+
+RUNCPM_DECL void _getNextStreamInChar(void) {
+    _nextStreamInChar = streamInputFile ? fgetc(streamInputFile) : EOF;
+    if (EOF == _nextStreamInChar) {
+        streamInputActive = FALSE;
+    }
 }
 
-RUNCPM_DECL void _puthex16(uint16 w)	// puts a HHHH hex string
+RUNCPM_DECL uint8 _getStreamInChar(void) {
+    uint8 result = _nextStreamInChar;
+    _getNextStreamInChar();
+    // TODO: delegate to abstrction_posix.h
+    if (0x0a == result)
+        result = 0x0d;
+    return result;
+}
+
+RUNCPM_DECL uint8 _getStreamInCharEcho() {
+    uint8 result = _getStreamInChar();
+    _putcon(result);
+    return result;
+}
+
+RUNCPM_DECL void _streamioInit(void) {
+    _getNextStreamInChar();
+}
+
+RUNCPM_DECL void _streamioReset(void) {
+    if (streamOutputFile)
+        fclose(streamOutputFile);
+}
+#endif
+
+RUNCPM_DECL uint8 _chready(void) // Checks if there's a character ready for input
 {
-	_puthex8(w >> 8);
-	_puthex8(w & 0x00ff);
+#ifdef STREAMIO
+    if (streamInputActive)
+        return 0xff;
+    // TODO: Consider adding/keeping _abort_if_kbd_eof() here.
+    _abort_if_kbd_eof();
+#endif
+    return (_kbhit() ? 0xff : 0x00);
+}
+
+RUNCPM_DECL uint8 _getconNB(void) // Gets a character, non-blocking, no echo
+{
+#ifdef STREAMIO
+    if (streamInputActive)
+        return _getStreamInChar();
+    // TODO: Consider adding/keeping _abort_if_kbd_eof() here.
+    _abort_if_kbd_eof();
+#endif
+    return (_kbhit() ? _getch() : 0x00);
+}
+
+RUNCPM_DECL uint8 _getcon(void) // Gets a character, blocking, no echo
+{
+#ifdef STREAMIO
+    if (streamInputActive)
+        return _getStreamInChar();
+    // TODO: Consider adding/keeping _abort_if_kbd_eof() here.
+    _abort_if_kbd_eof();
+#endif
+    return _getch();
+}
+
+RUNCPM_DECL uint8 _getconE(void) // Gets a character, blocking, with echo
+{
+#ifdef STREAMIO
+    if (streamInputActive)
+        return _getStreamInCharEcho();
+    // TODO: Consider adding/keeping _abort_if_kbd_eof() here.
+    _abort_if_kbd_eof();
+#endif
+    return _getche();
 }
 
 #endif

--- a/lib/runcpm/console.h
+++ b/lib/runcpm/console.h
@@ -16,6 +16,29 @@ RUNCPM_DECL uint8 mask8bit = 0x7f; // TO be used for masking 8 bit characters (X
 
 RUNCPM_DECL void _putcon(uint8 ch) // Puts a character
 {
+#ifdef BUILD_ATARI
+    /* Terminal-compat (FujiNet): many CP/M programs emit a bare Form Feed
+     * (0x0C, ^L) to clear the screen — the convention of page-oriented
+     * terminals (Hazeltine, TeleVideo, Lear-Siegler...).  VT100/ANSI clients
+     * (xterm, iTerm2, the N:TELNET console, the Atari terminal) instead treat
+     * 0x0C as a line feed, so the screen scrolls but never clears.  Translate
+     * it to the same VT100 home+clear sequence RunCPM itself uses in _clrscr()
+     * (ESC [1;1H  ESC [2J), which makes ^L-clear work on every console
+     * transport (SIO 'G'/R:, N:CPM://, telnet).
+     *
+     * Gated on mask8bit == 0x7f: that is normal 7-bit console mode.  The XMODEM
+     * helpers switch to 8-bit transparent mode (mask8bit = 0xff via BDOS
+     * F_SETMASK) where 0x0C is binary payload, not a control code, and must
+     * pass through untouched.  Masking ch to 7 bits matches the byte that would
+     * otherwise have been emitted (ch & mask8bit below). */
+    if (mask8bit == 0x7f && (ch & 0x7f) == 0x0C)
+    {
+        _putch(0x1B); _putch('['); _putch('1'); _putch(';');
+        _putch('1');  _putch('H'); _putch(0x1B); _putch('[');
+        _putch('2');  _putch('J');
+        return;
+    }
+#endif
 #ifdef STREAMIO
     if (consoleOutputActive)
         _putch(ch & mask8bit);

--- a/lib/runcpm/cpm.h
+++ b/lib/runcpm/cpm.h
@@ -1,53 +1,140 @@
-#ifndef CPM_H
+ #ifndef CPM_H
 #define CPM_H
-
-#include "printer.h"
 
 #ifndef RUNCPM_DECL
 #define RUNCPM_DECL
 #endif
 
+/* FujiNet vendoring: pulls in the FujiNet device printer (SYSTEM_BUS /
+   getPrinter()->print_from_cpm) via the firmware include path, used by the
+   BUILD_ATARI/BUILD_APPLE printer routing in BDOS C=5 (L_WRITE) below. */
+#include "printer.h"
+
+enum eBIOSFunc {
+    // CP/M 2.2 Stuff
+    B_BOOT = 0,
+    B_WBOOT = 3,
+    B_CONST = 6,
+    B_CONIN = 9,
+    B_CONOUT = 12,
+    B_LIST = 15,
+    B_AUXOUT = 18,
+    B_READER = 21,
+    B_HOME = 24,
+    B_SELDSK = 27,
+    B_SETTRK = 30,
+    B_SETSEC = 33,
+    B_SETDMA = 36,
+    B_READ = 39,
+    B_WRITE = 42,
+    B_LISTST = 45,
+    B_SECTRAN = 48,
+    // CP/M 3.0 Stuff
+    B_CONOST = 51,
+    B_AUXIST = 54,
+    B_AUXOST = 57,
+    B_DEVTBL = 60,
+    B_DEVINI = 63,
+    B_DRVTBL = 66,
+    B_MULTIO = 69,
+    B_FLUSH = 72,
+    B_MOVE = 75,
+    B_TIME = 78,
+    B_SELMEM = 81,
+    B_SETBNK = 84,
+    B_XMOVE = 87,
+    B_USERF = 90, // Used by internal CCP to return to prompt
+    B_RESERV1 = 93,
+    B_RESERV2 = 96
+};
+
 enum eBDOSFunc {
-	F_BOOT = 0,
-	C_READ = 1,
-	C_WRITE = 2,
-	READER_IN = 3,
-	PUNCH_OUT = 4,
-	PRINT_OUT = 5,
-	DIRECT_IO = 6,
-	GET_IOBYTE = 7,
-	SET_IOBYTE = 8,
-	OUT_STRING = 9,
-	C_READSTR = 10,
-	C_STAT = 11,
-	GET_VERSION = 12,
-	DRV_ALLRESET = 13,
-	DRV_SET = 14,
-	F_OPEN = 15,
-	F_CLOSE = 16,
-	F_SEARCH_FIRST = 17,
-	F_SEARCH_NEXT = 18,
-	F_DELETE = 19,
-	F_READ = 20,
-	F_WRITE = 21,
-	F_MAKE = 22,
-	F_RENAME = 23,
-	DRV_LOGINVECTOR = 24,
-	DRV_GET = 25,
-	F_DMAOFF = 26,
-	DRV_GETADDRALLOC = 27,
-	DRV_WRITEPROTECT = 28,
-	DRV_GETROVECTOR = 29,
-	F_SETATTRIBUTES = 30,
-	DRV_GETDPB = 31,
-	F_USERNUM = 32,
-	F_READRANDOM = 33,
-	F_WRITERANDOM = 34,
-	F_COMPUTESIZE = 35,
-	F_SETRANDOM = 36,
-	DRV_RESET = 37,
-	F_WRITERANDOMZERO = 40,
-	F_RUNLUA = 254
+    // CP/M 2.2 Stuff
+    P_TERMCPM = 0,
+    C_READ = 1,
+    C_WRITE = 2,
+    A_READ = 3,
+    A_WRITE = 4,
+    L_WRITE = 5,
+    C_RAWIO = 6,
+    A_STATIN = 7,
+    A_STATOUT = 8,
+    C_WRITESTR = 9,
+    C_READSTR = 10,
+    C_STAT = 11,
+    S_BDOSVER = 12,
+    DRV_ALLRESET = 13,
+    DRV_SET = 14,
+    F_OPEN = 15,
+    F_CLOSE = 16,
+    F_SFIRST = 17,
+    F_SNEXT = 18,
+    F_DELETE = 19,
+    F_READ = 20,
+    F_WRITE = 21,
+    F_MAKE = 22,
+    F_RENAME = 23,
+    DRV_LOGINVEC = 24,
+    DRV_GET = 25,
+    F_DMAOFF = 26,
+    DRV_ALLOCVEC = 27,
+    DRV_SETRO = 28,
+    DRV_ROVEC = 29,
+    F_ATTRIB = 30,
+    DRV_PDB = 31,
+    F_USERNUM = 32,
+    F_READRAND = 33,
+    F_WRITERAND = 34,
+    F_SIZE = 35,
+    F_RANDREC = 36,
+    DRV_RESET = 37,
+    DRV_ACCESS_MPM = 38, // This is an MP/M function that is not supported under CP/M 3.
+    DRV_FREE_MPM = 39,   // This is an MP/M function that is not supported under CP/M 3.
+    F_WRITEZF = 40,
+    // CP/M 3.0 Stuff
+    F_TESTWRITE = 41,
+    F_LOCKFILE = 42,
+    F_UNLOCKFILE = 43,
+    F_MULTISEC = 44,
+    F_ERRMODE = 45,
+    DRV_SPACE = 46,
+    P_CHAIN = 47,
+    DRV_FLUSH = 48,
+    S_SCB = 49,
+    S_BIOS = 50,
+    P_LOAD = 59,
+    S_RSX = 60,
+    F_CLEANUP = 98,
+    F_TRUNCATE = 99,
+    DRV_SETLABEL = 100,
+    DRV_GETLABEL = 101,
+    F_TIMEDATE = 102,
+    F_WRITEXFCB = 103,
+    T_SET = 104,
+    T_GET = 105,
+    F_PASSWD = 106,
+    S_SERIAL = 107,
+    P_CODE = 108,
+    C_MODE = 109,
+    C_DELIMIT = 110,
+    C_WRITEBLK = 111,
+    L_WRITEBLK = 112,
+    F_PARSE = 152,
+    // RunCPM Stuff
+    F_PINMODE = 220,
+    F_DREAD = 221,
+    F_DWRITE = 222,
+    F_AREAD = 223,
+    F_AWRITE = 224,
+    F_SETMASK = 230,
+    F_BDOSCALL = 231,
+    F_UPTIME = 248,
+    F_MAKEDISK = 249,
+    F_HOSTOS = 250,
+    F_VERSION = 251,
+    F_CCPVERSION = 252,
+    F_CCPADDR = 253,
+    F_SETCPUSPEED = 254
 };
 
 /* see main.c for definition */
@@ -55,1322 +142,2030 @@ enum eBDOSFunc {
 #define JP 0xc3
 #define CALL 0xcd
 #define RET 0xc9
-#define INa 0xdb    // Triggers a BIOS call
-#define OUTa 0xd3   // Triggers a BDOS call
+#define INa 0xdb  // Triggers a BIOS call
+#define OUTa 0xd3 // Triggers a BDOS call
+// Interruption handling
+#define RST_08 0xcf  // RST 08h - BIOS calls
+#define RST_10 0xd7  // RST 10h - BDOS calls  
+#define RST_18 0xdf  // RST 18h - Hardware calls
+#define NOP 0x00     // No operation
 
 /* set up full PUN and LST filenames to be on drive A: user 0 */
 #ifdef USE_PUN
-char pun_file[17] = {'A', FOLDERCHAR, '0', FOLDERCHAR, 'P', 'U', 'N', '.', 'T', 'X', 'T', 0};
-
+RUNCPM_DECL char pun_file[17] = {'A', FOLDERCHAR, '0', FOLDERCHAR, 'P', 'U', 'N', '.', 'T', 'X', 'T', 0};
 #endif // ifdef USE_PUN
-#ifdef USE_LST
-char lst_file[17] = {'A', FOLDERCHAR, '0', FOLDERCHAR, 'L', 'S', 'T', '.', 'T', 'X', 'T', 0};
 
+#ifdef USE_LST
+RUNCPM_DECL char lst_file[17] = {'A', FOLDERCHAR, '0', FOLDERCHAR, 'L', 'S', 'T', '.', 'T', 'X', 'T', 0};
 #endif // ifdef USE_LST
 
 #ifdef PROFILE
-unsigned long time_start = 0;
-unsigned long time_now = 0;
-
+RUNCPM_DECL unsigned long time_start = 0;
+RUNCPM_DECL unsigned long time_now = 0;
 #endif // ifdef PROFILE
 
+RUNCPM_DECL void _PatchBIOS(void) {
+    uint16 i;
+
+    // Patches in the BIOS jump destinations
+    for (i = 0; i < 99; i = i + 3) {
+        _RamWrite(BIOSjmppage + i, JP);
+        _RamWrite16(BIOSjmppage + i + 1, BIOSpage + i);
+    }
+
+    // Patches in the BIOS page content
+    for (i = 0; i < 99; i = i + 3) {
+#ifdef INT_HANDOFF
+        _RamWrite(BIOSpage + i, RST_08);
+        _RamWrite(BIOSpage + i + 1, RET);
+        _RamWrite(BIOSpage + i + 2, NOP);
+#else
+        _RamWrite(BIOSpage + i, OUTa);
+        _RamWrite(BIOSpage + i + 1, 0xFF);
+        _RamWrite(BIOSpage + i + 2, RET);
+#endif
+    }
+} //_PatchBIOS
+
 RUNCPM_DECL void _PatchCPM(void) {
-	uint16 i;
+    uint16 i;
 
-	// **********  Patch CP/M page zero into the memory  **********
+    // **********  Patch CP/M page zero into the memory  **********
 
-	/* BIOS entry point */
-	_RamWrite(0x0000, JP);  /* JP BIOS+3 (warm boot) */
-	_RamWrite16(0x0001, BIOSjmppage + 3);
-	if (Status != 2) {
-		/* IOBYTE - Points to Console */
-		_RamWrite(	IOByte,		0x3D);
+    /* BIOS entry point */
+    _RamWrite(0x0000, JP); /* JP BIOS+3 (warm boot) */
+    _RamWrite16(0x0001, BIOSjmppage + 3);
+    if (Status != STATUS_RESTART) {
+        /* IOBYTE - Points to Console */
+        _RamWrite(IOByte, 0x3D);
 
-		/* Current drive/user - A:/0 */
-		_RamWrite(	DSKByte,	0x00);
-	}
-	/* BDOS entry point (0x0005) */
-	_RamWrite(0x0005, JP);
-	_RamWrite16(0x0006,				BDOSjmppage + 0x06);
+        /* Current drive/user - A:/0 */
+        _RamWrite(DSKByte, 0x00);
+    }
+    /* BDOS entry point (0x0005) */
+    _RamWrite(0x0005, JP);
+    _RamWrite16(0x0006, BDOSjmppage + 0x06);
 
-	// **********  Patch CP/M Version into the memory so the CCP can see it
-	_RamWrite16(BDOSjmppage,		0x1600);
-	_RamWrite16(BDOSjmppage + 2,	0x0000);
-	_RamWrite16(BDOSjmppage + 4,	0x0000);
+    // **********  Patch CP/M Version into the memory so the CCP can see it
+#ifdef ABDOS
+    // Loads the ABDOS.SYS file into memory or throws an error if it doesn't exist
+    if (_sys_exists((uint8 *)"A/0/ABDOS.SYS")) {
+        _RamLoad((uint8 *)"A/0/ABDOS.SYS", BDOSjmppage, 0);
+    } else {
+        _puts("\r\nABDOS.SYS not found");
+        exit(1);
+    }
+#else
+    _RamWrite16(BDOSjmppage, 0x1600);
+    _RamWrite16(BDOSjmppage + 2, 0x0000);
+    _RamWrite16(BDOSjmppage + 4, 0x0000);
 
-	// Patches in the BDOS jump destination
-	_RamWrite(BDOSjmppage + 6, JP);
-	_RamWrite16(BDOSjmppage + 7, BDOSpage);
+    // Patches in the BDOS jump destination
+    _RamWrite(BDOSjmppage + 6, JP);
+    _RamWrite16(BDOSjmppage + 7, BDOSpage);
 
-	// Patches in the BDOS page content
-	_RamWrite(	BDOSpage,		INa);
-	_RamWrite(	BDOSpage + 1,	0xFF);
-	_RamWrite(	BDOSpage + 2,	RET);
+    // Patches in the BDOS page content
+#ifdef INT_HANDOFF
+    _RamWrite(BDOSpage, RST_10);
+    _RamWrite(BDOSpage + 1, RET);
+    _RamWrite(BDOSpage + 2, NOP);
+#else
+    _RamWrite(BDOSpage, INa);
+    _RamWrite(BDOSpage + 1, 0xFF);
+    _RamWrite(BDOSpage + 2, RET);
+#endif
 
-	// Patches in the BIOS jump destinations
-	for (i = 0; i < 0x36; i = i + 3) {
-		_RamWrite(BIOSjmppage + i, JP);
-		_RamWrite16(BIOSjmppage + i + 1, BIOSpage + i);
-	}
+    _PatchBIOS();
+#endif
 
-	// Patches in the BIOS page content
-	for (i = 0; i < 0x36; i = i + 3) {
-		_RamWrite(	BIOSpage + i,		OUTa);
-		_RamWrite(	BIOSpage + i + 1,	0xFF);
-		_RamWrite(	BIOSpage + i + 2,	RET);
-	}
-	// **********  Patch CP/M (fake) Disk Paramater Block after the BDOS call entry  **********
-	i = DPBaddr;
-	_RamWrite(	i++,	64);    // spt - Sectors Per Track
-	_RamWrite(	i++,	0);
-	_RamWrite(	i++,	5);     // bsh - Data allocation "Block Shift Factor"
-	_RamWrite(	i++,	0x1F);  // blm - Data allocation Block Mask
-	_RamWrite(	i++,	1);     // exm - Extent Mask
-	_RamWrite(	i++,	0xFF);  // dsm - Total storage capacity of the disk drive
-	_RamWrite(	i++,	0x07);
-	_RamWrite(	i++,	255);   // drm - Number of the last directory entry
-	_RamWrite(	i++,	3);
-	_RamWrite(	i++,	0xFF);  // al0
-	_RamWrite(	i++,	0x00);  // al1
-	_RamWrite(	i++,	0);     // cks - Check area Size
-	_RamWrite(	i++,	0);
-	_RamWrite(	i++,	0x02);  // off - Number of system reserved tracks at the beginning of the ( logical ) disk
-	_RamWrite(	i++,	0x00);
-	blockShift = _RamRead(DPBaddr + 2);
-	blockMask = _RamRead(DPBaddr + 3);
-	extentMask = _RamRead(DPBaddr + 4);
-	numAllocBlocks = _RamRead16((DPBaddr + 5)) + 1;
-	extentsPerDirEntry = extentMask + 1;
+    // **********  Patch CP/M (fake) Disk Parameter Block after the BDOS call entry  **********
+    i = DPBaddr;
+    _RamWrite(i++, 0x00); // DEFW spt - Sectors Per Track (256)
+    _RamWrite(i++, 0x01);
+    _RamWrite(i++, 0x05); // DEFB bsh - Data allocation "Block Shift Factor" (for 4096 block size)
+    _RamWrite(i++, 0x1F); // DEFB blm - Data allocation Block Mask (31 for 4096 block size)
+    _RamWrite(i++, 0x01); // DEFB exm - Data allocation Extent Mask (1 = total blocks > 256)
+    _RamWrite(i++, 0xF7); // DEFW dsm - Logical disk size in blocks - 1 (2039)
+    _RamWrite(i++, 0x07);
+    _RamWrite(i++, 0xFF); // DEFW drm - Maximum directory entries - 1 (1023)
+    _RamWrite(i++, 0x03);
+    _RamWrite(i++, 0xFF); // DEFB al0 - Reserved directory blocks
+    _RamWrite(i++, 0x00); // DEFB al1 - Reserved directory blocks
+    _RamWrite(i++, 0x00); // DEFW cks - Check area Size (0 for fixed disks)
+    _RamWrite(i++, 0x00);
+    _RamWrite(i++, 0x01); // DEFW off - Number of system reserved tracks at the beginning of the ( logical ) disk
+    _RamWrite(i++, 0x00);
+    blockShift = _RamRead(DPBaddr + 2);
+    blockMask = _RamRead(DPBaddr + 3);
+    extentMask = _RamRead(DPBaddr + 4);
+    numAllocBlocks = _RamRead16(DPBaddr + 5) + 1;
+    extentsPerDirEntry = extentMask + 1;
 
-	// **********  Patch CP/M (fake) Disk Parameter Header after the Disk Parameter Block  **********
-	_RamWrite(	i++,	0); // Addr of the sector translation table
-	_RamWrite(	i++,	0);
-	_RamWrite(	i++,	0); // Workspace
-	_RamWrite(	i++,	0);
-	_RamWrite(	i++,	0);
-	_RamWrite(	i++,	0);
-	_RamWrite(	i++,	0);
-	_RamWrite(	i++,	0);
-	_RamWrite(	i++,	0x80);                  // Addr of the Sector Buffer
-	_RamWrite(	i++,	0);
-	_RamWrite(	i++,	LOW_REGISTER(DPBaddr)); // Addr of the DPB Disk Parameter Block
-	_RamWrite(	i++,	HIGH_REGISTER(DPBaddr));
-	_RamWrite(	i++,	0);                     // Addr of the Directory Checksum Vector
-	_RamWrite(	i++,	0);
-	_RamWrite(	i++,	0);                     // Addr of the Allocation Vector
-	_RamWrite(	i++,	0);
+    // **********  Patch CP/M (fake) Disk Parameter Header after the Disk Parameter Block  **********
+    _RamWrite(i++, 0); // Addr of the sector translation table
+    _RamWrite(i++, 0);
+    _RamWrite(i++, 0); // Workspace
+    _RamWrite(i++, 0);
+    _RamWrite(i++, 0);
+    _RamWrite(i++, 0);
+    _RamWrite(i++, 0);
+    _RamWrite(i++, 0);
+    _RamWrite(i++, 0x80); // Addr of the Sector Buffer
+    _RamWrite(i++, 0);
+    _RamWrite(i++, LOW_REGISTER(DPBaddr)); // Addr of the DPB Disk Parameter Block
+    _RamWrite(i++, HIGH_REGISTER(DPBaddr));
+    _RamWrite(i++, 0); // Addr of the Directory Checksum Vector
+    _RamWrite(i++, 0);
+    _RamWrite(i++, 0); // Addr of the Allocation Vector
+    _RamWrite(i++, 0);
 
-	//
+    //
 
-	// figure out the number of the first allocation block
-	// after the directory for the phoney allocation block
-	// list in _findnext()
-	firstBlockAfterDir = 0;
-	i = 0x80;
+    // figure out the number of the first allocation block
+    // after the directory for the phoney allocation block
+    // list in _findnext()
+    firstBlockAfterDir = 0;
+    i = 0x80;
 
-	while (_RamRead(DPBaddr + 9) & i) {
-		firstBlockAfterDir++;
-		i >>= 1;
-	}
-	if (_RamRead(DPBaddr + 9) == 0xFF) {
-		i = 0x80;
+    while (_RamRead(DPBaddr + 9) & i) {
+        firstBlockAfterDir++;
+        i >>= 1;
+    }
+    if (_RamRead(DPBaddr + 9) == 0xFF) {
+        i = 0x80;
 
-		while (_RamRead(DPBaddr + 10) & i) {
-			firstBlockAfterDir++;
-			i >>= 1;
-		}
-	}
-	physicalExtentBytes = logicalExtentBytes * (extentMask + 1);
+        while (_RamRead(DPBaddr + 10) & i) {
+            firstBlockAfterDir++;
+            i >>= 1;
+        }
+    }
+    physicalExtentBytes = logicalExtentBytes * (extentMask + 1);
 } // _PatchCPM
 
 #ifdef DEBUGLOG
-uint8 LogBuffer[128];
+RUNCPM_DECL uint8 LogBuffer[128];
 
 RUNCPM_DECL void _logRegs(void) {
-	uint8 J, I;
-	uint8 Flags[9] = {'S', 'Z', '5', 'H', '3', 'P', 'N', 'C'};
-	uint8 c = HIGH_REGISTER(AF);
+    uint8 J, I;
+    uint8 Flags[9] = {'S', 'Z', '5', 'H', '3', 'P', 'N', 'C'};
+    uint8 c = HIGH_REGISTER(AF);
 
-	if ((c < 32) || (c > 126)) {
-		c = 46;
-	}
+    if ((c < 32) || (c > 126))
+        c = 46;
 
-	for (J = 0, I = LOW_REGISTER(AF); J < 8; ++J, I <<= 1) {
-		Flags[J] = I & 0x80 ? Flags[J] : '.';
-	}
-	sprintf((char *)LogBuffer, "  BC:%04x DE:%04x HL:%04x AF:%02x(%c)|%s| IX:%04x IY:%04x SP:%04x PC:%04x\r\n",
-			WORD16(BC), WORD16(DE), WORD16(HL), HIGH_REGISTER(AF), c, Flags, WORD16(IX), WORD16(IY), WORD16(SP), WORD16(PC));
-	_sys_logbuffer(LogBuffer);
+    for (J = 0, I = LOW_REGISTER(AF); J < 8; ++J, I <<= 1)
+        Flags[J] = I & 0x80 ? Flags[J] : '.';
+    sprintf((char *)LogBuffer, "  BC:%04x DE:%04x HL:%04x AF:%02x(%c)|%s| IX:%04x IY:%04x SP:%04x PC:%04x\n",
+            WORD16(BC), WORD16(DE), WORD16(HL), HIGH_REGISTER(AF), c, Flags, WORD16(IX), WORD16(IY), WORD16(SP), WORD16(PC));
+    _sys_logbuffer(LogBuffer);
 } // _logRegs
 
-RUNCPM_DECL void _logMem(uint16 address, uint8 amount) {    // Amount = number of 16 bytes lines, so 1 CP/M block = 8, not 128
-	uint8 i, m, c, pos;
-	uint8 head = 8;
-	uint8 hexa[] = "0123456789ABCDEF";
+RUNCPM_DECL void _logMem(uint16 address, uint8 amount) { // Amount = number of 16 bytes lines, so 1 CP/M block = 8, not 128
+    uint8 i, m, c, pos;
+    uint8 head = 8;
+    uint8 hexa[] = "0123456789ABCDEF";
 
-	for (i = 0; i < amount; ++i) {
-		pos = 0;
+    for (i = 0; i < amount; ++i) {
+        pos = 0;
 
-		for (m = 0; m < head; ++m) {
-			LogBuffer[pos++] = ' ';
-		}
-		sprintf((char *)LogBuffer, "  %04x: ", address);
+        for (m = 0; m < head; ++m)
+            LogBuffer[pos++] = ' ';
+        sprintf((char *)LogBuffer, "  %04x: ", address);
 
-		for (m = 0; m < 16; ++m) {
-			c = _RamRead(address++);
-			LogBuffer[pos++] = hexa[c >> 4];
-			LogBuffer[pos++] = hexa[c & 0x0f];
-			LogBuffer[pos++] = ' ';
-			LogBuffer[m + head + 48] = c > 31 && c < 127 ? c : '.';
-		}
-		pos += 16;
-		LogBuffer[pos++] = 0x0a;
-		LogBuffer[pos++] = 0x00;
-		_sys_logbuffer(LogBuffer);
-	}
+        for (m = 0; m < 16; ++m) {
+            c = _RamRead(address++);
+            LogBuffer[pos++] = hexa[c >> 4];
+            LogBuffer[pos++] = hexa[c & 0x0f];
+            LogBuffer[pos++] = ' ';
+            LogBuffer[m + head + 48] = c > 31 && c < 127 ? c : '.';
+        }
+        pos += 16;
+        LogBuffer[pos++] = 0x0a;
+        LogBuffer[pos++] = 0x00;
+        _sys_logbuffer(LogBuffer);
+    }
 } // _logMem
 
 RUNCPM_DECL void _logChar(char *txt, uint8 c) {
-	uint8 asc[2];
+    uint8 asc[2];
 
-	asc[0] = c > 31 && c < 127 ? c : '.';
-	asc[1] = 0;
-	sprintf((char *)LogBuffer, "        %s = %02xh:%3d (%s)\r\n", txt, c, c, asc);
-	_sys_logbuffer(LogBuffer);
+    asc[0] = c > 31 && c < 127 ? c : '.';
+    asc[1] = 0;
+    sprintf((char *)LogBuffer, "        %s = %02xh:%3d (%s)\n", txt, c, c, asc);
+    _sys_logbuffer(LogBuffer);
 } // _logChar
 
 RUNCPM_DECL void _logBiosIn(uint8 ch) {
-#ifdef LOGBIOS_NOT
-	if (ch == LOGBIOS_NOT) {
-		return;
-	}
-#endif // ifdef LOGBIOS_NOT
-#ifdef LOGBIOS_ONLY
-	if (ch != LOGBIOS_ONLY) {
-		return;
-	}
-#endif // ifdef LOGBIOS_ONLY
-	static const char *BIOSCalls[18] =
-	{
-		"boot", "wboot", "const", "conin", "conout", "list", "punch/aux", "reader", "home", "seldsk", "settrk", "setsec", "setdma",
-		"read", "write", "listst", "sectran", "altwboot"
-	};
-	int index = ch / 3;
+    #ifdef LOGBIOS_NOT
+    if (ch == LOGBIOS_NOT)
+        return;
+    #endif // ifdef LOGBIOS_NOT
+    #ifdef LOGBIOS_ONLY
+    if (ch != LOGBIOS_ONLY)
+        return;
+    #endif // ifdef LOGBIOS_ONLY
+    static const char *BIOSCalls[33] =
+        {
+            "boot", "wboot", "const", "conin", "conout", "list", "punch/aux", "reader", "home", "seldsk", "settrk", "setsec", "setdma",
+            "read", "write", "listst", "sectran", "conost", "auxist", "auxost", "devtbl", "devini", "drvtbl", "multio", "flush", "move",
+            "time", "selmem", "setbnk", "xmove", "userf", "reserv1", "reserv2"};
+    int index = ch / 3;
 
-	if (index < 18) {
-		sprintf((char *)LogBuffer, "\nBios call: %3d/%02xh (%s) IN:\r\n", ch, ch, BIOSCalls[index]);
-		_sys_logbuffer(LogBuffer);
-	} else {
-		sprintf((char *)LogBuffer, "\nBios call: %3d/%02xh IN:\r\n", ch, ch);
-		_sys_logbuffer(LogBuffer);
-	}
-	_logRegs();
+    if (index < 18) {
+        sprintf((char *)LogBuffer, "\nBios call: %3d/%02xh (%s) IN:\n", ch, ch, BIOSCalls[index]);
+        _sys_logbuffer(LogBuffer);
+    } else {
+        sprintf((char *)LogBuffer, "\nBios call: %3d/%02xh IN:\n", ch, ch);
+        _sys_logbuffer(LogBuffer);
+    }
+    _logRegs();
 } // _logBiosIn
 
 RUNCPM_DECL void _logBiosOut(uint8 ch) {
-#ifdef LOGBIOS_NOT
-	if (ch == LOGBIOS_NOT) {
-		return;
-	}
-#endif // ifdef LOGBIOS_NOT
-#ifdef LOGBIOS_ONLY
-	if (ch != LOGBIOS_ONLY) {
-		return;
-	}
-#endif // ifdef LOGBIOS_ONLY
-	sprintf((char *)LogBuffer, "               OUT:\r\n");
-	_sys_logbuffer(LogBuffer);
-	_logRegs();
+    #ifdef LOGBIOS_NOT
+    if (ch == LOGBIOS_NOT)
+        return;
+    #endif // ifdef LOGBIOS_NOT
+    #ifdef LOGBIOS_ONLY
+    if (ch != LOGBIOS_ONLY)
+        return;
+    #endif // ifdef LOGBIOS_ONLY
+    sprintf((char *)LogBuffer, "               OUT:\n");
+    _sys_logbuffer(LogBuffer);
+    _logRegs();
 } // _logBiosOut
 
 RUNCPM_DECL void _logBdosIn(uint8 ch) {
-#ifdef LOGBDOS_NOT
-	if (ch == LOGBDOS_NOT) {
-		return;
-	}
-#endif // ifdef LOGBDOS_NOT
-#ifdef LOGBDOS_ONLY
-	if (ch != LOGBDOS_ONLY) {
-		return;
-	}
-#endif // ifdef LOGBDOS_ONLY
-	uint16 address = 0;
-	uint8 size = 0;
+    #ifdef LOGBDOS_NOT
+    if (ch == LOGBDOS_NOT)
+        return;
+    #endif // ifdef LOGBDOS_NOT
+    #ifdef LOGBDOS_ONLY
+    if (ch != LOGBDOS_ONLY)
+        return;
+    #endif // ifdef LOGBDOS_ONLY
+    uint16 address = 0;
+    uint8 size = 0;
 
-	static const char *CPMCalls[41] =
-	{
-		"System Reset", "Console Input", "Console Output", "Reader Input", "Punch Output", "List Output", "Direct I/O",
-		"Get IOByte",
-		"Set IOByte", "Print String", "Read Buffered", "Console Status", "Get Version", "Reset Disk", "Select Disk", "Open File",
-		"Close File", "Search First", "Search Next", "Delete File", "Read Sequential", "Write Sequential", "Make File",
-		"Rename File",
-		"Get Login Vector", "Get Current Disk", "Set DMA Address", "Get Alloc", "Write Protect Disk", "Get R/O Vector",
-		"Set File Attr", "Get Disk Params",
-		"Get/Set User", "Read Random", "Write Random", "Get File Size", "Set Random Record", "Reset Drive", "N/A", "N/A",
-		"Write Random 0 fill"
-	};
+    static const char *CPMCalls[41] =
+        {
+            "System Reset", "Console Input", "Console Output", "Reader Input", "Punch Output", "List Output", "Direct I/O",
+            "Get IOByte", "Set IOByte", "Print String", "Read Buffered", "Console Status", "Get Version", "Reset Disk",
+            "Select Disk", "Open File", "Close File", "Search First", "Search Next", "Delete File", "Read Sequential",
+            "Write Sequential", "Make File", "Rename File", "Get Login Vector", "Get Current Disk", "Set DMA Address",
+            "Get Alloc", "Write Protect Disk", "Get R/O Vector", "Set File Attr", "Get Disk Params", "Get/Set User",
+            "Read Random", "Write Random", "Get File Size", "Set Random Record", "Reset Drive", "N/A", "N/A",
+            "Write Random 0 fill"};
 
-	if (ch < 41) {
-		sprintf((char *)LogBuffer, "\nBdos call: %3d/%02xh (%s) IN from 0x%04x:\r\n", ch, ch, CPMCalls[ch], _RamRead16(SP) - 3);
-		_sys_logbuffer(LogBuffer);
-	} else {
-		sprintf((char *)LogBuffer, "\nBdos call: %3d/%02xh IN from 0x%04x:\r\n", ch, ch, _RamRead16(SP) - 3);
-		_sys_logbuffer(LogBuffer);
-	}
-	_logRegs();
+    if (ch < 41) {
+        sprintf((char *)LogBuffer, "\nBdos call: %3d/%02xh (%s) IN from 0x%04x:\n", ch, ch, CPMCalls[ch], _RamRead16(SP) - 3);
+        _sys_logbuffer(LogBuffer);
+    } else {
+        sprintf((char *)LogBuffer, "\nBdos call: %3d/%02xh IN from 0x%04x:\n", ch, ch, _RamRead16(SP) - 3);
+        _sys_logbuffer(LogBuffer);
+    }
+    _logRegs();
 
-	switch (ch) {
-		case 2:
-		case 4:
-		case 5:
-		case 6: {
-			_logChar("E", LOW_REGISTER(DE));
-			break;
-		}
+    switch (ch) {
+    case 2:
+    case 4:
+    case 5:
+    case 6: {
+        _logChar("E", LOW_REGISTER(DE));
+        break;
+    }
 
-		case 9:
-		case 10: {
-			address = DE;
-			size = 8;
-			break;
-		}
+    case 9:
+    case 10: {
+        address = DE;
+        size = 8;
+        break;
+    }
 
-		case 15:
-		case 16:
-		case 17:
-		case 18:
-		case 19:
-		case 22:
-		case 23:
-		case 30:
-		case 35:
-		case 36: {
-			address = DE;
-			size = 3;
-			break;
-		}
+    case 15:
+    case 16:
+    case 17:
+    case 18:
+    case 19:
+    case 22:
+    case 23:
+    case 30:
+    case 35:
+    case 36: {
+        address = DE;
+        size = 3;
+        break;
+    }
 
-		case 20:
-		case 21:
-		case 33:
-		case 34:
-		case 40: {
-			address = DE;
-			size = 3;
-			_logMem(address, size);
-			sprintf((char *)LogBuffer, "\r\n");
-			_sys_logbuffer(LogBuffer);
-			address = dmaAddr;
-			size = 8;
-			break;
-		}
+    case 20:
+    case 21:
+    case 33:
+    case 34:
+    case 40: {
+        address = DE;
+        size = 3;
+        _logMem(address, size);
+        sprintf((char *)LogBuffer, "\n");
+        _sys_logbuffer(LogBuffer);
+        address = dmaAddr;
+        size = 8;
+        break;
+    }
 
-		default: {
-			break;
-		}
-	} // switch
-	if (size) {
-		_logMem(address, size);
-	}
+    default: {
+        break;
+    }
+    } // switch
+    if (size)
+        _logMem(address, size);
 } // _logBdosIn
 
 RUNCPM_DECL void _logBdosOut(uint8 ch) {
-#ifdef LOGBDOS_NOT
-	if (ch == LOGBDOS_NOT) {
-		return;
-	}
-#endif // ifdef LOGBDOS_NOT
-#ifdef LOGBDOS_ONLY
-	if (ch != LOGBDOS_ONLY) {
-		return;
-	}
-#endif // ifdef LOGBDOS_ONLY
-	uint16 address = 0;
-	uint8 size = 0;
+    #ifdef LOGBDOS_NOT
+    if (ch == LOGBDOS_NOT)
+        return;
+    #endif // ifdef LOGBDOS_NOT
+    #ifdef LOGBDOS_ONLY
+    if (ch != LOGBDOS_ONLY)
+        return;
+    #endif // ifdef LOGBDOS_ONLY
+    uint16 address = 0;
+    uint8 size = 0;
 
-	sprintf((char *)LogBuffer, "              OUT:\r\n");
-	_sys_logbuffer(LogBuffer);
-	_logRegs();
+    sprintf((char *)LogBuffer, "              OUT:\n");
+    _sys_logbuffer(LogBuffer);
+    _logRegs();
 
-	switch (ch) {
-		case 1:
-		case 3:
-		case 6: {
-			_logChar("A", HIGH_REGISTER(AF));
-			break;
-		}
+    switch (ch) {
+    case 1:
+    case 3:
+    case 6: {
+        _logChar("A", HIGH_REGISTER(AF));
+        break;
+    }
 
-		case 10: {
-			address = DE;
-			size = 8;
-			break;
-		}
+    case 10: {
+        address = DE;
+        size = 8;
+        break;
+    }
 
-		case 20:
-		case 21:
-		case 33:
-		case 34:
-		case 40: {
-			address = DE;
-			size = 3;
-			_logMem(address, size);
-			sprintf((char *)LogBuffer, "\r\n");
-			_sys_logbuffer(LogBuffer);
-			address = dmaAddr;
-			size = 8;
-			break;
-		}
+    case 20:
+    case 21:
+    case 33:
+    case 34:
+    case 40: {
+        address = DE;
+        size = 3;
+        _logMem(address, size);
+        sprintf((char *)LogBuffer, "\n");
+        _sys_logbuffer(LogBuffer);
+        address = dmaAddr;
+        size = 8;
+        break;
+    }
 
-		case 26: {
-			address = dmaAddr;
-			size = 8;
-			break;
-		}
+    case 26: {
+        address = dmaAddr;
+        size = 8;
+        break;
+    }
 
-		case 35:
-		case 36: {
-			address = DE;
-			size = 3;
-			break;
-		}
+    case 15:
+    case 16:
+    case 17:
+    case 18:
+    case 19:
+    case 22:
+    case 23:
+    case 30:
+    case 35:
+    case 36: {
+        address = DE;
+        size = 3;
+        break;
+    }
 
-		default: {
-			break;
-		}
-	} // switch
-	if (size) {
-		_logMem(address, size);
-	}
+    default: {
+        break;
+    }
+    } // switch
+    if (size)
+        _logMem(address, size);
 } // _logBdosOut
 #endif // ifdef DEBUGLOG
 
 RUNCPM_DECL void _Bios(void) {
-	uint8 ch = LOW_REGISTER(PCX);
-	uint8 disk[2] = {'A', 0};
+    uint8 ch = LOW_REGISTER(PCX);
+    uint8 disk[2] = {'A', 0};
 
 #ifdef DEBUGLOG
-	_logBiosIn(ch);
+    _logBiosIn(ch);
 #endif
 
-	switch (ch) {
-		case 0x00: {
-			Status = 1; // 0 - BOOT - Ends RunCPM
-			break;
-		}
-
-		case 0x03: {
-			Status = 2; // 1 - WBOOT - Back to CCP
-			break;
-		}
-
-		case 0x06: {    // 2 - CONST - Console status
-			SET_HIGH_REGISTER(AF, _chready());
-			break;
-		}
-
-		case 0x09: {    // 3 - CONIN - Console input
-			SET_HIGH_REGISTER(AF, _getch());
+    switch (ch) {
+    case B_BOOT: {
+        Status = STATUS_EXIT; // 0 - Ends RunCPM
+        break;
+    }
+    case B_WBOOT: {
+        Status = STATUS_RESTART; // 1 - Back to CCP
+        break;
+    }
+    case B_CONST: { // 2 - Console status
+        SET_HIGH_REGISTER(AF, _chready());
+        break;
+    }
+    case B_CONIN: { // 3 - Console input
+        SET_HIGH_REGISTER(AF, _getcon());
 #ifdef DEBUG
-			if (HIGH_REGISTER(AF) == 4) {
-				Debug = 0;
-			}
+        if (HIGH_REGISTER(AF) == DEBUGKEY)
+            Debug = 1;
 #endif // ifdef DEBUG
-			break;
-		}
-
-		case 0x0C: {    // 4 - CONOUT - Console output
-			_putcon(LOW_REGISTER(BC));
-			break;
-		}
-
-		case 0x0F: {    // 5 - LIST - List output
-			break;
-		}
-
-		case 0x12: {    // 6 - PUNCH/AUXOUT - Punch output
-			break;
-		}
-
-		case 0x15: {    // 7 - READER - Reader input (0x1a = device not implemented)
-			SET_HIGH_REGISTER(AF, 0x1a);
-			break;
-		}
-
-		case 0x18: {    // 8 - HOME - Home disk head
-			break;
-		}
-
-		case 0x1B: {    // 9 - SELDSK - Select disk drive
-			disk[0] += LOW_REGISTER(BC);
-			if (_sys_select(&disk[0])) {
-				HL = DPHaddr;
-			} else {
-				HL = 0x0000;
-			}
-			break;
-		}
-
-		case 0x1E: {    // 10 - SETTRK - Set track number
-			break;
-		}
-
-		case 0x21: {    // 11 - SETSEC - Set sector number
-			break;
-		}
-
-		case 0x24: {    // 12 - SETDMA - Set DMA address
-			HL = BC;
-			dmaAddr = BC;
-			break;
-		}
-
-		case 0x27: {    // 13 - READ - Read selected sector
-			SET_HIGH_REGISTER(AF, 0x00);
-			break;
-		}
-
-		case 0x2A: {    // 14 - WRITE - Write selected sector
-			SET_HIGH_REGISTER(AF, 0x00);
-			break;
-		}
-
-		case 0x2D: {    // 15 - LISTST - Get list device status
-			SET_HIGH_REGISTER(AF, 0x0ff);
-			break;
-		}
-
-		case 0x30: {    // 16 - SECTRAN - Sector translate
-			HL = BC;    // HL=BC=No translation (1:1)
-			break;
-		}
-
-		case 0x33: {    // 17 - RETTOCCP - This allows programs ending in RET return to internal CCP
-			Status = 3;
-			break;
-		}
-
-		default: {
-#ifdef DEBUG    // Show unimplemented BIOS calls only when debugging
-			_puts(	"\r\nUnimplemented BIOS call.\r\n");
-			_puts(	"C = 0x");
-			_puthex8(ch);
-			_puts("\r\n");
+        break;
+    }
+    case B_CONOUT: { // 4 - Console output
+        _putcon(LOW_REGISTER(BC));
+        break;
+    }
+    case B_LIST: { // 5 - List output
+        break;
+    }
+    case B_AUXOUT: { // 6 - Aux/Punch output
+        break;
+    }
+    case B_READER: { // 7 - Reader input (returns 0x1a = device not implemented)
+        SET_HIGH_REGISTER(AF, 0x1a);
+        break;
+    }
+    case B_HOME: { // 8 - Home disk head
+        break;
+    }
+    case B_SELDSK: { // 9 - Select disk drive
+        disk[0] += LOW_REGISTER(BC);
+        HL = 0x0000;
+        if (_sys_select(&disk[0]))
+            HL = DPHaddr;
+        break;
+    }
+    case B_SETTRK: { // 10 - Set track number
+        break;
+    }
+    case B_SETSEC: { // 11 - Set sector number
+        break;
+    }
+    case B_SETDMA: { // 12 - Set DMA address
+        HL = BC;
+        dmaAddr = BC;
+        break;
+    }
+    case B_READ: { // 13 - Read selected sector
+        SET_HIGH_REGISTER(AF, 0x00);
+        break;
+    }
+    case B_WRITE: { // 14 - Write selected sector
+        SET_HIGH_REGISTER(AF, 0x00);
+        break;
+    }
+    case B_LISTST: { // 15 - Get list device status
+        SET_HIGH_REGISTER(AF, 0x0ff);
+        break;
+    }
+    case B_SECTRAN: { // 16 - Sector translate
+        HL = BC;      // HL=BC=No translation (1:1)
+        break;
+    }
+    case B_CONOST: { // 17 - Return status of current screen output device
+        SET_HIGH_REGISTER(AF, 0x0ff);
+        break;
+    }
+    case B_AUXIST: { // 18 - Return status of current auxiliary input device
+        SET_HIGH_REGISTER(AF, 0x00);
+        break;
+    }
+    case B_AUXOST: { // 19 - Return status of current auxiliary output device
+        SET_HIGH_REGISTER(AF, 0x00);
+        break;
+    }
+    case B_DEVTBL: { // 20 - Return the address of the devices table, or 0 if not implemented
+        HL = 0x0000;
+        break;
+    }
+    case B_DEVINI: { // 21 - Reinitialise character device number C
+        break;
+    }
+    case B_DRVTBL: { // 22 - Return the address of the drive table
+        HL = 0x0FFFF;
+        break;
+    }
+    case B_MULTIO: { // 23 - Notify the BIOS of multi sector transfer
+        break;
+    }
+    case B_FLUSH: { // 24 - Write any pending data to disc
+        SET_HIGH_REGISTER(AF, 0x00);
+        break;
+    }
+    case B_MOVE: { // 25 - Move a block of memory
+        if (!isXmove) {
+            srcBank = dstBank = curBank;
+            srcBankBase = dstBankBase = curBankBase;
+        }
+        while (BC--)
+            RAM[dstBankBase + HL++] = RAM[srcBankBase + DE++];
+        isXmove = FALSE;
+        break;
+    }
+    case B_TIME: { // 26 - Get/Set SCB time
+        break;
+    }
+    case B_SELMEM: { // 27 - Select memory bank
+        curBank = HIGH_REGISTER(AF);
+        curBankBase = ((uint32)curBank) << 16; // banks are 0-based: bank N -> RAM offset N*64K
+        break;
+    }
+    case B_SETBNK: { // 28 - Set the bank to be used for the next read/write sector operation
+        ioBank = HIGH_REGISTER(AF);
+        ioBankBase = ((uint32)ioBank) << 16;
+        break; // without this, SETBNK fell through into XMOVE and corrupted srcBank/dstBank/isXmove
+    }
+    case B_XMOVE: { // 29 - Preload banks for MOVE
+        srcBank = LOW_REGISTER(BC);
+        dstBank = HIGH_REGISTER(BC);
+        srcBankBase = ((uint32)srcBank) << 16;
+        dstBankBase = ((uint32)dstBank) << 16;
+        isXmove = TRUE;
+        break;
+    }
+    case B_USERF: { // 30 - This allows programs ending in RET return to internal CCP
+        Status = STATUS_RETURN;
+        break;
+    }
+    case B_RESERV1:
+    case B_RESERV2: {
+        break;
+    }
+    default: {
+#ifdef DEBUG // Show unimplemented BIOS calls only when debugging
+        _puts("\r\nUnimplemented BIOS call.\r\n");
+        _puts("C = 0x");
+        _puthex8(ch);
+        _puts("\r\n");
 #endif // ifdef DEBUG
-			break;
-		}
-	} // switch
+        break;
+    }
+    } // switch
 #ifdef DEBUGLOG
-	_logBiosOut(ch);
+    _logBiosOut(ch);
 #endif
 } // _Bios
 
-RUNCPM_DECL void _Bdos(void) {
-	uint16 i;
-	uint8 j, chr, ch = LOW_REGISTER(BC);
-	uint8 trans_ch = 0x9b;
+/* Packed BCD helpers for the CP/M 3 clock (BDOS 104/105) */
+#define BCD2DEC(b) ((((b) >> 4) & 0x0F) * 10 + ((b) & 0x0F))
+#define DEC2BCD(d) ((uint8)((((d) / 10) << 4) | ((d) % 10)))
 
-	(void)trans_ch;
+/* Difference (in seconds) between the host clock and the clock set via
+   BDOS 104 (T_SET). Lets a set time round-trip through BDOS 105 (T_GET). */
+static long clockOffset = 0;
+
+/* Program return code, get/set via BDOS 108 (P_CODE). */
+static uint16 programRetCode = 0;
+
+/* Console mode word, get/set via BDOS 109 (C_MODE). RunCPM's console layer is
+   already raw (no ^S pause, no tab expansion, no ^C termination, no ^P echo),
+   so most "disable" bits are effectively always on. Bits 8-9 are honored by
+   function 11 (Get console status). */
+static uint16 consoleMode = 0;
+
+RUNCPM_DECL void _Bdos(void) {
+    uint8 ch = LOW_REGISTER(BC);
+    uint8 trans_ch = 0x9b; // FujiNet vendoring: CR->ATASCII EOL for printer (C=5)
+    (void)trans_ch;
 
 #ifdef DEBUGLOG
-	_logBdosIn(ch);
+    _logBdosIn(ch);
 #endif
 
-	HL = 0x0000;                            // HL is reset by the BDOS
-	SET_LOW_REGISTER(BC, LOW_REGISTER(DE)); // C ends up equal to E
+    HL = 0x0000;                            // HL is reset by the BDOS
+    SET_LOW_REGISTER(BC, LOW_REGISTER(DE)); // C ends up equal to E
 
-	switch (ch) {
-		/*
-		   C = 0 : System reset
-		   Doesn't return. Reloads CP/M
-		 */
-		case F_BOOT: {
-			Status = 2; // Same as call to "BOOT"
-			break;
-		}
+    switch (ch) {
+#ifndef ABDOS
+    /*
+       C = 0 : System reset
+       Doesn't return. Reloads CP/M
+     */
+    case P_TERMCPM: {
+        Status = STATUS_RESTART; // Same as call to "BOOT"
+        break;
+    }
 
-		/*
-		   C = 1 : Console input
-		   Gets a char from the console
-		   Returns: A=Char
-		 */
-		case C_READ: {
-			HL = _getche();
-#ifdef DEBUG
-			if (HL == 4) {
-				Debug = 1;
-			}
-#endif // ifdef DEBUG
-			break;
-		}
+    /*
+       C = 1 : Console input
+       Gets a char from the console
+       Returns: A=Char
+     */
+    case C_READ: {
+        HL = _getconE();
+    #ifdef DEBUG
+        if (HL == DEBUGKEY)
+            Debug = 1;
+    #endif // ifdef DEBUG
+        break;
+    }
 
-		/*
-		   C = 2 : Console output
-		   E = Char
-		   Sends the char in E to the console
-		 */
-		case C_WRITE: {
-			_putcon(LOW_REGISTER(DE));
-			break;
-		}
+    /*
+       C = 2 : Console output
+       E = Char
+       Sends the char in E to the console
+     */
+    case C_WRITE: {
+        _putcon(LOW_REGISTER(DE));
+        break;
+    }
 
-		/*
-		   C = 3 : Auxiliary (Reader) input
-		   Returns: A=Char
-		 */
-		case READER_IN: {
-			HL = 0x1a;
-			break;
-		}
+    /*
+       C = 3 : Auxiliary (Reader) input
+       Returns: A=Char
+     */
+    case A_READ: {
+        HL = 0x1a;
+        break;
+    }
 
-		/*
-		   C = 4 : Auxiliary (Punch) output
-		 */
-		case PUNCH_OUT: {
-#ifdef USE_PUN
-			if (!pun_open) {
-				pun_dev = _sys_fopen_w((uint8 *)pun_file);
-				pun_open = TRUE;
-			}
-			if (pun_dev) {
-				_sys_fputc(LOW_REGISTER(DE), pun_dev);
-			}
-#endif // ifdef USE_PUN
-			break;
-		}
+    /*
+       C = 4 : Auxiliary (Punch) output
+     */
+    case A_WRITE: {
+    #ifdef USE_PUN
+        if (!pun_open) {
+            pun_dev = _sys_fopen_w((uint8 *)pun_file);
+            pun_open = TRUE;
+        }
+        if (pun_dev) {
+            _sys_fputc(LOW_REGISTER(DE), pun_dev);
+        }
+    #endif // ifdef USE_PUN
+        break;
+    }
 
-		/*
-		   C = 5 : Printer output
-		 */
-		case PRINT_OUT: {
-#ifdef BUILD_ATARI
-			if (LOW_REGISTER(DE) != 0x0A)
-			{
-				trans_ch = LOW_REGISTER(DE) == 0x0D ? 0x9B : LOW_REGISTER(DE);
-				SYSTEM_BUS.getPrinter()->print_from_cpm(LOW_REGISTER(DE));
-			}
-#endif /* BUILD_ATARI */
-#ifdef BUILD_APPLE
-			SYSTEM_BUS.getPrinter()->print_from_cpm(LOW_REGISTER(DE));
-#endif /* BUILD_APPLE */
-#ifdef USE_LST
-			if (!lst_open) {
-				lst_dev = _sys_fopen_w((uint8 *)lst_file);
-				lst_open = TRUE;
-			}
-			if (lst_dev) {
-				_sys_fputc(LOW_REGISTER(DE), lst_dev);
-			}
-#endif // ifdef USE_LST
-			break;
-		}
+    /*
+       C = 5 : Printer output
+     */
+    case L_WRITE: {
+    /* FujiNet vendoring: route CP/M printer output to the FujiNet device
+       printer. On Atari, translate CR (0x0D) to ATASCII EOL (0x9B) and drop
+       LF (0x0A); on Apple, pass through unchanged. */
+    #ifdef BUILD_ATARI
+        if (LOW_REGISTER(DE) != 0x0A) {
+            trans_ch = LOW_REGISTER(DE) == 0x0D ? 0x9B : LOW_REGISTER(DE);
+            SYSTEM_BUS.getPrinter()->print_from_cpm(LOW_REGISTER(DE));
+        }
+    #endif /* BUILD_ATARI */
+    #ifdef BUILD_APPLE
+        SYSTEM_BUS.getPrinter()->print_from_cpm(LOW_REGISTER(DE));
+    #endif /* BUILD_APPLE */
+    #ifdef USE_LST
+        if (!lst_open) {
+            lst_dev = _sys_fopen_w((uint8 *)lst_file);
+            lst_open = TRUE;
+        }
+        if (lst_dev)
+            _sys_fputc(LOW_REGISTER(DE), lst_dev);
+    #endif // ifdef USE_LST
+        break;
+    }
 
-		/*
-		   C = 6 : Direct console IO
-		   E = 0xFF : Checks for char available and returns it, or 0x00 if none (read)
-		   E = char : Outputs char (write)
-		   Returns: A=Char or 0x00 (on read)
-		 */
-		case DIRECT_IO: {
-			if (LOW_REGISTER(DE) == 0xff) {
-				HL = _getchNB();
-#ifdef DEBUG
-				if (HL == 4) {
-					Debug = 1;
-				}
-#endif // ifdef DEBUG
-			} else {
-				_putcon(LOW_REGISTER(DE));
-			}
-			break;
-		}
+    /*
+       C = 6 : Direct console IO
+       E = 0xFF : Checks for char available and returns it, or 0x00 if none (read)
+       E = 0xFE : Return console input status. Zero if no character is waiting, nonzero otherwise. (CPM3)
+       E = 0xFD : Wait until a character is ready, return it without echoing. (CPM3)
+       E = char : Outputs char (write)
+       Returns: A=Char or 0x00 (on read)
+     */
+    case C_RAWIO: {
+        uint8 e = LOW_REGISTER(DE);
+        if (e == 0xFF) {
+            // Check for char available and return it, or 0x00 if none (non-blocking read)
+            HL = _getconNB();
+    #ifdef DEBUG
+            if (HL == DEBUGKEY)
+                Debug = 1;
+    #endif // ifdef DEBUG
+    #ifdef CPM3
+        } else if (e == 0xFE) {
+            // Return console input status. Zero if no character is waiting, nonzero otherwise. (CPM3)
+            HL = _chready() ? 0x00FF : 0x0000;
+        } else if (e == 0xFD) {
+            // Wait until a character is ready, return it without echoing. (CPM3)
+            HL = _getcon();
+    #ifdef DEBUG
+            if (HL == DEBUGKEY)
+                Debug = 1;
+    #endif // ifdef DEBUG
+    #endif // ifdef CPM3
+        } else {
+            // E = char : Outputs char (write)
+            _putcon(e);
+        }
+        break;
+    }
 
-		/*
-		   C = 7 : Get IOBYTE
-		   Gets the system IOBYTE
-		   Returns: A = IOBYTE
-		 */
-		case GET_IOBYTE: {
-			HL = _RamRead(0x0003);
-			break;
-		}
+    /*
+       C = 7 : Get IOBYTE (CPM2)
+       Gets the system IOBYTE
+       Returns: A = IOBYTE (CPM2)
+       C = 7 : Auxiliary Input status (CPM3)
+       0FFh is returned if the Auxiliary Input device has a character ready; otherwise 0 is returned.
+       Returns: A=0 or 0FFh (CPM3)
+     */
+    case A_STATIN: {
+        #ifdef CPM3
+            HL = _chready() ? 0xFF : 0x00;
+        #else
+            HL = _RamRead(0x0003);
+        #endif
+        break;
+    }
 
-		/*
-		   C = 8 : Set IOBYTE
-		   E = IOBYTE
-		   Sets the system IOBYTE to E
-		 */
-		case SET_IOBYTE: {
-			_RamWrite(0x0003, LOW_REGISTER(DE));
-			break;
-		}
+    /*
+       C = 8 : Set IOBYTE (CPM2)
+       E = IOBYTE
+       Sets the system IOBYTE to E
+       C = 8 : Auxiliary Output status (CPM3)
+       0FFh is returned if the Auxiliary Output device is ready for characters; otherwise 0 is returned.
+       Returns: A=0 or 0FFh (CPM3)
+     */
+    case A_STATOUT: {
+        #ifdef CPM3
+            HL = 0xFF; // Auxiliary Output device is always ready
+        #else
+            _RamWrite(0x0003, LOW_REGISTER(DE));
+        #endif
+        break;
+    }
 
-		/*
-		   C = 9 : Output string
-		   DE = Address of string
-		   Sends the $ terminated string pointed by (DE) to the screen
-		 */
-		case OUT_STRING: {
-			while ((ch = _RamRead(DE++)) != '$') {
-				_putcon(ch);
-			}
-			break;
-		}
+    /*
+       C = 9 : Output string
+       DE = Address of string
+       Sends the $ terminated string pointed by (DE) to the screen
+       Under CP/M 3 the termination character can be changed by the user via BDOS call 110 (C_DELIMIT).
+     */
+    case C_WRITESTR: {
+        uint8 delim = outputDelimiter;
+        while ((ch = _RamRead(DE++)) != delim)
+            _putcon(ch);
+        break;
+    }
 
-		/*
-		   C = 10 (0Ah) : Buffered input
-		   DE = Address of buffer
-		   Reads (DE) bytes from the console
-		   Returns: A = Number os chars read
-		   DE) = First char
-		 */
-		case C_READSTR: {
-            uint16 chrsMaxIdx = WORD16(DE);                 //index to max number of characters
-            uint16 chrsCntIdx = (chrsMaxIdx + 1) & 0xFFFF;  //index to number of characters read
-            uint16 chrsIdx = (chrsCntIdx + 1) & 0xFFFF;     //index to characters
-            //printf("\n\r chrsMaxIdx: %0X, chrsCntIdx: %0X", chrsMaxIdx, chrsCntIdx);
+    /*
+       C = 10 (0Ah) : Buffered input
+       CP/M 2: 
+        DE = Address of buffer
+       CP/M 3:
+        DE = Address of buffer
+        DE = 0 Use DMA address abd the buffer already contains data
+            if DE=address:
+                buffer: DEFB    size
+                        DEFB    ?
+                        DEFB    bytes
+            if DE=0:
+                buffer: DEFB    size
+                        DEFB    len
+                        DEFB    bytes
 
-            static uint8 *last = 0;
-            if (!last) {
-                last = (uint8 *)calloc(1, 256);    //allocate one (for now!)
+            Reads (DE) bytes from the console
+       Returns: A = Number of chars read
+       DE) = First char
+     */
+    case C_READSTR: {
+        uint16 i;
+        uint8 j, chr;
+        // Under CP/M3 DE==0 means use the DMA buffer. Compute a common base address
+        // so the rest of the code can operate on either DE-provided buffer or DMA.
+        uint16 bufBase = (WORD16(DE) == 0) ? dmaAddr : WORD16(DE);
+        uint16 chrsMaxIdx = bufBase;                // index to max number of characters
+        uint16 chrsCntIdx = (chrsMaxIdx + 1) & 0xFFFF; // index to number of characters read
+        uint16 chrsIdx = (chrsCntIdx + 1) & 0xFFFF;    // index to characters
+        // printf("\n\r chrsMaxIdx: %0X, chrsCntIdx: %0X", chrsMaxIdx, chrsCntIdx);
+
+        static uint8 *last = 0;
+        if (!last)
+            last = (uint8 *)calloc(1, 256); // allocate one (for now!)
+
+    #ifdef PROFILE
+        if (time_start != 0) {
+            time_now = millis();
+            printf(" (%ld)\n", time_now - time_start);
+            time_start = 0;
+        }
+    #endif                                    // ifdef PROFILE
+        uint8 chrsMax = _RamRead(chrsMaxIdx); // Gets the max number of characters that can be read
+        uint8 chrsCnt = 0;                    // this is the number of characters read
+    #ifdef CPM3
+        // CP/M3 behaviour: if DE==0 the DMA buffer may already contain data
+        // Layout when DE==0: [size][len][bytes...]
+        if (WORD16(DE) == 0) {
+            uint8 existingLen = _RamRead(chrsCntIdx);
+            if (existingLen) { // buffer already contains data, return immediately
+                HL = existingLen;
+                break;
+            }
+            // otherwise fall through and fill the DMA buffer interactively
+        }
+    #endif // ifdef CPM3
+        uint8 curCol = 0;                     // this is the cursor column (relative to where it started)
+
+        while (chrsMax) {
+            // pre-backspace, retype & post backspace counts
+            uint8 preBS = 0, reType = 0, postBS = 0;
+
+            chr = _getcon(); // input a character
+
+            if (chr == 1) { // ^A - Move cursor one character to the left
+                if (curCol > 0) {
+                    preBS++; // backspace one
+                } else {
+                    _putcon('\007'); // ring the bell
+                }
             }
 
-#ifdef PROFILE
-			if (time_start != 0) {
-				time_now = millis();
-				printf(": %ld\r\n", time_now - time_start);
-				time_start = 0;
-			}
-#endif // ifdef PROFILE
-            uint8 chrsMax = _RamRead(chrsMaxIdx);   // Gets the max number of characters that can be read
-            uint8 chrsCnt = 0;                      // this is the number of characters read
-            uint8 curCol = 0;                       //this is the cursor column (relative to where it started)
+            if (chr == 2) { // ^B - Toggle between beginning & end of line
+                if (curCol) {
+                    preBS = curCol; // move to beginning
+                } else {
+                    reType = chrsCnt - curCol; // move to EOL
+                }
+            }
 
-            while (chrsMax) {
-                // pre-backspace, retype & post backspace counts
-                uint8 preBS = 0, reType = 0, postBS = 0;
+            if ((chr == 3) && (chrsCnt == 0)) { // ^C - Abort string input
+                _puts("^C");
+                Status = STATUS_RESTART;
+                break;
+            }
 
-                chr = _getch(); //input a character
+    #ifdef DEBUG
+            if (chr == DEBUGKEY) { // Enter debugger
+                Debug = 1;
+                break;
+            }
+    #endif // ifdef DEBUG
 
-                if (chr == 1) {                             // ^A - Move cursor one character to the left
-                    if (curCol > 0) {
-                        preBS++;            //backspace one
-                    } else {
-                        _putcon('\007');    //ring the bell
+            if (chr == 5) { // ^E - goto beginning of next line
+                _putcon('\n');
+                preBS = curCol;
+                reType = postBS = chrsCnt;
+            }
+
+            if (chr == 6) { // ^F - Move the cursor one character forward
+                if (curCol < chrsCnt) {
+                    reType++;
+                } else {
+                    _putcon('\007'); // ring the bell
+                }
+            }
+
+            if (chr == 7) { // ^G - Delete character at cursor
+                if (curCol < chrsCnt) {
+                    // delete this character from buffer
+                    for (i = curCol, j = i + 1; j < chrsCnt; i++, j++) {
+                        ch = _RamRead(((chrsIdx + j) & 0xFFFF));
+                        _RamWrite((chrsIdx + i) & 0xFFFF, ch);
                     }
+                    reType = postBS = chrsCnt - curCol;
+                    chrsCnt--;
+                } else {
+                    _putcon('\007'); // ring the bell
                 }
+            }
 
-                if (chr == 2) {                             // ^B - Toggle between beginning & end of line
-                    if (curCol) {
-                        preBS = curCol;             //move to beginning
+            if (((chr == 0x08) || (chr == 0x7F))) { // ^H and DEL - Delete one character to left of cursor
+                if (curCol > 0) {                   // not at BOL
+                    if (curCol < chrsCnt) {         // not at EOL
+                        // delete previous character from buffer
+                        for (i = curCol, j = i - 1; i < chrsCnt; i++, j++) {
+                            ch = _RamRead(((chrsIdx + i) & 0xFFFF));
+                            _RamWrite((chrsIdx + j) & 0xFFFF, ch);
+                        }
+                        preBS++; // pre-backspace one
+                        // note: does one extra to erase EOL
+                        reType = postBS = chrsCnt - curCol + 1;
                     } else {
-                        reType = chrsCnt - curCol;  //move to EOL
+                        preBS = reType = postBS = 1;
                     }
+                    chrsCnt--;
+                } else {
+                    _putcon('\007'); // ring the bell
                 }
+            }
 
-                if ((chr == 3) && (chrsCnt == 0)) {         // ^C - Abort string input
-                    _puts("^C");
-                    Status = 2;
-                    break;
+            if ((chr == 0x0A) || (chr == 0x0D)) { // ^J and ^M - Ends editing
+    #ifdef PROFILE
+                time_start = millis();
+    #endif
+                break;
+            }
+
+            if (chr == 0x0B) { // ^K - Delete to EOL from cursor
+                if (curCol < chrsCnt) {
+                    reType = postBS = chrsCnt - curCol;
+                    chrsCnt = curCol; // truncate buffer to here
+                } else {
+                    _putcon('\007'); // ring the bell
                 }
+            }
 
-#ifdef DEBUG
-                if (chr == 4) {                             // ^D - DEBUG
-                    Debug = 1;
+            if (chr == 18) { // ^R - Retype the command line
+                _puts("#\b\n");
+                preBS = curCol;            // backspace to BOL
+                reType = chrsCnt;          // retype everything
+                postBS = chrsCnt - curCol; // backspace to cursor column
+            }
 
-                    printf("\r\n curCol: %u, chrsCnt: %u, chrsMax: %u", curCol, chrsCnt, chrsMax);
-                    _puts("#\r\n  ");
-                    reType = chrsCnt;
-                    postBS = chrsCnt - curCol;
+            if (chr == 21) { // ^U - delete all characters
+                _puts("#\b\n");
+                preBS = curCol; // backspace to BOL
+                chrsCnt = 0;
+            }
+
+            if (chr == 23) {   // ^W - recall last command
+                if (!curCol) { // if at beginning of command line
+                    uint8 lastCnt = last[0];
+                    if (lastCnt) { // and there's a last command
+                        // restore last command
+                        for (j = 0; j <= lastCnt; j++) {
+                            _RamWrite((chrsCntIdx + j) & 0xFFFF, last[j]);
+                        }
+                        // retype to greater of chrsCnt & lastCnt
+                        reType = (chrsCnt > lastCnt) ? chrsCnt : lastCnt;
+                        chrsCnt = lastCnt; // this is the restored length
+                        // backspace to end of restored command
+                        postBS = reType - chrsCnt;
+                    } else {
+                        _putcon('\007'); // ring the bell
+                    }
+                } else if (curCol < chrsCnt) { // if not at EOL
+                    reType = chrsCnt - curCol; // move to EOL
                 }
-#endif // ifdef DEBUG
+            }
 
-                if (chr == 5) {                             // ^E - goto beginning of next line
-                    _puts("\r\n");
+            if (chr == 24) { // ^X - delete all character left of the cursor
+                if (curCol > 0) {
+                    // move rest of line to beginning of line
+                    for (i = 0, j = curCol; j < chrsCnt; i++, j++) {
+                        ch = _RamRead(((chrsIdx + j) & 0xFFFF));
+                        _RamWrite((chrsIdx + i) & 0xFFFF, ch);
+                    }
                     preBS = curCol;
-                    reType = postBS = chrsCnt;
-                }
-
-                if (chr == 6) {                             // ^F - Move the cursor one character forward
-                    if (curCol < chrsCnt) {
-                        reType++;
-                    } else {
-                        _putcon('\007');  //ring the bell
-                    }
-                }
-
-                if (chr == 7) {                             // ^G - Delete character at cursor
-                    if (curCol < chrsCnt) {
-                        //delete this character from buffer
-                        for (i = curCol, j = i + 1; j < chrsCnt; i++, j++) {
-                            ch = _RamRead(((chrsIdx + j) & 0xFFFF));
-                            _RamWrite((chrsIdx + i) & 0xFFFF, ch);
-                        }
-                        reType = postBS = chrsCnt - curCol;
-                        chrsCnt--;
-                    } else {
-                        _putcon('\007');  //ring the bell
-                    }
-                }
-
-                if (((chr == 0x08) || (chr == 0x7F))) {     // ^H and DEL - Delete one character to left of cursor
-                    if (curCol > 0) {   //not at BOL
-                        if (curCol < chrsCnt) { //not at EOL
-                            //delete previous character from buffer
-                            for (i = curCol, j = i - 1; i < chrsCnt; i++, j++) {
-                                ch = _RamRead(((chrsIdx + i) & 0xFFFF));
-                                _RamWrite((chrsIdx + j) & 0xFFFF, ch);
-                            }
-                            preBS++;    //pre-backspace one
-                            //note: does one extra to erase EOL
-                            reType = postBS = chrsCnt - curCol + 1;
-                        } else {
-                            preBS = reType = postBS = 1;
-                        }
-                        chrsCnt--;
-                    } else {
-                        _putcon('\007');  //ring the bell
-                    }
-                }
-
-                if ((chr == 0x0A) || (chr == 0x0D)) {   // ^J and ^M - Ends editing
-#ifdef PROFILE
-                    time_start = millis();
-#endif
-                    break;
-                }
-
-                if (chr == 0x0B) {                      // ^K - Delete to EOL from cursor
-                    if (curCol < chrsCnt) {
-                        reType = postBS = chrsCnt - curCol;
-                        chrsCnt = curCol;   //truncate buffer to here
-                    } else {
-                        _putcon('\007');  //ring the bell
-                    }
-                }
-
-                if (chr == 18) {                        // ^R - Retype the command line
-                    _puts("#\b\r\n");
-                    preBS = curCol;             //backspace to BOL
-                    reType = chrsCnt;           //retype everything
-                    postBS = chrsCnt - curCol;  //backspace to cursor column
-                }
-
-                if (chr == 21) {                        // ^U - delete all characters
-                    _puts("#\b\r\n");
-                    preBS = curCol; //backspace to BOL
-                    chrsCnt = 0;
-                }
-
-                if (chr == 23) {                        // ^W - recall last command
-                    if (!curCol) {      //if at beginning of command line
-                        if (last[0]) {  //and there's a last command
-                            //restore last command
-                            for (j = 0; j <= chrsCnt; j++) {
-                                _RamWrite((chrsCntIdx + j) & 0xFFFF, last[j]);
-                            }
-                            //retype & backspace to greater of chrsCnt & last[0]
-                            reType = postBS = (chrsCnt > last[0]) ? chrsCnt : last[0];
-                            chrsCnt = last[0];
-                        } else {
-                            _putcon('\007');  //ring the bell
-                        }
-                    } else if (curCol < chrsCnt) {  //if not at EOL
-                        reType = chrsCnt - curCol;  //move to EOL
-                    }
-                }
-
-                if (chr == 24) {                        // ^X - delete all character left of the cursor
-                    if (curCol > 0) {
-                        //move rest of line to beginning of line
-                        for (i = 0, j = curCol; j < chrsCnt;i++, j++) {
-                            ch = _RamRead(((chrsIdx + j) & 0xFFFF));
-                            _RamWrite((chrsIdx +i) & 0xFFFF, ch);
-                        }
-                        preBS = curCol;
-                        reType = chrsCnt;
-                        postBS = chrsCnt;
-                        chrsCnt -= curCol;
-                    } else {
-                        _putcon('\007');  //ring the bell
-                    }
-                }
-
-                if ((chr >= 0x20) && (chr <= 0x7E)) { //valid character
-                    if (curCol < chrsCnt) {
-                        //move rest of buffer one character right
-                        for (i = chrsCnt, j = i - 1; i > curCol; i--, j--) {
-                            ch = _RamRead(((chrsIdx + j) & 0xFFFF));
-                            _RamWrite((chrsIdx + i) & 0xFFFF, ch);
-                        }
-                    }
-                    //put the new character in the buffer
-                    _RamWrite((chrsIdx + curCol) & 0xffff, chr);
-
-                    chrsCnt++;
-                    reType = chrsCnt - curCol;
-                    postBS = reType - 1;
-                }
-
-                //pre-backspace
-                for (i = 0; i < preBS; i++) {
-                    _putcon('\b');
-                    curCol--;
-                }
-
-                //retype
-                for (i = 0; i < reType; i++) {
-                    if (curCol < chrsCnt) {
-                        ch = _RamRead(((chrsIdx + curCol) & 0xFFFF));
-                    } else {
-                        ch = ' ';
-                    }
-                    _putcon(ch);
-                    curCol++;
-                }
-
-                //post-backspace
-                for (i = 0; i < postBS; i++) {
-                    _putcon('\b');
-                    curCol--;
-                }
-
-                if (chrsCnt == chrsMax) {   // Reached the maximum count
-                    break;
-                }
-            }   // while (chrsMax)
-
-            // Save the number of characters read
-            _RamWrite(chrsCntIdx, chrsCnt);
-
-            //if there are characters...
-            if (chrsCnt) {
-                //... then save this as last command
-                for (j = 0; j <= chrsCnt; j++) {
-                    last[j] = _RamRead((chrsCntIdx + j) & 0xFFFF);
+                    reType = chrsCnt;
+                    postBS = chrsCnt;
+                    chrsCnt -= curCol;
+                } else {
+                    _putcon('\007'); // ring the bell
                 }
             }
-#if 0
-            printf("\n\r chrsMaxIdx: %0X, chrsMax: %u, chrsCnt: %u", chrsMaxIdx, chrsMax, chrsCnt);
-            for (j = 0; j < chrsCnt + 2; j++) {
-                printf("\n\r chrsMaxIdx[%u]: %0.2x", j, last[j]);
+
+            if (chr == 31) { // ^? - help
+                _puts("\n\r^A Left  ^B B/EOL ^C Abort ^E N/Lin ^F Right ^G Del@C ^H/Del BackSp\n\r");
+                _puts("^K DelEOL ^R Retype ^U DelAll ^W Recall ^X DelBOL ^? Help\n\r");
+                preBS = curCol;            // backspace to BOL
+                reType = chrsCnt;          // retype everything
+                postBS = chrsCnt - curCol; // backspace to cursor column
             }
+
+            if (((chr >= 0x20) && (chr <= 0x7E)) || (chr == 0x1A)) { // valid character (allow ^Z)
+                if (curCol < chrsCnt) {
+                    // move rest of buffer one character right
+                    for (i = chrsCnt, j = i - 1; i > curCol; i--, j--) {
+                        ch = _RamRead(((chrsIdx + j) & 0xFFFF));
+                        _RamWrite((chrsIdx + i) & 0xFFFF, ch);
+                    }
+                }
+                // put the new character in the buffer
+                _RamWrite((chrsIdx + curCol) & 0xffff, chr);
+
+                chrsCnt++;
+                reType = chrsCnt - curCol;
+                postBS = reType - 1;
+            }
+
+            // pre-backspace
+            for (i = 0; i < preBS; i++) {
+                _putcon('\b');
+                curCol--;
+            }
+
+            // retype
+            for (i = 0; i < reType; i++) {
+                if (curCol < chrsCnt) {
+                    ch = _RamRead(((chrsIdx + curCol) & 0xFFFF));
+                } else {
+                    ch = ' ';
+                }
+                _putcon(ch);
+                curCol++;
+            }
+
+            // post-backspace
+            for (i = 0; i < postBS; i++) {
+                _putcon('\b');
+                curCol--;
+            }
+
+            if (chrsCnt == chrsMax) // Reached the maximum count
+                break;
+        } // while (chrsMax)
+
+        // Save the number of characters read
+        _RamWrite(chrsCntIdx, chrsCnt);
+
+        // Return the number of characters read in A (low byte of HL)
+        HL = chrsCnt;
+
+        // if there are characters...
+        if (chrsCnt) {
+            //... then save this as last command
+            for (j = 0; j <= chrsCnt; j++) {
+                last[j] = _RamRead((chrsCntIdx + j) & 0xFFFF);
+            }
+        }
+        _putcon('\r'); // Gives a visual feedback that read ended
+        break;
+    }
+
+    /*
+       C = 11 (0Bh) : Get console status
+       Returns: A=0x00 or 0xFF
+       Under CP/M3 the console mode (BDOS 109) bits 8-9 override the result:
+       1 = always ready, 2 = never ready, 0/3 = normal hardware status.
+     */
+    case C_STAT: {
+#ifdef CPM3
+        uint8 sub = (consoleMode >> 8) & 0x03;
+        if (sub == 1) {
+            HL = 0xFF; // always returns true
+            break;
+        }
+        if (sub == 2) {
+            HL = 0x00; // always returns false
+            break;
+        }
 #endif
-            _putcon('\r');          // Gives a visual feedback that read ended
-			break;
-		}
+        HL = _chready();
+        break;
+    }
+#endif // ABDOS
 
-		/*
-		   C = 11 (0Bh) : Get console status
-		   Returns: A=0x00 or 0xFF
-		 */
-		case C_STAT: {
-			HL = _chready();
-			break;
-		}
+    /*
+       C = 12 (0Ch) : Get version number
+       Returns: B=H=system type, A=L=version number
+     */
+    case S_BDOSVER: {
+        #ifdef CPM3
+            HL = 0x31;
+        #else
+            HL = 0x22;
+        #endif
+        break;
+    }
 
-		/*
-		   C = 12 (0Ch) : Get version number
-		   Returns: B=H=system type, A=L=version number
-		 */
-		case GET_VERSION: {
-			HL = 0x22;
-			break;
-		}
+    /*
+       C = 13 (0Dh) : Reset disk system
+     */
+    case DRV_ALLRESET: {
+        roVector = 0; // Make all drives R/W
+        loginVector = 0;
+        dmaAddr = 0x0080;
+        multiRecordCount = 1; // CP/M 3 BDOS resets multi-sector count on system reset
+        cDrive = 0;           // userCode remains unchanged
+        HL = _CheckSUB();     // Checks if there's a $$$.SUB on the boot disk
+        break;
+    }
 
-		/*
-		   C = 13 (0Dh) : Reset disk system
-		 */
-		case DRV_ALLRESET: {
-			roVector = 0;       // Make all drives R/W
-			loginVector = 0;
-			dmaAddr = 0x0080;
-			cDrive = 0;         // userCode remains unchanged
-			HL = _CheckSUB();   // Checks if there's a $$$.SUB on the boot disk
-			break;
-		}
+    /*
+       C = 14 (0Eh) : Select Disk
+       Returns: A=0x00 or 0xFF
+     */
+    case DRV_SET: {
+        oDrive = cDrive;
+        cDrive = LOW_REGISTER(DE);
+        HL = _SelectDisk(LOW_REGISTER(DE) + 1); // +1 here is to allow SelectDisk to be used directly by disk.h as well
+        if (!HL) {
+            oDrive = cDrive;
+        } else {
+            if ((_RamRead(DSKByte) & 0x0f) == cDrive) {
+                cDrive = oDrive = 0;
+                _RamWrite(DSKByte, _RamRead(DSKByte) & 0xf0);
+            } else {
+                cDrive = oDrive;
+            }
+        }
+        break;
+    }
 
-		/*
-		   C = 14 (0Eh) : Select Disk
-		   Returns: A=0x00 or 0xFF
-		 */
-		case DRV_SET: {
-			oDrive = cDrive;
-			cDrive = LOW_REGISTER(DE);
-			HL = _SelectDisk(LOW_REGISTER(DE) + 1); // +1 here is to allow SelectDisk to be used directly by disk.h as well
-			if (!HL) {
-				oDrive = cDrive;
-			} else {
-				if ((_RamRead(DSKByte) & 0x0f) == cDrive) {
-					cDrive = oDrive = 0;
-					_RamWrite(DSKByte, _RamRead(DSKByte) & 0xf0);
-				} else {
-					cDrive = oDrive;
-				}
-			}
-			break;
-		}
+    /*
+       C = 15 (0Fh) : Open file
+       Entered with DE = address of FCB.
+       Returns: A = 0xFF on error or 0-3 on success (CP/M3 semantics).
+       On CP/M 3, a hardware error (when A=0xFF) may be returned in B/H.
+       If FCB->cr is 0xFF on entry, on return FCB->cr will contain the
+       last-record byte count (LRBC).
+     */
+    case F_OPEN: {
+        HL = _OpenFile(DE);
+        break;
+    }
 
-		/*
-		   C = 15 (0Fh) : Open file
-		   Returns: A=0x00 or 0xFF
-		 */
-		case F_OPEN: {
-			HL = _OpenFile(DE);
-			break;
-		}
+    /*
+       C = 16 (10h) : Close file
+       Entered with DE = address of FCB.
+       Returns: A = 0xFF on error or 0-3 on success.
+       On CP/M 3: If F5' (top bit of the 5th filename byte) is set then pending data
+       are written and the file remains open.
+       If A=0xFF, H/B contain hardware error.
+     */
+    case F_CLOSE: {
+        HL = _CloseFile(DE);
+        break;
+    }
 
-		/*
-		   C = 16 (10h) : Close file
-		 */
-		case F_CLOSE: {
-			HL = _CloseFile(DE);
-			break;
-		}
+    /*
+       C = 17 (11h) : Search for first
+     */
+    case F_SFIRST: {
+        HL = _SearchFirst(DE, TRUE); // TRUE = Creates a fake dir entry when finding the file
+        break;
+    }
 
-		/*
-		   C = 17 (11h) : Search for first
-		 */
-		case F_SEARCH_FIRST: {
-			HL = _SearchFirst(DE, TRUE);    // TRUE = Creates a fake dir entry when finding the file
-			break;
-		}
+    /*
+       C = 18 (12h) : Search for next
+     */
+    case F_SNEXT: {
+        HL = _SearchNext(DE, TRUE); // TRUE = Creates a fake dir entry when finding the file
+        break;
+    }
 
-		/*
-		   C = 18 (12h) : Search for next
-		 */
-		case F_SEARCH_NEXT: {
-			HL = _SearchNext(DE, TRUE); // TRUE = Creates a fake dir entry when finding the file
-			break;
-		}
+    /*
+       C = 19 (13h) : Delete file
+     */
+    case F_DELETE: {
+        HL = _DeleteFile(DE);
+        break;
+    }
 
-		/*
-		   C = 19 (13h) : Delete file
-		 */
-		case F_DELETE: {
-			HL = _DeleteFile(DE);
-			break;
-		}
+    /*
+       C = 20 (14h) : Read sequential
+       DE = address of FCB
+       ToDo under CP/M 3 this can be a multiple of 128 bytes
+       Returns: A = return code
+     */
+    case F_READ: {
+        HL = _ReadSeq(DE);
+        break;
+    }
 
-		/*
-		   C = 20 (14h) : Read sequential
-		 */
-		case F_READ: {
-			HL = _ReadSeq(DE);
-			break;
-		}
+    /*
+       C = 21 (15h) : Write sequential
+       DE = address of FCB
+       ToDo under CP/M 3 this can be a multiple of 128 bytes
+       Returns: A=return code
+       */
+    case F_WRITE: {
+        HL = _WriteSeq(DE);
+        break;
+    }
 
-		/*
-		   C = 21 (15h) : Write sequential
-		 */
-		case F_WRITE: {
-			HL = _WriteSeq(DE);
-			break;
-		}
+    /*
+       C = 22 (16h) : Make file
+     */
+    case F_MAKE: {
+        HL = _MakeFile(DE);
+        break;
+    }
 
-		/*
-		   C = 22 (16h) : Make file
-		 */
-		case F_MAKE: {
-			HL = _MakeFile(DE);
-			break;
-		}
+    /*
+       C = 23 (17h) : Rename file
+     */
+    case F_RENAME: {
+        HL = _RenameFile(DE);
+        break;
+    }
 
-		/*
-		   C = 23 (17h) : Rename file
-		 */
-		case F_RENAME: {
-			HL = _RenameFile(DE);
-			break;
-		}
+    /*
+       C = 24 (18h) : Return log-in vector (active drive map)
+     */
+    case DRV_LOGINVEC: {
+        HL = loginVector; // (todo) improve this
+        break;
+    }
 
-		/*
-		   C = 24 (18h) : Return log-in vector (active drive map)
-		 */
-		case DRV_LOGINVECTOR: {
-			HL = loginVector;   // (todo) improve this
-			break;
-		}
+    /*
+       C = 25 (19h) : Return current disk
+     */
+    case DRV_GET: {
+        HL = cDrive;
+        break;
+    }
 
-		/*
-		   C = 25 (19h) : Return current disk
-		 */
-		case DRV_GET: {
-			HL = cDrive;
-			break;
-		}
+    /*
+       C = 26 (1Ah) : Set DMA address
+     */
+    case F_DMAOFF: {
+        dmaAddr = DE;
+        break;
+    }
 
-		/*
-		   C = 26 (1Ah) : Set DMA address
-		 */
-		case F_DMAOFF: {
-			dmaAddr = DE;
-			break;
-		}
+    /*
+       C = 27 (1Bh) : Get ADDR(Alloc)
+     */
+    case DRV_ALLOCVEC: {
+        HL = SCBaddr;
+        break;
+    }
 
-		/*
-		   C = 27 (1Bh) : Get ADDR(Alloc)
-		 */
-		case DRV_GETADDRALLOC: {
-			HL = SCBaddr;
-			break;
-		}
+    /*
+       C = 28 (1Ch) : Write protect current disk
+     */
+    case DRV_SETRO: {
+        roVector = roVector | (1 << cDrive);
+        break;
+    }
 
-		/*
-		   C = 28 (1Ch) : Write protect current disk
-		 */
-		case DRV_WRITEPROTECT: {
-			roVector = roVector | (1 << cDrive);
-			break;
-		}
+    /*
+       C = 29 (1Dh) : Get R/O vector
+     */
+    case DRV_ROVEC: {
+        HL = roVector;
+        break;
+    }
 
-		/*
-		   C = 29 (1Dh) : Get R/O vector
-		 */
-		case DRV_GETROVECTOR: {
-			HL = roVector;
-			break;
-		}
+    /*
+       C = 30 (1Eh) : Set file attributes (does nothing)
+     */
+    case F_ATTRIB: {
+        HL = 0;
+        break;
+    }
 
-		/*
-		   C = 30 (1Eh) : Set file attributes (does nothing)
-		 */
-		case F_SETATTRIBUTES: {
-			HL = 0;
-			break;
-		}
+    /*
+       C = 31 (1Fh) : Get ADDR(Disk Parms)
+     */
+    case DRV_PDB: {
+        HL = DPBaddr;
+        break;
+    }
 
-		/*
-		   C = 31 (1Fh) : Get ADDR(Disk Parms)
-		 */
-		case DRV_GETDPB: {
-			HL = DPBaddr;
-			break;
-		}
+    /*
+       C = 32 (20h) : Get/Set user code
+     */
+    case F_USERNUM: {
+        if (LOW_REGISTER(DE) == 0xFF) {
+            HL = userCode;
+        } else {
+            _SetUser(DE);
+        }
+        break;
+    }
 
-		/*
-		   C = 32 (20h) : Get/Set user code
-		 */
-		case F_USERNUM: {
-			if (LOW_REGISTER(DE) == 0xFF) {
-				HL = userCode;
-			} else {
-				_SetUser(DE);
-			}
-			break;
-		}
+    /*
+       C = 33 (21h) : Read random
+       ToDo under CPM3, if A returns 0xFF, H returns hardware error
+     */
+    case F_READRAND: {
+        HL = _ReadRand(DE);
+        break;
+    }
 
-		/*
-		   C = 33 (21h) : Read random
-		 */
-		case F_READRANDOM: {
-			HL = _ReadRand(DE);
-			break;
-		}
+    /*
+       C = 34 (22h) : Write random
+       ToDo under CPM3, if A returns 0xFF, H returns hardware error
+       */
+    case F_WRITERAND: {
+        HL = _WriteRand(DE);
+        break;
+    }
 
-		/*
-		   C = 34 (22h) : Write random
-		 */
-		case F_WRITERANDOM: {
-			HL = _WriteRand(DE);
-			break;
-		}
+    /*
+       C = 35 (23h) : Compute file size
+     */
+    case F_SIZE: {
+        HL = _GetFileSize(DE);
+        break;
+    }
 
-		/*
-		   C = 35 (23h) : Compute file size
-		 */
-		case F_COMPUTESIZE: {
-			HL = _GetFileSize(DE);
-			break;
-		}
+    /*
+       C = 36 (24h) : Set random record
+     */
+    case F_RANDREC: {
+        HL = _SetRandom(DE);
+        break;
+    }
 
-		/*
-		   C = 36 (24h) : Set random record
-		 */
-		case F_SETRANDOM: {
-			HL = _SetRandom(DE);
-			break;
-		}
+    /*
+       C = 37 (25h) : Reset drive
+     */
+    case DRV_RESET: {
+        roVector = roVector & ~DE;
+        break;
+    }
 
-		/*
-		   C = 37 (25h) : Reset drive
-		 */
-		case DRV_RESET: {
-			roVector = roVector & ~DE;
-			break;
-		}
+    /*
+      ToDo C = 38 (26h) : Access drives (CPM3)
+        This is an MP/M function that is not supported under CP/M 3. If called, the file
+         system returns a zero In register A indicating that the access request is successful.
+     */
+    case DRV_ACCESS_MPM: {
+        HL = 0x0000;
+        break;
+    }
 
-		/* ********* Function 38: Not supported by CP/M 2.2 *********
-		  ********* Function 39: Not supported by CP/M 2.2 *********
-		  ********* (todo) Function 40: Write random with zero fill *********
-		 */
+    /*
+      ToDo C = 39 (27h) : Free drives (CPM3)
+        This is an MP/M function that is not supported under CP/M 3. If called, the file
+         system returns a zero In register A indicating that the access request is successful.
+     */
+    case DRV_FREE_MPM: {
+        HL = 0x0000;
+        break;
+    }
 
-		/*
-		   C = 40 (28h) : Write random with zero fill (we have no disk blocks, so just write random)
-		 */
-		case F_WRITERANDOMZERO: {
-			HL = _WriteRand(DE);
-			break;
-		}
+    /*
+       C = 40 (28h) : Write random with zero fill (we have no disk blocks, so just write random)
+       DE = address of FCB
+       Returns: A = return code
+                H = Physical Error
+     */
+    case F_WRITEZF: {
+        HL = _WriteRand(DE);
+        break;
+    }
+
+    /*
+       ToDo: C = 41 (29h) : Test and Write Record (CPM3)
+       DE = address of FCB
+       Returns: A = return code
+                H = Physical Error
+     */
+    case F_TESTWRITE: {
+        break;
+    }
+
+    /*
+       ToDo: C = 42 (2Ah) : Lock Record (CPM3)
+       DE = address of FCB
+       Returns: A = return code
+                H = Physical Error
+     */
+    case F_LOCKFILE: {
+        break;
+    }
+
+    /*
+       ToDo: C = 43 (2Bh) : Unlock Record (CPM3)
+       DE = address of FCB
+       Returns: A = return code
+                H = Physical Error
+     */
+    case F_UNLOCKFILE: {
+        break;
+    }
+
+    /*
+       C = 44 (2Ch) : Set number of records to read/write at once (CPM3)
+       E = Number of Sectors
+       Returns: A = return code (Returns A=0 if E was valid, 0FFh otherwise)
+     */
+    case F_MULTISEC: {
+#ifdef CPM3
+        {
+            uint8 e = LOW_REGISTER(DE);
+            if ((e >= 1) && (e <= 127)) {
+                multiRecordCount = e;
+                HL = 0x0000; /* A = 0 => OK */
+            } else {
+                HL = 0x00FF; /* A = 0xFF => invalid */
+            }
+        }
+#else
+        /* Not supported under CP/M 2.2 */
+        HL = 0x00FF;
+#endif
+        break;
+    }
+
+    /*
+       ToDo: C = 45 (2Dh) : Set BDOS Error Mode (CPM3)
+       E = BDOS Error Mode
+       E < 254 Compatibility mode; program is terminated and an error message printed.
+       E = 254 Error code is returned in H, error message is printed.
+       E = 255 Error code is returned in H, no error message is printed.
+       Returns: None
+     */
+    case F_ERRMODE: {
+        break;
+    }
+
+    /*
+       ToDo: C = 46 (2Eh) : Get Free Disk Space (CPM3)
+       E = Drive
+       Returns: A = return code
+                H = Physical Error
+                Binary result in the first 3 bytes of current DMA buffer
+     */
+    case DRV_SPACE: {
+        break;
+    }
+
+    /*
+       C = 47 (2Fh) : Chain to program (CPM3)
+       E = Chain flag (0xFF = pass current drive/user to the chained program,
+           otherwise the chained program starts at drive A: user 0)
+       The command line to run is stored null-terminated in the default DMA
+       buffer (0x0080). The call does not return to the caller: it warm boots
+       and the CCP runs the chained command.
+     */
+    case P_CHAIN: {
+#ifdef CPM3
+        uint16 src = 0x0080;
+        uint8 n = 0;
+        uint8 c;
+        while (n < (uint8)(sizeof(chainCmd) - 1) && (c = _RamRead(src + n)) != 0) {
+            chainCmd[n] = c;
+            ++n;
+        }
+        chainCmd[n] = 0;
+        chainLoad = 1;
+        if (LOW_REGISTER(DE) != 0xFF) { // do not inherit drive/user
+            userCode = 0;
+            cDrive = oDrive = 0;
+            _RamWrite(DSKByte, 0x00);
+        }
+        Status = STATUS_RESTART; // warm boot into the CCP
+#endif
+        break;
+    }
+
+    /*
+       C = 48 (30h) : Flush Buffers (CPM3)
+       E = Purge flag
+       Returns: A = return code (0 = OK)
+                H = Physical Error
+       RunCPM opens, writes and closes each file record individually, so regular
+       file data is already on disk. The only host buffers held open across calls
+       are the LST: and PUN: device streams - flush those.
+     */
+    case DRV_FLUSH: {
+#ifdef USE_LST
+        if (lst_open)
+            _sys_fflush(lst_dev);
+#endif
+#ifdef USE_PUN
+        if (pun_open)
+            _sys_fflush(pun_dev);
+#endif
+        HL = 0x0000; // A = 0 (OK), H = 0 (no physical error)
+        break;
+    }
+
+    /*
+       C = 49 (31h) : Get/Set System Control (CPM3)
+       DE = SCB PB Address. SCBPB layout (bytes):
+         +0 offset (0-99 into the SCB)
+         +1 set    (0xFF = set byte, 0xFE = set word, anything else = get)
+         +2 value  (byte or word to store when setting)
+       Returns: A = byte at offset, HL = word at offset (on get).
+                The BDOS forces A = low byte of HL on return, so the byte
+                value naturally falls out of HL's low half.
+     */
+    case S_SCB: {
+        uint16 pb = DE;
+        uint8 offset = _RamRead(pb + 0);
+        uint8 set = _RamRead(pb + 1);
+        if (set == 0xFF) {                  // set byte
+            _RamWrite(SCBaddr + offset, _RamRead(pb + 2));
+        } else if (set == 0xFE) {           // set word
+            _RamWrite16(SCBaddr + offset, _RamRead16(pb + 2));
+        } else {                            // get byte/word
+            HL = _RamRead16(SCBaddr + offset);
+        }
+        break;
+    }
+
+    /*
+       C = 50 (32h) : Direct BIOS Calls (CPM3)
+       DE = BIOS PB Address. BIOSPB layout (bytes):
+         +0 func (logical BIOS fn 0-32)  +1 A  +2 C  +3 B  +4 E  +5 D  +6 L  +7 H
+       Returns: for SELDSK(9)/SECTRAN(16)/DEVTBL(20)/DRVTBL(22) the BIOS HL result
+       in HL (and A=L, B=H); for every other function the BIOS A result in A and L.
+     */
+    case S_BIOS: {
+#ifdef CPM3
+        uint16 pb = DE;
+        uint8 fn = _RamRead(pb + 0); // logical BIOS function number
+        uint16 oldPC = PCX;
+
+        // Load the Z80 registers the BIOS will see from the parameter block.
+        // BC/DE/HL are stored low-byte-first, so _RamRead16 reads them directly.
+        SET_HIGH_REGISTER(AF, _RamRead(pb + 1)); // A
+        BC = _RamRead16(pb + 2);                 // C,B
+        DE = _RamRead16(pb + 4);                 // E,D
+        HL = _RamRead16(pb + 6);                 // L,H
+
+        // _Bios() dispatches on the low byte of PC, which equals (function * 3),
+        // i.e. the BIOS jump-table offset (B_WBOOT=3, B_SELMEM=81, ...).
+        SET_LOW_REGISTER(PCX, (uint8)(fn * 3));
+        _Bios();
+        PCX = oldPC; // restore PC so the caller resumes correctly
+
+        // Map the BIOS return onto the BDOS return convention (A=L(HL), B=H(HL)).
+        // SELDSK/SECTRAN/DEVTBL/DRVTBL return in HL (leave HL as the BIOS set it);
+        // all others return in A, so place A into HL so A and L both hold it.
+        if (fn != 9 && fn != 16 && fn != 20 && fn != 22)
+            HL = HIGH_REGISTER(AF);
+#endif // ifdef CPM3
+        break;
+    }
+
+    /*
+       ToDo: C = 59 (3Bh) : Load Overlay (CPM3)
+       DE = address of FCB
+       Returns: A = return code
+                H = Physical Error
+     */
+    case P_LOAD: {
+        break;
+    }
+
+    /*
+       C = 60 (3Ch) : Call Resident System Extension (RSX) (CPM3)
+       DE =  RSX PB Address
+       Returns: A = return code
+                H = Physical Error
+     */
+    case S_RSX: {
+#ifdef CPM3
+        // No RSX modules are loaded, so report the call as not handled
+        // (A = 0FFh).
+        HL = 0x00FF;
+#endif // ifdef CPM3
+        break;
+    }
+
+    /*
+       ToDo: C = 98 (62h) : Free Blocks (CPM3)
+       Returns: A = return code
+                H = Physical Error
+     */
+    case F_CLEANUP: {
+        break;
+    }
+
+    /*
+       C = 99 (63h) : Truncate File (CPM3)
+       DE = address of FCB. The random record field (r0/r1/r2) holds the new
+            size in 128-byte records; the file is truncated to record * 128.
+       Returns: A = Directory code (0 = OK, 0xFF = error)
+                H = Extended or Physical Error
+     */
+    case F_TRUNCATE: {
+#ifdef CPM3
+        HL = _TruncateFile(DE);
+#endif
+        break;
+    }
+
+    /*
+       ToDo: C = 100 (64h) : Set Directory Label (CPM3)
+       DE = address of FCB
+       Returns: A = Directory code
+                H = Extended or Physical Error
+     */
+    case DRV_SETLABEL: {
+        break;
+    }
+
+    /*
+       ToDo: C = 101 (65h) : Return Directory Label Data (CPM3)
+       E = Drive
+       Returns: A = Directory Label Data Byte or 0xFF
+                H = Physical Error
+     */
+    case DRV_GETLABEL: {
+        break;
+    }
+
+    /*
+       C = 102 (66h) : Read File Date Stamps and Password Mode (CPM3)
+       DE = address of FCB
+       Returns: A = Directory code (0xFF if the file was not found)
+                H = Physical Error
+       On success the FCB is filled in:
+                FCB+9 bit7 (t1') = set if the file is read-only
+                FCB+24..27      = create/access date stamp
+                FCB+28..31      = update date stamp
+                FCB+12 (ex)     = password mode (0, no password support here)
+       Each date stamp is: day count (word, day 1 = 1978-01-01), hour (BCD),
+       minute (BCD). The stamps are derived from the host file via BDOS only.
+     */
+    case F_TIMEDATE: {
+#ifdef CPM3
+        uint8 result = 0xff;
+        _FCBtoHostname(DE, &filename[0]);
+        unsigned long mt = _sys_filemtime(&filename[0]);
+        if (mt) {
+            time_t ft = (time_t)mt;
+            struct tm lt = *localtime(&ft);
+            struct tm base, fday;
+            time_t baseNoon, fNoon;
+            uint16 days;
+            uint8 bh = DEC2BCD(lt.tm_hour);
+            uint8 bm = DEC2BCD(lt.tm_min);
+            // Whole days between the file day (noon) and 1978-01-01 (noon)
+            memset(&base, 0, sizeof(base));
+            base.tm_year = 78;
+            base.tm_mon = 0;
+            base.tm_mday = 1;
+            base.tm_hour = 12;
+            base.tm_isdst = -1;
+            baseNoon = mktime(&base);
+            fday = lt;
+            fday.tm_hour = 12;
+            fday.tm_min = 0;
+            fday.tm_sec = 0;
+            fday.tm_isdst = -1;
+            fNoon = mktime(&fday);
+            days = (uint16)((fNoon - baseNoon) / 86400 + 1);
+            // Create/access stamp (host only exposes one timestamp, reuse it)
+            _RamWrite(DE + 24, days & 0xff);
+            _RamWrite(DE + 25, (days >> 8) & 0xff);
+            _RamWrite(DE + 26, bh);
+            _RamWrite(DE + 27, bm);
+            // Update stamp
+            _RamWrite(DE + 28, days & 0xff);
+            _RamWrite(DE + 29, (days >> 8) & 0xff);
+            _RamWrite(DE + 30, bh);
+            _RamWrite(DE + 31, bm);
+            // Password mode (none supported)
+            _RamWrite(DE + 12, 0x00);
+            // Read-only attribute lives in t1' (high bit of the first type byte)
+            if (_sys_isreadonly(&filename[0]))
+                _RamWrite(DE + 9, _RamRead(DE + 9) | 0x80);
+            else
+                _RamWrite(DE + 9, _RamRead(DE + 9) & 0x7f);
+            result = 0x00;
+        }
+        HL = result;
+#endif
+        break;
+    }
+
+    /*
+       ToDo: C = 103 (67h) : Write File XFCB (CPM3)
+       DE = address of FCB
+       Returns: A = Directory code
+                H = Physical Error
+     */
+    case F_WRITEXFCB: {
+        break;
+    }
+
+    /*
+       C = 104 (68h) : Set Date and Time (CPM3)
+       DE = Date and Time (DAT) Address
+            DAT+0/1 = Day count (little-endian, day 1 = 1978-01-01)
+            DAT+2   = Hour   (packed BCD)
+            DAT+3   = Minute (packed BCD)
+            DAT+4   = Second (packed BCD)
+       Returns: None
+     */
+    case T_SET: {
+        uint16 days = _RamRead(DE) | (_RamRead(DE + 1) << 8);
+        uint8 hour = BCD2DEC(_RamRead(DE + 2));
+        uint8 mins = BCD2DEC(_RamRead(DE + 3));
+        uint8 secs = BCD2DEC(_RamRead(DE + 4));
+        struct tm base;
+        time_t baseT, target;
+        memset(&base, 0, sizeof(base));
+        base.tm_year = 78;          // 1978
+        base.tm_mon = 0;            // January
+        base.tm_mday = 1;           // 1st
+        base.tm_hour = 12;          // noon, to avoid DST midnight ambiguity
+        base.tm_isdst = -1;
+        baseT = mktime(&base);
+        // baseT is noon on day 1; rewind to midnight, then add the DAT fields
+        target = baseT - 12 * 3600 + (time_t)(days - 1) * 86400
+                 + (time_t)hour * 3600 + (time_t)mins * 60 + secs;
+        clockOffset = (long)(target - time(NULL));
+        break;
+    }
+
+    /*
+       C = 105 (69h) : Get Date and Time (CPM3)
+       DE = Date and Time (DAT) Address (filled in, same layout as T_SET)
+       Returns: Date and Time (DAT) set
+                A = Seconds (in packed BCD format)
+     */
+    case T_GET: {
+        time_t now = time(NULL) + clockOffset;
+        struct tm cur, base;
+        time_t curNoon, baseNoon;
+        uint16 days;
+        uint8 hour, mins, secs;
+        cur = *localtime(&now);
+        hour = DEC2BCD(cur.tm_hour);
+        mins = DEC2BCD(cur.tm_min);
+        secs = DEC2BCD(cur.tm_sec);
+        // Day count = whole days between today (noon) and 1978-01-01 (noon)
+        cur.tm_hour = 12;
+        cur.tm_min = 0;
+        cur.tm_sec = 0;
+        cur.tm_isdst = -1;
+        curNoon = mktime(&cur);
+        memset(&base, 0, sizeof(base));
+        base.tm_year = 78;
+        base.tm_mon = 0;
+        base.tm_mday = 1;
+        base.tm_hour = 12;
+        base.tm_isdst = -1;
+        baseNoon = mktime(&base);
+        days = (uint16)((curNoon - baseNoon) / 86400 + 1);
+        _RamWrite(DE, days & 0xFF);
+        _RamWrite(DE + 1, (days >> 8) & 0xFF);
+        _RamWrite(DE + 2, hour);
+        _RamWrite(DE + 3, mins);
+        _RamWrite(DE + 4, secs);
+        HL = secs;          // A (low byte of HL) = seconds in packed BCD
+        break;
+    }
+
+    /*
+       ToDo: C = 106 (6Ah) : Set Default Password (CPM3)
+       DE = Password Address
+       Returns: None
+     */
+    case F_PASSWD: {
+        break;
+    }
+
+    /*
+       C = 107 (6Bh) : Return Serial Number (CPM3)
+       DE = Serial Number Field (6 bytes)
+       Returns: Serial number field set (printable ASCII)
+     */
+    case S_SERIAL: {
+        static const uint8 serial[6] = {'R', 'u', 'n', 'C', 'P', 'M'};
+        uint8 i;
+        for (i = 0; i < 6; ++i)
+            _RamWrite(DE + i, serial[i]);
+        break;
+    }
+
+    /*
+       C = 108 (6Ch) : Get/Set Program Return Code (CPM3)
+       DE =  0xFFFF (Get) or Program Return Code (Set)
+       Returns: HL = Program Return Code (on Get)
+     */
+    case P_CODE: {
+        if (WORD16(DE) == 0xFFFF) {
+            HL = programRetCode;
+        } else {
+            programRetCode = WORD16(DE);
+        }
+        break;
+    }
+
+    /*
+       C = 109 (6Dh) : Get/Set Console Mode (CPM3)
+       DE =  0xFFFF (Get) or Console Mode (Set)
+       Returns: HL = Console Mode (on Get)
+       Console mode bits (CP/M3): 0 = fn 11 detects only ^C, 1 = ^S no pause,
+       2 = no tab expand / no ^P echo, 3 = ^C does not terminate. RunCPM's
+       console is already raw, so those behaviours are intrinsic; bits 8-9 are
+       acted on by function 11 (Get console status).
+     */
+    case C_MODE: {
+        if (WORD16(DE) == 0xFFFF) {
+            HL = consoleMode;
+        } else {
+            consoleMode = WORD16(DE);
+        }
+        break;
+    }
+
+    /*
+       C = 110 (6Eh) : Get/Set Output Delimiter (CPM3)
+       DE =  0xFFFF (Get) or E = Delimiter (Set)
+       Returns: A = Output Delimiter (on Get)
+       The delimiter terminates strings printed by function 9 (default '$').
+     */
+    case C_DELIMIT: {
+        if (DE == 0xFFFF) {
+            HL = outputDelimiter; // A will receive low byte of HL
+        } else {
+            outputDelimiter = LOW_REGISTER(DE);
+        }
+        break;
+    }
+
+    /*
+       C = 111 (6Fh) : Print Block (CPM3)
+       DE =  address of a Character Control Block (CCB):
+             CCB+0 = buffer address (word)
+             CCB+2 = length in bytes (word)
+       Sends the block to the console using an explicit length (no delimiter).
+       Returns: None
+     */
+    case C_WRITEBLK: {
+        uint16 addr = _RamRead16(DE);
+        uint16 len = _RamRead16(DE + 2);
+        while (len--)
+            _putcon(_RamRead(addr++));
+        break;
+    }
+
+    /*
+       ToDo: C = 112 (70h) : List Block (CPM3)
+       DE =  address of CCB
+       Returns: None
+     */
+    case L_WRITEBLK: {
+        break;
+    }
+
+    /*
+       ToDo: C = 152 (98h) : List Block (CPM3)
+       DE =  address of PFCB
+       Returns: HL = Return code
+                Parsed file control block
+     */
+    case F_PARSE: {
+        break;
+    }
 
 #if defined board_digital_io
 
-		/*
-		   C = 220 (DCh) : PinMode
-		 */
-		case 220: {
-			pinMode(HIGH_REGISTER(DE), LOW_REGISTER(DE));
-			break;
-		}
+    /*
+       C = 220 (DCh) : PinMode
+     */
+    case F_PINMODE: {
+        pinMode(HIGH_REGISTER(DE), LOW_REGISTER(DE));
+        break;
+    }
 
-		/*
-		   C = 221 (DDh) : DigitalRead
-		 */
-		case 221: {
-			HL = digitalRead(HIGH_REGISTER(DE));
-			break;
-		}
+    /*
+       C = 221 (DDh) : DigitalRead
+     */
+    case F_DREAD: {
+        HL = digitalRead(HIGH_REGISTER(DE));
+        break;
+    }
 
-		/*
-		   C = 222 (DEh) : DigitalWrite
-		 */
-		case 222: {
-			digitalWrite(HIGH_REGISTER(DE), LOW_REGISTER(DE));
-			break;
-		}
+    /*
+       C = 222 (DEh) : DigitalWrite
+     */
+    case F_DWRITE: {
+        digitalWrite(HIGH_REGISTER(DE), LOW_REGISTER(DE));
+        break;
+    }
 
-		/*
-		   C = 223 (DFh) : AnalogRead
-		 */
-		case 223: {
-			HL = analogRead(HIGH_REGISTER(DE));
-			break;
-		}
-
+    /*
+       C = 223 (DFh) : AnalogRead
+     */
+    case F_AREAD: {
+        HL = analogRead(HIGH_REGISTER(DE));
+        break;
+    }
 #endif // if defined board_digital_io
 #if defined board_analog_io
 
-		/*
-		   C = 224 (E0h) : AnalogWrite
-		 */
-		case 224: {
-			analogWrite(HIGH_REGISTER(DE), LOW_REGISTER(DE));
-			break;
-		}
-
+    /*
+       C = 224 (E0h) : AnalogWrite
+     */
+    case F_AWRITE: {
+        analogWrite(HIGH_REGISTER(DE), LOW_REGISTER(DE));
+        break;
+    }
 #endif // if defined board_analog_io
 
-		/*
-		   C = 230 (E6h) : Set 8 bit masking
-		 */
-		case 230: {
-			mask8bit = LOW_REGISTER(DE);
-			break;
-		}
+    /*
+       C = 230 (E6h) : Set 8 bit masking
+     */
+    case F_SETMASK: {
+        mask8bit = LOW_REGISTER(DE);
+        break;
+    }
 
-		/*
-		   C = 231 (E7h) : Host specific BDOS call
-		 */
-		case 231: {
-			HL = hostbdos(DE);
-			break;
-		}
+    /*
+       C = 231 (E7h) : Host specific BDOS call
+     */
+    case F_BDOSCALL: {
+        HL = hostbdos(DE);
+        break;
+    }
 
-			/*
-			   C = 232 (E8h) : ESP32 specific BDOS call
-			 */
+    /*
+       C = 232 (E8h) : ESP32 specific BDOS call
+     */
 #if defined board_esp32
-		case 232: {
-			HL = esp32bdos(DE);
-			break;
-		}
+    case 232: {
+        HL = esp32bdos(DE);
+        break;
+    }
 
 #endif // if defined board_esp32
 #if defined board_stm32
-		case 232: {
-			HL = stm32bdos(DE);
-			break;
-		}
+    case 232: {
+        HL = stm32bdos(DE);
+        break;
+    }
 
 #endif // if defined board_stm32
 
-		/*
-		   C = 249 (F9h) : MakeDisk
-		   Makes a disk directory if not existent.
-		 */
-		case 249: {
-			HL = _MakeDisk(DE);
-			break;
-		}
+    /*
+       C = 248 (F8h) : Milliseconds Uptime
+       Returns the number of milliseconds (since the board started).
+     */
+    case F_UPTIME: {
+        timer = millis();
+        HL = timer & 0xFFFF;
+        DE = (timer >> 16) & 0xFFFF;
+        break;
+    }
 
-		/*
-		   C = 250 (FAh) : HostOS
-		   Returns: A = 0x00 - Windows / 0x01 - Arduino / 0x02 - Posix / 0x03 - Dos / 0x04 - Teensy / 0x05 - ESP32 / 0x06 - STM32
-		 */
-		case 250: {
-			HL = HostOS;
-			break;
-		}
+    /*
+       C = 249 (F9h) : MakeDisk
+       Makes a disk directory if not existent.
+     */
+    case F_MAKEDISK: {
+        HL = _MakeDisk(DE);
+        break;
+    }
 
-		/*
-		   C = 251 (FBh) : Version
-		   Returns: A = 0xVv - Version in BCD representation: V.v
-		 */
-		case 251: {
-			HL = VersionBCD;
-			break;
-		}
+    /*
+       C = 250 (FAh) : HostOS
+       Returns: A = 0x00 - Windows / 0x01 - Arduino / 0x02 - Posix / 0x03 - Dos / 0x04 - Teensy / 0x05 - ESP32 / 0x06 - STM32
+     */
+    case F_HOSTOS: {
+        HL = HostOS;
+        break;
+    }
 
-		/*
-		   C = 252 (FCh) : CCP version
-		   Returns: A = 0x00-0x04 = DRI|CCPZ|ZCPR2|ZCPR3|Z80CCP / 0xVv = Internal version in BCD: V.v
-		 */
-		case 252: {
-			HL = VersionCCP;
-			break;
-		}
+    /*
+       C = 251 (FBh) : Version
+       Returns: A = 0xVv - Version in BCD representation: V.v
+     */
+    case F_VERSION: {
+        HL = VersionBCD;
+        break;
+    }
 
-		/*
-		   C = 253 (FDh) : CCP address
-		 */
-		case 253: {
-			HL = CCPaddr;
-			break;
-		}
+    /*
+       C = 252 (FCh) : CCP version
+       Returns: A = 0x00-0x04 = DRI|CCPZ|ZCPR2|ZCPR3|Z80CCP / 0xVv = Internal version in BCD: V.v
+     */
+    case F_CCPVERSION: {
+        HL = VersionCCP;
+        break;
+    }
 
-#ifdef HASLUA
+    /*
+       C = 253 (FDh) : CCP address
+     */
+    case F_CCPADDR: {
+        HL = CCPaddr;
+        break;
+    }
 
-		/*
-		   C = 254 (FEh) : Run Lua file
-		 */
-		case 254: {
-			HL = _RunLua(DE);
-			break;
-		}
+    /*
+       C = 254 (FEh) : Set CPU speed
+       DE = Number of instructions to trigger the delay
+    */
+    case F_SETCPUSPEED: {
+        cpuDelayInstructions = DE;
+        break;
+    }
 
-#endif // ifdef HASLUA
-
-		/*
-		   Unimplemented calls get listed
-		 */
-		default: {
-#ifdef DEBUG    // Show unimplemented BDOS calls only when debugging
-			_puts(	"\r\nUnimplemented BDOS call.\r\n");
-			_puts(	"C = 0x");
-			_puthex8(ch);
-			_puts("\r\n");
+    /*
+       Unimplemented calls get listed
+     */
+    default: {
+#ifdef DEBUG // Show unimplemented BDOS calls only when debugging
+        _puts("\r\nUnimplemented BDOS call.\r\n");
+        _puts("C = 0x");
+        _puthex8(ch);
+        _puts("\r\n");
 #endif // ifdef DEBUG
-			break;
-		}
-	} // switch
+        break;
+    }
+    } // switch
 
-	// CP/M BDOS does this before returning
-	SET_HIGH_REGISTER(	BC, HIGH_REGISTER(HL));
-	SET_HIGH_REGISTER(	AF, LOW_REGISTER(HL));
+    // CP/M BDOS does this before returning
+    SET_HIGH_REGISTER(BC, HIGH_REGISTER(HL));
+    SET_HIGH_REGISTER(AF, LOW_REGISTER(HL));
 
 #ifdef DEBUGLOG
-	_logBdosOut(ch);
+    _logBdosOut(ch);
 #endif
 } // _Bdos
 
 #endif // ifndef CPM_H
-

--- a/lib/runcpm/cpm.h
+++ b/lib/runcpm/cpm.h
@@ -578,10 +578,10 @@ RUNCPM_DECL void _Bios(void) {
     }
     case B_CONIN: { // 3 - Console input
         SET_HIGH_REGISTER(AF, _getcon());
-#ifdef DEBUG
+#if RUNCPMDEBUG
         if (HIGH_REGISTER(AF) == DEBUGKEY)
             Debug = 1;
-#endif // ifdef DEBUG
+#endif // RUNCPMDEBUG
         break;
     }
     case B_CONOUT: { // 4 - Console output
@@ -705,12 +705,12 @@ RUNCPM_DECL void _Bios(void) {
         break;
     }
     default: {
-#ifdef DEBUG // Show unimplemented BIOS calls only when debugging
+#if RUNCPMDEBUG // Show unimplemented BIOS calls only when debugging
         _puts("\r\nUnimplemented BIOS call.\r\n");
         _puts("C = 0x");
         _puthex8(ch);
         _puts("\r\n");
-#endif // ifdef DEBUG
+#endif // RUNCPMDEBUG
         break;
     }
     } // switch
@@ -766,10 +766,10 @@ RUNCPM_DECL void _Bdos(void) {
      */
     case C_READ: {
         HL = _getconE();
-    #ifdef DEBUG
+    #if RUNCPMDEBUG
         if (HL == DEBUGKEY)
             Debug = 1;
-    #endif // ifdef DEBUG
+    #endif // RUNCPMDEBUG
         break;
     }
 
@@ -848,10 +848,10 @@ RUNCPM_DECL void _Bdos(void) {
         if (e == 0xFF) {
             // Check for char available and return it, or 0x00 if none (non-blocking read)
             HL = _getconNB();
-    #ifdef DEBUG
+    #if RUNCPMDEBUG
             if (HL == DEBUGKEY)
                 Debug = 1;
-    #endif // ifdef DEBUG
+    #endif // RUNCPMDEBUG
     #ifdef CPM3
         } else if (e == 0xFE) {
             // Return console input status. Zero if no character is waiting, nonzero otherwise. (CPM3)
@@ -859,10 +859,10 @@ RUNCPM_DECL void _Bdos(void) {
         } else if (e == 0xFD) {
             // Wait until a character is ready, return it without echoing. (CPM3)
             HL = _getcon();
-    #ifdef DEBUG
+    #if RUNCPMDEBUG
             if (HL == DEBUGKEY)
                 Debug = 1;
-    #endif // ifdef DEBUG
+    #endif // RUNCPMDEBUG
     #endif // ifdef CPM3
         } else {
             // E = char : Outputs char (write)
@@ -1004,12 +1004,12 @@ RUNCPM_DECL void _Bdos(void) {
                 break;
             }
 
-    #ifdef DEBUG
+    #if RUNCPMDEBUG
             if (chr == DEBUGKEY) { // Enter debugger
                 Debug = 1;
                 break;
             }
-    #endif // ifdef DEBUG
+    #endif // RUNCPMDEBUG
 
             if (chr == 5) { // ^E - goto beginning of next line
                 _putcon('\n');
@@ -2149,12 +2149,12 @@ RUNCPM_DECL void _Bdos(void) {
        Unimplemented calls get listed
      */
     default: {
-#ifdef DEBUG // Show unimplemented BDOS calls only when debugging
+#if RUNCPMDEBUG // Show unimplemented BDOS calls only when debugging
         _puts("\r\nUnimplemented BDOS call.\r\n");
         _puts("C = 0x");
         _puthex8(ch);
         _puts("\r\n");
-#endif // ifdef DEBUG
+#endif // RUNCPMDEBUG
         break;
     }
     } // switch

--- a/lib/runcpm/cpu.h
+++ b/lib/runcpm/cpu.h
@@ -39,7 +39,7 @@ RUNCPM_DECL int32 Step = -1;
    compatibility globals.  `Watch` is suppressed when DEBUG/iDEBUG is on so
    it does not clash with debug.h's own definition. */
 RUNCPM_DECL int32 Break = -1;
-#if !defined(DEBUG) && !defined(iDEBUG)
+#if !RUNCPMDEBUG && !defined(iDEBUG)
 RUNCPM_DECL int32 Watch = -1;
 #endif
 
@@ -1059,7 +1059,7 @@ static inline void Z80reset(void) {
 	#endif
 }
 
-#if defined(DEBUG) || defined(iDEBUG)
+#if RUNCPMDEBUG || defined(iDEBUG)
 #include "debug.h"
 #endif
 
@@ -1098,7 +1098,7 @@ static inline void Z80run(uint32 cpu_delay) {
         	}
 		}
 
-#ifdef DEBUG
+#if RUNCPMDEBUG
 		if (z80_check_breakpoints_on_exec(PC)) {
 			Debug = 1;
 		}
@@ -1116,7 +1116,7 @@ static inline void Z80run(uint32 cpu_delay) {
 	INCR(1); /* Add one M1 cycle to refresh counter */
 
 	/* push instruction into trace (before it is executed) */
-#if defined(DEBUG) || defined(iDEBUG)
+#if RUNCPMDEBUG || defined(iDEBUG)
 	z80_trace_push(PCX);
 #endif
 
@@ -1702,7 +1702,7 @@ static inline void Z80run(uint32 cpu_delay) {
 			break;
 
 		case 0x76:      /* HALT */
-#ifdef DEBUG
+#if RUNCPMDEBUG
 			_puts("\r\n::CPU HALTED::\r\n");	// A halt is a good indicator of broken code
 			_puts("Press any key...");
 			_getcon();

--- a/lib/runcpm/cpu.h
+++ b/lib/runcpm/cpu.h
@@ -1,14 +1,16 @@
 #ifndef CPU_H
 #define CPU_H
 
-/* see main.c for definition */
-
-/* Fallback: globals.h normally defines RUNCPM_DECL before cpu.h is included.
- * This guard handles the case where cpu.h is inspected in isolation. */
 #ifndef RUNCPM_DECL
 #define RUNCPM_DECL
 #endif
 
+/* Model 1 - Larger code, original */
+/* 6 MHz on an Arduino Due */
+
+#define CPU_IS "Model 1"
+
+/* Register Definitions */
 RUNCPM_DECL int32 PCX; /* external view of PC                          */
 RUNCPM_DECL int32 AF;  /* AF register                                  */
 RUNCPM_DECL int32 BC;  /* BC register                                  */
@@ -24,10 +26,22 @@ RUNCPM_DECL int32 DE1; /* alternate DE register                        */
 RUNCPM_DECL int32 HL1; /* alternate HL register                        */
 RUNCPM_DECL int32 IFF; /* Interrupt Flip Flop                          */
 RUNCPM_DECL int32 IR;  /* Interrupt (upper) / Refresh (lower) register */
-RUNCPM_DECL int32 Status = 0; /* Status of the CPU 0=running 1=end request 2=back to CCP */
+RUNCPM_DECL int32 Status = STATUS_RUNNING; /* Status of the CPU 0=running 1=end request 2=back to CCP */
 RUNCPM_DECL int32 Debug = 0;
-RUNCPM_DECL int32 Break = -1;
 RUNCPM_DECL int32 Step = -1;
+
+/* FujiNet vendoring: RunCPM 6.9 dropped the standalone `Break` debugger
+   variable and moved `Watch` into debug.h behind the DEBUG/iDEBUG gate
+   (and debug.h is only #included when DEBUG/iDEBUG is defined - see the
+   guarded include below).  The frozen FujiNet consumers (siocpm.cpp,
+   CPM.cpp, etc.) still assign `Break` and `Watch` unconditionally, exactly
+   as they did against RunCPM 5.8, so define them here as plain
+   compatibility globals.  `Watch` is suppressed when DEBUG/iDEBUG is on so
+   it does not clash with debug.h's own definition. */
+RUNCPM_DECL int32 Break = -1;
+#if !defined(DEBUG) && !defined(iDEBUG)
+RUNCPM_DECL int32 Watch = -1;
+#endif
 
 #ifdef iDEBUG
 RUNCPM_DECL FILE* iLogFile;
@@ -45,33 +59,34 @@ RUNCPM_DECL const char* iLogTxt;
 /*
 	Functions needed by the soft CPU implementation
 */
-RUNCPM_DECL void cpu_out(const uint32 Port, const uint32 Value) {
-	if (Port == 0xFF) {
+RUNCPM_DECL void cpu_out(const uint32 p, const uint32 v) {
+#ifdef INT_HANDOFF
+	_HardwareOut(p, v);
+#else
+	if (p == 0xFF) {
 		_Bios();
 	} else {
-		_HardwareOut(Port, Value);
+		_HardwareOut(p, v);
 	}
+#endif
 }
 
-RUNCPM_DECL uint32 cpu_in(const uint32 Port) {
-	uint32 Result;
-	if (Port == 0xFF) {
+RUNCPM_DECL uint32 cpu_in(const uint32 p) {
+	uint32 v;
+#ifdef INT_HANDOFF
+	v = _HardwareIn(p);
+#else
+	if (p == 0xFF) {
 		_Bdos();
-		Result = HIGH_REGISTER(AF);
+		v = HIGH_REGISTER(AF);
 	} else {
-		Result = _HardwareIn(Port);
+		v = _HardwareIn(p);
 	}
-	return(Result);
+#endif
+	return(v);
 }
 
 /* Z80 Custom soft core */
-
-/* simulator stop codes */
-#define STOP_HALT       0   /* HALT                                             */
-#define STOP_IBKPT      1   /* breakpoint   (program counter)                   */
-#define STOP_MEM        2   /* breakpoint   (memory access)                     */
-#define STOP_INSTR      3   /* breakpoint   (instruction access)                */
-#define STOP_OPCODE     4   /* invalid operation encountered (8080, Z80, 8086)  */
 
 #define ADDRMASK        0xffff
 
@@ -85,14 +100,12 @@ RUNCPM_DECL uint32 cpu_in(const uint32 Port) {
 #define SETFLAG(f,c)    (AF = (c) ? AF | FLAG_ ## f : AF & ~FLAG_ ## f)
 #define TSTFLAG(f)      ((AF & FLAG_ ## f) != 0)
 
-#define PARITY(x)   parityTable[(x) & 0xff]
-
 #define SET_PVS(s)  (((cbits >> 6) ^ (cbits >> 5)) & 4)
 #define SET_PV      (SET_PVS(sum))
 #define SET_PV2(x)  ((temp == (x)) << 2)
 
 #define POP(x)  {                               \
-    uint32 y = RAM_PP(SP);             \
+    uint32 y = RAM_PP(SP);                      \
     x = y + (RAM_PP(SP) << 8);                  \
 }
 
@@ -100,17 +113,19 @@ RUNCPM_DECL uint32 cpu_in(const uint32 Port) {
     if (cond) {                                 \
         PC = GET_WORD(PC);                      \
     } else {                                    \
-        PC += 2;                                \
+		PC++;                                   \
+        PC++;                                   \
     }                                           \
 }
 
 #define CALLC(cond) {                           \
     if (cond) {                                 \
-        uint32 adrr = GET_WORD(PC);    \
+        uint32 a = GET_WORD(PC);                \
         PUSH(PC + 2);                           \
-        PC = adrr;                              \
+        PC = a;                                 \
     } else {                                    \
-        PC += 2;                                \
+		PC++;                                   \
+        PC++;                                   \
     }                                           \
 }
 
@@ -140,7 +155,10 @@ rrdrldTable[i]          0..255  (i << 8) | (i & 0xa8) | (((i & 0xff) == 0) << 6)
 cpTable[i]              0..255  (i & 0x80) | (((i & 0xff) == 0) << 6)
 */
 
+//#define preTables // Use precomputed tables (increases the size of the binary by 4k or more)
+
 /* parityTable[i] = (number of 1's in i is odd) ? 0 : 4, i = 0..255 */
+#ifdef preTables
 static const uint8 parityTable[256] = {
 	4,0,0,4,0,4,4,0,0,4,4,0,4,0,0,4,
 	0,4,4,0,4,0,0,4,4,0,0,4,0,4,4,0,
@@ -904,247 +922,89 @@ static const uint8 cpTable[256] = {
 	128,128,128,128,128,128,128,128,128,128,128,128,128,128,128,128,
 };
 
-#if defined(DEBUG) || defined(iDEBUG)
-static const char* Mnemonics[256] =
-{
-	"NOP", "LD BC,#h", "LD (BC),A", "INC BC", "INC B", "DEC B", "LD B,*h", "RLCA",
-	"EX AF,AF'", "ADD HL,BC", "LD A,(BC)", "DEC BC", "INC C", "DEC C", "LD C,*h", "RRCA",
-	"DJNZ @h", "LD DE,#h", "LD (DE),A", "INC DE", "INC D", "DEC D", "LD D,*h", "RLA",
-	"JR @h", "ADD HL,DE", "LD A,(DE)", "DEC DE", "INC E", "DEC E", "LD E,*h", "RRA",
-	"JR NZ,@h", "LD HL,#h", "LD (#h),HL", "INC HL", "INC H", "DEC H", "LD H,*h", "DAA",
-	"JR Z,@h", "ADD HL,HL", "LD HL,(#h)", "DEC HL", "INC L", "DEC L", "LD L,*h", "CPL",
-	"JR NC,@h", "LD SP,#h", "LD (#h),A", "INC SP", "INC (HL)", "DEC (HL)", "LD (HL),*h", "SCF",
-	"JR C,@h", "ADD HL,SP", "LD A,(#h)", "DEC SP", "INC A", "DEC A", "LD A,*h", "CCF",
-	"LD B,B", "LD B,C", "LD B,D", "LD B,E", "LD B,H", "LD B,L", "LD B,(HL)", "LD B,A",
-	"LD C,B", "LD C,C", "LD C,D", "LD C,E", "LD C,H", "LD C,L", "LD C,(HL)", "LD C,A",
-	"LD D,B", "LD D,C", "LD D,D", "LD D,E", "LD D,H", "LD D,L", "LD D,(HL)", "LD D,A",
-	"LD E,B", "LD E,C", "LD E,D", "LD E,E", "LD E,H", "LD E,L", "LD E,(HL)", "LD E,A",
-	"LD H,B", "LD H,C", "LD H,D", "LD H,E", "LD H,H", "LD H,L", "LD H,(HL)", "LD H,A",
-	"LD L,B", "LD L,C", "LD L,D", "LD L,E", "LD L,H", "LD L,L", "LD L,(HL)", "LD L,A",
-	"LD (HL),B", "LD (HL),C", "LD (HL),D", "LD (HL),E", "LD (HL),H", "LD (HL),L", "HALT", "LD (HL),A",
-	"LD A,B", "LD A,C", "LD A,D", "LD A,E", "LD A,H", "LD A,L", "LD A,(HL)", "LD A,A",
-	"ADD B", "ADD C", "ADD D", "ADD E", "ADD H", "ADD L", "ADD (HL)", "ADD A",
-	"ADC B", "ADC C", "ADC D", "ADC E", "ADC H", "ADC L", "ADC (HL)", "ADC A",
-	"SUB B", "SUB C", "SUB D", "SUB E", "SUB H", "SUB L", "SUB (HL)", "SUB A",
-	"SBC B", "SBC C", "SBC D", "SBC E", "SBC H", "SBC L", "SBC (HL)", "SBC A",
-	"AND B", "AND C", "AND D", "AND E", "AND H", "AND L", "AND (HL)", "AND A",
-	"XOR B", "XOR C", "XOR D", "XOR E", "XOR H", "XOR L", "XOR (HL)", "XOR A",
-	"OR B", "OR C", "OR D", "OR E", "OR H", "OR L", "OR (HL)", "OR A",
-	"CP B", "CP C", "CP D", "CP E", "CP H", "CP L", "CP (HL)", "CP A",
-	"RET NZ", "POP BC", "JP NZ,#h", "JP #h", "CALL NZ,#h", "PUSH BC", "ADD *h", "RST 00h",
-	"RET Z", "RET", "JP Z,#h", "PFX_CB", "CALL Z,#h", "CALL #h", "ADC *h", "RST 08h",
-	"RET NC", "POP DE", "JP NC,#h", "OUTA (*h)", "CALL NC,#h", "PUSH DE", "SUB *h", "RST 10h",
-	"RET C", "EXX", "JP C,#h", "INA (*h)", "CALL C,#h", "PFX_DD", "SBC *h", "RST 18h",
-	"RET PO", "POP HL", "JP PO,#h", "EX HL,(SP)", "CALL PO,#h", "PUSH HL", "AND *h", "RST 20h",
-	"RET PE", "LD PC,HL", "JP PE,#h", "EX DE,HL", "CALL PE,#h", "PFX_ED", "XOR *h", "RST 28h",
-	"RET P", "POP AF", "JP P,#h", "DI", "CALL P,#h", "PUSH AF", "OR *h", "RST 30h",
-	"RET M", "LD SP,HL", "JP M,#h", "EI", "CALL M,#h", "PFX_FD", "CP *h", "RST 38h"
-};
+#else
 
-static const char* MnemonicsCB[256] =
-{
-	"RLC B", "RLC C", "RLC D", "RLC E", "RLC H", "RLC L", "RLC (HL)", "RLC A",
-	"RRC B", "RRC C", "RRC D", "RRC E", "RRC H", "RRC L", "RRC (HL)", "RRC A",
-	"RL B", "RL C", "RL D", "RL E", "RL H", "RL L", "RL (HL)", "RL A",
-	"RR B", "RR C", "RR D", "RR E", "RR H", "RR L", "RR (HL)", "RR A",
-	"SLA B", "SLA C", "SLA D", "SLA E", "SLA H", "SLA L", "SLA (HL)", "SLA A",
-	"SRA B", "SRA C", "SRA D", "SRA E", "SRA H", "SRA L", "SRA (HL)", "SRA A",
-	"SLL B", "SLL C", "SLL D", "SLL E", "SLL H", "SLL L", "SLL (HL)", "SLL A",
-	"SRL B", "SRL C", "SRL D", "SRL E", "SRL H", "SRL L", "SRL (HL)", "SRL A",
-	"BIT 0,B", "BIT 0,C", "BIT 0,D", "BIT 0,E", "BIT 0,H", "BIT 0,L", "BIT 0,(HL)", "BIT 0,A",
-	"BIT 1,B", "BIT 1,C", "BIT 1,D", "BIT 1,E", "BIT 1,H", "BIT 1,L", "BIT 1,(HL)", "BIT 1,A",
-	"BIT 2,B", "BIT 2,C", "BIT 2,D", "BIT 2,E", "BIT 2,H", "BIT 2,L", "BIT 2,(HL)", "BIT 2,A",
-	"BIT 3,B", "BIT 3,C", "BIT 3,D", "BIT 3,E", "BIT 3,H", "BIT 3,L", "BIT 3,(HL)", "BIT 3,A",
-	"BIT 4,B", "BIT 4,C", "BIT 4,D", "BIT 4,E", "BIT 4,H", "BIT 4,L", "BIT 4,(HL)", "BIT 4,A",
-	"BIT 5,B", "BIT 5,C", "BIT 5,D", "BIT 5,E", "BIT 5,H", "BIT 5,L", "BIT 5,(HL)", "BIT 5,A",
-	"BIT 6,B", "BIT 6,C", "BIT 6,D", "BIT 6,E", "BIT 6,H", "BIT 6,L", "BIT 6,(HL)", "BIT 6,A",
-	"BIT 7,B", "BIT 7,C", "BIT 7,D", "BIT 7,E", "BIT 7,H", "BIT 7,L", "BIT 7,(HL)", "BIT 7,A",
-	"RES 0,B", "RES 0,C", "RES 0,D", "RES 0,E", "RES 0,H", "RES 0,L", "RES 0,(HL)", "RES 0,A",
-	"RES 1,B", "RES 1,C", "RES 1,D", "RES 1,E", "RES 1,H", "RES 1,L", "RES 1,(HL)", "RES 1,A",
-	"RES 2,B", "RES 2,C", "RES 2,D", "RES 2,E", "RES 2,H", "RES 2,L", "RES 2,(HL)", "RES 2,A",
-	"RES 3,B", "RES 3,C", "RES 3,D", "RES 3,E", "RES 3,H", "RES 3,L", "RES 3,(HL)", "RES 3,A",
-	"RES 4,B", "RES 4,C", "RES 4,D", "RES 4,E", "RES 4,H", "RES 4,L", "RES 4,(HL)", "RES 4,A",
-	"RES 5,B", "RES 5,C", "RES 5,D", "RES 5,E", "RES 5,H", "RES 5,L", "RES 5,(HL)", "RES 5,A",
-	"RES 6,B", "RES 6,C", "RES 6,D", "RES 6,E", "RES 6,H", "RES 6,L", "RES 6,(HL)", "RES 6,A",
-	"RES 7,B", "RES 7,C", "RES 7,D", "RES 7,E", "RES 7,H", "RES 7,L", "RES 7,(HL)", "RES 7,A",
-	"SET 0,B", "SET 0,C", "SET 0,D", "SET 0,E", "SET 0,H", "SET 0,L", "SET 0,(HL)", "SET 0,A",
-	"SET 1,B", "SET 1,C", "SET 1,D", "SET 1,E", "SET 1,H", "SET 1,L", "SET 1,(HL)", "SET 1,A",
-	"SET 2,B", "SET 2,C", "SET 2,D", "SET 2,E", "SET 2,H", "SET 2,L", "SET 2,(HL)", "SET 2,A",
-	"SET 3,B", "SET 3,C", "SET 3,D", "SET 3,E", "SET 3,H", "SET 3,L", "SET 3,(HL)", "SET 3,A",
-	"SET 4,B", "SET 4,C", "SET 4,D", "SET 4,E", "SET 4,H", "SET 4,L", "SET 4,(HL)", "SET 4,A",
-	"SET 5,B", "SET 5,C", "SET 5,D", "SET 5,E", "SET 5,H", "SET 5,L", "SET 5,(HL)", "SET 5,A",
-	"SET 6,B", "SET 6,C", "SET 6,D", "SET 6,E", "SET 6,H", "SET 6,L", "SET 6,(HL)", "SET 6,A",
-	"SET 7,B", "SET 7,C", "SET 7,D", "SET 7,E", "SET 7,H", "SET 7,L", "SET 7,(HL)", "SET 7,A"
-};
+static uint8 parityTable[256];
+static uint8 incTable[257];
+static uint8 decTable[256];
+static uint8 cbitsTable[512];
+static uint16 cbitsDup8Table[512];
+static uint8 cbitsDup16Table[512];
+static uint8 cbits2Table[512];
+static uint16 rrcaTable[256];
+static uint16 rraTable[256];
+static uint16 addTable[512];
+static uint16 subTable[256];
+static uint16 andTable[256];
+static uint16 xororTable[256];
+static uint8 rotateShiftTable[256];
+static uint8 incZ80Table[257];
+static uint8 decZ80Table[256];
+static uint8 cbitsZ80Table[512];
+static uint8 cbitsZ80DupTable[512];
+static uint8 cbits2Z80Table[512];
+static uint8 cbits2Z80DupTable[512];
+static uint8 negTable[256];
+static uint16 rrdrldTable[256];
+static uint8 cpTable[256];
 
-static const char* MnemonicsED[256] =
-{
-	"DB EDh,00h", "DB EDh,01h", "DB EDh,02h", "DB EDh,03h",
-	"DB EDh,04h", "DB EDh,05h", "DB EDh,06h", "DB EDh,07h",
-	"DB EDh,08h", "DB EDh,09h", "DB EDh,0Ah", "DB EDh,0Bh",
-	"DB EDh,0Ch", "DB EDh,0Dh", "DB EDh,0Eh", "DB EDh,0Fh",
-	"DB EDh,10h", "DB EDh,11h", "DB EDh,12h", "DB EDh,13h",
-	"DB EDh,14h", "DB EDh,15h", "DB EDh,16h", "DB EDh,17h",
-	"DB EDh,18h", "DB EDh,19h", "DB EDh,1Ah", "DB EDh,1Bh",
-	"DB EDh,1Ch", "DB EDh,1Dh", "DB EDh,1Eh", "DB EDh,1Fh",
-	"DB EDh,20h", "DB EDh,21h", "DB EDh,22h", "DB EDh,23h",
-	"DB EDh,24h", "DB EDh,25h", "DB EDh,26h", "DB EDh,27h",
-	"DB EDh,28h", "DB EDh,29h", "DB EDh,2Ah", "DB EDh,2Bh",
-	"DB EDh,2Ch", "DB EDh,2Dh", "DB EDh,2Eh", "DB EDh,2Fh",
-	"DB EDh,30h", "DB EDh,31h", "DB EDh,32h", "DB EDh,33h",
-	"DB EDh,34h", "DB EDh,35h", "DB EDh,36h", "DB EDh,37h",
-	"DB EDh,38h", "DB EDh,39h", "DB EDh,3Ah", "DB EDh,3Bh",
-	"DB EDh,3Ch", "DB EDh,3Dh", "DB EDh,3Eh", "DB EDh,3Fh",
-	"IN B,(C)", "OUT (C),B", "SBC HL,BC", "LD (#h),BC",
-	"NEG", "RETN", "IM 0", "LD I,A",
-	"IN C,(C)", "OUT (C),C", "ADC HL,BC", "LD BC,(#h)",
-	"DB EDh,4Ch", "RETI", "DB EDh,4Eh", "LD R,A",
-	"IN D,(C)", "OUT (C),D", "SBC HL,DE", "LD (#h),DE",
-	"DB EDh,54h", "DB EDh,55h", "IM 1", "LD A,I",
-	"IN E,(C)", "OUT (C),E", "ADC HL,DE", "LD DE,(#h)",
-	"DB EDh,5Ch", "DB EDh,5Dh", "IM 2", "LD A,R",
-	"IN H,(C)", "OUT (C),H", "SBC HL,HL", "LD (#h),HL",
-	"DB EDh,64h", "DB EDh,65h", "DB EDh,66h", "RRD",
-	"IN L,(C)", "OUT (C),L", "ADC HL,HL", "LD HL,(#h)",
-	"DB EDh,6Ch", "DB EDh,6Dh", "DB EDh,6Eh", "RLD",
-	"IN F,(C)", "DB EDh,71h", "SBC HL,SP", "LD (#h),SP",
-	"DB EDh,74h", "DB EDh,75h", "DB EDh,76h", "DB EDh,77h",
-	"IN A,(C)", "OUT (C),A", "ADC HL,SP", "LD SP,(#h)",
-	"DB EDh,7Ch", "DB EDh,7Dh", "DB EDh,7Eh", "DB EDh,7Fh",
-	"DB EDh,80h", "DB EDh,81h", "DB EDh,82h", "DB EDh,83h",
-	"DB EDh,84h", "DB EDh,85h", "DB EDh,86h", "DB EDh,87h",
-	"DB EDh,88h", "DB EDh,89h", "DB EDh,8Ah", "DB EDh,8Bh",
-	"DB EDh,8Ch", "DB EDh,8Dh", "DB EDh,8Eh", "DB EDh,8Fh",
-	"DB EDh,90h", "DB EDh,91h", "DB EDh,92h", "DB EDh,93h",
-	"DB EDh,94h", "DB EDh,95h", "DB EDh,96h", "DB EDh,97h",
-	"DB EDh,98h", "DB EDh,99h", "DB EDh,9Ah", "DB EDh,9Bh",
-	"DB EDh,9Ch", "DB EDh,9Dh", "DB EDh,9Eh", "DB EDh,9Fh",
-	"LDI", "CPI", "INI", "OUTI",
-	"DB EDh,A4h", "DB EDh,A5h", "DB EDh,A6h", "DB EDh,A7h",
-	"LDD", "CPD", "IND", "OUTD",
-	"DB EDh,ACh", "DB EDh,ADh", "DB EDh,AEh", "DB EDh,AFh",
-	"LDIR", "CPIR", "INIR", "OTIR",
-	"DB EDh,B4h", "DB EDh,B5h", "DB EDh,B6h", "DB EDh,B7h",
-	"LDDR", "CPDR", "INDR", "OTDR",
-	"DB EDh,BCh", "DB EDh,BDh", "DB EDh,BEh", "DB EDh,BFh",
-	"DB EDh,C0h", "DB EDh,C1h", "DB EDh,C2h", "DB EDh,C3h",
-	"DB EDh,C4h", "DB EDh,C5h", "DB EDh,C6h", "DB EDh,C7h",
-	"DB EDh,C8h", "DB EDh,C9h", "DB EDh,CAh", "DB EDh,CBh",
-	"DB EDh,CCh", "DB EDh,CDh", "DB EDh,CEh", "DB EDh,CFh",
-	"DB EDh,D0h", "DB EDh,D1h", "DB EDh,D2h", "DB EDh,D3h",
-	"DB EDh,D4h", "DB EDh,D5h", "DB EDh,D6h", "DB EDh,D7h",
-	"DB EDh,D8h", "DB EDh,D9h", "DB EDh,DAh", "DB EDh,DBh",
-	"DB EDh,DCh", "DB EDh,DDh", "DB EDh,DEh", "DB EDh,DFh",
-	"DB EDh,E0h", "DB EDh,E1h", "DB EDh,E2h", "DB EDh,E3h",
-	"DB EDh,E4h", "DB EDh,E5h", "DB EDh,E6h", "DB EDh,E7h",
-	"DB EDh,E8h", "DB EDh,E9h", "DB EDh,EAh", "DB EDh,EBh",
-	"DB EDh,ECh", "DB EDh,EDh", "DB EDh,EEh", "DB EDh,EFh",
-	"DB EDh,F0h", "DB EDh,F1h", "DB EDh,F2h", "DB EDh,F3h",
-	"DB EDh,F4h", "DB EDh,F5h", "DB EDh,F6h", "DB EDh,F7h",
-	"DB EDh,F8h", "DB EDh,F9h", "DB EDh,FAh", "DB EDh,FBh",
-	"DB EDh,FCh", "DB EDh,FDh", "DB EDh,FEh", "DB EDh,FFh"
-};
-
-static const char* MnemonicsXX[256] =
-{
-	"NOP", "LD BC,#h", "LD (BC),A", "INC BC", "INC B", "DEC B", "LD B,*h", "RLCA",
-	"EX AF,AF'", "ADD I%,BC", "LD A,(BC)", "DEC BC", "INC C", "DEC C", "LD C,*h", "RRCA",
-	"DJNZ @h", "LD DE,#h", "LD (DE),A", "INC DE", "INC D", "DEC D", "LD D,*h", "RLA",
-	"JR @h", "ADD I%,DE", "LD A,(DE)", "DEC DE", "INC E", "DEC E", "LD E,*h", "RRA",
-	"JR NZ,@h", "LD I%,#h", "LD (#h),I%", "INC I%", "INC I%h", "DEC I%h", "LD I%h,*h", "DAA",
-	"JR Z,@h", "ADD I%,I%", "LD I%,(#h)", "DEC I%", "INC I%l", "DEC I%l", "LD I%l,*h", "CPL",
-	"JR NC,@h", "LD SP,#h", "LD (#h),A", "INC SP", "INC (I%+^h)", "DEC (I%+^h)", "LD (I%+^h),*h", "SCF",
-	"JR C,@h", "ADD I%,SP", "LD A,(#h)", "DEC SP", "INC A", "DEC A", "LD A,*h", "CCF",
-	"LD B,B", "LD B,C", "LD B,D", "LD B,E", "LD B,I%h", "LD B,I%l", "LD B,(I%+^h)", "LD B,A",
-	"LD C,B", "LD C,C", "LD C,D", "LD C,E", "LD C,I%h", "LD C,I%l", "LD C,(I%+^h)", "LD C,A",
-	"LD D,B", "LD D,C", "LD D,D", "LD D,E", "LD D,I%h", "LD D,I%l", "LD D,(I%+^h)", "LD D,A",
-	"LD E,B", "LD E,C", "LD E,D", "LD E,E", "LD E,I%h", "LD E,I%l", "LD E,(I%+^h)", "LD E,A",
-	"LD I%h,B", "LD I%h,C", "LD I%h,D", "LD I%h,E", "LD I%h,I%h", "LD I%h,I%l", "LD H,(I%+^h)", "LD I%h,A",
-	"LD I%l,B", "LD I%l,C", "LD I%l,D", "LD I%l,E", "LD I%l,I%h", "LD I%l,I%l", "LD L,(I%+^h)", "LD I%l,A",
-	"LD (I%+^h),B", "LD (I%+^h),C", "LD (I%+^h),D", "LD (I%+^h),E", "LD (I%+^h),H", "LD (I%+^h),L", "HALT", "LD (I%+^h),A",
-	"LD A,B", "LD A,C", "LD A,D", "LD A,E", "LD A,I%h", "LD A,I%l", "LD A,(I%+^h)", "LD A,A",
-	"ADD B", "ADD C", "ADD D", "ADD E", "ADD I%h", "ADD I%l", "ADD (I%+^h)", "ADD A",
-	"ADC B", "ADC C", "ADC D", "ADC E", "ADC I%h", "ADC I%l", "ADC (I%+^h)", "ADC,A",
-	"SUB B", "SUB C", "SUB D", "SUB E", "SUB I%h", "SUB I%l", "SUB (I%+^h)", "SUB A",
-	"SBC B", "SBC C", "SBC D", "SBC E", "SBC I%h", "SBC I%l", "SBC (I%+^h)", "SBC A",
-	"AND B", "AND C", "AND D", "AND E", "AND I%h", "AND I%l", "AND (I%+^h)", "AND A",
-	"XOR B", "XOR C", "XOR D", "XOR E", "XOR I%h", "XOR I%l", "XOR (I%+^h)", "XOR A",
-	"OR B", "OR C", "OR D", "OR E", "OR I%h", "OR I%l", "OR (I%+^h)", "OR A",
-	"CP B", "CP C", "CP D", "CP E", "CP I%h", "CP I%l", "CP (I%+^h)", "CP A",
-	"RET NZ", "POP BC", "JP NZ,#h", "JP #h", "CALL NZ,#h", "PUSH BC", "ADD *h", "RST 00h",
-	"RET Z", "RET", "JP Z,#h", "PFX_CB", "CALL Z,#h", "CALL #h", "ADC *h", "RST 08h",
-	"RET NC", "POP DE", "JP NC,#h", "OUTA (*h)", "CALL NC,#h", "PUSH DE", "SUB *h", "RST 10h",
-	"RET C", "EXX", "JP C,#h", "INA (*h)", "CALL C,#h", "PFX_DD", "SBC *h", "RST 18h",
-	"RET PO", "POP I%", "JP PO,#h", "EX I%,(SP)", "CALL PO,#h", "PUSH I%", "AND *h", "RST 20h",
-	"RET PE", "LD PC,I%", "JP PE,#h", "EX DE,I%", "CALL PE,#h", "PFX_ED", "XOR *h", "RST 28h",
-	"RET P", "POP AF", "JP P,#h", "DI", "CALL P,#h", "PUSH AF", "OR *h", "RST 30h",
-	"RET M", "LD SP,I%", "JP M,#h", "EI", "CALL M,#h", "PFX_FD", "CP *h", "RST 38h"
-};
-
-static const char* MnemonicsXCB[256] =
-{
-	"RLC B", "RLC C", "RLC D", "RLC E", "RLC H", "RLC L", "RLC (I%@h)", "RLC A",
-	"RRC B", "RRC C", "RRC D", "RRC E", "RRC H", "RRC L", "RRC (I%@h)", "RRC A",
-	"RL B", "RL C", "RL D", "RL E", "RL H", "RL L", "RL (I%@h)", "RL A",
-	"RR B", "RR C", "RR D", "RR E", "RR H", "RR L", "RR (I%@h)", "RR A",
-	"SLA B", "SLA C", "SLA D", "SLA E", "SLA H", "SLA L", "SLA (I%@h)", "SLA A",
-	"SRA B", "SRA C", "SRA D", "SRA E", "SRA H", "SRA L", "SRA (I%@h)", "SRA A",
-	"SLL B", "SLL C", "SLL D", "SLL E", "SLL H", "SLL L", "SLL (I%@h)", "SLL A",
-	"SRL B", "SRL C", "SRL D", "SRL E", "SRL H", "SRL L", "SRL (I%@h)", "SRL A",
-	"BIT 0,B", "BIT 0,C", "BIT 0,D", "BIT 0,E", "BIT 0,H", "BIT 0,L", "BIT 0,(I%@h)", "BIT 0,A",
-	"BIT 1,B", "BIT 1,C", "BIT 1,D", "BIT 1,E", "BIT 1,H", "BIT 1,L", "BIT 1,(I%@h)", "BIT 1,A",
-	"BIT 2,B", "BIT 2,C", "BIT 2,D", "BIT 2,E", "BIT 2,H", "BIT 2,L", "BIT 2,(I%@h)", "BIT 2,A",
-	"BIT 3,B", "BIT 3,C", "BIT 3,D", "BIT 3,E", "BIT 3,H", "BIT 3,L", "BIT 3,(I%@h)", "BIT 3,A",
-	"BIT 4,B", "BIT 4,C", "BIT 4,D", "BIT 4,E", "BIT 4,H", "BIT 4,L", "BIT 4,(I%@h)", "BIT 4,A",
-	"BIT 5,B", "BIT 5,C", "BIT 5,D", "BIT 5,E", "BIT 5,H", "BIT 5,L", "BIT 5,(I%@h)", "BIT 5,A",
-	"BIT 6,B", "BIT 6,C", "BIT 6,D", "BIT 6,E", "BIT 6,H", "BIT 6,L", "BIT 6,(I%@h)", "BIT 6,A",
-	"BIT 7,B", "BIT 7,C", "BIT 7,D", "BIT 7,E", "BIT 7,H", "BIT 7,L", "BIT 7,(I%@h)", "BIT 7,A",
-	"RES 0,B", "RES 0,C", "RES 0,D", "RES 0,E", "RES 0,H", "RES 0,L", "RES 0,(I%@h)", "RES 0,A",
-	"RES 1,B", "RES 1,C", "RES 1,D", "RES 1,E", "RES 1,H", "RES 1,L", "RES 1,(I%@h)", "RES 1,A",
-	"RES 2,B", "RES 2,C", "RES 2,D", "RES 2,E", "RES 2,H", "RES 2,L", "RES 2,(I%@h)", "RES 2,A",
-	"RES 3,B", "RES 3,C", "RES 3,D", "RES 3,E", "RES 3,H", "RES 3,L", "RES 3,(I%@h)", "RES 3,A",
-	"RES 4,B", "RES 4,C", "RES 4,D", "RES 4,E", "RES 4,H", "RES 4,L", "RES 4,(I%@h)", "RES 4,A",
-	"RES 5,B", "RES 5,C", "RES 5,D", "RES 5,E", "RES 5,H", "RES 5,L", "RES 5,(I%@h)", "RES 5,A",
-	"RES 6,B", "RES 6,C", "RES 6,D", "RES 6,E", "RES 6,H", "RES 6,L", "RES 6,(I%@h)", "RES 6,A",
-	"RES 7,B", "RES 7,C", "RES 7,D", "RES 7,E", "RES 7,H", "RES 7,L", "RES 7,(I%@h)", "RES 7,A",
-	"SET 0,B", "SET 0,C", "SET 0,D", "SET 0,E", "SET 0,H", "SET 0,L", "SET 0,(I%@h)", "SET 0,A",
-	"SET 1,B", "SET 1,C", "SET 1,D", "SET 1,E", "SET 1,H", "SET 1,L", "SET 1,(I%@h)", "SET 1,A",
-	"SET 2,B", "SET 2,C", "SET 2,D", "SET 2,E", "SET 2,H", "SET 2,L", "SET 2,(I%@h)", "SET 2,A",
-	"SET 3,B", "SET 3,C", "SET 3,D", "SET 3,E", "SET 3,H", "SET 3,L", "SET 3,(I%@h)", "SET 3,A",
-	"SET 4,B", "SET 4,C", "SET 4,D", "SET 4,E", "SET 4,H", "SET 4,L", "SET 4,(I%@h)", "SET 4,A",
-	"SET 5,B", "SET 5,C", "SET 5,D", "SET 5,E", "SET 5,H", "SET 5,L", "SET 5,(I%@h)", "SET 5,A",
-	"SET 6,B", "SET 6,C", "SET 6,D", "SET 6,E", "SET 6,H", "SET 6,L", "SET 6,(I%@h)", "SET 6,A",
-	"SET 7,B", "SET 7,C", "SET 7,D", "SET 7,E", "SET 7,H", "SET 7,L", "SET 7,(I%@h)", "SET 7,A"
-};
-
-static const char* CPMCalls[41] =
-{
-	"System Reset", "Console Input", "Console Output", "Reader Input", "Punch Output", "List Output", "Direct I/O", "Get IOByte",
-	"Set IOByte", "Print String", "Read Buffered", "Console Status", "Get Version", "Reset Disk", "Select Disk", "Open File",
-	"Close File", "Search First", "Search Next", "Delete File", "Read Sequential", "Write Sequential", "Make File", "Rename File",
-	"Get Login Vector", "Get Current Disk", "Set DMA Address", "Get Alloc", "Write Protect Disk", "Get R/O Vector", "Set File Attr", "Get Disk Params",
-	"Get/Set User", "Read Random", "Write Random", "Get File Size", "Set Random Record", "Reset Drive", "N/A", "N/A", "Write Random 0 fill"
-};
-
-RUNCPM_DECL int32 Watch = -1;
+RUNCPM_DECL void initTables(void) {
+	// 256 bytes tables
+	for (int i = 0; i < 256; i++) {
+		char c = 0;
+		for (int j = 0; j < 8; j++) {
+			if (i & (1 << j))
+				c++;
+		}
+		parityTable[i] = (c & 1) ? 0 : 4;
+		decTable[i] = (i & 0xa8) | (((i & 0xff) == 0) << 6) | (((i & 0xf) == 0xf) << 4) | 2;
+		rrcaTable[i] = ((i & 1) << 15) | ((i >> 1) << 8) | ((i >> 1) & 0x28) | (i & 1);
+		rraTable[i] = ((i >> 1) << 8) | ((i >> 1) & 0x28) | (i & 1);
+		subTable[i] = ((i & 0xff) << 8) | (i & 0xa8) | (((i & 0xff) == 0) << 6) | 2;
+		andTable[i] = (i << 8) | (i & 0xa8) | ((i == 0) << 6) | 0x10 | parityTable[i];
+		xororTable[i] = (i << 8) | (i & 0xa8) | ((i == 0) << 6) | parityTable[i];
+		rotateShiftTable[i] = (i & 0xa8) | (((i & 0xff) == 0) << 6) | parityTable[i & 0xff];
+		decZ80Table[i] = (i & 0xa8) | (((i & 0xff) == 0) << 6) | (((i & 0xf) == 0xf) << 4) | ((i == 0x7f) << 2) | 2;
+		negTable[i] = (((i & 0x0f) != 0) << 4) | ((i == 0x80) << 2) | 2 | (i != 0);
+		rrdrldTable[i] = (i << 8) | (i & 0xa8) | (((i & 0xff) == 0) << 6) | parityTable[i];
+		cpTable[i] = (i & 0x80) | (((i & 0xff) == 0) << 6);
+	}
+	// 257 bytes tables
+	for (int i = 0; i < 257; i++) {
+		incTable[i] = (i & 0xa8) | (((i & 0xff) == 0) << 6) | (((i & 0xf) == 0) << 4);
+		incZ80Table[i] = (i & 0xa8) | (((i & 0xff) == 0) << 6) | (((i & 0xf) == 0) << 4) | ((i == 0x80) << 2);
+	}
+	// 512 bytes tables
+	for (int i = 0; i < 512; i++) {
+		cbitsTable[i] = (i & 0x10) | ((i >> 8) & 1);
+		cbitsDup8Table[i] = (i & 0x10) | ((i >> 8) & 1) | ((i & 0xff) << 8) | (i & 0xa8) | (((i & 0xff) == 0) << 6);
+		cbitsDup16Table[i] = (i & 0x10) | ((i >> 8) & 1) | (i & 0x28);
+		cbits2Table[i] = (i & 0x10) | ((i >> 8) & 1) | 2;
+		addTable[i] = ((i & 0xff) << 8) | (i & 0xa8) | (((i & 0xff) == 0) << 6);
+		cbitsZ80Table[i] = (i & 0x10) | (((i >> 6) ^ (i >> 5)) & 4) | ((i >> 8) & 1);
+		cbitsZ80DupTable[i] = (i & 0x10) | (((i >> 6) ^ (i >> 5)) & 4) | ((i >> 8) & 1) | (i & 0xa8);
+		cbits2Z80Table[i] = (i & 0x10) | (((i >> 6) ^ (i >> 5)) & 4) | ((i >> 8) & 1) | 2;
+		cbits2Z80DupTable[i] = (i & 0x10) | (((i >> 6) ^ (i >> 5)) & 4) | ((i >> 8) & 1) | 2 | (i & 0xa8);
+	}
+}
 #endif
 
 /* Memory management    */
-static uint8 GET_BYTE(uint32 Addr) {
-	return _RamRead(Addr & ADDRMASK);
+static uint8 GET_BYTE(uint16 a) {
+	return _RamRead(a);
 }
 
-static void PUT_BYTE(uint32 Addr, uint32 Value) {
-	_RamWrite(Addr & ADDRMASK, Value);
+static void PUT_BYTE(uint16 a, uint8 v) {
+	_RamWrite(a, v);
 }
 
-static uint16 GET_WORD(uint32 a) {
-	return GET_BYTE(a) | (GET_BYTE(a + 1) << 8);
+static uint16 GET_WORD(uint16 a) {
+	return _RamRead(a) | (_RamRead(a + 1) << 8);
 }
 
-static void PUT_WORD(uint32 Addr, uint32 Value) {
-	_RamWrite(Addr, Value);
-	_RamWrite(++Addr, Value >> 8);
+static void PUT_WORD(uint16 a, uint32 v) {
+	_RamWrite(a, v);
+	_RamWrite(++a, v >> 8);
 }
 
 #define RAM_MM(a)   GET_BYTE(a--)
@@ -1190,297 +1050,56 @@ static inline void Z80reset(void) {
 	PC = 0;
 	IFF = 0;
 	IR = 0;
-	Status = 0;
+	Status = STATUS_RUNNING;
 	Debug = 0;
-	Break = -1;
 	Step = -1;
+
+	#ifndef preTables
+		initTables();
+	#endif
 }
 
-#ifdef DEBUG
-RUNCPM_DECL void watchprint(uint16 pos) {
-	uint8 I, J;
-	_puts("\r\n");
-	_puts("  Watch : "); _puthex16(Watch);
-	_puts(" = "); _puthex8(_RamRead(Watch)); _putcon(':'); _puthex8(_RamRead(Watch + 1));
-	_puts(" / ");
-	for (J = 0, I = _RamRead(Watch); J < 8; ++J, I <<= 1) _putcon(I & 0x80 ? '1' : '0');
-	_putcon(':');
-	for (J = 0, I = _RamRead(Watch + 1); J < 8; ++J, I <<= 1) _putcon(I & 0x80 ? '1' : '0');
-}
-
-RUNCPM_DECL void memdump(uint16 pos) {
-	uint16 h = pos;
-	uint16 c = pos;
-	uint8 l, i;
-	uint8 ch = pos & 0xff;
-
-	_puts("       ");
-	for (i = 0; i < 16; ++i) {
-		_puthex8(ch++ & 0x0f);
-		_puts(" ");
-	}
-	_puts("\r\n");
-	_puts("       ");
-	for (i = 0; i < 16; ++i)
-		_puts("---");
-	_puts("\r\n");
-	for (l = 0; l < 16; ++l) {
-		_puthex16(h);
-		_puts(" : ");
-		for (i = 0; i < 16; ++i) {
-			_puthex8(_RamRead(h++));
-			_puts(" ");
-		}
-		for (i = 0; i < 16; ++i) {
-			ch = _RamRead(c++);
-			_putcon(ch > 31 && ch < 127 ? ch : '.');
-		}
-		_puts("\r\n");
-	}
-}
-
-RUNCPM_DECL uint8 Disasm(uint16 pos) {
-	const char* txt;
-	char jr;
-	uint8 ch = _RamRead(pos);
-	uint8 count = 1;
-	uint8 C = 0;
-
-	switch (ch) {
-	case 0xCB: ++pos; txt = MnemonicsCB[_RamRead(pos++)]; count++; break;
-	case 0xED: ++pos; txt = MnemonicsED[_RamRead(pos++)]; count++; break;
-	case 0xDD: ++pos; C = 'X';
-		if (_RamRead(pos) != 0xCB) {
-			txt = MnemonicsXX[_RamRead(pos++)]; ++count;
-		} else {
-			++pos; txt = MnemonicsXCB[_RamRead(pos++)]; count += 2;
-		}
-		break;
-	case 0xFD: ++pos; C = 'Y';
-		if (_RamRead(pos) != 0xCB) {
-			txt = MnemonicsXX[_RamRead(pos++)]; ++count;
-		} else {
-			++pos; txt = MnemonicsXCB[_RamRead(pos++)]; count += 2;
-		}
-		break;
-	default:   txt = Mnemonics[_RamRead(pos++)];
-	}
-	while (*txt != 0) {
-		switch (*txt) {
-		case '*':
-			txt += 2;
-			++count;
-			_puthex8(_RamRead(pos++));
-			break;
-		case '^':
-			txt += 2;
-			++count;
-			_puthex8(_RamRead(pos++));
-			break;
-		case '#':
-			txt += 2;
-			count += 2;
-			_puthex8(_RamRead(pos + 1));
-			_puthex8(_RamRead(pos));
-			break;
-		case '@':
-			txt += 2;
-			++count;
-			jr = _RamRead(pos++);
-			_puthex16(pos + jr);
-			break;
-		case '%':
-			_putch(C);
-			++txt;
-			break;
-		default:
-			_putch(*txt);
-			++txt;
-		}
-	}
-
-	return(count);
-}
-
-RUNCPM_DECL void Z80debug(void) {
-	uint8 ch = 0;
-	uint16 pos, l;
-	static const char Flags[9] = "SZ5H3PNC";
-	uint8 J, I;
-	unsigned int bpoint;
-	uint8 loop = TRUE;
-	uint8 res = 0;
-
-	while (loop) {
-		pos = PC;
-		_puts("\r\n");
-		_puts("BC:");  _puthex16(BC);
-		_puts(" DE:"); _puthex16(DE);
-		_puts(" HL:"); _puthex16(HL);
-		_puts(" AF:"); _puthex16(AF);
-		_puts(" : [");
-		for (J = 0, I = LOW_REGISTER(AF); J < 8; ++J, I <<= 1) _putcon(I & 0x80 ? Flags[J] : '.');
-		_puts("]\r\n");
-		_puts("IX:");  _puthex16(IX);
-		_puts(" IY:"); _puthex16(IY);
-		_puts(" SP:"); _puthex16(SP);
-		_puts(" PC:"); _puthex16(PC);
-		_puts(" : ");
-
-		Disasm(pos);
-
-		if (PC == 0x0005) {
-			if (LOW_REGISTER(BC) > 40) {
-				_puts(" (Unknown)");
-			} else {
-				_puts(" (");
-				_puts(CPMCalls[LOW_REGISTER(BC)]);
-				_puts(")");
-			}
-		}
-
-		if (Watch != -1) {
-			watchprint(Watch);
-		}
-
-		_puts("\r\n");
-		_puts("Command|? : ");
-		ch = _getch();
-		if (ch > 21 && ch < 127)
-			_putch(ch);
-		switch (ch) {
-		case 't':
-			loop = FALSE;
-			break;
-		case 'c':
-			loop = FALSE;
-			_puts("\r\n");
-			Debug = 0;
-			break;
-		case 'b':
-			_puts("\r\n"); memdump(BC); break;
-		case 'd':
-			_puts("\r\n"); memdump(DE); break;
-		case 'h':
-			_puts("\r\n"); memdump(HL); break;
-		case 'p':
-			_puts("\r\n"); memdump(PC & 0xFF00); break;
-		case 's':
-			_puts("\r\n"); memdump(SP & 0xFF00); break;
-		case 'x':
-			_puts("\r\n"); memdump(IX & 0xFF00); break;
-		case 'y':
-			_puts("\r\n"); memdump(IY & 0xFF00); break;
-		case 'a':
-			_puts("\r\n"); memdump(dmaAddr); break;
-		case 'l':
-			_puts("\r\n");
-			I = 16;
-			l = pos;
-			while (I > 0) {
-				_puthex16(l);
-				_puts(" : ");
-				l += Disasm(l);
-				_puts("\r\n");
-				--I;
-			}
-			break;
-		case 'B':
-			_puts(" Addr: ");
-			res=scanf("%04x", &bpoint);
-			if (res) {
-				Break = bpoint;
-				_puts("Breakpoint set to ");
-				_puthex16(Break);
-				_puts("\r\n");
-			}
-			break;
-		case 'C':
-			Break = -1;
-			_puts(" Breakpoint cleared\r\n");
-			break;
-		case 'D':
-			_puts(" Addr: ");
-			res=scanf("%04x", &bpoint);
-			if(res)
-				memdump(bpoint);
-			break;
-		case 'L':
-			_puts(" Addr: ");
-			res=scanf("%04x", &bpoint);
-			if (res) {
-				I = 16;
-				l = bpoint;
-				while (I > 0) {
-					_puthex16(l);
-					_puts(" : ");
-					l += Disasm(l);
-					_puts("\r\n");
-					--I;
-				}
-			}
-			break;
-		case 'T':
-			loop = FALSE;
-			Step = pos + 3; // This only works correctly with CALL
-							// If the called function messes with the stack, this will fail as well.
-			Debug = 0;
-			break;
-		case 'W':
-			_puts(" Addr: ");
-			res=scanf("%04x", &bpoint);
-			if (res) {
-				Watch = bpoint;
-				_puts("Watch set to ");
-				_puthex16(Watch);
-				_puts("\r\n");
-			}
-			break;
-		case '?':
-			_puts("\r\n");
-			_puts("Lowercase commands:\r\n");
-			_puts("  t - traces to the next instruction\r\n");
-			_puts("  c - Continue execution\r\n");
-			_puts("  b - Dumps memory pointed by (BC)\r\n");
-			_puts("  d - Dumps memory pointed by (DE)\r\n");
-			_puts("  h - Dumps memory pointed by (HL)\r\n");
-			_puts("  p - Dumps the page (PC) points to\r\n");
-			_puts("  s - Dumps the page (SP) points to\r\n");
-			_puts("  x - Dumps the page (IX) points to\r\n");
-			_puts("  y - Dumps the page (IY) points to\r\n");
-			_puts("  a - Dumps memory pointed by dmaAddr\r\n");
-			_puts("  l - Disassembles from current PC\r\n");
-			_puts("Uppercase commands:\r\n");
-			_puts("  B - Sets breakpoint at address\r\n");
-			_puts("  C - Clears breakpoint\r\n");
-			_puts("  D - Dumps memory at address\r\n");
-			_puts("  L - Disassembles at address\r\n");
-			_puts("  T - Steps over a call\r\n");
-			_puts("  W - Sets a byte/word watch\r\n");
-			break;
-		default:
-			_puts(" ???\r\n");
-		}
-	}
-}
+#if defined(DEBUG) || defined(iDEBUG)
+#include "debug.h"
 #endif
 
-static inline void Z80run(void) {
+static inline void Z80run(uint32 cpu_delay) {
 	uint32 temp = 0;
-	uint32 acu = 0;
-	uint32 sum = 0;
-	uint32 cbits = 0;
+	uint32 acu;
+	uint32 sum;
+	uint32 cbits;
 	uint32 op = 0;
-	uint32 adr = 0;
+	uint32 adr;
+
+    static uint32 instr_cnt = 0;
+    static uint32 last_millis = 0;
+
+    if (last_millis == 0) last_millis = millis();
 
 	/* main instruction fetch/decode loop */
 	while (!Status) {	/* loop until Status != 0 */
 
+        /* Throttling to CPU_DELAY instructions */
+		if (cpu_delay != 0) {
+	        if (++instr_cnt >= cpu_delay) {
+    	        uint32 now = millis();
+        	    if ((now - last_millis) < 10) {
+            	    uint32 delay_ms = 10 - (now - last_millis);
+#ifdef _WIN32
+                	Sleep(delay_ms);
+#elif defined(ARDUINO)
+            	    delay(delay_ms);
+#else
+                	usleep(delay_ms * 1000);
+#endif
+            	}
+            	last_millis = millis();
+            	instr_cnt = 0;
+        	}
+		}
+
 #ifdef DEBUG
-		if (PC == Break) {
-			_puts(":BREAK at ");
-			_puthex16(Break);
-			_puts(":");
+		if (z80_check_breakpoints_on_exec(PC)) {
 			Debug = 1;
 		}
 		if (PC == Step) {
@@ -1489,10 +1108,17 @@ static inline void Z80run(void) {
 		}
 		if (Debug)
 			Z80debug();
+		if (Status)
+			break;
 #endif
 
-		PCX = PC;
-		INCR(1); /* Add one M1 cycle to refresh counter */
+	PCX = PC;
+	INCR(1); /* Add one M1 cycle to refresh counter */
+
+	/* push instruction into trace (before it is executed) */
+#if defined(DEBUG) || defined(iDEBUG)
+	z80_trace_push(PCX);
+#endif
 
 #ifdef iDEBUG
 		iLogFile = fopen("iDump.log", "a");
@@ -1508,7 +1134,7 @@ static inline void Z80run(void) {
 			}
 		default: iLogTxt = Mnemonics[RAM[PCX & 0xffff]];
 		}
-		sprintf(iLogBuffer, "0x%04x : 0x%02x = %s\r\n", PCX, RAM[PCX & 0xffff], iLogTxt);
+		sprintf(iLogBuffer, "0x%04x : 0x%02x = %s\n", PCX, RAM[PCX & 0xffff], iLogTxt);
 		fputs(iLogBuffer, iLogFile);
 		fclose(iLogFile);
 #endif
@@ -1519,8 +1145,8 @@ static inline void Z80run(void) {
 			break;
 
 		case 0x01:      /* LD BC,nnnn */
-			BC = GET_WORD(PC);
-			PC += 2;
+			BC = GET_WORD(PC++);
+			++PC;
 			break;
 
 		case 0x02:      /* LD (BC),A */
@@ -1553,9 +1179,9 @@ static inline void Z80run(void) {
 			break;
 
 		case 0x08:      /* EX AF,AF' */
-			temp = AF;
-			AF = AF1;
-			AF1 = temp;
+		    AF ^= AF1;
+    		AF1 ^= AF;
+    		AF ^= AF1;
 			break;
 
 		case 0x09:      /* ADD HL,BC */
@@ -1602,8 +1228,8 @@ static inline void Z80run(void) {
 			break;
 
 		case 0x11:      /* LD DE,nnnn */
-			DE = GET_WORD(PC);
-			PC += 2;
+			DE = GET_WORD(PC++);
+			++PC;
 			break;
 
 		case 0x12:      /* LD (DE),A */
@@ -1683,14 +1309,13 @@ static inline void Z80run(void) {
 			break;
 
 		case 0x21:      /* LD HL,nnnn */
-			HL = GET_WORD(PC);
-			PC += 2;
+			HL = GET_WORD(PC++);
+			++PC;
 			break;
 
 		case 0x22:      /* LD (nnnn),HL */
-			temp = GET_WORD(PC);
-			PUT_WORD(temp, HL);
-			PC += 2;
+			PUT_WORD(GET_WORD(PC++), HL);
+			++PC;
 			break;
 
 		case 0x23:      /* INC HL */
@@ -1753,9 +1378,8 @@ static inline void Z80run(void) {
 			break;
 
 		case 0x2a:      /* LD HL,(nnnn) */
-			temp = GET_WORD(PC);
-			HL = GET_WORD(temp);
-			PC += 2;
+			HL = GET_WORD(GET_WORD(PC++));
+			++PC;
 			break;
 
 		case 0x2b:      /* DEC HL */
@@ -1790,14 +1414,13 @@ static inline void Z80run(void) {
 			break;
 
 		case 0x31:      /* LD SP,nnnn */
-			SP = GET_WORD(PC);
-			PC += 2;
+			SP = GET_WORD(PC++);
+			++PC;
 			break;
 
 		case 0x32:      /* LD (nnnn),A */
-			temp = GET_WORD(PC);
-			PUT_BYTE(temp, HIGH_REGISTER(AF));
-			PC += 2;
+			PUT_BYTE(GET_WORD(PC++), HIGH_REGISTER(AF));
+			++PC;
 			break;
 
 		case 0x33:      /* INC SP */
@@ -1840,9 +1463,8 @@ static inline void Z80run(void) {
 			break;
 
 		case 0x3a:      /* LD A,(nnnn) */
-			temp = GET_WORD(PC);
-			SET_HIGH_REGISTER(AF, GET_BYTE(temp));
-			PC += 2;
+			SET_HIGH_REGISTER(AF, GET_BYTE(GET_WORD(PC++)));
+			++PC;
 			break;
 
 		case 0x3b:      /* DEC SP */
@@ -2081,12 +1703,17 @@ static inline void Z80run(void) {
 
 		case 0x76:      /* HALT */
 #ifdef DEBUG
-			_puts("\r\n::CPU HALTED::");	// A halt is a good indicator of broken code
+			_puts("\r\n::CPU HALTED::\r\n");	// A halt is a good indicator of broken code
 			_puts("Press any key...");
-			_getch();
+			_getcon();
+	#ifdef DEBUGONHALT
+			_puts("\r\n");
+			Debug = 1;
+			Z80debug();
+	#endif
 #endif
 			--PC;
-			goto end_decode;
+			Status = STATUS_EXIT;
 			break;
 
 		case 0x77:      /* LD (HL),A */
@@ -2594,91 +2221,88 @@ static inline void Z80run(void) {
 			switch ((op = GET_BYTE(PC)) & 7) {
 
 			case 0:
-				++PC;
 				acu = HIGH_REGISTER(BC);
 				break;
 
 			case 1:
-				++PC;
 				acu = LOW_REGISTER(BC);
 				break;
 
 			case 2:
-				++PC;
 				acu = HIGH_REGISTER(DE);
 				break;
 
 			case 3:
-				++PC;
 				acu = LOW_REGISTER(DE);
 				break;
 
 			case 4:
-				++PC;
 				acu = HIGH_REGISTER(HL);
 				break;
 
 			case 5:
-				++PC;
 				acu = LOW_REGISTER(HL);
 				break;
 
 			case 6:
-				++PC;
 				acu = GET_BYTE(adr);
 				break;
 
-			case 7:
-				++PC;
+			default:
 				acu = HIGH_REGISTER(AF);
 				break;
 			}
+			++PC;
 			switch (op & 0xc0) {
 
 			case 0x00:  /* shift/rotate */
 				switch (op & 0x38) {
 
-				case 0x00:/* RLC */
-					temp = (acu << 1) | (acu >> 7);
-					cbits = temp & 1;
-					goto cbshflg1;
+					case 0x00:/* RLC */
+						temp = (acu << 1) | (acu >> 7);
+						cbits = temp & 1;
+						break;
 
-				case 0x08:/* RRC */
-					temp = (acu >> 1) | (acu << 7);
-					cbits = temp & 0x80;
-					goto cbshflg1;
+					case 0x08:/* RRC */
+						temp = (acu >> 1) | (acu << 7);
+						cbits = temp & 0x80;
+						break;
 
-				case 0x10:/* RL */
-					temp = (acu << 1) | TSTFLAG(C);
-					cbits = acu & 0x80;
-					goto cbshflg1;
+					case 0x10:/* RL */
+						temp = (acu << 1) | TSTFLAG(C);
+						cbits = acu & 0x80;
+						break;
 
-				case 0x18:/* RR */
-					temp = (acu >> 1) | (TSTFLAG(C) << 7);
-					cbits = acu & 1;
-					goto cbshflg1;
+					case 0x18:/* RR */
+						temp = (acu >> 1) | (TSTFLAG(C) << 7);
+						cbits = acu & 1;
+						break;
 
-				case 0x20:/* SLA */
-					temp = acu << 1;
-					cbits = acu & 0x80;
-					goto cbshflg1;
+					case 0x20:/* SLA */
+						temp = acu << 1;
+						cbits = acu & 0x80;
+						break;
 
-				case 0x28:/* SRA */
-					temp = (acu >> 1) | (acu & 0x80);
-					cbits = acu & 1;
-					goto cbshflg1;
+					case 0x28:/* SRA */
+						temp = (acu >> 1) | (acu & 0x80);
+						cbits = acu & 1;
+						break;
 
-				case 0x30:/* SLIA */
-					temp = (acu << 1) | 1;
-					cbits = acu & 0x80;
-					goto cbshflg1;
+					case 0x30:/* SLIA */
+						temp = (acu << 1) | 1;
+						cbits = acu & 0x80;
+						break;
 
-				case 0x38:/* SRL */
-					temp = acu >> 1;
-					cbits = acu & 1;
-				cbshflg1:
+					case 0x38:/* SRL */
+						temp = acu >> 1;
+						cbits = acu & 1;
+						break;
+
+					default:
+						temp = acu;
+						cbits = 0;
+					}
 					AF = (AF & ~0xff) | rotateShiftTable[temp & 0xff] | !!cbits;
-				}
 				break;
 
 			case 0x40:  /* BIT */
@@ -2729,7 +2353,7 @@ static inline void Z80run(void) {
 				PUT_BYTE(adr, temp);
 				break;
 
-			case 7:
+			default:
 				SET_HIGH_REGISTER(AF, temp);
 				break;
 			}
@@ -2754,6 +2378,10 @@ static inline void Z80run(void) {
 		case 0xcf:      /* RST 8 */
 			PUSH(PC);
 			PC = 8;
+#ifdef INT_HANDOFF
+			_Bios();
+			POP(PC);
+#endif
 			break;
 
 		case 0xd0:      /* RET NC */
@@ -2792,6 +2420,10 @@ static inline void Z80run(void) {
 		case 0xd7:      /* RST 10H */
 			PUSH(PC);
 			PC = 0x10;
+#ifdef INT_HANDOFF
+			_Bdos();
+			POP(PC);
+#endif
 			break;
 
 		case 0xd8:      /* RET C */
@@ -2800,15 +2432,15 @@ static inline void Z80run(void) {
 			break;
 
 		case 0xd9:      /* EXX */
-			temp = BC;
-			BC = BC1;
-			BC1 = temp;
-			temp = DE;
-			DE = DE1;
-			DE1 = temp;
-			temp = HL;
-			HL = HL1;
-			HL1 = temp;
+			BC ^= BC1;
+			BC1 ^= BC;
+			BC ^= BC1;
+			DE ^= DE1;
+			DE1 ^= DE;
+			DE ^= DE1;
+			HL ^= HL1;
+			HL1 ^= HL;
+			HL ^= HL1;
 			break;
 
 		case 0xda:      /* JP C,nnnn */
@@ -2844,14 +2476,13 @@ static inline void Z80run(void) {
 				break;
 
 			case 0x21:      /* LD IX,nnnn */
-				IX = GET_WORD(PC);
-				PC += 2;
+				IX = GET_WORD(PC++);
+				++PC;
 				break;
 
 			case 0x22:      /* LD (nnnn),IX */
-				temp = GET_WORD(PC);
-				PUT_WORD(temp, IX);
-				PC += 2;
+				PUT_WORD(GET_WORD(PC++), IX);
+				++PC;
 				break;
 
 			case 0x23:      /* INC IX */
@@ -2880,9 +2511,8 @@ static inline void Z80run(void) {
 				break;
 
 			case 0x2a:      /* LD IX,(nnnn) */
-				temp = GET_WORD(PC);
-				IX = GET_WORD(temp);
-				PC += 2;
+				IX = GET_WORD(GET_WORD(PC++));
+				++PC;
 				break;
 
 			case 0x2b:      /* DEC IX */
@@ -2941,8 +2571,7 @@ static inline void Z80run(void) {
 				break;
 
 			case 0x46:      /* LD B,(IX+dd) */
-				adr = IX + (int8)RAM_PP(PC);
-				SET_HIGH_REGISTER(BC, GET_BYTE(adr));
+				SET_HIGH_REGISTER(BC, GET_BYTE(IX + (int8)RAM_PP(PC)));
 				break;
 
 			case 0x4c:      /* LD C,IXH */
@@ -2954,8 +2583,7 @@ static inline void Z80run(void) {
 				break;
 
 			case 0x4e:      /* LD C,(IX+dd) */
-				adr = IX + (int8)RAM_PP(PC);
-				SET_LOW_REGISTER(BC, GET_BYTE(adr));
+				SET_LOW_REGISTER(BC, GET_BYTE(IX + (int8)RAM_PP(PC)));
 				break;
 
 			case 0x54:      /* LD D,IXH */
@@ -2967,8 +2595,7 @@ static inline void Z80run(void) {
 				break;
 
 			case 0x56:      /* LD D,(IX+dd) */
-				adr = IX + (int8)RAM_PP(PC);
-				SET_HIGH_REGISTER(DE, GET_BYTE(adr));
+				SET_HIGH_REGISTER(DE, GET_BYTE(IX + (int8)RAM_PP(PC)));
 				break;
 
 			case 0x5c:      /* LD E,IXH */
@@ -2980,8 +2607,7 @@ static inline void Z80run(void) {
 				break;
 
 			case 0x5e:      /* LD E,(IX+dd) */
-				adr = IX + (int8)RAM_PP(PC);
-				SET_LOW_REGISTER(DE, GET_BYTE(adr));
+				SET_LOW_REGISTER(DE, GET_BYTE(IX + (int8)RAM_PP(PC)));
 				break;
 
 			case 0x60:      /* LD IXH,B */
@@ -3008,8 +2634,7 @@ static inline void Z80run(void) {
 				break;
 
 			case 0x66:      /* LD H,(IX+dd) */
-				adr = IX + (int8)RAM_PP(PC);
-				SET_HIGH_REGISTER(HL, GET_BYTE(adr));
+				SET_HIGH_REGISTER(HL, GET_BYTE(IX + (int8)RAM_PP(PC)));
 				break;
 
 			case 0x67:      /* LD IXH,A */
@@ -3040,8 +2665,7 @@ static inline void Z80run(void) {
 				break;
 
 			case 0x6e:      /* LD L,(IX+dd) */
-				adr = IX + (int8)RAM_PP(PC);
-				SET_LOW_REGISTER(HL, GET_BYTE(adr));
+				SET_LOW_REGISTER(HL, GET_BYTE(IX + (int8)RAM_PP(PC)));
 				break;
 
 			case 0x6f:      /* LD IXL,A */
@@ -3049,38 +2673,31 @@ static inline void Z80run(void) {
 				break;
 
 			case 0x70:      /* LD (IX+dd),B */
-				adr = IX + (int8)RAM_PP(PC);
-				PUT_BYTE(adr, HIGH_REGISTER(BC));
+				PUT_BYTE(IX + (int8)RAM_PP(PC), HIGH_REGISTER(BC));
 				break;
 
 			case 0x71:      /* LD (IX+dd),C */
-				adr = IX + (int8)RAM_PP(PC);
-				PUT_BYTE(adr, LOW_REGISTER(BC));
+				PUT_BYTE(IX + (int8)RAM_PP(PC), LOW_REGISTER(BC));
 				break;
 
 			case 0x72:      /* LD (IX+dd),D */
-				adr = IX + (int8)RAM_PP(PC);
-				PUT_BYTE(adr, HIGH_REGISTER(DE));
+				PUT_BYTE(IX + (int8)RAM_PP(PC), HIGH_REGISTER(DE));
 				break;
 
 			case 0x73:      /* LD (IX+dd),E */
-				adr = IX + (int8)RAM_PP(PC);
-				PUT_BYTE(adr, LOW_REGISTER(DE));
+				PUT_BYTE(IX + (int8)RAM_PP(PC), LOW_REGISTER(DE));
 				break;
 
 			case 0x74:      /* LD (IX+dd),H */
-				adr = IX + (int8)RAM_PP(PC);
-				PUT_BYTE(adr, HIGH_REGISTER(HL));
+				PUT_BYTE(IX + (int8)RAM_PP(PC), HIGH_REGISTER(HL));
 				break;
 
 			case 0x75:      /* LD (IX+dd),L */
-				adr = IX + (int8)RAM_PP(PC);
-				PUT_BYTE(adr, LOW_REGISTER(HL));
+				PUT_BYTE(IX + (int8)RAM_PP(PC), LOW_REGISTER(HL));
 				break;
 
 			case 0x77:      /* LD (IX+dd),A */
-				adr = IX + (int8)RAM_PP(PC);
-				PUT_BYTE(adr, HIGH_REGISTER(AF));
+				PUT_BYTE(IX + (int8)RAM_PP(PC), HIGH_REGISTER(AF));
 				break;
 
 			case 0x7c:      /* LD A,IXH */
@@ -3092,8 +2709,7 @@ static inline void Z80run(void) {
 				break;
 
 			case 0x7e:      /* LD A,(IX+dd) */
-				adr = IX + (int8)RAM_PP(PC);
-				SET_HIGH_REGISTER(AF, GET_BYTE(adr));
+				SET_HIGH_REGISTER(AF, GET_BYTE(IX + (int8)RAM_PP(PC)));
 				break;
 
 			case 0x84:      /* ADD A,IXH */
@@ -3150,7 +2766,6 @@ static inline void Z80run(void) {
 
 			case 0x94:      /* SUB IXH */
 				SETFLAG(C, 0);/* fall through, a bit less efficient but smaller code */
-				[[fallthrough]];
 
 			case 0x9c:      /* SBC A,IXH */
 				temp = HIGH_REGISTER(IX);
@@ -3161,7 +2776,6 @@ static inline void Z80run(void) {
 
 			case 0x95:      /* SUB IXL */
 				SETFLAG(C, 0);/* fall through, a bit less efficient but smaller code */
-				[[fallthrough]];
 
 			case 0x9d:      /* SBC A,IXL */
 				temp = LOW_REGISTER(IX);
@@ -3187,8 +2801,7 @@ static inline void Z80run(void) {
 				break;
 
 			case 0xa6:      /* AND (IX+dd) */
-				adr = IX + (int8)RAM_PP(PC);
-				AF = andTable[((AF >> 8)& GET_BYTE(adr)) & 0xff];
+				AF = andTable[((AF >> 8)& GET_BYTE(IX + (int8)RAM_PP(PC))) & 0xff];
 				break;
 
 			case 0xac:      /* XOR IXH */
@@ -3200,8 +2813,7 @@ static inline void Z80run(void) {
 				break;
 
 			case 0xae:      /* XOR (IX+dd) */
-				adr = IX + (int8)RAM_PP(PC);
-				AF = xororTable[((AF >> 8) ^ GET_BYTE(adr)) & 0xff];
+				AF = xororTable[((AF >> 8) ^ GET_BYTE(IX + (int8)RAM_PP(PC))) & 0xff];
 				break;
 
 			case 0xb4:      /* OR IXH */
@@ -3213,8 +2825,7 @@ static inline void Z80run(void) {
 				break;
 
 			case 0xb6:      /* OR (IX+dd) */
-				adr = IX + (int8)RAM_PP(PC);
-				AF = xororTable[((AF >> 8) | GET_BYTE(adr)) & 0xff];
+				AF = xororTable[((AF >> 8) | GET_BYTE(IX + (int8)RAM_PP(PC))) & 0xff];
 				break;
 
 			case 0xbc:      /* CP IXH */
@@ -3250,91 +2861,88 @@ static inline void Z80run(void) {
 				switch ((op = GET_BYTE(PC)) & 7) {
 
 				case 0:
-					++PC;
 					acu = HIGH_REGISTER(BC);
 					break;
 
 				case 1:
-					++PC;
 					acu = LOW_REGISTER(BC);
 					break;
 
 				case 2:
-					++PC;
 					acu = HIGH_REGISTER(DE);
 					break;
 
 				case 3:
-					++PC;
 					acu = LOW_REGISTER(DE);
 					break;
 
 				case 4:
-					++PC;
 					acu = HIGH_REGISTER(HL);
 					break;
 
 				case 5:
-					++PC;
 					acu = LOW_REGISTER(HL);
 					break;
 
 				case 6:
-					++PC;
 					acu = GET_BYTE(adr);
 					break;
 
-				case 7:
-					++PC;
+				default:
 					acu = HIGH_REGISTER(AF);
 					break;
 				}
+				++PC;
 				switch (op & 0xc0) {
 
 				case 0x00:  /* shift/rotate */
 					switch (op & 0x38) {
 
-					case 0x00:/* RLC */
-						temp = (acu << 1) | (acu >> 7);
-						cbits = temp & 1;
-						goto cbshflg2;
+						case 0x00:/* RLC */
+							temp = (acu << 1) | (acu >> 7);
+							cbits = temp & 1;
+							break;
 
-					case 0x08:/* RRC */
-						temp = (acu >> 1) | (acu << 7);
-						cbits = temp & 0x80;
-						goto cbshflg2;
+						case 0x08:/* RRC */
+							temp = (acu >> 1) | (acu << 7);
+							cbits = temp & 0x80;
+							break;
 
-					case 0x10:/* RL */
-						temp = (acu << 1) | TSTFLAG(C);
-						cbits = acu & 0x80;
-						goto cbshflg2;
+						case 0x10:/* RL */
+							temp = (acu << 1) | TSTFLAG(C);
+							cbits = acu & 0x80;
+							break;
 
-					case 0x18:/* RR */
-						temp = (acu >> 1) | (TSTFLAG(C) << 7);
-						cbits = acu & 1;
-						goto cbshflg2;
+						case 0x18:/* RR */
+							temp = (acu >> 1) | (TSTFLAG(C) << 7);
+							cbits = acu & 1;
+							break;
 
-					case 0x20:/* SLA */
-						temp = acu << 1;
-						cbits = acu & 0x80;
-						goto cbshflg2;
+						case 0x20:/* SLA */
+							temp = acu << 1;
+							cbits = acu & 0x80;
+							break;
 
-					case 0x28:/* SRA */
-						temp = (acu >> 1) | (acu & 0x80);
-						cbits = acu & 1;
-						goto cbshflg2;
+						case 0x28:/* SRA */
+							temp = (acu >> 1) | (acu & 0x80);
+							cbits = acu & 1;
+							break;
 
-					case 0x30:/* SLIA */
-						temp = (acu << 1) | 1;
-						cbits = acu & 0x80;
-						goto cbshflg2;
+						case 0x30:/* SLIA */
+							temp = (acu << 1) | 1;
+							cbits = acu & 0x80;
+							break;
 
-					case 0x38:/* SRL */
-						temp = acu >> 1;
-						cbits = acu & 1;
-					cbshflg2:
-						AF = (AF & ~0xff) | rotateShiftTable[temp & 0xff] | !!cbits;
+						case 0x38:/* SRL */
+							temp = acu >> 1;
+							cbits = acu & 1;
+							break;
+
+						default:
+							temp = acu;
+							cbits = 0;
 					}
+					AF = (AF & ~0xff) | rotateShiftTable[temp & 0xff] | !!cbits;
 					break;
 
 				case 0x40:  /* BIT */
@@ -3385,7 +2993,7 @@ static inline void Z80run(void) {
 					PUT_BYTE(adr, temp);
 					break;
 
-				case 7:
+				default:
 					SET_HIGH_REGISTER(AF, temp);
 					break;
 				}
@@ -3481,9 +3089,9 @@ static inline void Z80run(void) {
 			break;
 
 		case 0xeb:      /* EX DE,HL */
-			temp = HL;
-			HL = DE;
-			DE = temp;
+			HL ^= DE;
+			DE ^= HL;
+			HL ^= DE;
 			break;
 
 		case 0xec:      /* CALL PE,nnnn */
@@ -3514,9 +3122,8 @@ static inline void Z80run(void) {
 				break;
 
 			case 0x43:      /* LD (nnnn),BC */
-				temp = GET_WORD(PC);
-				PUT_WORD(temp, BC);
-				PC += 2;
+				PUT_WORD(GET_WORD(PC++), BC);
+				++PC;
 				break;
 
 			case 0x44:      /* NEG */
@@ -3584,9 +3191,8 @@ static inline void Z80run(void) {
 				break;
 
 			case 0x4b:      /* LD BC,(nnnn) */
-				temp = GET_WORD(PC);
-				BC = GET_WORD(temp);
-				PC += 2;
+				BC = GET_WORD(GET_WORD(PC++));
+				++PC;
 				break;
 
 			case 0x4d:      /* RETI */
@@ -3618,9 +3224,8 @@ static inline void Z80run(void) {
 				break;
 
 			case 0x53:      /* LD (nnnn),DE */
-				temp = GET_WORD(PC);
-				PUT_WORD(temp, DE);
-				PC += 2;
+				PUT_WORD(GET_WORD(PC++), DE);
+				++PC;
 				break;
 
 			case 0x56:      /* IM 1 */
@@ -3651,9 +3256,8 @@ static inline void Z80run(void) {
 				break;
 
 			case 0x5b:      /* LD DE,(nnnn) */
-				temp = GET_WORD(PC);
-				DE = GET_WORD(temp);
-				PC += 2;
+				DE = GET_WORD(GET_WORD(PC++));
+				++PC;
 				break;
 
 			case 0x5e:      /* IM 2 */
@@ -3684,9 +3288,8 @@ static inline void Z80run(void) {
 				break;
 
 			case 0x63:      /* LD (nnnn),HL */
-				temp = GET_WORD(PC);
-				PUT_WORD(temp, HL);
-				PC += 2;
+				PUT_WORD(GET_WORD(PC++), HL);
+				++PC;
 				break;
 
 			case 0x67:      /* RRD */
@@ -3715,9 +3318,8 @@ static inline void Z80run(void) {
 				break;
 
 			case 0x6b:      /* LD HL,(nnnn) */
-				temp = GET_WORD(PC);
-				HL = GET_WORD(temp);
-				PC += 2;
+				HL = GET_WORD(GET_WORD(PC++));
+				++PC;
 				break;
 
 			case 0x6f:      /* RLD */
@@ -3747,9 +3349,8 @@ static inline void Z80run(void) {
 				break;
 
 			case 0x73:      /* LD (nnnn),SP */
-				temp = GET_WORD(PC);
-				PUT_WORD(temp, SP);
-				PC += 2;
+				PUT_WORD(GET_WORD(PC++), SP);
+				++PC;
 				break;
 
 			case 0x78:      /* IN A,(C) */
@@ -3772,9 +3373,8 @@ static inline void Z80run(void) {
 				break;
 
 			case 0x7b:      /* LD SP,(nnnn) */
-				temp = GET_WORD(PC);
-				SP = GET_WORD(temp);
-				PC += 2;
+				SP = GET_WORD(GET_WORD(PC++));
+				++PC;
 				break;
 
 			case 0xa0:      /* LDI */
@@ -4093,14 +3693,14 @@ static inline void Z80run(void) {
 				break;
 
 			case 0x21:      /* LD IY,nnnn */
-				IY = GET_WORD(PC);
-				PC += 2;
+				IY = GET_WORD(PC++);
+				++PC;
 				break;
 
 			case 0x22:      /* LD (nnnn),IY */
-				temp = GET_WORD(PC);
+				temp = GET_WORD(PC++);
 				PUT_WORD(temp, IY);
-				PC += 2;
+				++PC;
 				break;
 
 			case 0x23:      /* INC IY */
@@ -4129,9 +3729,8 @@ static inline void Z80run(void) {
 				break;
 
 			case 0x2a:      /* LD IY,(nnnn) */
-				temp = GET_WORD(PC);
-				IY = GET_WORD(temp);
-				PC += 2;
+				IY = GET_WORD(GET_WORD(PC++));
+				++PC;
 				break;
 
 			case 0x2b:      /* DEC IY */
@@ -4190,8 +3789,7 @@ static inline void Z80run(void) {
 				break;
 
 			case 0x46:      /* LD B,(IY+dd) */
-				adr = IY + (int8)RAM_PP(PC);
-				SET_HIGH_REGISTER(BC, GET_BYTE(adr));
+				SET_HIGH_REGISTER(BC, GET_BYTE(IY + (int8)RAM_PP(PC)));
 				break;
 
 			case 0x4c:      /* LD C,IYH */
@@ -4203,8 +3801,7 @@ static inline void Z80run(void) {
 				break;
 
 			case 0x4e:      /* LD C,(IY+dd) */
-				adr = IY + (int8)RAM_PP(PC);
-				SET_LOW_REGISTER(BC, GET_BYTE(adr));
+				SET_LOW_REGISTER(BC, GET_BYTE(IY + (int8)RAM_PP(PC)));
 				break;
 
 			case 0x54:      /* LD D,IYH */
@@ -4216,8 +3813,7 @@ static inline void Z80run(void) {
 				break;
 
 			case 0x56:      /* LD D,(IY+dd) */
-				adr = IY + (int8)RAM_PP(PC);
-				SET_HIGH_REGISTER(DE, GET_BYTE(adr));
+				SET_HIGH_REGISTER(DE, GET_BYTE(IY + (int8)RAM_PP(PC)));
 				break;
 
 			case 0x5c:      /* LD E,IYH */
@@ -4229,8 +3825,7 @@ static inline void Z80run(void) {
 				break;
 
 			case 0x5e:      /* LD E,(IY+dd) */
-				adr = IY + (int8)RAM_PP(PC);
-				SET_LOW_REGISTER(DE, GET_BYTE(adr));
+				SET_LOW_REGISTER(DE, GET_BYTE(IY + (int8)RAM_PP(PC)));
 				break;
 
 			case 0x60:      /* LD IYH,B */
@@ -4257,8 +3852,7 @@ static inline void Z80run(void) {
 				break;
 
 			case 0x66:      /* LD H,(IY+dd) */
-				adr = IY + (int8)RAM_PP(PC);
-				SET_HIGH_REGISTER(HL, GET_BYTE(adr));
+				SET_HIGH_REGISTER(HL, GET_BYTE(IY + (int8)RAM_PP(PC)));
 				break;
 
 			case 0x67:      /* LD IYH,A */
@@ -4289,8 +3883,7 @@ static inline void Z80run(void) {
 				break;
 
 			case 0x6e:      /* LD L,(IY+dd) */
-				adr = IY + (int8)RAM_PP(PC);
-				SET_LOW_REGISTER(HL, GET_BYTE(adr));
+				SET_LOW_REGISTER(HL, GET_BYTE(IY + (int8)RAM_PP(PC)));
 				break;
 
 			case 0x6f:      /* LD IYL,A */
@@ -4298,38 +3891,31 @@ static inline void Z80run(void) {
 				break;
 
 			case 0x70:      /* LD (IY+dd),B */
-				adr = IY + (int8)RAM_PP(PC);
-				PUT_BYTE(adr, HIGH_REGISTER(BC));
+				PUT_BYTE(IY + (int8)RAM_PP(PC), HIGH_REGISTER(BC));
 				break;
 
 			case 0x71:      /* LD (IY+dd),C */
-				adr = IY + (int8)RAM_PP(PC);
-				PUT_BYTE(adr, LOW_REGISTER(BC));
+				PUT_BYTE(IY + (int8)RAM_PP(PC), LOW_REGISTER(BC));
 				break;
 
 			case 0x72:      /* LD (IY+dd),D */
-				adr = IY + (int8)RAM_PP(PC);
-				PUT_BYTE(adr, HIGH_REGISTER(DE));
+				PUT_BYTE(IY + (int8)RAM_PP(PC), HIGH_REGISTER(DE));
 				break;
 
 			case 0x73:      /* LD (IY+dd),E */
-				adr = IY + (int8)RAM_PP(PC);
-				PUT_BYTE(adr, LOW_REGISTER(DE));
+				PUT_BYTE(IY + (int8)RAM_PP(PC), LOW_REGISTER(DE));
 				break;
 
 			case 0x74:      /* LD (IY+dd),H */
-				adr = IY + (int8)RAM_PP(PC);
-				PUT_BYTE(adr, HIGH_REGISTER(HL));
+				PUT_BYTE(IY + (int8)RAM_PP(PC), HIGH_REGISTER(HL));
 				break;
 
 			case 0x75:      /* LD (IY+dd),L */
-				adr = IY + (int8)RAM_PP(PC);
-				PUT_BYTE(adr, LOW_REGISTER(HL));
+				PUT_BYTE(IY + (int8)RAM_PP(PC), LOW_REGISTER(HL));
 				break;
 
 			case 0x77:      /* LD (IY+dd),A */
-				adr = IY + (int8)RAM_PP(PC);
-				PUT_BYTE(adr, HIGH_REGISTER(AF));
+				PUT_BYTE(IY + (int8)RAM_PP(PC), HIGH_REGISTER(AF));
 				break;
 
 			case 0x7c:      /* LD A,IYH */
@@ -4341,8 +3927,7 @@ static inline void Z80run(void) {
 				break;
 
 			case 0x7e:      /* LD A,(IY+dd) */
-				adr = IY + (int8)RAM_PP(PC);
-				SET_HIGH_REGISTER(AF, GET_BYTE(adr));
+				SET_HIGH_REGISTER(AF, GET_BYTE(IY + (int8)RAM_PP(PC)));
 				break;
 
 			case 0x84:      /* ADD A,IYH */
@@ -4399,7 +3984,6 @@ static inline void Z80run(void) {
 
 			case 0x94:      /* SUB IYH */
 				SETFLAG(C, 0);/* fall through, a bit less efficient but smaller code */
-				[[fallthrough]];
 
 			case 0x9c:      /* SBC A,IYH */
 				temp = HIGH_REGISTER(IY);
@@ -4410,7 +3994,6 @@ static inline void Z80run(void) {
 
 			case 0x95:      /* SUB IYL */
 				SETFLAG(C, 0);/* fall through, a bit less efficient but smaller code */
-				[[fallthrough]];
 
 			case 0x9d:      /* SBC A,IYL */
 				temp = LOW_REGISTER(IY);
@@ -4436,8 +4019,7 @@ static inline void Z80run(void) {
 				break;
 
 			case 0xa6:      /* AND (IY+dd) */
-				adr = IY + (int8)RAM_PP(PC);
-				AF = andTable[((AF >> 8)& GET_BYTE(adr)) & 0xff];
+				AF = andTable[((AF >> 8)& GET_BYTE(IY + (int8)RAM_PP(PC))) & 0xff];
 				break;
 
 			case 0xac:      /* XOR IYH */
@@ -4449,8 +4031,7 @@ static inline void Z80run(void) {
 				break;
 
 			case 0xae:      /* XOR (IY+dd) */
-				adr = IY + (int8)RAM_PP(PC);
-				AF = xororTable[((AF >> 8) ^ GET_BYTE(adr)) & 0xff];
+				AF = xororTable[((AF >> 8) ^ GET_BYTE(IY + (int8)RAM_PP(PC))) & 0xff];
 				break;
 
 			case 0xb4:      /* OR IYH */
@@ -4462,8 +4043,7 @@ static inline void Z80run(void) {
 				break;
 
 			case 0xb6:      /* OR (IY+dd) */
-				adr = IY + (int8)RAM_PP(PC);
-				AF = xororTable[((AF >> 8) | GET_BYTE(adr)) & 0xff];
+				AF = xororTable[((AF >> 8) | GET_BYTE(IY + (int8)RAM_PP(PC))) & 0xff];
 				break;
 
 			case 0xbc:      /* CP IYH */
@@ -4499,91 +4079,88 @@ static inline void Z80run(void) {
 				switch ((op = GET_BYTE(PC)) & 7) {
 
 				case 0:
-					++PC;
 					acu = HIGH_REGISTER(BC);
 					break;
 
 				case 1:
-					++PC;
 					acu = LOW_REGISTER(BC);
 					break;
 
 				case 2:
-					++PC;
 					acu = HIGH_REGISTER(DE);
 					break;
 
 				case 3:
-					++PC;
 					acu = LOW_REGISTER(DE);
 					break;
 
 				case 4:
-					++PC;
 					acu = HIGH_REGISTER(HL);
 					break;
 
 				case 5:
-					++PC;
 					acu = LOW_REGISTER(HL);
 					break;
 
 				case 6:
-					++PC;
 					acu = GET_BYTE(adr);
 					break;
 
-				case 7:
-					++PC;
+				default:
 					acu = HIGH_REGISTER(AF);
 					break;
 				}
+				++PC;
 				switch (op & 0xc0) {
 
 				case 0x00:  /* shift/rotate */
 					switch (op & 0x38) {
 
-					case 0x00:/* RLC */
-						temp = (acu << 1) | (acu >> 7);
-						cbits = temp & 1;
-						goto cbshflg3;
-
-					case 0x08:/* RRC */
-						temp = (acu >> 1) | (acu << 7);
-						cbits = temp & 0x80;
-						goto cbshflg3;
-
-					case 0x10:/* RL */
-						temp = (acu << 1) | TSTFLAG(C);
-						cbits = acu & 0x80;
-						goto cbshflg3;
-
-					case 0x18:/* RR */
-						temp = (acu >> 1) | (TSTFLAG(C) << 7);
-						cbits = acu & 1;
-						goto cbshflg3;
-
-					case 0x20:/* SLA */
-						temp = acu << 1;
-						cbits = acu & 0x80;
-						goto cbshflg3;
-
-					case 0x28:/* SRA */
-						temp = (acu >> 1) | (acu & 0x80);
-						cbits = acu & 1;
-						goto cbshflg3;
-
-					case 0x30:/* SLIA */
-						temp = (acu << 1) | 1;
-						cbits = acu & 0x80;
-						goto cbshflg3;
-
-					case 0x38:/* SRL */
-						temp = acu >> 1;
-						cbits = acu & 1;
-					cbshflg3:
-						AF = (AF & ~0xff) | rotateShiftTable[temp & 0xff] | !!cbits;
+						case 0x00:/* RLC */
+							temp = (acu << 1) | (acu >> 7);
+							cbits = temp & 1;
+							break;
+	
+						case 0x08:/* RRC */
+							temp = (acu >> 1) | (acu << 7);
+							cbits = temp & 0x80;
+							break;
+	
+						case 0x10:/* RL */
+							temp = (acu << 1) | TSTFLAG(C);
+							cbits = acu & 0x80;
+							break;
+	
+						case 0x18:/* RR */
+							temp = (acu >> 1) | (TSTFLAG(C) << 7);
+							cbits = acu & 1;
+							break;
+	
+						case 0x20:/* SLA */
+							temp = acu << 1;
+							cbits = acu & 0x80;
+							break;
+	
+						case 0x28:/* SRA */
+							temp = (acu >> 1) | (acu & 0x80);
+							cbits = acu & 1;
+							break;
+	
+						case 0x30:/* SLIA */
+							temp = (acu << 1) | 1;
+							cbits = acu & 0x80;
+							break;
+	
+						case 0x38:/* SRL */
+							temp = acu >> 1;
+							cbits = acu & 1;
+							break;
+	
+						default:
+							temp = acu;
+							cbits = 0;
 					}
+					AF = (AF & ~0xff) | rotateShiftTable[temp & 0xff] | !!cbits;
 					break;
 
 				case 0x40:  /* BIT */
@@ -4634,7 +4211,7 @@ static inline void Z80run(void) {
 					PUT_BYTE(adr, temp);
 					break;
 
-				case 7:
+				default:
 					SET_HIGH_REGISTER(AF, temp);
 					break;
 				}
@@ -4682,9 +4259,8 @@ static inline void Z80run(void) {
 			PC = 0x38;
 		}
 	}
-end_decode:
-	;
 }
 
+#include "cpu_mhz.h"
 
 #endif

--- a/lib/runcpm/cpu_mhz.h
+++ b/lib/runcpm/cpu_mhz.h
@@ -1,0 +1,122 @@
+#ifndef CPU_MHZ_H
+#define CPU_MHZ_H
+
+#ifndef RUNCPM_DECL
+#define RUNCPM_DECL
+#endif
+
+#include <stdint.h>
+
+/* T-states for main Z80 instructions */
+static const uint8 z80_tstates_main[256] = {
+    4, 10, 7, 6, 4, 4, 7, 4, 4, 11, 7, 6, 4, 4, 7, 4,
+    13, 10, 7, 6, 4, 4, 7, 4, 12, 11, 7, 6, 4, 4, 7, 4,
+    12, 10, 16, 6, 4, 4, 7, 4, 12, 11, 7, 6, 4, 4, 7, 4,
+    12, 10, 7, 6, 11, 11, 10, 4, 7, 7, 7, 7, 4, 4, 7, 4,
+    4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
+    4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
+    4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
+    7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7,
+    4, 4, 4, 4, 4, 4, 7, 4, 5, 5, 5, 5, 5, 5, 7, 4,
+    4, 4, 4, 4, 4, 4, 7, 4, 5, 5, 5, 5, 5, 5, 7, 4,
+    4, 4, 4, 4, 4, 4, 7, 4, 4, 4, 4, 4, 4, 4, 7, 4,
+    4, 4, 4, 4, 4, 4, 7, 4, 4, 4, 4, 4, 4, 4, 7, 4,
+    5, 10, 10, 11, 10, 11, 7, 12, 10, 10, 10, 10, 7, 10, 7, 12,
+    5, 10, 12, 11, 10, 11, 7, 12, 10, 12, 10, 10, 7, 10, 7, 12,
+    5, 10, 12, 11, 10, 11, 7, 12, 10, 12, 10, 10, 7, 10, 7, 12,
+    5, 10, 12, 11, 10, 11, 7, 12, 10, 12, 10, 10, 7, 10, 7, 11
+};
+
+/* Run a small Z80 code and measure the time to estimate emulated clock.
+   This will load a small z80 code into RAM, run it until halt, then compute the 
+   estimated clock at which the CPU is running */
+RUNCPM_DECL void Z80estimateClock(void) {
+	const uint8 testCode[] = {
+#ifdef ARDUINO
+		0x11, 0xF4, 0x01, // LD DE, 500
+		0x01, 0xE8, 0x03, // LD BC, 1000
+#else
+		0x11, 0xE8, 0x03, // LD DE, 1000
+		0x01, 0x10, 0x27, // LD BC, 10000
+#endif
+		0x0B,             // DEC BC
+		0x78,             // LD A, B
+		0xB1,             // OR C
+		0x20, 0xFB,       // JR NZ, -5
+		0x1B,             // DEC DE
+		0x7A,             // LD A, D
+		0xB3,             // OR E
+		0x20, 0xF3,       // JR NZ, -13
+		0x76              // HALT
+	};
+
+	uint64 time_start = 0;
+	uint64 time_now = 0;
+	
+	// Load test code into RAM at address 0x0000
+	for (uint16 addr = 0; addr < sizeof(testCode); addr++) {
+		PUT_BYTE(addr, testCode[addr]);
+	}
+	
+	// Reset CPU
+	Z80reset();
+	
+	// Start timing
+	time_start = millis();
+	
+	// Run until HALT
+	while (Status == STATUS_RUNNING) {
+		Z80run(0);
+	}
+	
+	// End timing
+	time_now = millis();
+	
+	// Calculate total T-states executed
+	uint8 t_ld_de = z80_tstates_main[0x11];
+	uint8 t_ld_bc = z80_tstates_main[0x01];
+	uint8 t_dec = z80_tstates_main[0x0B];
+	uint8 t_ld_a = z80_tstates_main[0x78];
+	uint8 t_or = z80_tstates_main[0xB1];
+	uint8 t_jr = z80_tstates_main[0x20];
+	uint8 t_halt = z80_tstates_main[0x76];
+	
+#ifdef ARDUINO
+	uint16 outer_iters = 500;
+	uint16 inner_iters = 1000;
+#else
+	uint16 outer_iters = 1000;
+	uint16 inner_iters = 10000;
+#endif
+	
+	uint64 inner_body = t_dec + t_ld_a + t_or + t_jr;
+	uint64 inner_exit = t_dec + t_ld_a + t_or + 7; // JR not taken
+	uint64 total_inner = t_ld_bc + (inner_iters - 1) * inner_body + inner_exit;
+	
+	uint64 outer_body = total_inner + t_dec + t_ld_a + t_or + t_jr;
+	uint64 outer_exit = total_inner + t_dec + t_ld_a + t_or + 7; // JR not taken
+	uint64 total_outer = t_ld_de + (outer_iters - 1) * outer_body + outer_exit;
+
+	// Final T-states count (full count, not in millions)
+    uint64 tstates = total_outer + t_halt;
+
+    // Calculate elapsed time in milliseconds
+    uint64 elapsedTime = time_now - time_start;
+
+    // Estimate clock speed in Hz
+    if (elapsedTime == 0) elapsedTime = 1; // Prevent division by zero
+    uint64 estimatedHz = (tstates * 1000) / elapsedTime;
+
+    // Convert to MHz
+    uint32 estimatedMHz = (uint32)(estimatedHz / 1000000);
+    char buffer[64];
+    sprintf(buffer, "%llu T-states in %llu ms\r\n", tstates, elapsedTime);
+    _puts(buffer);
+    sprintf(buffer, "Estimated Z80 clock speed: %u MHz\r\n", estimatedMHz);
+    _puts(buffer);
+	
+	// Reset CPU
+	Z80reset();
+}
+
+#endif // CPU_MHZ_H

--- a/lib/runcpm/debug.h
+++ b/lib/runcpm/debug.h
@@ -6,7 +6,7 @@
 #endif
 
 /* Mnemonic tables for Z80 disassembly - shared by all CPU models */
-#if defined(DEBUG) || defined(iDEBUG)
+#if RUNCPMDEBUG || defined(iDEBUG)
 
 static const char* Mnemonics[256] =
 {
@@ -231,7 +231,7 @@ static const char* CPMCalls[41] =
 
 RUNCPM_DECL int32 Watch = -1;
 
-#endif /* defined(DEBUG) || defined(iDEBUG) */
+#endif /* RUNCPMDEBUG || defined(iDEBUG) */
 
 RUNCPM_DECL void watchprint(uint16 pos) {
     uint8 I, J;
@@ -638,6 +638,16 @@ RUNCPM_DECL uint8 Disasm(uint16 pos) {
    Implemented inline here to avoid changing platform Makefiles.
    Trace records last N executed instructions (pc, bytes, len, reg snapshot).
 */
+/* FujiNet/ESP32 note: the instruction-trace history is a developer-only
+   debugger aid.  trace_buf is ~20KB of static .bss.  The RunCPM engine is now
+   compiled exactly once (lib/runcpm/runcpm_core.cpp), but on the Atari ESP32
+   build even a single ~20KB trace buffer is precious internal DRAM, so the
+   feature is compiled out unless RUNCPM_TRACE is defined to 1 (e.g. on a PC
+   debug build with RAM to spare). */
+#ifndef RUNCPM_TRACE
+#define RUNCPM_TRACE 0
+#endif
+
 #define TRACE_CAPACITY 512
 typedef struct {
     uint16 pc;
@@ -646,6 +656,7 @@ typedef struct {
     int32 AF, BC, DE, HL, IX, IY, SP;
 } trace_entry_t;
 
+#if RUNCPM_TRACE
 static trace_entry_t trace_buf[TRACE_CAPACITY];
 static uint32 trace_pos = 0; /* next write index */
 static int trace_enabled = 1;
@@ -670,6 +681,9 @@ static void __attribute__((unused)) z80_trace_push(uint16 pc) {
     e->IY = IY;
     e->SP = SP;
 }
+#else
+static inline void __attribute__((unused)) z80_trace_push(uint16 pc) { (void)pc; }
+#endif /* RUNCPM_TRACE */
 
 RUNCPM_DECL void z80_print_flags(uint16 AF) {
     static const char Flags[9] = "SZ5H3PNC";
@@ -680,6 +694,7 @@ RUNCPM_DECL void z80_print_flags(uint16 AF) {
     _puts("]");
 }
 
+#if RUNCPM_TRACE
 static void z80_trace_dump(void) {
     uint32 start = trace_pos;
     uint32 i;
@@ -714,6 +729,11 @@ static void z80_trace_dump(void) {
     }
     _puts("--- end trace ---\r\n");
 }
+#else
+static void __attribute__((unused)) z80_trace_dump(void) {
+    _puts("\r\nTrace disabled in this build.\r\n");
+}
+#endif /* RUNCPM_TRACE */
 
 /* Exec breakpoints: small fixed-size list. Only the bp_addrs[] list is used. */
 #define MAX_BREAKPOINTS 32

--- a/lib/runcpm/debug.h
+++ b/lib/runcpm/debug.h
@@ -1,0 +1,1064 @@
+#ifndef DEBUG_H
+#define DEBUG_H
+
+#ifndef RUNCPM_DECL
+#define RUNCPM_DECL
+#endif
+
+/* Mnemonic tables for Z80 disassembly - shared by all CPU models */
+#if defined(DEBUG) || defined(iDEBUG)
+
+static const char* Mnemonics[256] =
+{
+	"NOP", "LD BC,#h", "LD (BC),A", "INC BC", "INC B", "DEC B", "LD B,*h", "RLCA",
+	"EX AF,AF'", "ADD HL,BC", "LD A,(BC)", "DEC BC", "INC C", "DEC C", "LD C,*h", "RRCA",
+	"DJNZ @h", "LD DE,#h", "LD (DE),A", "INC DE", "INC D", "DEC D", "LD D,*h", "RLA",
+	"JR @h", "ADD HL,DE", "LD A,(DE)", "DEC DE", "INC E", "DEC E", "LD E,*h", "RRA",
+	"JR NZ,@h", "LD HL,#h", "LD (#h),HL", "INC HL", "INC H", "DEC H", "LD H,*h", "DAA",
+	"JR Z,@h", "ADD HL,HL", "LD HL,(#h)", "DEC HL", "INC L", "DEC L", "LD L,*h", "CPL",
+	"JR NC,@h", "LD SP,#h", "LD (#h),A", "INC SP", "INC (HL)", "DEC (HL)", "LD (HL),*h", "SCF",
+	"JR C,@h", "ADD HL,SP", "LD A,(#h)", "DEC SP", "INC A", "DEC A", "LD A,*h", "CCF",
+	"LD B,B", "LD B,C", "LD B,D", "LD B,E", "LD B,H", "LD B,L", "LD B,(HL)", "LD B,A",
+	"LD C,B", "LD C,C", "LD C,D", "LD C,E", "LD C,H", "LD C,L", "LD C,(HL)", "LD C,A",
+	"LD D,B", "LD D,C", "LD D,D", "LD D,E", "LD D,H", "LD D,L", "LD D,(HL)", "LD D,A",
+	"LD E,B", "LD E,C", "LD E,D", "LD E,E", "LD E,H", "LD E,L", "LD E,(HL)", "LD E,A",
+	"LD H,B", "LD H,C", "LD H,D", "LD H,E", "LD H,H", "LD H,L", "LD H,(HL)", "LD H,A",
+	"LD L,B", "LD L,C", "LD L,D", "LD L,E", "LD L,H", "LD L,L", "LD L,(HL)", "LD L,A",
+	"LD (HL),B", "LD (HL),C", "LD (HL),D", "LD (HL),E", "LD (HL),H", "LD (HL),L", "HALT", "LD (HL),A",
+	"LD A,B", "LD A,C", "LD A,D", "LD A,E", "LD A,H", "LD A,L", "LD A,(HL)", "LD A,A",
+	"ADD B", "ADD C", "ADD D", "ADD E", "ADD H", "ADD L", "ADD (HL)", "ADD A",
+	"ADC B", "ADC C", "ADC D", "ADC E", "ADC H", "ADC L", "ADC (HL)", "ADC A",
+	"SUB B", "SUB C", "SUB D", "SUB E", "SUB H", "SUB L", "SUB (HL)", "SUB A",
+	"SBC B", "SBC C", "SBC D", "SBC E", "SBC H", "SBC L", "SBC (HL)", "SBC A",
+	"AND B", "AND C", "AND D", "AND E", "AND H", "AND L", "AND (HL)", "AND A",
+	"XOR B", "XOR C", "XOR D", "XOR E", "XOR H", "XOR L", "XOR (HL)", "XOR A",
+	"OR B", "OR C", "OR D", "OR E", "OR H", "OR L", "OR (HL)", "OR A",
+	"CP B", "CP C", "CP D", "CP E", "CP H", "CP L", "CP (HL)", "CP A",
+	"RET NZ", "POP BC", "JP NZ,#h", "JP #h", "CALL NZ,#h", "PUSH BC", "ADD *h", "RST 00h",
+	"RET Z", "RET", "JP Z,#h", "PFX_CB", "CALL Z,#h", "CALL #h", "ADC *h", "RST 08h",
+	"RET NC", "POP DE", "JP NC,#h", "OUTA (*h)", "CALL NC,#h", "PUSH DE", "SUB *h", "RST 10h",
+	"RET C", "EXX", "JP C,#h", "INA (*h)", "CALL C,#h", "PFX_DD", "SBC *h", "RST 18h",
+	"RET PO", "POP HL", "JP PO,#h", "EX HL,(SP)", "CALL PO,#h", "PUSH HL", "AND *h", "RST 20h",
+	"RET PE", "LD PC,HL", "JP PE,#h", "EX DE,HL", "CALL PE,#h", "PFX_ED", "XOR *h", "RST 28h",
+	"RET P", "POP AF", "JP P,#h", "DI", "CALL P,#h", "PUSH AF", "OR *h", "RST 30h",
+	"RET M", "LD SP,HL", "JP M,#h", "EI", "CALL M,#h", "PFX_FD", "CP *h", "RST 38h"
+};
+
+static const char* MnemonicsCB[256] =
+{
+	"RLC B", "RLC C", "RLC D", "RLC E", "RLC H", "RLC L", "RLC (HL)", "RLC A",
+	"RRC B", "RRC C", "RRC D", "RRC E", "RRC H", "RRC L", "RRC (HL)", "RRC A",
+	"RL B", "RL C", "RL D", "RL E", "RL H", "RL L", "RL (HL)", "RL A",
+	"RR B", "RR C", "RR D", "RR E", "RR H", "RR L", "RR (HL)", "RR A",
+	"SLA B", "SLA C", "SLA D", "SLA E", "SLA H", "SLA L", "SLA (HL)", "SLA A",
+	"SRA B", "SRA C", "SRA D", "SRA E", "SRA H", "SRA L", "SRA (HL)", "SRA A",
+	"SLL B", "SLL C", "SLL D", "SLL E", "SLL H", "SLL L", "SLL (HL)", "SLL A",
+	"SRL B", "SRL C", "SRL D", "SRL E", "SRL H", "SRL L", "SRL (HL)", "SRL A",
+	"BIT 0,B", "BIT 0,C", "BIT 0,D", "BIT 0,E", "BIT 0,H", "BIT 0,L", "BIT 0,(HL)", "BIT 0,A",
+	"BIT 1,B", "BIT 1,C", "BIT 1,D", "BIT 1,E", "BIT 1,H", "BIT 1,L", "BIT 1,(HL)", "BIT 1,A",
+	"BIT 2,B", "BIT 2,C", "BIT 2,D", "BIT 2,E", "BIT 2,H", "BIT 2,L", "BIT 2,(HL)", "BIT 2,A",
+	"BIT 3,B", "BIT 3,C", "BIT 3,D", "BIT 3,E", "BIT 3,H", "BIT 3,L", "BIT 3,(HL)", "BIT 3,A",
+	"BIT 4,B", "BIT 4,C", "BIT 4,D", "BIT 4,E", "BIT 4,H", "BIT 4,L", "BIT 4,(HL)", "BIT 4,A",
+	"BIT 5,B", "BIT 5,C", "BIT 5,D", "BIT 5,E", "BIT 5,H", "BIT 5,L", "BIT 5,(HL)", "BIT 5,A",
+	"BIT 6,B", "BIT 6,C", "BIT 6,D", "BIT 6,E", "BIT 6,H", "BIT 6,L", "BIT 6,(HL)", "BIT 6,A",
+	"BIT 7,B", "BIT 7,C", "BIT 7,D", "BIT 7,E", "BIT 7,H", "BIT 7,L", "BIT 7,(HL)", "BIT 7,A",
+	"RES 0,B", "RES 0,C", "RES 0,D", "RES 0,E", "RES 0,H", "RES 0,L", "RES 0,(HL)", "RES 0,A",
+	"RES 1,B", "RES 1,C", "RES 1,D", "RES 1,E", "RES 1,H", "RES 1,L", "RES 1,(HL)", "RES 1,A",
+	"RES 2,B", "RES 2,C", "RES 2,D", "RES 2,E", "RES 2,H", "RES 2,L", "RES 2,(HL)", "RES 2,A",
+	"RES 3,B", "RES 3,C", "RES 3,D", "RES 3,E", "RES 3,H", "RES 3,L", "RES 3,(HL)", "RES 3,A",
+	"RES 4,B", "RES 4,C", "RES 4,D", "RES 4,E", "RES 4,H", "RES 4,L", "RES 4,(HL)", "RES 4,A",
+	"RES 5,B", "RES 5,C", "RES 5,D", "RES 5,E", "RES 5,H", "RES 5,L", "RES 5,(HL)", "RES 5,A",
+	"RES 6,B", "RES 6,C", "RES 6,D", "RES 6,E", "RES 6,H", "RES 6,L", "RES 6,(HL)", "RES 6,A",
+	"RES 7,B", "RES 7,C", "RES 7,D", "RES 7,E", "RES 7,H", "RES 7,L", "RES 7,(HL)", "RES 7,A",
+	"SET 0,B", "SET 0,C", "SET 0,D", "SET 0,E", "SET 0,H", "SET 0,L", "SET 0,(HL)", "SET 0,A",
+	"SET 1,B", "SET 1,C", "SET 1,D", "SET 1,E", "SET 1,H", "SET 1,L", "SET 1,(HL)", "SET 1,A",
+	"SET 2,B", "SET 2,C", "SET 2,D", "SET 2,E", "SET 2,H", "SET 2,L", "SET 2,(HL)", "SET 2,A",
+	"SET 3,B", "SET 3,C", "SET 3,D", "SET 3,E", "SET 3,H", "SET 3,L", "SET 3,(HL)", "SET 3,A",
+	"SET 4,B", "SET 4,C", "SET 4,D", "SET 4,E", "SET 4,H", "SET 4,L", "SET 4,(HL)", "SET 4,A",
+	"SET 5,B", "SET 5,C", "SET 5,D", "SET 5,E", "SET 5,H", "SET 5,L", "SET 5,(HL)", "SET 5,A",
+	"SET 6,B", "SET 6,C", "SET 6,D", "SET 6,E", "SET 6,H", "SET 6,L", "SET 6,(HL)", "SET 6,A",
+	"SET 7,B", "SET 7,C", "SET 7,D", "SET 7,E", "SET 7,H", "SET 7,L", "SET 7,(HL)", "SET 7,A"
+};
+
+static const char* MnemonicsED[256] =
+{
+	"DB EDh,00h", "DB EDh,01h", "DB EDh,02h", "DB EDh,03h",
+	"DB EDh,04h", "DB EDh,05h", "DB EDh,06h", "DB EDh,07h",
+	"DB EDh,08h", "DB EDh,09h", "DB EDh,0Ah", "DB EDh,0Bh",
+	"DB EDh,0Ch", "DB EDh,0Dh", "DB EDh,0Eh", "DB EDh,0Fh",
+	"DB EDh,10h", "DB EDh,11h", "DB EDh,12h", "DB EDh,13h",
+	"DB EDh,14h", "DB EDh,15h", "DB EDh,16h", "DB EDh,17h",
+	"DB EDh,18h", "DB EDh,19h", "DB EDh,1Ah", "DB EDh,1Bh",
+	"DB EDh,1Ch", "DB EDh,1Dh", "DB EDh,1Eh", "DB EDh,1Fh",
+	"DB EDh,20h", "DB EDh,21h", "DB EDh,22h", "DB EDh,23h",
+	"DB EDh,24h", "DB EDh,25h", "DB EDh,26h", "DB EDh,27h",
+	"DB EDh,28h", "DB EDh,29h", "DB EDh,2Ah", "DB EDh,2Bh",
+	"DB EDh,2Ch", "DB EDh,2Dh", "DB EDh,2Eh", "DB EDh,2Fh",
+	"DB EDh,30h", "DB EDh,31h", "DB EDh,32h", "DB EDh,33h",
+	"DB EDh,34h", "DB EDh,35h", "DB EDh,36h", "DB EDh,37h",
+	"DB EDh,38h", "DB EDh,39h", "DB EDh,3Ah", "DB EDh,3Bh",
+	"DB EDh,3Ch", "DB EDh,3Dh", "DB EDh,3Eh", "DB EDh,3Fh",
+	"IN B,(C)", "OUT (C),B", "SBC HL,BC", "LD (#h),BC",
+	"NEG", "RETN", "IM 0", "LD I,A",
+	"IN C,(C)", "OUT (C),C", "ADC HL,BC", "LD BC,(#h)",
+	"DB EDh,4Ch", "RETI", "DB EDh,4Eh", "LD R,A",
+	"IN D,(C)", "OUT (C),D", "SBC HL,DE", "LD (#h),DE",
+	"DB EDh,54h", "DB EDh,55h", "IM 1", "LD A,I",
+	"IN E,(C)", "OUT (C),E", "ADC HL,DE", "LD DE,(#h)",
+	"DB EDh,5Ch", "DB EDh,5Dh", "IM 2", "LD A,R",
+	"IN H,(C)", "OUT (C),H", "SBC HL,HL", "LD (#h),HL",
+	"DB EDh,64h", "DB EDh,65h", "DB EDh,66h", "RRD",
+	"IN L,(C)", "OUT (C),L", "ADC HL,HL", "LD HL,(#h)",
+	"DB EDh,6Ch", "DB EDh,6Dh", "DB EDh,6Eh", "RLD",
+	"IN F,(C)", "DB EDh,71h", "SBC HL,SP", "LD (#h),SP",
+	"DB EDh,74h", "DB EDh,75h", "DB EDh,76h", "DB EDh,77h",
+	"IN A,(C)", "OUT (C),A", "ADC HL,SP", "LD SP,(#h)",
+	"DB EDh,7Ch", "DB EDh,7Dh", "DB EDh,7Eh", "DB EDh,7Fh",
+	"DB EDh,80h", "DB EDh,81h", "DB EDh,82h", "DB EDh,83h",
+	"DB EDh,84h", "DB EDh,85h", "DB EDh,86h", "DB EDh,87h",
+	"DB EDh,88h", "DB EDh,89h", "DB EDh,8Ah", "DB EDh,8Bh",
+	"DB EDh,8Ch", "DB EDh,8Dh", "DB EDh,8Eh", "DB EDh,8Fh",
+	"DB EDh,90h", "DB EDh,91h", "DB EDh,92h", "DB EDh,93h",
+	"DB EDh,94h", "DB EDh,95h", "DB EDh,96h", "DB EDh,97h",
+	"DB EDh,98h", "DB EDh,99h", "DB EDh,9Ah", "DB EDh,9Bh",
+	"DB EDh,9Ch", "DB EDh,9Dh", "DB EDh,9Eh", "DB EDh,9Fh",
+	"LDI", "CPI", "INI", "OUTI",
+	"DB EDh,A4h", "DB EDh,A5h", "DB EDh,A6h", "DB EDh,A7h",
+	"LDD", "CPD", "IND", "OUTD",
+	"DB EDh,ACh", "DB EDh,ADh", "DB EDh,AEh", "DB EDh,AFh",
+	"LDIR", "CPIR", "INIR", "OTIR",
+	"DB EDh,B4h", "DB EDh,B5h", "DB EDh,B6h", "DB EDh,B7h",
+	"LDDR", "CPDR", "INDR", "OTDR",
+	"DB EDh,BCh", "DB EDh,BDh", "DB EDh,BEh", "DB EDh,BFh",
+	"DB EDh,C0h", "DB EDh,C1h", "DB EDh,C2h", "DB EDh,C3h",
+	"DB EDh,C4h", "DB EDh,C5h", "DB EDh,C6h", "DB EDh,C7h",
+	"DB EDh,C8h", "DB EDh,C9h", "DB EDh,CAh", "DB EDh,CBh",
+	"DB EDh,CCh", "DB EDh,CDh", "DB EDh,CEh", "DB EDh,CFh",
+	"DB EDh,D0h", "DB EDh,D1h", "DB EDh,D2h", "DB EDh,D3h",
+	"DB EDh,D4h", "DB EDh,D5h", "DB EDh,D6h", "DB EDh,D7h",
+	"DB EDh,D8h", "DB EDh,D9h", "DB EDh,DAh", "DB EDh,DBh",
+	"DB EDh,DCh", "DB EDh,DDh", "DB EDh,DEh", "DB EDh,DFh",
+	"DB EDh,E0h", "DB EDh,E1h", "DB EDh,E2h", "DB EDh,E3h",
+	"DB EDh,E4h", "DB EDh,E5h", "DB EDh,E6h", "DB EDh,E7h",
+	"DB EDh,E8h", "DB EDh,E9h", "DB EDh,EAh", "DB EDh,EBh",
+	"DB EDh,ECh", "DB EDh,EDh", "DB EDh,EEh", "DB EDh,EFh",
+	"DB EDh,F0h", "DB EDh,F1h", "DB EDh,F2h", "DB EDh,F3h",
+	"DB EDh,F4h", "DB EDh,F5h", "DB EDh,F6h", "DB EDh,F7h",
+	"DB EDh,F8h", "DB EDh,F9h", "DB EDh,FAh", "DB EDh,FBh",
+	"DB EDh,FCh", "DB EDh,FDh", "DB EDh,FEh", "DB EDh,FFh"
+};
+
+static const char* MnemonicsXX[256] =
+{
+	"NOP", "LD BC,#h", "LD (BC),A", "INC BC", "INC B", "DEC B", "LD B,*h", "RLCA",
+	"EX AF,AF'", "ADD I%,BC", "LD A,(BC)", "DEC BC", "INC C", "DEC C", "LD C,*h", "RRCA",
+	"DJNZ @h", "LD DE,#h", "LD (DE),A", "INC DE", "INC D", "DEC D", "LD D,*h", "RLA",
+	"JR @h", "ADD I%,DE", "LD A,(DE)", "DEC DE", "INC E", "DEC E", "LD E,*h", "RRA",
+	"JR NZ,@h", "LD I%,#h", "LD (#h),I%", "INC I%", "INC I%h", "DEC I%h", "LD I%h,*h", "DAA",
+	"JR Z,@h", "ADD I%,I%", "LD I%,(#h)", "DEC I%", "INC I%l", "DEC I%l", "LD I%l,*h", "CPL",
+	"JR NC,@h", "LD SP,#h", "LD (#h),A", "INC SP", "INC (I%+^h)", "DEC (I%+^h)", "LD (I%+^h),*h", "SCF",
+	"JR C,@h", "ADD I%,SP", "LD A,(#h)", "DEC SP", "INC A", "DEC A", "LD A,*h", "CCF",
+	"LD B,B", "LD B,C", "LD B,D", "LD B,E", "LD B,I%h", "LD B,I%l", "LD B,(I%+^h)", "LD B,A",
+	"LD C,B", "LD C,C", "LD C,D", "LD C,E", "LD C,I%h", "LD C,I%l", "LD C,(I%+^h)", "LD C,A",
+	"LD D,B", "LD D,C", "LD D,D", "LD D,E", "LD D,I%h", "LD D,I%l", "LD D,(I%+^h)", "LD D,A",
+	"LD E,B", "LD E,C", "LD E,D", "LD E,E", "LD E,I%h", "LD E,I%l", "LD E,(I%+^h)", "LD E,A",
+	"LD I%h,B", "LD I%h,C", "LD I%h,D", "LD I%h,E", "LD I%h,I%h", "LD I%h,I%l", "LD H,(I%+^h)", "LD I%h,A",
+	"LD I%l,B", "LD I%l,C", "LD I%l,D", "LD I%l,E", "LD I%l,I%h", "LD I%l,I%l", "LD L,(I%+^h)", "LD I%l,A",
+	"LD (I%+^h),B", "LD (I%+^h),C", "LD (I%+^h),D", "LD (I%+^h),E", "LD (I%+^h),H", "LD (I%+^h),L", "HALT", "LD (I%+^h),A",
+	"LD A,B", "LD A,C", "LD A,D", "LD A,E", "LD A,I%h", "LD A,I%l", "LD A,(I%+^h)", "LD A,A",
+	"ADD B", "ADD C", "ADD D", "ADD E", "ADD I%h", "ADD I%l", "ADD (I%+^h)", "ADD A",
+	"ADC B", "ADC C", "ADC D", "ADC E", "ADC I%h", "ADC I%l", "ADC (I%+^h)", "ADC,A",
+	"SUB B", "SUB C", "SUB D", "SUB E", "SUB I%h", "SUB I%l", "SUB (I%+^h)", "SUB A",
+	"SBC B", "SBC C", "SBC D", "SBC E", "SBC I%h", "SBC I%l", "SBC (I%+^h)", "SBC A",
+	"AND B", "AND C", "AND D", "AND E", "AND I%h", "AND I%l", "AND (I%+^h)", "AND A",
+	"XOR B", "XOR C", "XOR D", "XOR E", "XOR I%h", "XOR I%l", "XOR (I%+^h)", "XOR A",
+	"OR B", "OR C", "OR D", "OR E", "OR I%h", "OR I%l", "OR (I%+^h)", "OR A",
+	"CP B", "CP C", "CP D", "CP E", "CP I%h", "CP I%l", "CP (I%+^h)", "CP A",
+	"RET NZ", "POP BC", "JP NZ,#h", "JP #h", "CALL NZ,#h", "PUSH BC", "ADD *h", "RST 00h",
+	"RET Z", "RET", "JP Z,#h", "PFX_CB", "CALL Z,#h", "CALL #h", "ADC *h", "RST 08h",
+	"RET NC", "POP DE", "JP NC,#h", "OUTA (*h)", "CALL NC,#h", "PUSH DE", "SUB *h", "RST 10h",
+	"RET C", "EXX", "JP C,#h", "INA (*h)", "CALL C,#h", "PFX_DD", "SBC *h", "RST 18h",
+	"RET PO", "POP I%", "JP PO,#h", "EX I%,(SP)", "CALL PO,#h", "PUSH I%", "AND *h", "RST 20h",
+	"RET PE", "LD PC,I%", "JP PE,#h", "EX DE,I%", "CALL PE,#h", "PFX_ED", "XOR *h", "RST 28h",
+	"RET P", "POP AF", "JP P,#h", "DI", "CALL P,#h", "PUSH AF", "OR *h", "RST 30h",
+	"RET M", "LD SP,I%", "JP M,#h", "EI", "CALL M,#h", "PFX_FD", "CP *h", "RST 38h"
+};
+
+static const char* MnemonicsXCB[256] =
+{
+	"RLC B", "RLC C", "RLC D", "RLC E", "RLC H", "RLC L", "RLC (I%@h)", "RLC A",
+	"RRC B", "RRC C", "RRC D", "RRC E", "RRC H", "RRC L", "RRC (I%@h)", "RRC A",
+	"RL B", "RL C", "RL D", "RL E", "RL H", "RL L", "RL (I%@h)", "RL A",
+	"RR B", "RR C", "RR D", "RR E", "RR H", "RR L", "RR (I%@h)", "RR A",
+	"SLA B", "SLA C", "SLA D", "SLA E", "SLA H", "SLA L", "SLA (I%@h)", "SLA A",
+	"SRA B", "SRA C", "SRA D", "SRA E", "SRA H", "SRA L", "SRA (I%@h)", "SRA A",
+	"SLL B", "SLL C", "SLL D", "SLL E", "SLL H", "SLL L", "SLL (I%@h)", "SLL A",
+	"SRL B", "SRL C", "SRL D", "SRL E", "SRL H", "SRL L", "SRL (I%@h)", "SRL A",
+	"BIT 0,B", "BIT 0,C", "BIT 0,D", "BIT 0,E", "BIT 0,H", "BIT 0,L", "BIT 0,(I%@h)", "BIT 0,A",
+	"BIT 1,B", "BIT 1,C", "BIT 1,D", "BIT 1,E", "BIT 1,H", "BIT 1,L", "BIT 1,(I%@h)", "BIT 1,A",
+	"BIT 2,B", "BIT 2,C", "BIT 2,D", "BIT 2,E", "BIT 2,H", "BIT 2,L", "BIT 2,(I%@h)", "BIT 2,A",
+	"BIT 3,B", "BIT 3,C", "BIT 3,D", "BIT 3,E", "BIT 3,H", "BIT 3,L", "BIT 3,(I%@h)", "BIT 3,A",
+	"BIT 4,B", "BIT 4,C", "BIT 4,D", "BIT 4,E", "BIT 4,H", "BIT 4,L", "BIT 4,(I%@h)", "BIT 4,A",
+	"BIT 5,B", "BIT 5,C", "BIT 5,D", "BIT 5,E", "BIT 5,H", "BIT 5,L", "BIT 5,(I%@h)", "BIT 5,A",
+	"BIT 6,B", "BIT 6,C", "BIT 6,D", "BIT 6,E", "BIT 6,H", "BIT 6,L", "BIT 6,(I%@h)", "BIT 6,A",
+	"BIT 7,B", "BIT 7,C", "BIT 7,D", "BIT 7,E", "BIT 7,H", "BIT 7,L", "BIT 7,(I%@h)", "BIT 7,A",
+	"RES 0,B", "RES 0,C", "RES 0,D", "RES 0,E", "RES 0,H", "RES 0,L", "RES 0,(I%@h)", "RES 0,A",
+	"RES 1,B", "RES 1,C", "RES 1,D", "RES 1,E", "RES 1,H", "RES 1,L", "RES 1,(I%@h)", "RES 1,A",
+	"RES 2,B", "RES 2,C", "RES 2,D", "RES 2,E", "RES 2,H", "RES 2,L", "RES 2,(I%@h)", "RES 2,A",
+	"RES 3,B", "RES 3,C", "RES 3,D", "RES 3,E", "RES 3,H", "RES 3,L", "RES 3,(I%@h)", "RES 3,A",
+	"RES 4,B", "RES 4,C", "RES 4,D", "RES 4,E", "RES 4,H", "RES 4,L", "RES 4,(I%@h)", "RES 4,A",
+	"RES 5,B", "RES 5,C", "RES 5,D", "RES 5,E", "RES 5,H", "RES 5,L", "RES 5,(I%@h)", "RES 5,A",
+	"RES 6,B", "RES 6,C", "RES 6,D", "RES 6,E", "RES 6,H", "RES 6,L", "RES 6,(I%@h)", "RES 6,A",
+	"RES 7,B", "RES 7,C", "RES 7,D", "RES 7,E", "RES 7,H", "RES 7,L", "RES 7,(I%@h)", "RES 7,A",
+	"SET 0,B", "SET 0,C", "SET 0,D", "SET 0,E", "SET 0,H", "SET 0,L", "SET 0,(I%@h)", "SET 0,A",
+	"SET 1,B", "SET 1,C", "SET 1,D", "SET 1,E", "SET 1,H", "SET 1,L", "SET 1,(I%@h)", "SET 1,A",
+	"SET 2,B", "SET 2,C", "SET 2,D", "SET 2,E", "SET 2,H", "SET 2,L", "SET 2,(I%@h)", "SET 2,A",
+	"SET 3,B", "SET 3,C", "SET 3,D", "SET 3,E", "SET 3,H", "SET 3,L", "SET 3,(I%@h)", "SET 3,A",
+	"SET 4,B", "SET 4,C", "SET 4,D", "SET 4,E", "SET 4,H", "SET 4,L", "SET 4,(I%@h)", "SET 4,A",
+	"SET 5,B", "SET 5,C", "SET 5,D", "SET 5,E", "SET 5,H", "SET 5,L", "SET 5,(I%@h)", "SET 5,A",
+	"SET 6,B", "SET 6,C", "SET 6,D", "SET 6,E", "SET 6,H", "SET 6,L", "SET 6,(I%@h)", "SET 6,A",
+	"SET 7,B", "SET 7,C", "SET 7,D", "SET 7,E", "SET 7,H", "SET 7,L", "SET 7,(I%@h)", "SET 7,A"
+};
+
+static const char* CPMCalls[41] =
+{
+	"System Reset", "Console Input", "Console Output", "Reader Input", "Punch Output", "List Output", "Direct I/O", "Get IOByte",
+	"Set IOByte", "Print String", "Read Buffered", "Console Status", "Get Version", "Reset Disk", "Select Disk", "Open File",
+	"Close File", "Search First", "Search Next", "Delete File", "Read Sequential", "Write Sequential", "Make File", "Rename File",
+	"Get Login Vector", "Get Current Disk", "Set DMA Address", "Get Alloc", "Write Protect Disk", "Get R/O Vector", "Set File Attr", "Get Disk Params",
+	"Get/Set User", "Read Random", "Write Random", "Get File Size", "Set Random Record", "Reset Drive", "N/A", "N/A", "Write Random 0 fill"
+};
+
+RUNCPM_DECL int32 Watch = -1;
+
+#endif /* defined(DEBUG) || defined(iDEBUG) */
+
+RUNCPM_DECL void watchprint(uint16 pos) {
+    uint8 I, J;
+    _puts("\r\n");
+    _puts("  Watch : ");
+    _puthex16(Watch);
+    _puts(" = ");
+    _puthex8(_RamRead(Watch));
+    _putcon(':');
+    _puthex8(_RamRead(Watch + 1));
+    _puts(" / ");
+    for (J = 0, I = _RamRead(Watch); J < 8; ++J, I <<= 1)
+        _putcon(I & 0x80 ? '1' : '0');
+    _putcon(':');
+    for (J = 0, I = _RamRead(Watch + 1); J < 8; ++J, I <<= 1)
+        _putcon(I & 0x80 ? '1' : '0');
+}
+
+RUNCPM_DECL void memdump(uint16 pos) {
+    uint16 h = pos;
+    uint16 c = pos;
+    uint8 l, i;
+    uint8 ch = pos & 0xff;
+
+    _puts("       ");
+    for (i = 0; i < 16; ++i) {
+        _puthex8(ch++ & 0x0f);
+        _puts(" ");
+    }
+    _puts("\r\n");
+    _puts("       ");
+    for (i = 0; i < 16; ++i)
+        _puts("---");
+    _puts("\r\n");
+    for (l = 0; l < 16; ++l) {
+        _puthex16(h);
+        _puts(" : ");
+        for (i = 0; i < 16; ++i) {
+            _puthex8(_RamRead(h++));
+            _puts(" ");
+        }
+        for (i = 0; i < 16; ++i) {
+            ch = _RamRead(c++);
+            _putcon(ch > 31 && ch < 127 ? ch : '.');
+        }
+        _puts("\r\n");
+    }
+}
+
+static int read_hex8(uint8 *out) {
+    unsigned int v = 0;
+    int count = 0;
+    int ch;
+
+    /* Read characters until newline/carriage return */
+    while (1) {
+        ch = _getcon();
+        /* End on CR or LF */
+        if (ch == '\r' || ch == '\n')
+            break;
+
+        /* Backspace handling (BS=8, DEL=127) */
+        if (ch == 8 || ch == 127) {
+            if (count > 0) {
+                /* erase last hex digit visually (basic backspace handling) */
+                _putcon('\b');
+                _putcon(' ');
+                _putcon('\b');
+                v >>= 4;
+                --count;
+            }
+            continue;
+        }
+
+        /* Accept 0-9 */
+        if (ch >= '0' && ch <= '9') {
+            if (count < 2) {
+                v = (v << 4) | (unsigned int)(ch - '0');
+                ++count;
+                _putcon((char)ch);
+            }
+            continue;
+        }
+
+        /* Accept a-f */
+        if (ch >= 'a' && ch <= 'f') {
+            if (count < 2) {
+                v = (v << 4) | (unsigned int)(10 + ch - 'a');
+                ++count;
+                _putcon((char)ch);
+            }
+            continue;
+        }
+
+        /* Accept A-F */
+        if (ch >= 'A' && ch <= 'F') {
+            if (count < 2) {
+                v = (v << 4) | (unsigned int)(10 + ch - 'A');
+                ++count;
+                _putcon((char)ch);
+            }
+            continue;
+        }
+
+        /* Ignore 'x'/'X' to allow typing "0x..." */
+        if (ch == 'x' || ch == 'X')
+            continue;
+
+        /* Ignore any other characters */
+    }
+
+    /* move to next line visually */
+    _putcon('\r');
+    _putcon('\n');
+
+    if (count == 0)
+        return 0; /* no digits entered */
+
+    *out = (uint8)(v & 0xFFu);
+    return 1;
+}
+
+static int read_hex16(uint16 *out) {
+    unsigned int v = 0;
+    int count = 0;
+    int ch;
+
+    /* Read characters until newline/carriage return */
+    while (1) {
+        ch = _getcon();
+        /* End on CR or LF */
+        if (ch == '\r' || ch == '\n')
+            break;
+
+        /* Backspace handling (BS=8, DEL=127) */
+        if (ch == 8 || ch == 127) {
+            if (count > 0) {
+                /* erase last hex digit visually (basic backspace handling) */
+                _putcon('\b');
+                _putcon(' ');
+                _putcon('\b');
+                v >>= 4;
+                --count;
+            }
+            continue;
+        }
+
+        /* Accept 0-9 */
+        if (ch >= '0' && ch <= '9') {
+            if (count < 4) {
+                v = (v << 4) | (unsigned int)(ch - '0');
+                ++count;
+                _putcon((char)ch);
+            }
+            continue;
+        }
+
+        /* Accept a-f */
+        if (ch >= 'a' && ch <= 'f') {
+            if (count < 4) {
+                v = (v << 4) | (unsigned int)(10 + ch - 'a');
+                ++count;
+                _putcon((char)ch);
+            }
+            continue;
+        }
+
+        /* Accept A-F */
+        if (ch >= 'A' && ch <= 'F') {
+            if (count < 4) {
+                v = (v << 4) | (unsigned int)(10 + ch - 'A');
+                ++count;
+                _putcon((char)ch);
+            }
+            continue;
+        }
+
+        /* Ignore 'x'/'X' to allow typing "0x..." */
+        if (ch == 'x' || ch == 'X')
+            continue;
+
+        /* Ignore any other characters */
+    }
+
+    /* move to next line visually */
+    _putcon('\r');
+    _putcon('\n');
+
+    if (count == 0)
+        return 0; /* no digits entered */
+
+    *out = (uint16)(v & 0xFFFFu);
+    return 1;
+}
+
+/* Read opcode prefixes from memory at 'pos', advance pos to the
+   first operand byte and return the mnemonic pointer. It also returns the
+   initial byte-count (prefixes + opcode bytes consumed so far) via *countp
+   and an optional prefix character ('X'/'Y' or 0) via *prefixp.
+
+   Inputs:
+         posp  - pointer to the position (will be advanced to operand start)
+   Outputs:
+         returns const char* mnemonic string (one of Mnemonics*, MnemonicsCB, ...)
+         *countp set to initial consumed bytes (1 or more)
+         *prefixp set to 'X' or 'Y' or 0 if applicable
+*/
+static const char *GetMnemonicAt(uint16 *posp, uint8 *countp, char *prefixp) {
+    uint16 pos = *posp;
+    uint8 ch = _RamRead(pos);
+    uint8 count = 1;
+    char C = 0;
+    const char *txt;
+
+    switch (ch) {
+    case 0xCB:
+        ++pos;
+        txt = MnemonicsCB[_RamRead(pos++)];
+        count++;
+        break;
+    case 0xED:
+        ++pos;
+        txt = MnemonicsED[_RamRead(pos++)];
+        count++;
+        break;
+    case 0xDD:
+        ++pos;
+        C = 'X';
+        if (_RamRead(pos) != 0xCB) {
+            txt = MnemonicsXX[_RamRead(pos++)];
+            ++count;
+        } else {
+            ++pos;
+            txt = MnemonicsXCB[_RamRead(pos++)];
+            count += 2;
+        }
+        break;
+    case 0xFD:
+        ++pos;
+        C = 'Y';
+        if (_RamRead(pos) != 0xCB) {
+            txt = MnemonicsXX[_RamRead(pos++)];
+            ++count;
+        } else {
+            ++pos;
+            txt = MnemonicsXCB[_RamRead(pos++)];
+            count += 2;
+        }
+        break;
+    default:
+        /* Normal opcode */
+        txt = Mnemonics[_RamRead(pos++)];
+        break;
+    }
+
+    *posp = pos;     /* advanced to first operand byte (if any) */
+    *countp = count; /* consumed opcode/prefix bytes so far */
+    if (prefixp)
+        *prefixp = C;
+    return txt;
+}
+
+/* InstructionLength - compute the number of bytes used by the instruction at pos */
+static uint8 InstructionLength(uint16 pos) {
+    uint8 count = 0;
+    uint8 initial;
+    char C = 0;
+    const char *txt;
+
+    /* Get mnemonic and advance pos to the operand area. initial counts prefixes/opcode */
+    txt = GetMnemonicAt(&pos, &initial, &C);
+    count = initial;
+
+    /* Walk the mnemonic-format string to count operand bytes */
+    while (*txt != 0) {
+        switch (*txt) {
+        case '*': /* one immediate byte */
+        case '^': /* one immediate byte */
+            txt += 2;
+            ++count;
+            ++pos;
+            break;
+        case '#': /* two-byte immediate (word) */
+            txt += 2;
+            count += 2;
+            pos += 2;
+            break;
+        case '@': /* relative displacement (one byte) */
+            txt += 2;
+            ++count;
+            ++pos;
+            break;
+        case '%': /* prefix placeholder in mnemonic text, no operand */
+            ++txt;
+            break;
+        default:
+            ++txt;
+        }
+    }
+
+    return count;
+}
+
+/* TextLength - compute the length of the text representation of the instruction at pos */
+static uint8 TextLength(uint16 pos) {
+    uint8 len = 0;
+    const char *txt = GetMnemonicAt(&pos, &len, NULL);
+    len = 0;
+    while (*txt != 0) {
+        switch (*txt) {
+        case '*':
+        case '^':
+            txt += 2;
+            len += 2; // 1 byte + 2 hex digits
+            break;
+        case '#':
+            txt += 2;
+            len += 4; // 2 bytes + 2 hex digits
+            break;
+        case '@':
+            txt += 2;
+            len += 4; // 1 byte + 2 hex digits
+            break;
+        case '%':
+            ++txt;
+            ++len;
+            break;
+        default:
+            ++txt;
+            ++len;
+        }
+    }
+    return len;
+}
+
+/* Disassemble instruction at given address */
+RUNCPM_DECL uint8 Disasm(uint16 pos) {
+    /* New Disasm: print full opcode byte column, then mnemonic. */
+    const char *txt;
+    uint8 Cflag = 0;
+    uint8 len = InstructionLength(pos);
+    uint16 op_pos = pos;
+    uint8 initial = 0;
+
+    /* Print opcode bytes (up to len) */
+    for (uint8 i = 0; i < len; ++i) {
+        _puthex8(_RamRead((pos + i) & 0xffff));
+        _putcon(' ');
+    }
+
+    /* pad bytes area to fixed column (use 3 chars per byte, target 12 chars) */
+    int bytes_width = (int)len * 3;
+    int target = 12; /* enough for up to 4 bytes */
+    for (int s = bytes_width; s < target; ++s)
+        _putcon(' ');
+
+    /* Get mnemonic template (advances a temporary pos to operand start) */
+    txt = GetMnemonicAt(&op_pos, &initial, (char *)&Cflag);
+
+    /* Now print mnemonic with formatted operands. When we encounter operand markers
+       we consume bytes from op_pos (which points to first operand byte). */
+    while (*txt != 0) {
+        switch (*txt) {
+        case '*':
+        case '^': {
+            /* single byte immediate */
+            txt += 2;
+            uint8 v = _RamRead(op_pos++);
+            _puthex8(v);
+            break;
+        }
+        case '#': {
+            /* word immediate: print as 16-bit hex (little-endian) */
+            txt += 2;
+            uint8 lo = _RamRead(op_pos);
+            uint8 hi = _RamRead(op_pos + 1);
+            uint16 w = (uint16)lo | ((uint16)hi << 8);
+            op_pos += 2;
+            _puthex16(w);
+            break;
+        }
+        case '@': {
+            /* relative displacement - show target address */
+            char jr = (char)_RamRead(op_pos++);
+            uint16 target = (op_pos + jr) & 0xffff;
+            txt += 2;
+            _puthex16(target);
+            break;
+        }
+        case '%':
+            _putcon((char)Cflag);
+            ++txt;
+            break;
+        default:
+            _putcon(*txt);
+            ++txt;
+        }
+    }
+
+    return (len);
+}
+
+/* --- Simple instruction trace buffer and exec breakpoints ---
+   Implemented inline here to avoid changing platform Makefiles.
+   Trace records last N executed instructions (pc, bytes, len, reg snapshot).
+*/
+#define TRACE_CAPACITY 512
+typedef struct {
+    uint16 pc;
+    uint8 len;
+    uint8 bytes[8];
+    int32 AF, BC, DE, HL, IX, IY, SP;
+} trace_entry_t;
+
+static trace_entry_t trace_buf[TRACE_CAPACITY];
+static uint32 trace_pos = 0; /* next write index */
+static int trace_enabled = 1;
+
+static void __attribute__((unused)) z80_trace_push(uint16 pc) {
+    if (!trace_enabled)
+        return;
+    trace_entry_t *e = &trace_buf[trace_pos++ % TRACE_CAPACITY];
+    uint8 len = InstructionLength(pc);
+    if (len > 8)
+        len = 8;
+    e->pc = pc;
+    e->len = len;
+    for (uint8 i = 0; i < len; ++i) {
+        e->bytes[i] = _RamRead((pc + i) & 0xffff);
+    }
+    e->AF = AF;
+    e->BC = BC;
+    e->DE = DE;
+    e->HL = HL;
+    e->IX = IX;
+    e->IY = IY;
+    e->SP = SP;
+}
+
+RUNCPM_DECL void z80_print_flags(uint16 AF) {
+    static const char Flags[9] = "SZ5H3PNC";
+    uint8 J, I;
+    _puts(" [");
+    for (J = 0, I = LOW_REGISTER(AF); J < 8; ++J, I <<= 1)
+        _putcon(I & 0x80 ? Flags[J] : '.');
+    _puts("]");
+}
+
+static void z80_trace_dump(void) {
+    uint32 start = trace_pos;
+    uint32 i;
+    uint8 len;
+    _puts("\r\n--- Trace dump (most recent last) ---\r\n");
+    for (i = 0; i < TRACE_CAPACITY; ++i) {
+        trace_entry_t *e = &trace_buf[(start + i) % TRACE_CAPACITY];
+        /* skip empty entries (pc==0 and len==0) */
+        if (e->len == 0 && e->pc == 0)
+            continue;
+        _puthex16(e->pc);
+        _puts(": ");
+        /* print disassembly for this address */
+        Disasm(e->pc);
+        len = TextLength(e->pc);
+        /* pad to fixed column (target 16 chars) */
+        int target = 16;
+        for (int s = len; s < target; ++s)
+            _putcon(' ');
+        _puts("BC:");
+        _puthex16(e->BC);
+        _puts(" DE:");
+        _puthex16(e->DE);
+        _puts(" HL:");
+        _puthex16(e->HL);
+        _puts(" AF:");
+        _puthex16(e->AF);
+        z80_print_flags(e->AF);
+        _puts(" SP:");
+        _puthex16(e->SP);
+        _puts("\r\n");
+    }
+    _puts("--- end trace ---\r\n");
+}
+
+/* Exec breakpoints: small fixed-size list. Only the bp_addrs[] list is used. */
+#define MAX_BREAKPOINTS 32
+static uint16 bp_addrs[MAX_BREAKPOINTS];
+static int bp_count = 0;
+
+static int z80_add_breakpoint(uint16 addr) {
+    /* prevent duplicates */
+    for (int i = 0; i < bp_count; ++i)
+        if (bp_addrs[i] == addr)
+            return -2;
+    if (bp_count >= MAX_BREAKPOINTS)
+        return -1;
+    bp_addrs[bp_count++] = addr;
+    return 0;
+}
+
+static void z80_clear_breakpoints(void) {
+    bp_count = 0;
+}
+
+static int z80_remove_breakpoint(uint16 addr) {
+    for (int i = 0; i < bp_count; ++i) {
+        if (bp_addrs[i] == addr) {
+            /* shift remaining */
+            for (int j = i; j + 1 < bp_count; ++j)
+                bp_addrs[j] = bp_addrs[j + 1];
+            --bp_count;
+            return 0;
+        }
+    }
+    return -1; /* not found */
+}
+
+static int __attribute__((unused)) z80_check_breakpoints_on_exec(uint16 pc) {
+    for (int i = 0; i < bp_count; ++i)
+        if (bp_addrs[i] == pc)
+            return 1;
+    return 0;
+}
+
+RUNCPM_DECL void Z80debug(void) {
+    uint8 ch = 0;
+    uint16 pos, l;
+    uint8 I;
+    uint16 bpoint; /* changed from unsigned int to 16-bit */
+    uint8 loop = TRUE;
+    int res = 0; /* use a signed int for result checks */
+
+    _puts("\r\nDebug Mode - Press '?' for help");
+
+    while (loop && Debug) {
+        pos = PC;
+        _puts("\r\n");
+        _puts("BC:");
+        _puthex16(BC);
+        _puts(" DE:");
+        _puthex16(DE);
+        _puts(" HL:");
+        _puthex16(HL);
+        _puts(" AF:");
+        _puthex16(AF);
+        _puts(" :");
+        z80_print_flags(AF);
+        _puts("\r\n");
+        _puts("IX:");
+        _puthex16(IX);
+        _puts(" IY:");
+        _puthex16(IY);
+        _puts(" SP:");
+        _puthex16(SP);
+        _puts(" PC:");
+        _puthex16(PC);
+        _puts(" : ");
+
+        Disasm(pos);
+
+        if (PC == 0x0005) {
+            if (LOW_REGISTER(BC) > 40) {
+                _puts(" (Unknown)");
+            } else {
+                _puts(" (");
+                _puts(CPMCalls[LOW_REGISTER(BC)]);
+                _puts(")");
+            }
+        }
+
+        if (Watch != -1) {
+            watchprint(Watch);
+        }
+
+        _puts("\r\n");
+        _puts("Command|? : ");
+        ch = _getcon();
+        if (ch > 21 && ch < 127)
+            _putcon(ch);
+        switch (ch) {
+        case 't':
+            /* Trace to next instruction */
+            loop = FALSE;
+            break;
+        case 'c':
+            /* Continue execution */
+            loop = FALSE;
+            _puts("\r\n");
+            Debug = 0;
+            break;
+        case 'b':
+            /* Dump memory pointed by (BC) */
+            _puts("\r\n");
+            memdump(BC);
+            break;
+        case 'd':
+            /* Dump memory pointed by (DE) */
+            _puts("\r\n");
+            memdump(DE);
+            break;
+        case 'h':
+            /* Dump memory pointed by (HL) */
+            _puts("\r\n");
+            memdump(HL);
+            break;
+        case 'p':
+            /* Dump memory page pointed by (PC) */
+            _puts("\r\n");
+            memdump(PC & 0xFF00);
+            break;
+        case 's':
+            /* Dump memory page pointed by (SP) */
+            _puts("\r\n");
+            memdump(SP & 0xFF00);
+            break;
+        case 'x':
+            /* Dump memory page pointed by (IX) */
+            _puts("\r\n");
+            memdump(IX & 0xFF00);
+            break;
+        case 'y':
+            /* Dump memory page pointed by (IY) */
+            _puts("\r\n");
+            memdump(IY & 0xFF00);
+            break;
+        case 'a':
+            /* Dump memory pointed by dmaAddr */
+            _puts("\r\n");
+            memdump(dmaAddr);
+            break;
+        case 'l':
+            /* Disassemble from current PC */
+            _puts("\r\n");
+            I = 16;
+            l = pos;
+            while (I > 0) {
+                _puthex16(l);
+                _puts(" : ");
+                l += Disasm(l);
+                _puts("\r\n");
+                --I;
+            }
+            break;
+        case 'A':
+            /* Add breakpoint at address */
+            _puts(" Addr: ");
+            res = read_hex16(&bpoint);
+            if (res) {
+                if (z80_add_breakpoint(bpoint) == 0) {
+                    _puts("Breakpoint added: ");
+                    _puthex16(bpoint);
+                    _puts("\r\n");
+                } else {
+                    _puts("Breakpoint list full\r\n");
+                }
+            } else {
+                _puts("Invalid address\r\n");
+            }
+            break;
+        case 'B':
+            /* List breakpoints set via 'A' */
+            _puts(" Breakpoints:\r\n");
+            if (bp_count == 0) {
+                _puts("  (none)\r\n");
+            } else {
+                for (int i = 0; i < bp_count; ++i) {
+                    uint16 a = bp_addrs[i];
+                    _puthex16(a);
+                    _puts(" : ");
+                    Disasm(a);
+                    _puts("\r\n");
+                }
+            }
+            break;
+        case 'C':
+            /* Clear all breakpoints */
+            z80_clear_breakpoints();
+            _puts(" Breakpoints cleared\r\n");
+            break;
+        case 'D':
+            /* Dump memory at address */
+            _puts(" Addr: ");
+            res = read_hex16(&bpoint);
+            if (res)
+                memdump(bpoint);
+            else
+                _puts("Invalid address\r\n");
+            break;
+        case 'E':
+            /* Erase breakpoint at address */
+            _puts(" Addr: ");
+            res = read_hex16(&bpoint);
+            if (res) {
+                if (z80_remove_breakpoint(bpoint) == 0) {
+                    _puts("Breakpoint removed: ");
+                    _puthex16(bpoint);
+                    _puts("\r\n");
+                } else {
+                    _puts("Breakpoint not found\r\n");
+                }
+            } else {
+                _puts("Invalid address\r\n");
+            }
+            break;
+        case 'J':
+            /* Jump - set PC to address */
+            _puts(" Addr: ");
+            res = read_hex16(&bpoint);
+            if (res) {
+                PC = bpoint;
+                _puts("PC set to ");
+                _puthex16(PC);
+                _puts("\r\n");
+            } else {
+                _puts("Invalid address\r\n");
+            }
+            break;
+        case 'L':
+            /* Disassemble at address */
+            _puts(" Addr: ");
+            res = read_hex16(&bpoint);
+            if (res) {
+                I = 16;
+                l = bpoint;
+                while (I > 0) {
+                    _puthex16(l);
+                    _puts(" : ");
+                    l += Disasm(l);
+                    _puts("\r\n");
+                    --I;
+                }
+            } else {
+                _puts("Invalid address\r\n");
+            }
+            break;
+        case 'M':
+            /* Modify memory byte at address until Enter is pressed */
+            _puts("\r\n Addr: ");
+            res = read_hex16(&bpoint);
+            if (res) {
+                uint16 addr = bpoint;
+                uint8 val;
+                while (1) {
+                    _puthex16(addr);
+                    _puts(" : ");
+                    val = _RamRead(addr);
+                    _puthex8(val);
+                    _puts(" -> ");
+                    res = read_hex8(&val);
+                    if (res) {
+                        _RamWrite(addr, val);
+                        addr = (addr + 1) & 0xFFFF;
+                    } else {
+                        break; /* exit on no input */
+                    }
+                }
+            } else {
+                _puts("Invalid address\r\n");
+            }
+            break;
+        case 'R':
+            /* Dump recent trace */
+            z80_trace_dump();
+            break;
+        case 'T':
+            /* Step over a call */
+            loop = FALSE;
+            Step = pos + InstructionLength(pos);
+            Debug = 0;
+            break;
+        case 'U':
+            /* Unwatch - clear any byte/word watch */
+            Watch = -1;
+            _puts("\r\nWatch cleared\r\n");
+            break;
+        case 'W':
+            /* Watch - set a byte/word watch */
+            _puts(" Addr: ");
+            res = read_hex16(&bpoint);
+            if (res) {
+                Watch = bpoint;
+                _puts("Watch set to ");
+                _puthex16(Watch);
+                _puts("\r\n");
+            } else {
+                _puts("Invalid address\r\n");
+            }
+            break;
+        case 'X':
+            /* Exit RunCPM */
+            _puts("\r\nExiting...\r\n");
+            Debug = 0;
+            Status = 1;
+            break;
+        case '?':
+            /* Help */
+            _puts("\r\n");
+            _puts("Lowercase commands:\r\n");
+            _puts("  t - traces to the next instruction\r\n");
+            _puts("  c - Continue execution\r\n");
+            _puts("  b - Dumps memory pointed by (BC)\r\n");
+            _puts("  d - Dumps memory pointed by (DE)\r\n");
+            _puts("  h - Dumps memory pointed by (HL)\r\n");
+            _puts("  p - Dumps the page (PC) points to\r\n");
+            _puts("  s - Dumps the page (SP) points to\r\n");
+            _puts("  x - Dumps the page (IX) points to\r\n");
+            _puts("  y - Dumps the page (IY) points to\r\n");
+            _puts("  a - Dumps memory pointed by dmaAddr\r\n");
+            _puts("  l - Disassembles from current PC\r\n");
+            _puts("Uppercase commands:\r\n");
+            _puts("  A - Add breakpoint at address\r\n");
+            _puts("  B - List breakpoints\r\n");
+            _puts("  C - Clear all breakpoints\r\n");
+            _puts("  D - Dumps memory at address\r\n");
+            _puts("  E - Erase breakpoint at address\r\n");
+            _puts("  J - Jumps to address (sets PC)\r\n");
+            _puts("  L - Disassembles at address\r\n");
+            _puts("  M - Modify memory at address\r\n");
+            _puts("  R - Dump recent trace\r\n");
+            _puts("  T - Steps over a call\r\n");
+            _puts("  U - Clears the byte/word watch\r\n");
+            _puts("  W - Sets a byte/word watch\r\n");
+            _puts("  X - Exit RunCPM\r\n");
+            break;
+        default:
+            _puts(" ???\r\n");
+        }
+    }
+}
+
+#endif // ifndef DEBUG_H

--- a/lib/runcpm/disk.h
+++ b/lib/runcpm/disk.h
@@ -1,3 +1,8 @@
+/* FujiNet vendoring: use CPM_DISK_H (not the upstream 6.9 DISK_H) so this
+   header's include guard does not collide with the bus-device disk headers
+   (lib/device/sio/disk.h, rc2014/disk.h, h89/disk.h) which all define DISK_H.
+   A collision would silently skip this file's body, leaving every BDOS disk
+   helper (_SelectDisk, _OpenFile, _CheckSUB, …) undeclared. */
 #ifndef CPM_DISK_H
 #define CPM_DISK_H
 
@@ -8,11 +13,11 @@
 /* see main.c for definition */
 
 #ifdef __linux__
-#include <sys/stat.h>
+    #include <sys/stat.h>
 #endif
 
 #ifdef __DJGPP__
-#include <dirent.h>
+    #include <dirent.h>
 #endif
 
 /*
@@ -21,619 +26,842 @@ Disk errors
 #define errWRITEPROT 1
 #define errSELECT 2
 
-#define RW	(roVector & (1 << cDrive))
+#define RW (roVector & (1 << cDrive))
 
 // Prints out a BDOS error
 RUNCPM_DECL void _error(uint8 error) {
-	_puts("\r\nBdos Err on ");
-	_putcon('A' + cDrive);
-	_puts(": ");
-	switch (error) {
-	case errWRITEPROT:
-		_puts("R/O");
-		break;
-	case errSELECT:
-		_puts("Select");
-		break;
-	default:
-		_puts("\r\nCP/M ERR");
-		break;
-	}
-	Status = _getch();
-	_puts("\r\n");
-	cDrive = oDrive = _RamRead(DSKByte) & 0x0f;
-	Status = 2;
+    _puts("\r\nBdos Err on ");
+    _putcon('A' + cDrive);
+    _puts(": ");
+    switch (error) {
+        case errWRITEPROT:
+            _puts("R/O");
+            break;
+        case errSELECT:
+            _puts("Select");
+            break;
+        default:
+            _puts("\r\nCP/M ERR");
+            break;
+    }
+    Status = _getcon();
+    _puts("\r\n");
+    cDrive = oDrive = _RamRead(DSKByte) & 0x0f;
+    Status = STATUS_RESTART;
 }
 
 // Selects the disk to be used by the next disk function
 RUNCPM_DECL int _SelectDisk(uint8 dr) {
-	uint8 result = 0xff;
-	uint8 disk[2] = { 'A', 0 };
+    uint8 result = 0xff;
+    uint8 disk[2] = {'A', 0};
 
-	if (!dr || dr == '?') {
-		dr = cDrive;	// This will set dr to defDisk in case no disk is passed
-	} else {
-		--dr;			// Called from BDOS, set dr back to 0=A: format
-	}
+    if (!dr || dr == '?') {
+        dr = cDrive; // This will set dr to defDisk in case no disk is passed
+    } else {
+        --dr; // Called from BDOS, set dr back to 0=A: format
+    }
 
-	disk[0] += dr;
-	if (_sys_select(&disk[0])) {
-		loginVector = loginVector | (1 << (disk[0] - 'A'));
-		result = 0x00;
-	} else {
-		_error(errSELECT);
-	}
+    disk[0] += dr;
+    if (_sys_select(&disk[0])) {
+        loginVector = loginVector | (1 << (disk[0] - 'A'));
+        result = 0x00;
+    } else {
+        cDrive = oDrive = dr;
+        _error(errSELECT);
+    }
 
-	return(result);
+    return (result);
 }
 
 // Converts a FCB entry onto a host OS filename string
-RUNCPM_DECL uint8 _FCBtoHostname(uint16 fcbaddr, uint8* filename) {
-	uint8 addDot = TRUE;
-	CPM_FCB* F = (CPM_FCB*)_RamSysAddr(fcbaddr);
-	uint8 i = 0;
-	uint8 unique = TRUE;
-	uint8 c;
+RUNCPM_DECL uint8 _FCBtoHostname(uint16 fcbaddr, uint8 *filename) {
+    uint8 addDot = TRUE;
+    CPM_FCB *F = (CPM_FCB *)_RamSysAddr(fcbaddr);
+    uint8 i = 0;
+    uint8 unique = TRUE;
+    uint8 c;
 
-	if (F->dr && F->dr != '?') {
-		*(filename++) = (F->dr - 1) + 'A';
-	} else {
-		*(filename++) = cDrive + 'A';
-	}
-	*(filename++) = FOLDERCHAR;
+    if (F->dr && F->dr != '?') {
+        *(filename++) = (F->dr - 1) + 'A';
+    } else {
+        *(filename++) = cDrive + 'A';
+    }
+    *(filename++) = FOLDERCHAR;
 
-	*(filename++) = toupper(tohex(userCode));
-	*(filename++) = FOLDERCHAR;
+    *(filename++) = toupper(tohex(userCode));
+    *(filename++) = FOLDERCHAR;
 
-	if (F->dr != '?') {
-		while (i < 8) {
-			c = F->fn[i] & 0x7F;
+    if (F->dr != '?') {
+        while (i < 8) {
+            c = F->fn[i] & 0x7F;
 #ifdef NOSLASH
-			if (c == '/')
-				c = '_';
+            if (c == '/')
+                c = '_';
 #endif
-			if (c > 32)
-				*(filename++) = toupper(c);
-			if (c == '?')
-				unique = FALSE;
-			++i;
-		}
-		i = 0;
-		while (i < 3) {
-			c = F->tp[i] & 0x7F;
-			if (c > 32) {
-				if (addDot) {
-					addDot = FALSE;
-					*(filename++) = '.';  // Only add the dot if there's an extension
-				}
+            if (c > 32)
+                *(filename++) = toupper(c);
+            if (c == '?')
+                unique = FALSE;
+            ++i;
+        }
+        i = 0;
+        while (i < 3) {
+            c = F->tp[i] & 0x7F;
+            if (c > 32) {
+                if (addDot) {
+                    addDot = FALSE;
+                    *(filename++) = '.'; // Only add the dot if there's an extension
+                }
 #ifdef NOSLASH
-				if (c == '/')
-					c = '_';
+                if (c == '/')
+                    c = '_';
 #endif
-				*(filename++) = toupper(c);
-			}
-			if (c == '?')
-				unique = FALSE;
-			++i;
-		}
-	} else {
-		for (i = 0; i < 8; ++i) {
-			*(filename++) = '?';
-		}
-		*(filename++) = '.';
-		for (i = 0; i < 3; ++i) {
-			*(filename++) = '?';
-		}
-		unique = FALSE;
-	}
-	*filename = 0x00;
+                *(filename++) = toupper(c);
+            }
+            if (c == '?')
+                unique = FALSE;
+            ++i;
+        }
+    } else {
+        for (i = 0; i < 8; ++i)
+            *(filename++) = '?';
+        *(filename++) = '.';
+        for (i = 0; i < 3; ++i)
+            *(filename++) = '?';
+        unique = FALSE;
+    }
+    *filename = 0x00;
 
-	return(unique);
+    return (unique);
 }
 
-// Convers a host OS filename string onto a FCB entry
-RUNCPM_DECL void _HostnameToFCB(uint16 fcbaddr, uint8* filename) {
-	CPM_FCB* F = (CPM_FCB*)_RamSysAddr(fcbaddr);
-	uint8 i = 0;
+// Converts a host OS filename string onto a FCB entry
+RUNCPM_DECL void _HostnameToFCB(uint16 fcbaddr, uint8 *filename) {
+    CPM_FCB *F = (CPM_FCB *)_RamSysAddr(fcbaddr);
+    uint8 i = 0;
 
-	++filename;
-	if (*filename == FOLDERCHAR) {	// Skips the drive and / if needed
-		filename += 3;
-	} else {
-		--filename;
-	}
+    ++filename;
+    if (*filename == FOLDERCHAR) { // Skips the drive and / if needed
+        filename += 3;
+    } else {
+        --filename;
+    }
 
-	while (*filename != 0 && *filename != '.') {
-		F->fn[i] = toupper(*filename);
-		++filename;
-		++i;
-	}
-	while (i < 8) {
-		F->fn[i] = ' ';
-		++i;
-	}
-	if (*filename == '.')
-		++filename;
-	i = 0;
-	while (*filename != 0) {
-		F->tp[i] = toupper(*filename);
-		++filename;
-		++i;
-	}
-	while (i < 3) {
-		F->tp[i] = ' ';
-		++i;
-	}
+    while (*filename != 0 && *filename != '.') {
+        F->fn[i] = toupper(*filename);
+        ++filename;
+        ++i;
+    }
+    while (i < 8) {
+        F->fn[i] = ' ';
+        ++i;
+    }
+    if (*filename == '.')
+        ++filename;
+    i = 0;
+    while (*filename != 0) {
+        F->tp[i] = toupper(*filename);
+        ++filename;
+        ++i;
+    }
+    while (i < 3) {
+        F->tp[i] = ' ';
+        ++i;
+    }
 }
 
 // Converts a string name (AB.TXT) onto FCB name (AB      TXT)
-RUNCPM_DECL void _HostnameToFCBname(uint8* from, uint8* to) {
-	int i = 0;
+RUNCPM_DECL void _HostnameToFCBname(uint8 *from, uint8 *to) {
+    int i = 0;
 
-	++from;
-	if (*from == FOLDERCHAR) {	// Skips the drive and / if needed
-		from += 3;
-	} else {
-		--from;
-	}
+    ++from;
+    if (*from == FOLDERCHAR) { // Skips the drive and / if needed
+        from += 3;
+    } else {
+        --from;
+    }
 
-	while (*from != 0 && *from != '.') {
-		*to = toupper(*from);
-		++to; ++from; ++i;
-	}
-	while (i < 8) {
-		*to = ' ';
-		++to;  ++i;
-	}
-	if (*from == '.')
-		++from;
-	i = 0;
-	while (*from != 0) {
-		*to = toupper(*from);
-		++to; ++from; ++i;
-	}
-	while (i < 3) {
-		*to = ' ';
-		++to;  ++i;
-	}
-	*to = 0;
+    while (*from != 0 && *from != '.') {
+        *to = toupper(*from);
+        ++to;
+        ++from;
+        ++i;
+    }
+    while (i < 8) {
+        *to = ' ';
+        ++to;
+        ++i;
+    }
+    if (*from == '.')
+        ++from;
+    i = 0;
+    while (*from != 0) {
+        *to = toupper(*from);
+        ++to;
+        ++from;
+        ++i;
+    }
+    while (i < 3) {
+        *to = ' ';
+        ++to;
+        ++i;
+    }
+    *to = 0;
 }
 
 // Creates a fake directory entry for the current dmaAddr FCB
-RUNCPM_DECL void _mockupDirEntry(void) {
-	CPM_DIRENTRY* DE = (CPM_DIRENTRY*)_RamSysAddr(dmaAddr);
-	uint8 blocks, i;
+RUNCPM_DECL void _mockupDirEntry(uint8 mode) {
+    CPM_DIRENTRY *DirEntry = (CPM_DIRENTRY *)_RamSysAddr(dmaAddr);
+    uint8 blocks, i;
 
-	for (i = 0; i < sizeof(CPM_DIRENTRY); ++i) {
-		_RamWrite(dmaAddr + i, 0x00); // zero out directory entry
-	}
-	_HostnameToFCB(dmaAddr, (uint8*)findNextDirName);
+    for (i = 0; i < sizeof(CPM_DIRENTRY); ++i)
+        _RamWrite(dmaAddr + i, 0x00); // zero out directory entry
+    unsigned char *shortName;
+    if (mode) {
+        shortName = (unsigned char *)&findNextDirName[strlen(FILEBASE)];
+    } else {
+        shortName = (unsigned char *)&findNextDirName[0];
+    }
+    _HostnameToFCB(dmaAddr, (uint8 *)shortName);
 
-	if (allUsers) {
-		DE->dr = currFindUser; // set user code for return
-	} else {
-		DE->dr = userCode;
-	}
-	// does file fit in a single directory entry?
-	if (fileExtents <= extentsPerDirEntry) {
-		if (fileExtents) {
-			DE->ex = (fileExtents - 1 + fileExtentsUsed) % (MaxEX + 1);
-			DE->s2 = (fileExtents - 1 + fileExtentsUsed) / (MaxEX + 1);
-			DE->rc = fileRecords - (BlkEX * (fileExtents - 1));
-		}
-		blocks = (fileRecords >> blockShift) + ((fileRecords & blockMask) ? 1 : 0);
-		fileRecords = 0;
-		fileExtents = 0;
-		fileExtentsUsed = 0;
-	} else { // no, max out the directory entry
-		DE->ex = (extentsPerDirEntry - 1 + fileExtentsUsed) % (MaxEX + 1);
-		DE->s2 = (extentsPerDirEntry - 1 + fileExtentsUsed) / (MaxEX + 1);
-		DE->rc = BlkEX;
-		blocks = numAllocBlocks < 256 ? 16 : 8;
-		// update remaining records and extents for next call
-		fileRecords -= BlkEX * extentsPerDirEntry;
-		fileExtents -= extentsPerDirEntry;
-		fileExtentsUsed += extentsPerDirEntry;
-	}
-	// phoney up an appropriate number of allocation blocks
-	if (numAllocBlocks < 256) {
-		for (i = 0; i < blocks; ++i) {
-			DE->al[i] = (uint8)firstFreeAllocBlock++;
-		}
-	} else {
-		for (i = 0; i < 2 * blocks; i += 2) {
-			DE->al[i] = firstFreeAllocBlock & 0xFF;
-			DE->al[i + 1] = firstFreeAllocBlock >> 8;
-			++firstFreeAllocBlock;
-		}
-	}
+    if (allUsers) {
+        DirEntry->dr = currFindUser; // set user code for return
+    } else {
+        DirEntry->dr = userCode;
+    }
+
+    /* Ensure S1 is deterministic (zero) — we already zeroed the entry above,
+       but make the intent explicit so callers/readers aren't surprised. */
+    DirEntry->s1 = 0;
+
+    // does file fit in a single directory entry?
+    if (fileExtents <= extentsPerDirEntry) {
+        if (fileExtents) {
+            DirEntry->ex = (fileExtents - 1 + fileExtentsUsed) % (MaxEX + 1);
+            DirEntry->s2 = (fileExtents - 1 + fileExtentsUsed) / (MaxEX + 1);
+            DirEntry->rc = fileRecords - (BlkEX * (fileExtents - 1));
+        }
+        blocks = (fileRecords >> blockShift) + ((fileRecords & blockMask) ? 1 : 0);
+        fileRecords = 0;
+        fileExtents = 0;
+        fileExtentsUsed = 0;
+    } else { // no, max out the directory entry
+        DirEntry->ex = (extentsPerDirEntry - 1 + fileExtentsUsed) % (MaxEX + 1);
+        DirEntry->s2 = (extentsPerDirEntry - 1 + fileExtentsUsed) / (MaxEX + 1);
+        DirEntry->rc = BlkEX;
+        blocks = numAllocBlocks < 256 ? 16 : 8;
+        // update remaining records and extents for next call
+        fileRecords -= BlkEX * extentsPerDirEntry;
+        fileExtents -= extentsPerDirEntry;
+        fileExtentsUsed += extentsPerDirEntry;
+    }
+
+    /* SAFETY: clamp blocks so we never overflow DirEntry->al[].
+       On small disks AL is 16 bytes (one byte per block),
+       on large disks AL is 16 bytes but stored as 8 16-bit values (pairs). */
+    uint8 maxBlocks = (numAllocBlocks < 256) ? 16 : 8;
+    if (blocks > maxBlocks)
+        blocks = maxBlocks;
+
+    // phoney up an appropriate number of allocation blocks
+    if (numAllocBlocks < 256) {
+        for (i = 0; i < blocks; ++i)
+            DirEntry->al[i] = (uint8)firstFreeAllocBlock++;
+    } else {
+        for (i = 0; i < 2 * blocks; i += 2) {
+            DirEntry->al[i] = firstFreeAllocBlock & 0xFF;
+            DirEntry->al[i + 1] = firstFreeAllocBlock >> 8;
+            ++firstFreeAllocBlock;
+        }
+    }
 }
 
 // Matches a FCB name to a search pattern
-RUNCPM_DECL uint8 match(uint8* fcbname, uint8* pattern) {
-	uint8 result = 1;
-	uint8 i;
+RUNCPM_DECL uint8 match(uint8 *fcbname, uint8 *pattern) {
+    uint8 result = 1;
+    uint8 i;
 
-	for (i = 0; i < 12; ++i) {
-		if (*pattern == '?' || *pattern == *fcbname) {
-			++pattern; ++fcbname;
-			continue;
-		} else {
-			result = 0;
-			break;
-		}
-	}
-	return(result);
+    for (i = 0; i < 12; ++i) {
+        if (*pattern == '?' || *pattern == *fcbname) {
+            ++pattern;
+            ++fcbname;
+            continue;
+        } else {
+            result = 0;
+            break;
+        }
+    }
+    return (result);
 }
 
 // Returns the size of a file
 RUNCPM_DECL long _FileSize(uint16 fcbaddr) {
-	CPM_FCB* F = (CPM_FCB*)_RamSysAddr(fcbaddr);
-	long r, l = -1;
+    CPM_FCB *F = (CPM_FCB *)_RamSysAddr(fcbaddr);
+    long r, l = -1;
 
-	if (!_SelectDisk(F->dr)) {
-		_FCBtoHostname(fcbaddr, &filename[0]);
-		l = _sys_filesize(filename);
-		r = l % BlkSZ;
-		if (r)
-			l = l + BlkSZ - r;
-	}
-	return(l);
+    if (!_SelectDisk(F->dr)) {
+        _FCBtoHostname(fcbaddr, &filename[0]);
+        l = _sys_filesize(filename);
+        if (l != -1) {
+            r = l % BlkSZ;
+            if (r)
+                l = l + BlkSZ - r;
+        }
+    }
+    return (l);
 }
 
 // Opens a file
-RUNCPM_DECL uint8 _OpenFile(uint16 fcbaddr) {
-	CPM_FCB* F = (CPM_FCB*)_RamSysAddr(fcbaddr);
-	uint8 result = 0xff;
-	long len;
-	int32 i;
+// Returns a 16-bit packed value: (hardware_error<<8) | result
+// result (A) = 0-3 for success or 0xFF for error (CP/M3 semantics)
+RUNCPM_DECL uint16 _OpenFile(uint16 fcbaddr) {
+    CPM_FCB *F = (CPM_FCB *)_RamSysAddr(fcbaddr);
+    uint8 result = 0xff;   // low byte -> A
+    uint8 hwerr = 0x00;    // high byte -> B/H (hardware error when result==0xFF)
+    long records;
+    int32 i;
 
-	if (!_SelectDisk(F->dr)) {
-		_FCBtoHostname(fcbaddr, &filename[0]);
-		if (_sys_openfile(&filename[0])) {
+    if (!_SelectDisk(F->dr)) {
+        _FCBtoHostname(fcbaddr, &filename[0]);
+        if (!filename[4])
+            return (((uint16)hwerr << 8) | result); // Invalid filename
 
-			len = _FileSize(fcbaddr) / BlkSZ;	// Compute the len on the file in blocks
+        if (_sys_openfile(&filename[0])) {
+            /* Get raw file size and compute record counts (round up). */
+            long rawsize = _sys_filesize(&filename[0]);
+            if (rawsize < 0)
+                return (((uint16)hwerr << 8) | result);
 
-			F->s1 = 0x00;
-			F->s2 = 0x80;	// set unmodified flag
+            records = (rawsize + (BlkSZ - 1)) / BlkSZ; // rounded-up records
 
+            F->s1 = 0x00;
+            F->s2 = 0x80; // set unmodified flag
 
-			F->rc = len > MaxRC ? MaxRC : (uint8)len;
-			for (i = 0; i < 16; ++i)	// Clean up AL
-				F->al[i] = 0x00;
+            /* rc = number of 128-byte records in the current logical extent.
+               Clamp to the extent size (BlkEX). */
+            F->rc = (records > BlkEX) ? (uint8)BlkEX : (uint8)records;
 
-			result = 0x00;
-		}
-	}
-	return(result);
+            for (i = 0; i < 16; ++i) // Clean up AL
+                F->al[i] = 0x00;
+
+        #ifdef CPM3
+            /* CP/M3 behaviour: if CR was set to 0xFF on entry, return the
+               last-record byte count in CR. */
+            if (F->cr == 0xFF) {
+                if (rawsize <= 0) {
+                    F->cr = 0x00;
+                } else {
+                    uint8 lrbc = rawsize % BlkSZ;
+                    if (lrbc == 0)
+                        lrbc = BlkSZ;
+                    F->cr = lrbc;
+                }
+            }
+        #endif // ifdef CPM3
+
+            result = 0x00;
+        }
+    } else {
+        /* Disk selection failed; _SelectDisk has already triggered an error.
+           Report a hardware/select error in the high byte. */
+        hwerr = errSELECT;
+    }
+    return (((uint16)hwerr << 8) | result);
 }
 
 // Closes a file
-RUNCPM_DECL uint8 _CloseFile(uint16 fcbaddr) {
-	CPM_FCB* F = (CPM_FCB*)_RamSysAddr(fcbaddr);
-	uint8 result = 0xff;
+// Returns a 16-bit packed value: (hardware_error<<8) | result
+// result (A) = 0-3 for success or 0xFF for error (CP/M3 semantics)
+RUNCPM_DECL uint16 _CloseFile(uint16 fcbaddr) {
+    CPM_FCB *F = (CPM_FCB *)_RamSysAddr(fcbaddr);
+    uint8 result = 0xff;
+    uint8 hwerr = 0x00;
 
-	if (!_SelectDisk(F->dr)) {
-		if (!(F->s2 & 0x80)) {					// if file is modified
-			if (!RW) {
-				_FCBtoHostname(fcbaddr, &filename[0]);
-				if (fcbaddr == BatchFCB)
-					_Truncate((char*)filename, F->rc);	// Truncate $$$.SUB to F->rc CP/M records so SUBMIT.COM can work
-				result = 0x00;
-			} else {
-				_error(errWRITEPROT);
-			}
-		} else {
-			result = 0x00;
-		}
-	}
-	return(result);
+    if (!_SelectDisk(F->dr)) {
+        if (!(F->s2 & 0x80)) { // if file is modified
+            if (!RW) {
+                _FCBtoHostname(fcbaddr, &filename[0]);
+                if (!filename[4])
+                    return (((uint16)hwerr << 8) | result); // Invalid filename
+                if (fcbaddr == BatchFCB)
+                    _Truncate((char *)filename, F->rc); // Truncate $$$.SUB to F->rc CP/M records so SUBMIT.COM can work
+
+                /* Under CP/M3, if F5' (top bit of fn[4]) is set then the pending
+                   data are written and the file is made consistent but remains open.
+                   In both cases ensure the FCB is marked unmodified on success. */
+#ifdef CPM3
+                if (F->fn[4] & 0x80) {
+                    F->s2 |= 0x80; // mark unmodified (file made consistent)
+                    result = 0x00; // success, file remains open
+                } else {
+                    F->s2 |= 0x80; // mark unmodified (file made consistent)
+                    result = 0x00; // success, file closed
+                }
+#else
+                result = 0x00;
+#endif // ifdef CPM3
+            } else {
+#ifdef CPM3
+                /* CP/M3 should return a hardware error instead of invoking the
+                   host error handler. */
+                hwerr = errWRITEPROT;
+#else
+                _error(errWRITEPROT);
+#endif
+            }
+        } else {
+            result = 0x00;
+        }
+    } else {
+        hwerr = errSELECT;
+    }
+    return (((uint16)hwerr << 8) | result);
 }
 
 // Creates a file
 RUNCPM_DECL uint8 _MakeFile(uint16 fcbaddr) {
-	CPM_FCB* F = (CPM_FCB*)_RamSysAddr(fcbaddr);
-	uint8 result = 0xff;
-	uint8 i;
+    CPM_FCB *F = (CPM_FCB *)_RamSysAddr(fcbaddr);
+    uint8 result = 0xff;
+    uint8 i;
 
-	if (!_SelectDisk(F->dr)) {
-		if (!RW) {
-			_FCBtoHostname(fcbaddr, &filename[0]);
-			if (_sys_makefile(&filename[0])) {
-				F->ex = 0x00;	// Makefile also initializes the FCB (file becomes "open")
-				F->s1 = 0x00;
-				F->s2 = 0x00;		// newly created files are already modified
-				F->rc = 0x00;
-				for (i = 0; i < 16; ++i)	// Clean up AL
-					F->al[i] = 0x00;
-				F->cr = 0x00;
-				result = 0x00;
-			}
-		} else {
-			_error(errWRITEPROT);
-		}
-	}
-	return(result);
+    if (!_SelectDisk(F->dr)) {
+        if (!RW) {
+            _FCBtoHostname(fcbaddr, &filename[0]);
+            if (!filename[4])
+                return (result); // Invalid filename
+            if (_sys_makefile(&filename[0])) {
+                F->ex = 0x00; // Makefile also initializes the FCB (file becomes "open")
+                F->s1 = 0x00;
+                F->s2 = 0x00; // newly created files are already modified
+                F->rc = 0x00;
+                for (i = 0; i < 16; ++i) // Clean up AL
+                    F->al[i] = 0x00;
+                F->cr = 0x00;
+                result = 0x00;
+            }
+        } else {
+            _error(errWRITEPROT);
+        }
+    }
+    return (result);
 }
 
 // Searches for the first directory file
 RUNCPM_DECL uint8 _SearchFirst(uint16 fcbaddr, uint8 isdir) {
-	CPM_FCB* F = (CPM_FCB*)_RamSysAddr(fcbaddr);
-	uint8 result = 0xff;
+    CPM_FCB *F = (CPM_FCB *)_RamSysAddr(fcbaddr);
+    uint8 result = 0xff;
 
-	if (!_SelectDisk(F->dr)) {
-		_FCBtoHostname(fcbaddr, &filename[0]);
-		allUsers = F->dr == '?';
-		allExtents = F->ex == '?';
-		if (allUsers) {
-			result = _findfirstallusers(isdir);
-		} else {
-			result = _findfirst(isdir);
-		}
-	}
-	return(result);
+    if (!_SelectDisk(F->dr)) {
+        _FCBtoHostname(fcbaddr, &filename[0]);
+        if (!filename[4])
+            return (result); // Invalid filename
+        allUsers = F->dr == '?';
+        allExtents = F->ex == '?';
+        if (allUsers) {
+            result = _findfirstallusers(isdir);
+        } else {
+            result = _findfirst(isdir);
+        }
+    }
+    return (result);
 }
 
 // Searches for the next directory file
 RUNCPM_DECL uint8 _SearchNext(uint16 fcbaddr, uint8 isdir) {
-	CPM_FCB* F = (CPM_FCB*)_RamSysAddr(tmpFCB);
-	uint8 result = 0xff;
+    CPM_FCB *F = (CPM_FCB *)_RamSysAddr(tmpFCB);
+    uint8 result = 0xff;
 
-	if (!_SelectDisk(F->dr)) {
-		if (allUsers) {
-			result = _findnextallusers(isdir);
-		} else {
-			result = _findnext(isdir);
-		}
-	}
-	return(result);
+    if (!_SelectDisk(F->dr)) {
+        if (allUsers) {
+            result = _findnextallusers(isdir);
+        } else {
+            result = _findnext(isdir);
+        }
+    }
+    return (result);
 }
 
 // Deletes a file
 RUNCPM_DECL uint8 _DeleteFile(uint16 fcbaddr) {
-	CPM_FCB* F = (CPM_FCB*)_RamSysAddr(fcbaddr);
+    CPM_FCB *F = (CPM_FCB *)_RamSysAddr(fcbaddr);
 #if defined(USE_PUN) || defined(USE_LST)
-	CPM_FCB* T = (CPM_FCB*)_RamSysAddr(tmpFCB);
+    CPM_FCB *T = (CPM_FCB *)_RamSysAddr(tmpFCB);
 #endif
-	uint8 result = 0xff;
-	uint8 deleted = 0xff;
+    uint8 result = 0xff;
+    uint8 deleted = 0xff;
 
-	if (!_SelectDisk(F->dr)) {
-		if (!RW) {
-			result = _SearchFirst(fcbaddr, FALSE);	// FALSE = Does not create a fake dir entry when finding the file
-			while (result != 0xff) {
+    if (!_SelectDisk(F->dr)) {
+        if (!RW) {
+            result = _SearchFirst(fcbaddr, FALSE); // FALSE = Does not create a fake dir entry when finding the file
+            while (result != 0xff) {
 #ifdef USE_PUN
-				if (!strcmp((char*)T->fn, "PUN     TXT") && pun_open) {
-					_sys_fclose(pun_dev);
-					pun_open = FALSE;
-				}
+                if (!strcmp((char *)T->fn, "PUN     TXT") && pun_open) {
+                    _sys_fclose(pun_dev);
+                    pun_open = FALSE;
+                }
 #endif
 #ifdef USE_LST
-				if (!strcmp((char*)T->fn, "LST     TXT") && lst_open) {
-					_sys_fclose(lst_dev);
-					lst_open = FALSE;
-				}
+                if (!strcmp((char *)T->fn, "LST     TXT") && lst_open) {
+                    _sys_fclose(lst_dev);
+                    lst_open = FALSE;
+                }
 #endif
-				_FCBtoHostname(tmpFCB, &filename[0]);
-				if (_sys_deletefile(&filename[0]))
-					deleted = 0x00;
-				result = _SearchFirst(fcbaddr, FALSE);	// FALSE = Does not create a fake dir entry when finding the file
-			}
-		} else {
-			_error(errWRITEPROT);
-		}
-	}
-	return(deleted);
+                _FCBtoHostname(tmpFCB, &filename[0]);
+                if (_sys_deletefile(&filename[0])) {
+                    deleted = 0x00;
+                } else {
+                    _error(errWRITEPROT);
+                    break;
+                }
+                result = _SearchFirst(fcbaddr, FALSE); // FALSE = Does not create a fake dir entry when finding the file
+            }
+        } else {
+            _error(errWRITEPROT);
+        }
+    }
+    return (deleted);
 }
 
 // Renames a file
 RUNCPM_DECL uint8 _RenameFile(uint16 fcbaddr) {
-	CPM_FCB* F = (CPM_FCB*)_RamSysAddr(fcbaddr);
-	uint8 result = 0xff;
+    CPM_FCB *F = (CPM_FCB *)_RamSysAddr(fcbaddr);
+    uint8 result = 0xff;
 
-	if (!_SelectDisk(F->dr)) {
-		if (!RW) {
-			_RamWrite(fcbaddr + 16, _RamRead(fcbaddr));	// Prevents rename from moving files among folders
-			_FCBtoHostname(fcbaddr + 16, &newname[0]);
-			_FCBtoHostname(fcbaddr, &filename[0]);
-			if (_sys_renamefile(&filename[0], &newname[0]))
-				result = 0x00;
-		} else {
-			_error(errWRITEPROT);
-		}
-	}
-	return(result);
+    if (!_SelectDisk(F->dr)) {
+        if (!RW) {
+            _RamWrite(fcbaddr + 16, _RamRead(fcbaddr)); // Prevents rename from moving files between folders
+            _FCBtoHostname(fcbaddr + 16, &newname[0]);
+            _FCBtoHostname(fcbaddr, &filename[0]);
+            if (!newname[4])
+                return (result); // Invalid filename
+            if (!filename[4])
+                return (result); // Invalid filename
+            if (_sys_renamefile(&filename[0], &newname[0]))
+                result = 0x00;
+        } else {
+            _error(errWRITEPROT);
+        }
+    }
+    return (result);
 }
 
 // Sequential read
-RUNCPM_DECL uint8 _ReadSeq(uint16 fcbaddr) {
-	CPM_FCB* F = (CPM_FCB*)_RamSysAddr(fcbaddr);
-	uint8 result = 0xff;
+// Returns a 16-bit value: (H = number of records processed, L = BDOS return code)
+RUNCPM_DECL uint16 _ReadSeq(uint16 fcbaddr) {
+    CPM_FCB *F = (CPM_FCB *)_RamSysAddr(fcbaddr);
+    uint8 result = 0xff;
+    uint16 processed = 0;
 
-	long fpos = ((F->s2 & MaxS2) * BlkS2 * BlkSZ) +
-		(F->ex * BlkEX * BlkSZ) +
-		(F->cr * BlkSZ);
+    // multiRecordCount is always 1 under CP/M 2.2, so this loop runs once and
+    // behaves exactly like a single-record read; CP/M 3 may transfer several.
+    if (!_SelectDisk(F->dr)) {
+        _FCBtoHostname(fcbaddr, &filename[0]);
+        long saved_dma = dmaAddr;
+        uint8 toRead = multiRecordCount ? multiRecordCount : 1;
 
-	if (!_SelectDisk(F->dr)) {
-		_FCBtoHostname(fcbaddr, &filename[0]);
-		result = _sys_readseq(&filename[0], fpos);
-		if (!result) {	// Read succeeded, adjust FCB
-			++F->cr;
-			if (F->cr > MaxCR) {
-				F->cr = 1;
-				++F->ex;
-			}
-			if (F->ex > MaxEX) {
-				F->ex = 0;
-				++F->s2;
-			}
-			if ((F->s2 & 0x7F) > MaxS2)
-				result = 0xfe;	// (todo) not sure what to do 
-		}
-	}
-	return(result);
+        for (uint8 i = 0; i < toRead; ++i) {
+            long fpos = ((F->s2 & MaxS2) * BlkS2 * BlkSZ) +
+                        (F->ex * BlkEX * BlkSZ) +
+                        (F->cr * BlkSZ);
+
+            dmaAddr = saved_dma + (processed * BlkSZ);
+            result = _sys_readseq(&filename[0], fpos);
+
+            if (result != 0x00) {
+                // stop on first non-OK result
+                break;
+            }
+
+            // Read succeeded, adjust FCB as for a single record
+            ++F->cr;
+            /* CR counts 0..(MaxCR-1) logically (0..127). When we reach MaxCR records
+               we must roll CR to 0 and advance EX. Use >= to catch MaxCR itself. */
+            if (F->cr >= MaxCR) {
+                F->cr = 0;
+                ++F->ex;
+            }
+            if (F->ex > MaxEX) {
+                F->ex = 0;
+                ++F->s2;
+            }
+            /* strip possible high-bit and compare S2 low bits against allowed MaxS2 */
+            if ((F->s2 & 0x7F) > MaxS2) {
+                result = 0xfe;
+                break;
+            }
+
+            ++processed;
+        }
+
+        dmaAddr = saved_dma;
+    }
+
+    // 0xFF is a hardware error. On full success (result 0) H must be 0; only on a
+    // mid-transfer error does H carry the count of records read before the error.
+    // Under CP/M 2.2 (single record) H is always 0, so A alone is significant.
+    if (result == 0xFF)
+        return (uint16)0x00FF;
+    if (result == 0x00)
+        return (uint16)0x0000;
+    return (uint16)((processed << 8) | (uint16)result);
 }
 
 // Sequential write
-RUNCPM_DECL uint8 _WriteSeq(uint16 fcbaddr) {
-	CPM_FCB* F = (CPM_FCB*)_RamSysAddr(fcbaddr);
-	uint8 result = 0xff;
+// Returns a 16-bit value: (H = number of records processed, L = BDOS return code)
+RUNCPM_DECL uint16 _WriteSeq(uint16 fcbaddr) {
+    CPM_FCB *F = (CPM_FCB *)_RamSysAddr(fcbaddr);
+    uint8 result = 0xff;
+    uint16 processed = 0;
 
-	long fpos = ((F->s2 & MaxS2) * BlkS2 * BlkSZ) +
-		(F->ex * BlkEX * BlkSZ) +
-		(F->cr * BlkSZ);
+    // multiRecordCount is always 1 under CP/M 2.2, so this loop runs once and
+    // behaves exactly like a single-record write; CP/M 3 may transfer several.
+    if (!_SelectDisk(F->dr)) {
+        if (!RW) {
+            _FCBtoHostname(fcbaddr, &filename[0]);
+            long saved_dma = dmaAddr;
+            uint8 toWrite = multiRecordCount ? multiRecordCount : 1;
 
-	if (!_SelectDisk(F->dr)) {
-		if (!RW) {
-			_FCBtoHostname(fcbaddr, &filename[0]);
-			result = _sys_writeseq(&filename[0], fpos);
-			if (!result) {	// Write succeeded, adjust FCB
-				F->s2 &= 0x7F;		// reset unmodified flag
-				++F->cr;
-				if (F->cr > MaxCR) {
-					F->cr = 1;
-					++F->ex;
-				}
-				if (F->ex > MaxEX) {
-					F->ex = 0;
-					++F->s2;
-				}
-				if (F->s2 > MaxS2)
-					result = 0xfe;	// (todo) not sure what to do 
-			}
-		} else {
-			_error(errWRITEPROT);
-		}
-	}
-	return(result);
+            for (uint8 i = 0; i < toWrite; ++i) {
+                long fpos = ((F->s2 & MaxS2) * BlkS2 * BlkSZ) +
+                            (F->ex * BlkEX * BlkSZ) +
+                            (F->cr * BlkSZ);
+
+                dmaAddr = saved_dma + (processed * BlkSZ);
+                result = _sys_writeseq(&filename[0], fpos);
+
+                if (result != 0x00) {
+                    break;
+                }
+
+                /* clear unmodified flag (bit 7) */
+                F->s2 &= 0x7F;
+
+                /* advance record index; records are 0..(MaxCR-1) */
+                ++F->cr;
+
+                /* if we've rolled past the last record in the extent,
+                   start at record 0 of the next extent */
+                if (F->cr >= MaxCR) {
+                    F->cr = 0;
+                    ++F->ex;
+                    /* first record in the new extent */
+                    F->rc = 1;
+                } else {
+                    /* still in same extent - increment rc */
+                    ++F->rc;
+                }
+
+                /* handle extent overflow -> advance S2/module */
+                if (F->ex > MaxEX) {
+                    F->ex = 0;
+                    ++F->s2;
+                    /* first record in the new module/extents group */
+                    F->rc = 1;
+                }
+
+                /* check S2 numeric overflow (ignore high-bit flag) */
+                if ((F->s2 & 0x7F) > MaxS2) {
+                    result = 0xfe;
+                    break;
+                }
+
+                ++processed;
+            }
+
+            dmaAddr = saved_dma;
+        } else {
+            _error(errWRITEPROT);
+        }
+    }
+
+    // Under CP/M 2.2 (single record) H is always 0, so A alone is significant.
+    if (result == 0xFF)
+        return (uint16)0x00FF;
+    if (result == 0x00)
+        return (uint16)0x0000; // full success: A = 0, H = 0 (no records "before the error")
+    // partial transfer error: H = records written before the error, A = error code
+    return (uint16)((processed << 8) | (uint16)result);
 }
 
 // Random read
-RUNCPM_DECL uint8 _ReadRand(uint16 fcbaddr) {
-	CPM_FCB* F = (CPM_FCB*)_RamSysAddr(fcbaddr);
-	uint8 result = 0xff;
+// Returns a 16-bit value: (H = number of records processed, L = BDOS return code)
+RUNCPM_DECL uint16 _ReadRand(uint16 fcbaddr) {
+    CPM_FCB *F = (CPM_FCB *)_RamSysAddr(fcbaddr);
+    uint8 result = 0xff;
+    uint16 processed = 0;
 
-	int32 record = (F->r2 << 16) | (F->r1 << 8) | F->r0;
-	long fpos = record * BlkSZ;
+    int32 startRecord = (F->r2 << 16) | (F->r1 << 8) | F->r0;
 
-	if (!_SelectDisk(F->dr)) {
-		_FCBtoHostname(fcbaddr, &filename[0]);
-		result = _sys_readrand(&filename[0], fpos);
-		if (result == 0 || result == 1 || result == 4) {
-			// adjust FCB unless error #6 (seek past 8MB - max CP/M file & disk size)
-			F->cr = record & 0x7F;
-			F->ex = (record >> 7) & 0x1f;
-			if (F->s2 & 0x80) {
-				F->s2 = ((record >> 12) & MaxS2) | 0x80;
-			} else {
-				F->s2 = (record >> 12) & MaxS2;
-			}
-		}
-	}
-	return(result);
+    // multiRecordCount is always 1 under CP/M 2.2, so this loop runs once and
+    // behaves exactly like a single-record read; CP/M 3 may transfer several.
+    if (!_SelectDisk(F->dr)) {
+        _FCBtoHostname(fcbaddr, &filename[0]);
+        long saved_dma = dmaAddr;
+        uint8 toRead = multiRecordCount ? multiRecordCount : 1;
+
+        for (uint8 i = 0; i < toRead; ++i) {
+            int32 record = startRecord + processed;
+            long fpos = record * BlkSZ;
+            dmaAddr = saved_dma + (processed * BlkSZ);
+            result = _sys_readrand(&filename[0], fpos);
+
+            // adjust FCB unless error #6 (seek past 8MB - max CP/M file & disk size)
+            if (!(result == 0 || result == 1 || result == 4)) {
+                break;
+            }
+
+            // adjust FCB to the last record read
+            F->cr = record & (MaxCR - 1);
+            F->ex = (record >> 7) & MaxEX;
+            /* preserve 0x80 (unmodified) bit in s2 if previously present */
+            F->s2 = ((record >> 12) & MaxS2) | (F->s2 & 0x80);
+
+            ++processed;
+        }
+
+        dmaAddr = saved_dma;
+    }
+
+    if (result == 0xFF)
+        return (uint16)0x00FF;
+    // 0/1/4 are normal outcomes (data read, or reading unwritten data/extent); these
+    // return with H = 0, exactly as CP/M 2.2 does. Only a genuine mid-transfer error
+    // leaves H carrying the count of records read before the error.
+    if (result == 0x00 || result == 0x01 || result == 0x04)
+        return (uint16)(uint8)result;
+    return (uint16)((processed << 8) | (uint16)result);
 }
 
 // Random write
-RUNCPM_DECL uint8 _WriteRand(uint16 fcbaddr) {
-	CPM_FCB* F = (CPM_FCB*)_RamSysAddr(fcbaddr);
-	uint8 result = 0xff;
+// Returns a 16-bit value: (H = number of records processed, L = BDOS return code)
+RUNCPM_DECL uint16 _WriteRand(uint16 fcbaddr) {
+    CPM_FCB *F = (CPM_FCB *)_RamSysAddr(fcbaddr);
+    uint8 result = 0xff;
+    uint16 processed = 0;
 
-	int32 record = (F->r2 << 16) | (F->r1 << 8) | F->r0;
-	long fpos = record * BlkSZ;
+    int32 startRecord = (F->r2 << 16) | (F->r1 << 8) | F->r0;
 
-	if (!_SelectDisk(F->dr)) {
-		if (!RW) {
-			_FCBtoHostname(fcbaddr, &filename[0]);
-			result = _sys_writerand(&filename[0], fpos);
-			if (!result) {	// Write succeeded, adjust FCB
-				F->cr = record & 0x7F;
-				F->ex = (record >> 7) & 0x1f;
-				F->s2 = (record >> 12) & MaxS2;	// resets unmodified flag
-			}
-		} else {
-			_error(errWRITEPROT);
-		}
-	}
-	return(result);
+    // multiRecordCount is always 1 under CP/M 2.2, so this loop runs once and
+    // behaves exactly like a single-record write; CP/M 3 may transfer several.
+    if (!_SelectDisk(F->dr)) {
+        if (!RW) {
+            _FCBtoHostname(fcbaddr, &filename[0]);
+            long saved_dma = dmaAddr;
+            uint8 toWrite = multiRecordCount ? multiRecordCount : 1;
+
+            for (uint8 i = 0; i < toWrite; ++i) {
+                int32 record = startRecord + processed;
+                long fpos = record * BlkSZ;
+                dmaAddr = saved_dma + (processed * BlkSZ);
+                result = _sys_writerand(&filename[0], fpos);
+
+                if (result != 0x00) {
+                    break;
+                }
+
+                F->cr = record & (MaxCR - 1);
+                F->ex = (record >> 7) & MaxEX;
+                F->s2 = (record >> 12) & MaxS2; // resets unmodified flag
+
+                ++processed;
+            }
+
+            dmaAddr = saved_dma;
+        } else {
+            _error(errWRITEPROT);
+        }
+    }
+
+    // Under CP/M 2.2 (single record) H is always 0, so A alone is significant.
+    if (result == 0xFF)
+        return (uint16)0x00FF;
+    if (result == 0x00)
+        return (uint16)0x0000; // full success: A = 0, H = 0
+    // partial transfer error: H = records written before the error, A = error code
+    return (uint16)((processed << 8) | (uint16)result);
 }
 
 // Returns the size of a CP/M file
 RUNCPM_DECL uint8 _GetFileSize(uint16 fcbaddr) {
-	CPM_FCB* F = (CPM_FCB*)_RamSysAddr(fcbaddr);
-	uint8 result = 0xff;
-	int32 count = _FileSize(DE) >> 7;
+    CPM_FCB *F = (CPM_FCB *)_RamSysAddr(fcbaddr);
+    uint8 result = 0xff;
+    int32 count = _FileSize(DE) >> 7;
 
-	if (count != -1) {
-		F->r0 = count & 0xff;
-		F->r1 = (count >> 8) & 0xff;
-		F->r2 = (count >> 16) & 0xff;
-	}
-	return(result);
+    if (count != -1) {
+        F->r0 = count & 0xff;
+        F->r1 = (count >> 8) & 0xff;
+        F->r2 = (count >> 16) & 0xff;
+        result = 0x00;
+    }
+    return (result);
 }
+
+#ifdef CPM3
+// Truncates a file to the random record count held in the FCB (record * 128
+// bytes). Returns 0 on success, 0xFF on error.
+RUNCPM_DECL uint8 _TruncateFile(uint16 fcbaddr) {
+    CPM_FCB *F = (CPM_FCB *)_RamSysAddr(fcbaddr);
+    uint8 result = 0xff;
+
+    if (!_SelectDisk(F->dr)) {
+        if (!RW) {
+            _FCBtoHostname(fcbaddr, &filename[0]);
+            long records = F->r0 | (F->r1 << 8) | ((long)F->r2 << 16);
+            if (!_sys_truncate(&filename[0], records * 128))
+                result = 0x00;
+        }
+    }
+    return (result);
+}
+#endif
 
 // Set the next random record
 RUNCPM_DECL uint8 _SetRandom(uint16 fcbaddr) {
-	CPM_FCB* F = (CPM_FCB*)_RamSysAddr(fcbaddr);
-	uint8 result = 0x00;
+    CPM_FCB *F = (CPM_FCB *)_RamSysAddr(fcbaddr);
+    uint8 result = 0x00;
 
-	int32 count = F->cr & 0x7f;
-	count += (F->ex & 0x1f) << 7;
-	count += (F->s2 & MaxS2) << 12;
+    int32 count = F->cr & (MaxCR - 1);
+    count += (F->ex & MaxEX) << 7;
+    count += (F->s2 & MaxS2) << 12;
 
-	F->r0 = count & 0xff;
-	F->r1 = (count >> 8) & 0xff;
-	F->r2 = (count >> 16) & 0xff;
+    F->r0 = count & 0xff;
+    F->r1 = (count >> 8) & 0xff;
+    F->r2 = (count >> 16) & 0xff;
 
-	return(result);
+    return (result);
 }
 
 // Sets the current user area
 RUNCPM_DECL void _SetUser(uint8 user) {
-	userCode = user & 0x1f;	// BDOS unoficially allows user areas 0-31
-							// this may create folders from G-V if this function is called from an user program
-							// It is an unwanted behavior, but kept as BDOS does it
+    userCode = user & 0x1f; // BDOS unoficially allows user areas 0-31
+                            // this may create folders from G-V if this function is called from an user program
+                            // It is an unwanted behavior, but kept as BDOS does it
 #ifdef NOHIGHUSER
-	if(userCode < 16)
+    if (userCode < 16)
 #endif
-	_MakeUserDir();			// Creates the user dir (0-F[G-V]) if needed
+        _MakeUserDir(); // Creates the user dir (0-F[G-V]) if needed
 }
 
 // Creates a disk directory folder
 RUNCPM_DECL uint8 _MakeDisk(uint16 fcbaddr) {
-	CPM_FCB* F = (CPM_FCB*)_RamSysAddr(fcbaddr);
-	return(_sys_makedisk(F->dr));
+    CPM_FCB *F = (CPM_FCB *)_RamSysAddr(fcbaddr);
+    return (_sys_makedisk(F->dr));
 }
 
 // Checks if there's a temp submit file present
 RUNCPM_DECL uint8 _CheckSUB(void) {
-	uint8 result;
-	uint8 oCode = userCode;							// Saves the current user code (original BDOS does not do this)
-	_HostnameToFCB(tmpFCB, (uint8*)"$???????.???");	// The original BDOS in fact only looks for a file which start with $
+    uint8 result;
+    uint8 oCode = userCode;                          // Saves the current user code (original BDOS does not do this)
+    _HostnameToFCB(tmpFCB, (uint8 *)"$???????.???"); // The original BDOS in fact only looks for a file which start with $
 #ifdef BATCHA
-	_RamWrite(tmpFCB, 1);							// Forces it to be checked on drive A:
+    _RamWrite(tmpFCB, 1); // Forces it to be checked on drive A:
 #endif
 #ifdef BATCH0
-	userCode = 0;									// Forces it to be checked on user 0
+    userCode = 0; // Forces it to be checked on user 0
 #endif
-	result = (_SearchFirst(tmpFCB, FALSE) == 0x00) ? 0xff : 0x00;
-	userCode = oCode;								// Restores the current user code
-	return(result);
+    result = (_SearchFirst(tmpFCB, FALSE) == 0x00) ? 0xff : 0x00;
+    userCode = oCode; // Restores the current user code
+    return (result);
 }
 
-#ifdef HASLUA
-// Executes a Lua script
-RUNCPM_DECL uint8 _RunLua(uint16 fcbaddr) {
-	uint8 luascript[17];
-	uint8 result = 0xff;
-
-	if (_FCBtoHostname(fcbaddr, &luascript[0])) {	// Script name must be unique
-		if (!_SearchFirst(fcbaddr, FALSE)) {		// and must exist
-			result = _RunLuaScript((char*)&luascript[0]);
-		}
-	}
-
-	return(result);
-}
 #endif
-
-#endif /* CPM_DISK_H */

--- a/lib/runcpm/globals.h
+++ b/lib/runcpm/globals.h
@@ -142,7 +142,10 @@
 #else
     #define CPM_VERSTR "CP/M 2.2"
 #endif
-#define CCPHEAD "\r\nRunCPM Version " VERSION " (" CCPname ") - " CPM_VERSTR DBG ABD "\r\n"
+/* FujiNet vendoring: rebranded banner ("FujiNet CP/M 2.2 - RunCPM 6.9").
+   DBG/ABD (debug/ABDOS build markers, normally empty) are kept so a debug build
+   is still flagged.  CCPname (the internal CCP version) is no longer shown. */
+#define CCPHEAD "\r\nFujiNet " CPM_VERSTR " - RunCPM " VERSION DBG ABD "\r\n"
 
 #define NOSLASH // Will translate '/' to '_' on filenames to prevent directory errors
 

--- a/lib/runcpm/globals.h
+++ b/lib/runcpm/globals.h
@@ -3,211 +3,338 @@
 
 /* Some definitions needed globally */
 #ifdef __MINGW32__
-#include <ctype.h>
+    #include <ctype.h>
 #endif
 
+/* Definition of which CPU to use: cpu.h, cpu2.h, cpu3.h, cpu4.h */
+#ifndef CPU
+    #define CPU "cpu1.h"
+#endif
+
+/* Definition of CP/M version */
+// #define CPM3 // If defined, CP/M 3.0 will be emulated, otherwise CP/M 2.2 will be emulated
+
+/* CPU speed for throttling (0 = disabled/fastest, 500 = slow, smaller number = slower) */
+#define CPU_SPEED 0 // Defines the number of instructions to execute before checking the time
+                    // and possibly delaying execution to throttle CPU speed
+
 /* Definition for enabling incrementing the R register for each M1 cycle */
-#define DO_INCR
+#define DO_INCR // Loses a bit of performance in favor or realistic R register emulation
 
 /* Definitions for enabling PUN: and LST: devices */
-//#define USE_PUN	// The pun.txt and lst.txt files will appear on drive A: user 0
-//#define USE_LST
+/* FujiNet vendoring: PUN:/LST: pull in pun_dev/lst_dev FILE* globals that live
+   in RunCPM's main.c (which FujiNet never compiles) plus _sys_fopen_w; leave
+   them disabled to match the working 5.8 setup. */
+// #define USE_PUN // The pun.txt and lst.txt files will appear on drive A: user 0
+// #define USE_LST
 
 /* Definitions for file/console based debugging */
-//#define DEBUG				// Enables the internal debugger (enabled by default on vstudio debug builds)
-//#define iDEBUG			// Enables instruction logging onto iDebug.log (for development debug only)
-//#define DEBUGLOG			// Writes extensive call trace information to RunCPM.log
-//#define CONSOLELOG		// Writes debug information to console instead of file
-//#define LOGBIOS_NOT 01	// If defined will not log this BIOS function number
-//#define LOGBIOS_ONLY 02	// If defines will log only this BIOS function number
-//#define LOGBDOS_NOT 06	// If defined will not log this BDOS function number
-//#define LOGBDOS_ONLY 22	// If defines will log only this BDOS function number
+// #define DEBUG			// Enables the internal debugger (enabled by default on visual studio debug builds)
+// #define DEBUGONHALT		// Enables the internal debugger when the CPU halts
+// #define iDEBUG			// Enables instruction logging onto iDebug.log (for development debug only)
+// #define DEBUGLOG			// Writes extensive call trace information to RunCPM.log
+#define DEBUGKEY 4 // Key to trigger the debugger. 4 = ^D
+
+// #define CONSOLELOG		// Writes debug information to console instead of file
+// #define LOGBIOS_NOT 01	// If defined will not log this BIOS function number
+// #define LOGBIOS_ONLY 02	// If defined will log only this BIOS function number
+// #define LOGBDOS_NOT 06	// If defined will not log this BDOS function number
+// #define LOGBDOS_ONLY 22	// If defined will log only this BDOS function number
 #define LogName "RunCPM.log"
 
 /* RunCPM version for the greeting header */
-#define VERSION	"5.8"
-#define VersionBCD 0x58
+#define VERSION "6.9"
+#define VersionBCD 0x69
 
-/* Definition of which CCP to use (must define only one) */
-#define CCP_INTERNAL		// If this is defined, an internal CCP will emulated
-//#define CCP_DR
-//#define CCP_CCPZ
-//#define CCP_ZCPR2
-//#define CCP_ZCPR3
-//#define CCP_Z80
+/* Definition of which BDOS to use (not for Internal CCP, set to 60K CCPs by default) */
+// #define ABDOS				// Based on work by Pavel Zampach (https://www.chstercius.cz/runcpm/)
+//  This requires ABDOS.SYS to be present on A: user 0 - see 'abdos' folder under 'tools'
+
+#ifdef _WIN32   // Windows needs a default CCP defined to compile as there's no Makefile
+    #define CCP_INTERNAL
+// #define CCP_DR
+// #define CCP_CCPZ
+// #define CCP_ZCPR2
+// #define CCP_ZCPR3
+// #define CCP_Z80
+#endif
 
 /* Definition of the CCP memory information */
 //
 #ifdef CCP_INTERNAL
-#define CCPname		"INTERNAL v2.6"			// Will use the CCP from ccp.h
-#define VersionCCP	0x26					// 0x10 and above reserved for Internal CCP
-#define BatchFCB	(tmpFCB + 36)
-#define CCPaddr		(BDOSjmppage-0x0800)
+    #define CCPname "CCP-INTERNAL v3.3" // Will use the CCP from ccp.h
+    #define VersionCCP 0x33             // 0x10 and above reserved for Internal CCP
+    #define BatchFCB (tmpFCB + 48)
+    #define CCPaddr BDOSjmppage // Internal CCP has size 0
 #endif
 //
 #ifdef CCP_DR
-#define CCPname		"CCP-DR." STR(TPASIZE) "K"
-#define VersionCCP	0x00					// Version to be used by INFO.COM
-#define BatchFCB	(CCPaddr + 0x7AC)		// Position of the $$$.SUB fcb on this CCP
-#define CCPaddr		(BDOSjmppage-0x0800)	// CCP memory address
+    #define CCPname "CCP-DR." STR(TPASIZE) "K"
+    #define VersionCCP 0x00                // Version to be used by INFO.COM
+    #define BatchFCB (CCPaddr + 0x7AC)     // Position of the $$$.SUB fcb on this CCP
+    #define CCPaddr (BDOSjmppage - 0x0800) // CCP memory address
 #endif
 //
 #ifdef CCP_CCPZ
-#define CCPname		"CCP-CCPZ." STR(TPASIZE) "K"
-#define VersionCCP	0x01
-#define BatchFCB	(CCPaddr + 0x7A)		// Position of the $$$.SUB fcb on this CCP
-#define CCPaddr		(BDOSjmppage-0x0800)
+    #define CCPname "CCP-CCPZ." STR(TPASIZE) "K"
+    #define VersionCCP 0x01
+    #define BatchFCB (CCPaddr + 0x7A) // Position of the $$$.SUB fcb on this CCP
+    #define CCPaddr (BDOSjmppage - 0x0800)
 #endif
 //
 #ifdef CCP_ZCPR2
-#define CCPname		"CCP-ZCP2." STR(TPASIZE) "K"
-#define VersionCCP	0x02
-#define BatchFCB	(CCPaddr + 0x5E)		// Position of the $$$.SUB fcb on this CCP
-#define CCPaddr		(BDOSjmppage-0x0800)
+    #define CCPname "CCP-ZCP2." STR(TPASIZE) "K"
+    #define VersionCCP 0x02
+    #define BatchFCB (CCPaddr + 0x5E) // Position of the $$$.SUB fcb on this CCP
+    #define CCPaddr (BDOSjmppage - 0x0800)
 #endif
 //
 #ifdef CCP_ZCPR3
-#define CCPname		"CCP-ZCP3." STR(TPASIZE) "K"
-#define VersionCCP	0x03
-#define BatchFCB	(CCPaddr + 0x5E)		// Position of the $$$.SUB fcb on this CCP
-#define CCPaddr		(BDOSjmppage-0x1000)
+    #define CCPname "CCP-ZCP3." STR(TPASIZE) "K"
+    #define VersionCCP 0x03
+    #define BatchFCB (CCPaddr + 0x5E) // Position of the $$$.SUB fcb on this CCP
+    #define CCPaddr (BDOSjmppage - 0x1000)
 #endif
 //
 #ifdef CCP_Z80
-#define CCPname		"CCP-Z80." STR(TPASIZE) "K"
-#define VersionCCP	0x04
-#define BatchFCB	(CCPaddr + 0x79E)		// Position of the $$$.SUB fcb on this CCP
-#define CCPaddr		(BDOSjmppage-0x0800)
+    #define CCPname "CCP-Z80." STR(TPASIZE) "K"
+    #define VersionCCP 0x04
+    #define BatchFCB (CCPaddr + 0x79E) // Position of the $$$.SUB fcb on this CCP
+    #define CCPaddr (BDOSjmppage - 0x0800)
 #endif
 //
 #ifndef CCPname
-#error No CCP defined
+    #error No CCP defined, use 'make <platform> CCP=<CCP_NAME> build' to define one of the available CCPs
 #endif
 //
+#ifdef CCP_INTERNAL
+    #ifdef ABDOS
+        #error Internal CCP does not support ABDOS
+    #endif
+#endif
+
 #define STR_HELPER(x) #x
 #define STR(x) STR_HELPER(x)
-#define CCPHEAD		"\r\nRunCPM Version " VERSION " (CP/M 2.2 " STR(TPASIZE) "K)\r\n"
+#ifdef DEBUG
+    #define DBG " - DEBUG"
+#else
+    #define DBG
+#endif
+#ifdef ABDOS
+    #define ABD " (ABDOS)"
+#else
+    #define ABD
+#endif
+#ifdef CPM3
+    #define CPM "CP/M 3"
+#else
+    #define CPM "CP/M 2.2"
+#endif
+#define CCPHEAD "\r\nRunCPM Version " VERSION " (" CCPname ") - " CPM DBG ABD "\r\n"
 
-#define NOSLASH			// Will translate '/' to '_' on filenames to prevent directory errors
+#define NOSLASH // Will translate '/' to '_' on filenames to prevent directory errors
 
-//#define HASLUA		// Will enable Lua scripting (BDOS call 254)
-						// Should be passed externally per-platform with -DHASLUA
+// #define STREAMIO					// Will enable command line flags to read
+//  console input from file and to log console output to file
+//  Should be passed externally per-platform with -DSTREAMIO
 
-//#define PROFILE		// For measuring time taken to run a CP/M command
-						// This should be enabled only for debugging purposes when trying to improve emulation speed
+// #define PROFILE					// For measuring time taken to run a CP/M command
+//  This should be enabled only for debugging purposes when trying to improve emulation speed
 
-#define NOHIGHUSER		// Prevents the creation of user folders above 'F' (15) by programs
-						// Original CP/M BDOS allows it, but I prefer to keep the folders clean
+#define NOHIGHUSER // Prevents the creation of user folders above 'F' (15) by programs
+                   // Original CP/M BDOS allows it, but I prefer to keep the folders clean
 
 /* Definition for CP/M 2.2 user number support */
 
-#define BATCHA			// If this is defined, the $$$.SUB will be looked for on drive A:
-//#define BATCH0		// If this is defined, the $$$.SUB will be looked for on user area 0
-						// The default behavior of DRI's CP/M 2.2 was to have $$$.SUB created on the current drive/user while looking for it
-						// on drive A: current user, which made it complicated to run SUBMITs when not logged to drive A: user 0
+#define BATCHA // If this is defined, the $$$.SUB file will be looked for on drive A:
+// #define BATCH0					// If this is defined, the $$$.SUB file will be looked for on user area 0
+//  The default behavior of DRI's CP/M 2.2 was to have $$$.SUB created on the current drive/user while looking for it
+//  on drive A: current user, which made it complicated to run SUBMITs when not logged to drive A: user 0
 
 /* Some environment and type definitions */
 
 #ifndef TRUE
-#define FALSE 0
-#define TRUE 1
+    #define FALSE 0
+    #define TRUE 1
 #endif
 
-typedef signed char     int8;
-typedef signed short    int16;
-typedef signed int      int32;
-typedef unsigned char   uint8;
-typedef unsigned short  uint16;
-typedef unsigned int    uint32;
+/* Define Status types */
+#define STATUS_RUNNING 0
+#define STATUS_EXIT 1
+#define STATUS_RESTART 2
+#define STATUS_RETURN 3
 
-#define LOW_DIGIT(x)     ((x) & 0xf)
-#define HIGH_DIGIT(x)    (((x) >> 4) & 0xf)
-#define LOW_REGISTER(x)  ((x) & 0xff)
+typedef signed char int8;
+typedef signed short int16;
+typedef signed int int32;
+typedef signed long long int64;
+typedef unsigned char uint8;
+typedef unsigned short uint16;
+typedef unsigned int uint32;
+typedef unsigned long long uint64;
+
+#define LOW_DIGIT(x) ((x) & 0xf)
+#define HIGH_DIGIT(x) (((x) >> 4) & 0xf)
+#define LOW_REGISTER(x) ((x) & 0xff)
 #define HIGH_REGISTER(x) (((x) >> 8) & 0xff)
 
-#define SET_LOW_REGISTER(x, v)  x = (((x) & 0xff00) | ((v) & 0xff))
+#define SET_LOW_REGISTER(x, v) x = (((x) & 0xff00) | ((v) & 0xff))
 #define SET_HIGH_REGISTER(x, v) x = (((x) & 0xff) | (((v) & 0xff) << 8))
 
-#define WORD16(x)	((x) & 0xffff)
+#define WORD16(x) ((x) & 0xffff)
 
 /* CP/M Page 0 definitions */
 #define IOByte 0x03
 #define DSKByte 0x04
 
 /* CP/M disk definitions */
-#define BlkSZ 128	// CP/M block size
-#define BlkEX 128	// Number of blocks on an extension
+#define BlkSZ 128 // CP/M block size
+#define BlkEX 128 // Number of blocks on an extension
 #define ExtSZ (BlkSZ * BlkEX)
-#define BlkS2 4096	// Number of blocks on a S2 (module)
-#define MaxEX 31	// Maximum value the EX field can take
-#define MaxS2 15	// Maximum value the S2 (modules) field can take - Can be set to 63 to emulate CP/M Plus
-#define MaxCR 128	// Maximum value the CR field can take
-#define MaxRC 128	// Maximum value the RC field can take
+#define BlkS2 4096 // Number of blocks on a S2 (module)
+#define MaxEX 31   // Maximum value the EX field can take
+#define MaxS2 15   // Maximum value the S2 (modules) field can take - Can be set to 63 to emulate CP/M Plus
+#define MaxCR 128  // Maximum value the CR field can take
+#define MaxRC 128  // Maximum value the RC field can take
 
 /* CP/M memory definitions */
-#define RAM_FAST	// If this is defined, all RAM function calls become direct access (see below)
-					// This saves about 2K on the Arduino code and should bring speed improvements
+#define TPASIZE 60 // Can be 60 for batter CP/M 2.2 compatibility or 64 for extra memory
+                   // Values other than 60 or 64 would require rebuilding the CCP
+                   // For TPASIZE<60 CCP ORG = (SIZEK * 1024) - 0x0C00
 
-#define TPASIZE 60	// Can be 60 for CP/M 2.2 compatibility or more, up to 64 for extra memory
-					// Values other than 60 or 64 would require rebuilding the CCP
-					// For TPASIZE<60 CCP ORG = (SIZEK * 1024) - 0x0C00
-
-#define MEMSIZE 64 * 1024	// RAM(plus ROM) needs to be 64K to avoid compatibility issues
-
-#ifdef RAM_FAST		// Makes all function calls to memory access into direct RAM access (less calls / less code)
-	static uint8 *RAM;
-	#define _RamSysAddr(a)		&RAM[a]
-	#define _RamRead(a)			RAM[a]
-	#define _RamRead16(a)		((RAM[(a & 0xffff) + 1] << 8) | RAM[a & 0xffff])
-	#define _RamWrite(a, v)		RAM[a] = v
-	#define _RamWrite16(a, v)	RAM[a] = (v) & 0xff; RAM[a + 1] = (v) >> 8
+#ifndef BANKS
+    /* FujiNet vendoring: 1 bank = 64K (auto-enables RAM_FAST below). The 6.9
+       default of 8 banks (512K) is impossible on ESP32 and unnecessary for the
+       CP/M 2.2 single-bank setup FujiNet has always used. */
+    #define BANKS 1 // Number of memory banks available (defined in Makefile per platform)
 #endif
+static uint8 curBank = 0;     // Number of the current RAM bank in use (0-based, 0 to BANKS-1, as in CP/M 3)
+static uint8 isXmove = FALSE; // Used by BIOS
+static uint8 srcBank = 0;     // Source bank for memory MOVE
+static uint8 dstBank = 0;     // Destination bank for memory MOVE
+static uint8 ioBank = 0;      // Destination bank for sector IO
+static uint32 curBankBase = 0;
+static uint32 srcBankBase = 0;
+static uint32 dstBankBase = 0;
+static uint32 ioBankBase = 0;
+
+#define PAGESIZE (64 * 1024)        // RAM(plus ROM) needs to be 64K to avoid compatibility issues
+#define MEMSIZE (PAGESIZE * BANKS)  // Total RAM size
+
+#if BANKS == 1
+    #define RAM_FAST // If this is defined, all RAM function calls become direct access (see below)
+                     // This saves about 2K on the Arduino code and should bring speed improvements
+                     // This feature is only available if there is only one bank of RAM
+#endif
+
+#ifdef RAM_FAST // Makes all function calls to memory access into direct RAM access (less calls / less code)
+/* FujiNet vendoring: RAM is a heap pointer (the consumer .cpp does
+   RAM = malloc(MEMSIZE) / free(RAM)) rather than a static array, to keep the
+   64K buffer off the small ESP32 static-BSS budget. */
+static uint8 *RAM;
+    #define _RamSysAddr(a) &RAM[a]
+    #define _RamRead(a) RAM[a]
+    #define _RamRead16(a) ((RAM[((a) & 0xffff) + 1] << 8) | RAM[(a) & 0xffff])
+    #define _RamWrite(a, v) RAM[a] = v
+    #define _RamWrite16(a, v) \
+        RAM[a] = (v) & 0xff;  \
+        RAM[(a) + 1] = (v) >> 8
+#endif
+
+// If this is defined, the emulator will use interrupt-based BIOS/BDOS calls instead of
+// the legacy IN/OUT method for handing control to the emulated BIOS/BDOS routines
+/* FujiNet vendoring: keep the legacy IN/OUT port-0xFF handoff (5.8 behavior);
+   FujiNet's _HardwareIn/_HardwareOut in the abstraction layer drive it. */
+// #define INT_HANDOFF
 
 // Size of the allocated pages (Minimum size = 1 page = 256 bytes)
 
-// BIOS Pages (always on the top of memory)
-#define BIOSpage	(MEMSIZE - 256)
-#define BIOSjmppage	(BIOSpage - 256)
+// BIOS Pages (512 bytes from the top of memory)
+#define BIOSjmppage (PAGESIZE - 512)
+#define BIOSpage (BIOSjmppage + 256)
 
-// BDOS Pages (depend on TPASIZE)
-#define BDOSpage (TPASIZE * 1024) - 768
-#define BDOSjmppage	(BDOSpage - 256)
+// BDOS Pages (depends on TPASIZE for external CCPs)
+#if defined CCP_INTERNAL
+    #define BDOSjmppage (BIOSjmppage - 256)
+    #define BDOSpage (BDOSjmppage + 16)
+#else
+    #define BDOSjmppage (TPASIZE * 1024) - 1024
+    #define BDOSpage (BDOSjmppage + 256)
+#endif
 
-#define DPBaddr (BIOSpage + 64)		// Address of the Disk Parameter Block (Hardcoded in BIOS)
-#define DPHaddr (DPBaddr + 15)		// Address of the Disk Parameter Header 
+#define DPBaddr (BIOSpage + 128) // Address of the Disk Parameter Block (Hardcoded in BIOS)
+#define DPHaddr (DPBaddr + 15)   // Address of the Disk Parameter Header
 
-#define SCBaddr (BDOSpage + 16)		// Address of the System Control Block
-#define tmpFCB  (BDOSpage + 64)		// Address of the temporary FCB
+#ifdef ABDOS
+    #define SCBaddr (BDOSpage + 480) // Address of the System Control Block
+    #define tmpFCB (BDOSpage + 444)  // Address of the temporary FCB
+#else
+    #define SCBaddr (BDOSpage + 3) // Address of the System Control Block
+    #define tmpFCB (BDOSpage + 16) // Address of the temporary FCB
+#endif
 
 /* Definition of global variables */
-static uint8	filename[17];		// Current filename in host filesystem format
-static uint8	newname[17];		// New filename in host filesystem format
-static uint8	fcbname[13];		// Current filename in CP/M format
-static uint8	pattern[13];		// File matching pattern in CP/M format
-static uint16	dmaAddr = 0x0080;	// Current dmaAddr
-static uint8	oDrive = 0;			// Old selected drive
-static uint8	cDrive = 0;			// Currently selected drive
-static uint8	userCode = 0;		// Current user code
-static uint16	roVector = 0;
-static uint16	loginVector = 0;
-static uint8	allUsers = FALSE;	// true when dr is '?' in BDOS search first
-static uint8	allExtents = FALSE;	// true when ex is '?' in BDOS search first
-static uint8	currFindUser = 0;	// user number of current directory in BDOS search first on all user numbers
-static uint8	blockShift;			// disk allocation block shift
-static uint8	blockMask;			// disk allocation block mask
-static uint8	extentMask;			// disk extent mask
-static uint16	firstBlockAfterDir;	// first allocation block after directory
-static uint16	numAllocBlocks;		// # of allocation blocks on disk
-static uint8	extentsPerDirEntry;	// # of logical (16K) extents in a directory entry
-#define logicalExtentBytes (16*1024UL)
-static uint16	physicalExtentBytes;// # bytes described by 1 directory entry
+static uint8 filename[17];      // Current filename in host filesystem format
+static uint8 newname[17];       // New filename in host filesystem format
+static uint8 fcbname[13];       // Current filename in CP/M format
+static uint8 pattern[13];       // File matching pattern in CP/M format
+static uint16 dmaAddr = 0x0080; // Current dmaAddr
+static uint8 oDrive = 0;        // Old selected drive
+static uint8 cDrive = 0;        // Currently selected drive
+static uint8 userCode = 0;      // Current user code
+static uint16 roVector = 0;
+static uint16 loginVector = 0;
+static uint8 allUsers = FALSE;    // true when dr is '?' in BDOS search first
+static uint8 allExtents = FALSE;  // true when ex is '?' in BDOS search first
+static uint8 currFindUser = 0;    // user number of current directory in BDOS search first on all user numbers
+static uint8 blockShift;          // disk allocation block shift
+static uint8 blockMask;           // disk allocation block mask
+static uint8 extentMask;          // disk extent mask
+static uint16 firstBlockAfterDir; // first allocation block after directory
+static uint16 numAllocBlocks;     // # of allocation blocks on disk
+static uint8 extentsPerDirEntry;  // # of logical (16K) extents in a directory entry
+#define logicalExtentBytes (16 * 1024UL)
+static uint16 physicalExtentBytes; // # bytes described by 1 directory entry
+static uint16 cpuDelayInstructions = CPU_SPEED;
 
-#define tohex(x)	((x) < 10 ? (x) + 48 : (x) + 87)
+// Output delimiter used by BDOS C_WRITESTR (default '$')
+static uint8 outputDelimiter = 0x24;
+// Number of 128-byte records to transfer at once (set by BDOS F_MULTISEC).
+// Only CP/M 3 ever changes this; under CP/M 2.2 it stays 1, so the shared
+// read/write loops in disk.h behave exactly like single-record transfers.
+static uint8 multiRecordCount = 1; /* default = 1 record */
 
-/* When RUNCPM_STATIC_IMPL is defined, RunCPM symbols get internal (static)
+#define tohex(x) ((x) < 10 ? (x) + 48 : (x) + 87)
+
+/* definition of an autoexec functionality */
+static uint8 firstBoot = TRUE;  // True if this is the first boot
+#define AUTOEXEC "AUTOEXEC.TXT" // Name of the autoexec file
+#define BOOTONLY FALSE          // If TRUE, the autoexec file will only be loaded on the first boot
+
+#ifdef CPM3
+/* BDOS function 47 (Chain To Program) state: the command line a program
+   chained to, to be run by the CCP after the next warm boot */
+static uint8 chainCmd[128];
+static uint8 chainLoad = 0;
+#endif
+
+static uint32 timer;
+
+#ifdef STREAMIO
+    #include <stdio.h>
+static FILE *streamInputFile = NULL;
+static FILE *streamOutputFile = NULL;
+static uint8 streamInputActive = FALSE;
+static uint8 consoleOutputActive = TRUE;
+#endif
+
+/* FujiNet vendoring: RUNCPM_DECL linkage shim (carried over from 5.8).
+ * When RUNCPM_STATIC_IMPL is defined, RunCPM symbols get internal (static)
  * linkage so this translation unit can coexist with another TU that also
  * includes the RunCPM headers (e.g. a bus-specific CPM device and the
- * network-protocol CPM adapter built into the same binary). */
+ * network-protocol CPM adapter built into the same binary). The core headers
+ * tag every non-static file-scope definition with RUNCPM_DECL; their own
+ * `#ifndef RUNCPM_DECL` fallback is a no-op because we define it here first. */
 #ifdef RUNCPM_STATIC_IMPL
 #define RUNCPM_DECL static
 #else
@@ -222,35 +349,34 @@ static uint16	physicalExtentBytes;// # bytes described by 1 directory entry
  * these forward-decls must match in linkage to avoid a C++ constraint error. */
 static void _Bdos(void);
 static void _Bios(void);
-static void _HostnameToFCB(uint16 fcbaddr, uint8* filename);
-static void _HostnameToFCBname(uint8* from, uint8* to);
-static void _mockupDirEntry(void);
-static uint8 match(uint8* fcbname, uint8* pattern);
-static void _puts(const char* str);
+static void _HostnameToFCB(uint16 fcbaddr, uint8 *filename);
+static void _HostnameToFCBname(uint8 *from, uint8 *to);
+static void _mockupDirEntry(uint8 mode);
+static uint8 match(uint8 *fcbname, uint8 *pattern);
+static void _puts(const char *str);
 #ifndef RAM_FAST
-static uint8* _RamSysAddr(uint16 address);
+static uint8 *_RamSysAddr(uint16 address);
 static void _RamWrite(uint16 address, uint8 value);
 #endif
 #else /* !RUNCPM_STATIC_IMPL */
 #ifdef __cplusplus // If building on Arduino
-extern "C"
-{
+extern "C" {
 #endif
 
 #ifndef RAM_FAST
-	extern uint8* _RamSysAddr(uint16 address);
-	extern void _RamWrite(uint16 address, uint8 value);
+extern uint8 *_RamSysAddr(uint16 address);
+extern void _RamWrite(uint16 address, uint8 value);
 #endif
 
-	extern void _Bdos(void);
-	extern void _Bios(void);
+extern void _Bdos(void);
+extern void _Bios(void);
 
-	extern void _HostnameToFCB(uint16 fcbaddr, uint8* filename);
-	extern void _HostnameToFCBname(uint8* from, uint8* to);
-	extern void _mockupDirEntry(void);
-	extern uint8 match(uint8* fcbname, uint8* pattern);
+extern void _HostnameToFCB(uint16 fcbaddr, uint8 *filename);
+extern void _HostnameToFCBname(uint8 *from, uint8 *to);
+extern void _mockupDirEntry(uint8 mode);
+extern uint8 match(uint8 *fcbname, uint8 *pattern);
 
-	extern void _puts(const char* str);
+extern void _puts(const char *str);
 
 #ifdef __cplusplus // If building on Arduino
 }

--- a/lib/runcpm/globals.h
+++ b/lib/runcpm/globals.h
@@ -29,6 +29,14 @@
 // #define USE_LST
 
 /* Definitions for file/console based debugging */
+/* FujiNet: PlatformIO `build_type = debug` injects a global -DDEBUG, which
+   would otherwise switch on RunCPM's internal Z80 debugger (debug.h) and the
+   " - DEBUG" CCP greeting suffix.  That debugger pulls ~20KB .bss per RunCPM
+   TU (three TUs) and overflows ESP32 DRAM, and the banner leaks to modem/
+   telnet users.  We therefore key RunCPM's debugger off a dedicated
+   RUNCPMDEBUG macro (default false) instead of the ambient DEBUG, so the
+   firmware build never enables it regardless of build_type. */
+#define RUNCPMDEBUG false
 // #define DEBUG			// Enables the internal debugger (enabled by default on visual studio debug builds)
 // #define DEBUGONHALT		// Enables the internal debugger when the CPU halts
 // #define iDEBUG			// Enables instruction logging onto iDebug.log (for development debug only)
@@ -115,7 +123,7 @@
 
 #define STR_HELPER(x) #x
 #define STR(x) STR_HELPER(x)
-#ifdef DEBUG
+#if RUNCPMDEBUG
     #define DBG " - DEBUG"
 #else
     #define DBG

--- a/lib/runcpm/globals.h
+++ b/lib/runcpm/globals.h
@@ -133,12 +133,16 @@
 #else
     #define ABD
 #endif
+/* FujiNet vendoring: renamed RunCPM's banner macro from `CPM` to `CPM_VERSTR`
+   to avoid a collision with FujiNet's `CPM` enumerator (lib/bus/iwm/iwm.h),
+   which is pulled into the shared RunCPM core TU (runcpm_core.cpp) via the bus
+   headers on the APPLE/COCO targets.  The macro only feeds the CCPHEAD banner. */
 #ifdef CPM3
-    #define CPM "CP/M 3"
+    #define CPM_VERSTR "CP/M 3"
 #else
-    #define CPM "CP/M 2.2"
+    #define CPM_VERSTR "CP/M 2.2"
 #endif
-#define CCPHEAD "\r\nRunCPM Version " VERSION " (" CCPname ") - " CPM DBG ABD "\r\n"
+#define CCPHEAD "\r\nRunCPM Version " VERSION " (" CCPname ") - " CPM_VERSTR DBG ABD "\r\n"
 
 #define NOSLASH // Will translate '/' to '_' on filenames to prevent directory errors
 

--- a/lib/runcpm/host.h
+++ b/lib/runcpm/host.h
@@ -6,7 +6,7 @@
 #endif
 
 RUNCPM_DECL uint8 hostbdos(uint16 dmaaddr) {
-	return(0x00);
+    return (0x00);
 }
 
 #endif

--- a/lib/runcpm/ram.h
+++ b/lib/runcpm/ram.h
@@ -4,28 +4,46 @@
 /* see main.c for definition */
 
 #ifndef RAM_FAST
-static uint8 RAM[MEMSIZE];			// Definition of the emulated RAM
+static uint8 RAM[MEMSIZE]; // Definition of the emulated RAM
 
-uint8* _RamSysAddr(uint16 address) {
-	return(&RAM[address]);
+uint8 *_RamSysAddr(uint16 address) {
+    if (address < CCPaddr) {
+        return (&RAM[curBankBase + address]);
+    } else {
+        return (&RAM[address]);
+    }
 }
 
 uint8 _RamRead(uint16 address) {
-	return(RAM[address]);
+    if (address < CCPaddr) {
+        return (RAM[curBankBase + address]);
+    } else {
+        return (RAM[address]);
+    }
 }
 
 uint16 _RamRead16(uint16 address) {
-	return(RAM[address] + (RAM[address + 1] << 8));
+    if (address < CCPaddr) {
+        uint32 bankAddress = curBankBase + address;
+
+        return (RAM[bankAddress] + (RAM[bankAddress + 1] << 8));
+    } else {
+        return (RAM[address] + (RAM[address + 1] << 8));
+    }
 }
 
 void _RamWrite(uint16 address, uint8 value) {
-	RAM[address] = value;
+    if (address < CCPaddr) {
+        RAM[curBankBase + address] = value;
+    } else {
+        RAM[address] = value;
+    }
 }
 
 void _RamWrite16(uint16 address, uint16 value) {
-	// Z80 is a "little indian" (8 bit era joke)
-	_RamWrite(address, value & 0xff);
-	_RamWrite(address + 1, (value >> 8) & 0xff);
+    // Z80 is a "little indian" (8 bit era joke)
+    _RamWrite(address, value & 0xff);
+    _RamWrite(address + 1, (value >> 8) & 0xff);
 }
 #endif
 

--- a/lib/runcpm/resource.h
+++ b/lib/runcpm/resource.h
@@ -2,15 +2,15 @@
 // Microsoft Visual C++ generated include file.
 // Used by RunCPM.rc
 //
-#define IDI_ICON1                       101
+#define IDI_ICON1 101
 
 // Next default values for new objects
-// 
+//
 #ifdef APSTUDIO_INVOKED
-#ifndef APSTUDIO_READONLY_SYMBOLS
-#define _APS_NEXT_RESOURCE_VALUE        102
-#define _APS_NEXT_COMMAND_VALUE         40001
-#define _APS_NEXT_CONTROL_VALUE         1001
-#define _APS_NEXT_SYMED_VALUE           101
-#endif
+    #ifndef APSTUDIO_READONLY_SYMBOLS
+        #define _APS_NEXT_RESOURCE_VALUE 102
+        #define _APS_NEXT_COMMAND_VALUE 40001
+        #define _APS_NEXT_CONTROL_VALUE 1001
+        #define _APS_NEXT_SYMED_VALUE 101
+    #endif
 #endif

--- a/lib/runcpm/runcpm_core.cpp
+++ b/lib/runcpm/runcpm_core.cpp
@@ -87,6 +87,12 @@ extern "C" bool runcpm_session_run(const runcpm_console_ops *ops)
         Status = Debug = 0;
         Break = Step = Watch = -1;
 
+        /* Drop any sequential-read handle cached by a previous (warm) boot so a
+           file replaced on the SD card between boots is never read through a
+           stale handle.  See the _seq_cache_* block in
+           abstraction_fujinet_core.h. */
+        _seq_cache_close();
+
         RAM = (uint8_t *)malloc(MEMSIZE);
         if (!RAM)
             break;
@@ -107,6 +113,10 @@ extern "C" bool runcpm_session_run(const runcpm_console_ops *ops)
         if (Status == STATUS_EXIT)
             break;
     }
+
+    /* Release the cached read handle so it does not linger open across the
+       (idle) gap until the next session. */
+    _seq_cache_close();
 
     g_busy.store(false);
     return true;

--- a/lib/runcpm/runcpm_core.cpp
+++ b/lib/runcpm/runcpm_core.cpp
@@ -1,0 +1,126 @@
+/**
+ * runcpm_core.cpp — the SINGLE shared RunCPM core.
+ *
+ * This is the ONLY translation unit that compiles the RunCPM (Z80/CP/M 2.2)
+ * engine.  It is built WITHOUT RUNCPM_STATIC_IMPL, so every RunCPM symbol — the
+ * ~10 KB Z80 flag tables, all of the .bss state, and every function body — gets
+ * external linkage and is defined here exactly once.  The three transports
+ * (SIO 'G' / siocpm.cpp, the telnet console / vm_telnet.cpp, and N:CPM:// /
+ * CPM.cpp) no longer include the RunCPM header chain at all; they include only
+ * runcpm_session.h and act as thin console back-ends.  This removes the two
+ * redundant copies of the engine + state that previously triplicated ~30 KB of
+ * ESP32 DRAM.
+ *
+ * Only one CP/M session runs at a time (no concurrent modem + TCP), enforced by
+ * the g_busy interlock below.
+ */
+
+#define CCP_INTERNAL
+
+/*
+ * Use RunCPM's precomputed Z80 flag/arithmetic tables (cpu.h's `#ifdef preTables`
+ * branch) instead of computing them at boot into ~11 KB of writable .bss.  With
+ * preTables the 23 tables are `static const` and the linker places them in flash
+ * (.rodata) rather than DRAM, and initTables() is skipped.  This is the final
+ * piece that fits the single shared RunCPM core into the ESP32 dram0_0_seg:
+ * consolidating the three engine copies reclaimed ~22 KB, and moving these
+ * tables to flash reclaims the remaining ~11 KB of DRAM.  Must be defined before
+ * cpu.h is included.
+ */
+#define preTables
+
+#include <atomic>
+#include <stdlib.h>
+#include <string.h>
+#if !defined(_WIN32) && !defined(ARDUINO)
+#include <unistd.h> // cpu.h's Z80 throttle calls usleep() on POSIX/ESP-IDF
+#endif
+
+#include "fnSystem.h"
+#include "fnFS.h"
+#include "fnFsSD.h"
+
+#include "runcpm_session.h"
+
+/*
+ * RunCPM header chain (external linkage — NO RUNCPM_STATIC_IMPL).
+ * abstraction_fujinet_core.h supplies the disk/SD family and the transport-
+ * agnostic console shims that dispatch through g_runcpm_console (defined below).
+ */
+#include "globals.h"
+#include "abstraction_fujinet_core.h"
+#include "ram.h"
+#include "console.h"
+#include "cpu.h"
+#include "disk.h"
+#include "host.h"
+#include "cpm.h"
+#include "ccp.h"
+
+/* The active transport's console back-end.  Declared (extern "C") in
+   abstraction_fujinet_core.h; the console shims there route _getch/_getche/
+   _kbhit/_putch/_clrscr through it. */
+extern "C" runcpm_console_ops g_runcpm_console = {};
+
+/* Single-instance interlock: a second runcpm_session_run() returns false
+   immediately rather than clobbering the shared RAM/state. */
+static std::atomic<bool> g_busy{false};
+
+extern "C" bool runcpm_session_run(const runcpm_console_ops *ops)
+{
+    if (ops == nullptr)
+        return false;
+
+    /* Refuse a second concurrent session (no modem + TCP at once). */
+    if (g_busy.exchange(true))
+        return false;
+
+    g_runcpm_console = *ops;
+
+    /*
+     * CCP + warm-boot loop (mirrors the per-transport _cpm_run loops this
+     * consolidates).  Status == STATUS_EXIT (1) ends the session; STATUS_RESTART
+     * (2) re-boots CP/M as a real machine would on warm boot.
+     */
+    while (true)
+    {
+        Status = Debug = 0;
+        Break = Step = Watch = -1;
+
+        RAM = (uint8_t *)malloc(MEMSIZE);
+        if (!RAM)
+            break;
+
+        memset(RAM,      0, MEMSIZE);
+        memset(filename, 0, sizeof(filename));
+        memset(newname,  0, sizeof(newname));
+        memset(fcbname,  0, sizeof(fcbname));
+        memset(pattern,  0, sizeof(pattern));
+
+        _puts(CCPHEAD);
+        _PatchCPM();
+        _ccp();
+
+        free(RAM);
+        RAM = nullptr;
+
+        if (Status == STATUS_EXIT)
+            break;
+    }
+
+    g_busy.store(false);
+    return true;
+}
+
+extern "C" void runcpm_session_request_exit(void)
+{
+    /* BIOS-0-style end request: the CCP/Z80 loop stops at the next warm boot.
+       The caller is responsible for unblocking its own console back-end (e.g.
+       feeding a CR/CTRL-C so a blocking getch returns). */
+    Status = STATUS_EXIT;
+}
+
+extern "C" bool runcpm_session_active(void)
+{
+    return g_busy.load();
+}

--- a/lib/runcpm/runcpm_session.h
+++ b/lib/runcpm/runcpm_session.h
@@ -1,0 +1,68 @@
+#ifndef RUNCPM_SESSION_H
+#define RUNCPM_SESSION_H
+
+/*
+ * runcpm_session — public, RunCPM-internals-free entry point to the single
+ * shared RunCPM core (lib/runcpm/runcpm_core.cpp).
+ *
+ * Background: RunCPM is a header-only Z80/CP/M 2.2 emulator.  It used to be
+ * #included directly by three transports (SIO 'G' / siocpm.cpp, the telnet
+ * console / vm_telnet.cpp, and N:CPM:// / CPM.cpp).  Because globals.h tags
+ * symbols `static` under RUNCPM_STATIC_IMPL, every transport that included the
+ * header chain got its OWN private copy of all RunCPM state, the ~10 KB Z80
+ * flag tables and every function body — triplicating ~30 KB of ESP32 DRAM.
+ *
+ * Now exactly ONE translation unit (runcpm_core.cpp) compiles the RunCPM
+ * engine and owns the state.  The transports include only this header and act
+ * as thin console back-ends: each supplies a set of console callbacks and asks
+ * the core to run a session.  Only one CP/M session runs at a time (no
+ * concurrent modem + TCP), enforced by a simple busy interlock in the core.
+ */
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Console back-end supplied by a transport.  These mirror RunCPM's console
+ * primitives (_getch/_getche/_kbhit/_putch/_clrscr); the core routes its
+ * internal console I/O through whichever back-end started the active session.
+ */
+typedef struct runcpm_console_ops
+{
+    int  (*getch)(void);     /* blocking read of one char (0..255), no echo  */
+    int  (*getche)(void);    /* blocking read of one char, with echo         */
+    int  (*kbhit)(void);     /* non-blocking: nonzero if a char is ready     */
+    void (*putch)(uint8_t c);/* write one byte to the terminal               */
+    void (*clrscr)(void);    /* clear the screen (may be a no-op)            */
+} runcpm_console_ops;
+
+/*
+ * Run a full CP/M session (CCP + warm-boot loop) using the supplied console
+ * back-end.  BLOCKS until the session ends (clean exit or teardown request).
+ * Returns false immediately, running nothing, if a session is already active
+ * (the single-instance interlock); returns true once a session it started has
+ * finished.
+ */
+bool runcpm_session_run(const runcpm_console_ops *ops);
+
+/*
+ * Ask the active session's CCP (and any running Z80 program) to stop at the
+ * next opportunity.  Safe to call from another thread/task than the one that
+ * is blocked in runcpm_session_run().  The caller is still responsible for
+ * unblocking its own console back-end (e.g. feeding a CR/CTRL-C so a blocking
+ * getch returns), exactly as the transports did before.
+ */
+void runcpm_session_request_exit(void);
+
+/* True while a session is running. */
+bool runcpm_session_active(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* RUNCPM_SESSION_H */

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -145,6 +145,7 @@ FILE(GLOB_RECURSE SOURCES
     ${CMAKE_SOURCE_DIR}/lib/printer-emulator/*.cpp
     ${CMAKE_SOURCE_DIR}/lib/qrcode/*.c
     ${CMAKE_SOURCE_DIR}/lib/qrcode/*.cpp
+    ${CMAKE_SOURCE_DIR}/lib/runcpm/*.cpp
     ${CMAKE_SOURCE_DIR}/lib/sam/*.c
     ${CMAKE_SOURCE_DIR}/lib/sam/*.cpp
     ${CMAKE_SOURCE_DIR}/lib/task/*.cpp

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -50,6 +50,10 @@ Console console;
 #include "fnBluetooth.h"
 #endif
 
+#ifdef BUILD_ATARI
+#include "sio/vm_telnet.h" // loopback TELNET console for RunCPM (N:TELNET://127.0.0.1:8677)
+#endif
+
 // fnSystem is declared and defined in fnSystem.h/cpp
 // fnBtManager is declared and defined in fnBluetooth.h/cpp
 // fnLedManager is declared and defined in led.h/cpp
@@ -281,6 +285,13 @@ void main_setup(int argc, char *argv[])
 
     // Go setup SIO
     SYSTEM_BUS.setup();
+
+    // NOTE: the loopback TELNET console for RunCPM is started later, in
+    // fn_service_loop() after fnWiFi.start(), NOT here.  On ESP32 the lwIP
+    // tcpip thread / mbox is created by esp_netif_init() inside
+    // WiFiManager::start(); starting the telnet acceptor here (before WiFi is
+    // up) made its loopback socket call tcpip_send_msg_wait_sem() with an
+    // uninitialised mbox and panic in a boot loop.
 #endif // BUILD_ATARI
 
 #ifdef BUILD_COCO
@@ -517,6 +528,7 @@ void fn_service_loop(void *param)
 #endif
 
     // Now that our main service is running, try connecting to WiFi or BlueTooth
+    bool network_stack_up = false;
     if (Config.get_bt_status())
     {
 #ifdef BLUETOOTH_SUPPORT
@@ -531,7 +543,24 @@ void fn_service_loop(void *param)
         fnWiFi.start();
         // Go ahead and try reconnecting to WiFi
         fnWiFi.connect();
+        // fnWiFi.start() -> esp_netif_init() has now created the lwIP tcpip
+        // thread / mbox, so loopback sockets are safe to open from here on.
+        network_stack_up = true;
     }
+
+#ifdef BUILD_ATARI
+    // Start the loopback TELNET console for RunCPM (N:TELNET://127.0.0.1:8677)
+    // ONLY after the network stack exists.  On ESP32 lwIP is brought up by
+    // esp_netif_init() inside fnWiFi.start() above; starting the acceptor
+    // before that made its loopback socket panic in tcpip_send_msg_wait_sem()
+    // ("Invalid mbox") in a boot loop.  On FujiNet-PC the host OS stack is
+    // always up, so start it unconditionally there.
+#ifdef ESP_PLATFORM
+    if (network_stack_up)
+#endif
+        vm_telnet_start();
+#endif // BUILD_ATARI
+    (void)network_stack_up;
 
     // If we don't have config enabled, and no alternate config disk
     // selected, then just mount what we have so we are after all of
@@ -639,6 +668,14 @@ int main(int argc, char *argv[])
     main_setup(argc, argv);
     // Enter service loop
     fn_service_loop(nullptr);
+
+#ifdef BUILD_ATARI
+    // Wind down the RunCPM telnet console (acceptor + any live session) while
+    // its global queue mutexes are still valid.  Skipping this lets the
+    // detached worker threads race static destruction and abort the process
+    // with "mutex lock failed" at exit.
+    vm_telnet_stop();
+#endif
 
     if (exit_for_restart)
         fnSystem.reboot(); // calls exit(75)


### PR DESCRIPTION
## Summary

- **RunCPM 6.9 refactoring** — consolidate the three duplicate RunCPM engines (SIO `'G'`, `N:CPM://`, telnet) into ONE shared core. `runcpm_core.cpp` is now the only TU that compiles the Z80/CP/M chain (external linkage); the transports are thin console back-ends that plug into it through `runcpm_session.h`'s `runcpm_console_ops`, guarded by a `g_busy` single-instance interlock. `abstraction_fujinet_core.h` holds the shared disk/SD section. `preTables` moves the ~11 KB Z80 flag tables to flash and the consolidation reclaims ~22 KB, fixing the ESP32 `dram0_0_seg` overflow.
- **N:CPM telnet console on port 8677** — new `vm_telnet.cpp` exposes a loopback TELNET server (`127.0.0.1:8677`) bridged through libtelnet to the shared core, so an Atari reaches CP/M via `N:TELNET://127.0.0.1:8677`. It is started from `fn_service_loop` only after lwIP is up (`esp_netif_init` inside `fnWiFi.start`); the acceptor waits for an IP and is pinned to core 0 so the priority-17 SIO loop on core 1 cannot starve it.
- **RSX bar commands** — new `vm_bar.cpp/.h` implement the VM-generic bar-command gate (`|ftp`, `|wget`, `|fn`, `|apt`, `|help`) wired into `ccp.h` via `vm_bar_io` trampolines built from the core's `_getch/_putch/_puts`, so the bar talks to whichever transport is active. Named `vm_` (not `cpm_`) so future non-CP/M VMs can reuse the same telnet console + bar plumbing.

## ESP32 hardware bring-up fixes

Found and fixed on real Atari FujiNet (fujinet-atari-v1) hardware:
- **Boot loop** (`assert tcpip_send_msg_wait_sem ... Invalid mbox`): the telnet acceptor opened a socket before lwIP existed. Moved `vm_telnet_start()` out of `main_setup` into `fn_service_loop`, after the WiFi/BT block, gated on the network stack being up.
- **Listen-before-IP**: acceptor now waits for `fnWiFi.connected()` before `bind()/listen()`.
- **"Port open but no CP/M banner"**: the priority-10 acceptor pinned to core 1 was permanently starved by the priority-17 SIO loop. Pinned the acceptor to core 0.

## Test plan

- [x] FujiNet-PC: `cmake --build build --target dist` links clean; `nm` shows a single copy of the Z80 tables (`cbitsZ80Table`/`cbitsTable`/`cbits2Table`).
- [x] FujiNet-PC: `telnet 127.0.0.1 8677` → CP/M banner, `DIR`, run a `.COM`, `|help`, clean exit.
- [x] ESP32: `./build.sh -b` links (RAM 36.7%, no `dram0_0_seg` overflow).
- [x] ESP32 on hardware: boots without loop; `N:TELNET://127.0.0.1:8677` reaches CP/M (banner + session); bind restored to loopback `127.0.0.1:8677`.
- [ ] SIO `'G'` CP/M and `N:CPM://` regression on hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)