### PR TITLE
[iwm] Use spError_t constants whenever an spError_t is used.

### DIFF
--- a/lib/bus/iwm/iwm.cpp
+++ b/lib/bus/iwm/iwm.cpp
@@ -188,13 +188,13 @@ systemBus::iwm_phases_t systemBus::iwm_phases()
 
 //------------------------------------------------------
 
-int systemBus::iwm_send_packet(uint8_t source, iwm_packet_type_t packet_type, uint8_t status, const uint8_t *data, uint16_t num)
+int systemBus::iwm_send_packet(uint8_t source, iwm_packet_type_t packet_type, spError_t err, const uint8_t *data, uint16_t num)
 {
   int r;
   int retry = 5; // host seems to control the retries, this is here so we don't get stuck
 
   //print_packet ((uint8_t*) data, num); // before encoding
-  smartport.encode_packet(source, packet_type, status, data, num);
+  smartport.encode_packet(source, packet_type, static_cast<uint8_t>(err), data, num);
 #ifdef DEBUG
   //print_packet(smartport.packet_buffer,BLOCK_PACKET_LEN); // print raw packet contents to be sent
 #endif
@@ -243,14 +243,14 @@ void systemBus::setup(void)
 // to 4 partions, i.e. devices, so we need to specify when we are doing the last
 // init reply.
 //*****************************************************************************
-void virtualDevice::send_init_reply_packet(uint8_t source, uint8_t status)
+void virtualDevice::send_init_reply_packet(uint8_t source, spError_t err)
 {
-  SYSTEM_BUS.iwm_send_packet(source, iwm_packet_type_t::status, status, nullptr, 0);
+  SYSTEM_BUS.iwm_send_packet(source, iwm_packet_type_t::status, err, nullptr, 0);
 }
 
-void virtualDevice::send_reply_packet(uint8_t status)
+void virtualDevice::send_reply_packet(spError_t err)
 {
-  SYSTEM_BUS.iwm_send_packet(id(), iwm_packet_type_t::status, status, nullptr, 0);
+  SYSTEM_BUS.iwm_send_packet(id(), iwm_packet_type_t::status, err, nullptr, 0);
 }
 
 void virtualDevice::iwm_return_badcmd(iwm_decoded_cmd_t cmd)
@@ -270,21 +270,21 @@ void virtualDevice::iwm_return_badcmd(iwm_decoded_cmd_t cmd)
       print_packet(data_buffer, data_len);
       break;
     default: //just send the response and return like before
-      send_reply_packet(SP_ERR_BADCMD);
+      send_reply_packet(SP_ERR::BADCMD);
       Debug_printf("\r\nUnit %02x Bad Command %02x", id(), cmd.sp_command);
       return;
   }
 
   if(cmd.sp_command == SP_CMD_CONTROL) //Decode command control code
   {
-    send_reply_packet(SP_ERR_BADCTL); //we may be required to accept some control commands
+    send_reply_packet(SP_ERR::BADCTL); //we may be required to accept some control commands
                                       // but for now just report bad control if it's a control
                                       // command
     Debug_printf("\r\nbad command was a control command with control code %02x",cmd.control_status.fuji.command);
   }
   else
   {
-    send_reply_packet(SP_ERR_BADCMD); //response for Any other command with a data packet
+    send_reply_packet(SP_ERR::BADCMD); //response for Any other command with a data packet
   }
 }
 
@@ -305,38 +305,36 @@ void virtualDevice::iwm_return_device_offline(iwm_decoded_cmd_t cmd)
       print_packet((uint8_t *)data_buffer, data_len);
       break;
     default: //just send the response and return like before
-      send_reply_packet(SP_ERR_OFFLINE);
+      send_reply_packet(SP_ERR::OFFLINE);
       Debug_printf("\r\nUnit %02x Offline, Command %02x", id(), cmd.sp_command);
       return;
   }
 
   if(cmd.sp_command == SP_CMD_CONTROL) //Decode command control code
   {
-    send_reply_packet(SP_ERR_OFFLINE);
+    send_reply_packet(SP_ERR::OFFLINE);
     Debug_printf("\r\nOffline command was a control command with control code %02x",cmd.control_status.fuji.command);
   }
   else
   {
-    send_reply_packet(SP_ERR_OFFLINE); //response for Any other command with a data packet
+    send_reply_packet(SP_ERR::OFFLINE); //response for Any other command with a data packet
   }
 }
 
 void virtualDevice::iwm_return_ioerror()
 {
   // Debug_printf("\r\nUnit %02x Bad Command %02x", id(), cmd.sp_command);
-  send_reply_packet(SP_ERR_IOERROR);
+  send_reply_packet(SP_ERR::IOERROR);
 }
 
 void virtualDevice::iwm_return_noerror()
 {
-  send_reply_packet(SP_ERR_NOERROR);
+  send_reply_packet(SP_ERR::NOERROR);
 }
 
 void virtualDevice::iwm_status(iwm_decoded_cmd_t cmd) // override;
 {
-  uint8_t status_code = cmd.control_status.code;
-
-  if (status_code == SP_CMD_FORMAT)
+  if (cmd.control_status.code == SP_STAT_DIB)
   {
     Debug_printf("\r\nSending DIB Status for device 0x%02x", id());
     send_status_dib_reply_packet();
@@ -355,10 +353,10 @@ void virtualDevice::iwm_status(iwm_decoded_cmd_t cmd) // override;
 // data[..16 bytes ]      = name padded with spaces to 16 bytes
 // data[..2 bytes]        = device type
 // data[..2 byte]         = device version
-std::vector<uint8_t> virtualDevice::create_dib_reply_packet(const std::string& device_name, uint8_t status, const std::vector<uint8_t>& block_size, const std::array<uint8_t, 2>& type, const std::array<uint8_t, 2>& version)
+std::vector<uint8_t> virtualDevice::create_dib_reply_packet(const std::string& device_name, uint8_t device_status, const std::vector<uint8_t>& block_size, const std::array<uint8_t, 2>& type, const std::array<uint8_t, 2>& version)
 {
     std::vector<uint8_t> data;
-    data.push_back(status);
+    data.push_back(device_status);
     data.insert(data.end(), block_size.begin(), block_size.end());
     data.push_back(static_cast<uint8_t>(device_name.size()));
 
@@ -740,7 +738,7 @@ iwm_enable_state_t IRAM_ATTR systemBus::iwm_motor_state()
 
 void systemBus::handle_init()
 {
-  uint8_t status = 0;
+  spError_t err = SP_ERR::NOERROR;
   virtualDevice *pDevice = nullptr;
 
   fnLedManager.set(LED_BUS, true);
@@ -757,9 +755,9 @@ void systemBus::handle_init()
     {
       pDevice->_devnum = command_packet.dest; // assign address
       if (++it == _daisyChain.end())
-        status = 0xff; // end of the line, so status=non zero - to do: check GPIO for another device in the physical daisy chain
+        err = SP_ERR::ENDOFCHAIN; // end of the line, so status=non zero - to do: check GPIO for another device in the physical daisy chain
       Debug_printf("\r\nSending INIT Response Packet...");
-      pDevice->send_init_reply_packet(command_packet.dest, status);
+      pDevice->send_init_reply_packet(command_packet.dest, err);
 
       // smartport.iwm_send_packet_spi((uint8_t *)pDevice->packet_buffer); // timeout error return is not handled here (yet?)
 

--- a/lib/bus/iwm/iwm.h
+++ b/lib/bus/iwm/iwm.h
@@ -45,23 +45,31 @@ enum spCommandID_t : uint8_t {
   SP_ECMD_WRITE         = 0x49,
 };
 
-enum spError_t {
+// Windows defines this and it conflicts with the SmartPort erro
+// code. We don't need it, just undef it.
+#ifdef NOERROR
+#undef NOERROR
+#endif
+
+typedef enum class SP_ERR {
     // see page 81-82 in Apple IIc ROM reference and Table 7-5 in IIgs firmware ref
-    SP_ERR_NOERROR    = 0x00, // no error
-    SP_ERR_BADCMD     = 0x01, // invalid command
-    SP_ERR_BUSERR     = 0x06, // communications error
-    SP_ERR_BADCTL     = 0x21, // invalid status or control code
-    SP_ERR_BADCTLPARM = 0x22, // invalid parameter list
-    SP_ERR_IOERROR    = 0x27, // i/o error on device side
-    SP_ERR_NODRIVE    = 0x28, // no device connected
-    SP_ERR_NOWRITE    = 0x2b, // disk write protected
-    SP_ERR_BADBLOCK   = 0x2d, // invalid block number
-    SP_ERR_DISKSW     = 0x2e, // media has been swapped - extended calls only
-    SP_ERR_OFFLINE    = 0x2f, // device offline or no disk in drive
+    NOERROR    = 0x00, // no error
+    BADCMD     = 0x01, // invalid command
+    BUSERR     = 0x06, // communications error
+    BADCTL     = 0x21, // invalid status or control code
+    BADCTLPARM = 0x22, // invalid parameter list
+    IOERROR    = 0x27, // i/o error on device side
+    NODRIVE    = 0x28, // no device connected
+    NOWRITE    = 0x2b, // disk write protected
+    BADBLOCK   = 0x2d, // invalid block number
+    DISKSW     = 0x2e, // media has been swapped - extended calls only
+    OFFLINE    = 0x2f, // device offline or no disk in drive
 
     // $30-$3F are for device specific errors
-    SP_ERR_BADWIFI    = 0x30, // error connecting to new SSID - todo: implement usage
-};
+    BADWIFI    = 0x30, // error connecting to new SSID - todo: implement usage
+
+    ENDOFCHAIN = 0xff,
+} spError_t;
 
 #define STATCODE_BLOCK_DEVICE 0x01 << 7   // block device = 1, char device = 0
 #define STATCODE_WRITE_ALLOWED 0x01 << 6
@@ -232,10 +240,10 @@ protected:
 
    // void send_data_packet(); //encode smartport 512 byte data packet
   // void encode_data_packet(uint16_t num = 512); //encode smartport "num" byte data packet
-  void send_init_reply_packet(uint8_t source, uint8_t status);
+  void send_init_reply_packet(uint8_t source, spError_t err);
   virtual void send_status_reply_packet() = 0;
-  void send_reply_packet(uint8_t status);
-  // void send_reply_packet(uint8_t source, uint8_t status) { send_reply_packet(status); };
+  void send_reply_packet(spError_t err);
+  // void send_reply_packet(uint8_t source, spError_t err) { send_reply_packet(status); };
   virtual void send_status_dib_reply_packet() = 0;
 
   virtual void send_extended_status_reply_packet() = 0;
@@ -265,7 +273,7 @@ protected:
   static uint8_t data_buffer[MAX_DATA_LEN]; // un-encoded binary data (512 bytes for a block)
   static int data_len; // how many bytes in the data buffer
 
-  std::vector<uint8_t> create_dib_reply_packet(const std::string& device_name, uint8_t status, const std::vector<uint8_t>& block_size, const std::array<uint8_t, 2>& type, const std::array<uint8_t, 2>& version);
+  std::vector<uint8_t> create_dib_reply_packet(const std::string& device_name, uint8_t device_status, const std::vector<uint8_t>& block_size, const std::array<uint8_t, 2>& type, const std::array<uint8_t, 2>& version);
 
 public:
   bool device_active;
@@ -338,7 +346,7 @@ public:
 
   cmdPacket_t command_packet;
   bool iwm_decode_data_packet(uint8_t *a, int &n);
-   int iwm_send_packet(uint8_t source, iwm_packet_type_t packet_type, uint8_t status, const uint8_t* data, uint16_t num);
+   int iwm_send_packet(uint8_t source, iwm_packet_type_t packet_type, spError_t err, const uint8_t* data, uint16_t num);
 
   // these things stay for the most part
   void setup();

--- a/lib/device/iwm/clock.cpp
+++ b/lib/device/iwm/clock.cpp
@@ -35,7 +35,7 @@ void iwmClock::send_status_reply_packet()
     data[1] = 0; // block size 1
     data[2] = 0; // block size 2
     data[3] = 0; // block size 3
-    SYSTEM_BUS.iwm_send_packet(id(),iwm_packet_type_t::status,SP_ERR_NOERROR, data, 4);
+    SYSTEM_BUS.iwm_send_packet(id(),iwm_packet_type_t::status,SP_ERR::NOERROR, data, 4);
 }
 
 void iwmClock::send_status_dib_reply_packet()
@@ -48,7 +48,7 @@ void iwmClock::send_status_dib_reply_packet()
                 { SP_TYPE_BYTE_FUJINET_CLOCK, SP_SUBTYPE_BYTE_FUJINET_CLOCK },  // type, subtype
                 { 0x00, 0x01 }                                                  // version.
         );
-        SYSTEM_BUS.iwm_send_packet(id(), iwm_packet_type_t::status, SP_ERR_NOERROR, data.data(), data.size());
+        SYSTEM_BUS.iwm_send_packet(id(), iwm_packet_type_t::status, SP_ERR::NOERROR, data.data(), data.size());
 }
 
 void iwmClock::set_tz()
@@ -74,7 +74,7 @@ void iwmClock::iwm_ctrl(iwm_decoded_cmd_t cmd)
 
     SYSTEM_BUS.iwm_decode_data_packet((uint8_t *)data_buffer, data_len);
 
-    uint8_t err_result = SP_ERR_NOERROR;
+    spError_t err_result = SP_ERR::NOERROR;
 
     switch (cmd.control_status.fuji.command)
     {
@@ -85,7 +85,7 @@ void iwmClock::iwm_ctrl(iwm_decoded_cmd_t cmd)
             set_alternate_tz();
             break;
         default:
-            err_result = SP_ERR_BADCTL;
+            err_result = SP_ERR::BADCTL;
             break;
     }
 
@@ -184,24 +184,24 @@ void iwmClock::iwm_status(iwm_decoded_cmd_t cmd)
         break;
     }
     default:
-        send_reply_packet(SP_ERR_BADCTL);
+        send_reply_packet(SP_ERR::BADCTL);
         return;
     }
 
     // If we got here, we have data to send
-    SYSTEM_BUS.iwm_send_packet(id(), iwm_packet_type_t::data, SP_ERR_NOERROR, data_buffer, data_len);
+    SYSTEM_BUS.iwm_send_packet(id(), iwm_packet_type_t::data, SP_ERR::NOERROR, data_buffer, data_len);
 }
 
 void iwmClock::iwm_open(iwm_decoded_cmd_t cmd)
 {
     Debug_printf("\r\nClock: Open\n");
-    send_reply_packet(SP_ERR_NOERROR);
+    send_reply_packet(SP_ERR::NOERROR);
 }
 
 void iwmClock::iwm_close(iwm_decoded_cmd_t cmd)
 {
     Debug_printf("\r\nClock: Close\n");
-    send_reply_packet(SP_ERR_NOERROR);
+    send_reply_packet(SP_ERR::NOERROR);
 }
 
 

--- a/lib/device/iwm/cpm.cpp
+++ b/lib/device/iwm/cpm.cpp
@@ -64,7 +64,7 @@ void iwmCPM::send_status_reply_packet()
     data[1] = 0; // block size 1
     data[2] = 0; // block size 2
     data[3] = 0; // block size 3
-    SYSTEM_BUS.iwm_send_packet(id(), iwm_packet_type_t::status, SP_ERR_NOERROR, data, 4);
+    SYSTEM_BUS.iwm_send_packet(id(), iwm_packet_type_t::status, SP_ERR::NOERROR, data, 4);
 }
 
 void iwmCPM::send_status_dib_reply_packet()
@@ -77,7 +77,7 @@ void iwmCPM::send_status_dib_reply_packet()
                 { SP_TYPE_BYTE_FUJINET_CPM, SP_SUBTYPE_BYTE_FUJINET_CPM },  // type, subtype
                 { 0x00, 0x01 }                                              // version.
         );
-        SYSTEM_BUS.iwm_send_packet(id(), iwm_packet_type_t::status, SP_ERR_NOERROR, data.data(), data.size());
+        SYSTEM_BUS.iwm_send_packet(id(), iwm_packet_type_t::status, SP_ERR::NOERROR, data.data(), data.size());
 
 }
 
@@ -89,13 +89,13 @@ void iwmCPM::sio_status()
 
 void iwmCPM::iwm_open(iwm_decoded_cmd_t cmd)
 {
-    uint8_t err_result = SP_ERR_NOERROR;
+    spError_t err_result = SP_ERR::NOERROR;
 
     Debug_printf("\r\nCP/M: Open\n");
 #ifdef ESP_PLATFORM // OS
     if (!fnSystem.hasbuffer())
     {
-        err_result = SP_ERR_OFFLINE;
+        err_result = SP_ERR::OFFLINE;
     Debug_printf("FujiApple HASBUFFER Missing, not starting CP/M\n");
     }
     else
@@ -114,7 +114,7 @@ void iwmCPM::iwm_open(iwm_decoded_cmd_t cmd)
 void iwmCPM::iwm_close(iwm_decoded_cmd_t cmd)
 {
     Debug_printf("\r\nCP/M: Close\n");
-    send_reply_packet(SP_ERR_NOERROR);
+    send_reply_packet(SP_ERR::NOERROR);
 }
 
 void iwmCPM::iwm_status(iwm_decoded_cmd_t cmd)
@@ -158,12 +158,12 @@ void iwmCPM::iwm_status(iwm_decoded_cmd_t cmd)
         Debug_printf("CPM Task Running? %d %s", data_buffer[0],(data_buffer[0]) ? "=No" : "=Yes");
         break;
     default:
-        send_reply_packet(SP_ERR_BADCMD);
+        send_reply_packet(SP_ERR::BADCMD);
         return;
     }
 
     Debug_printf("\r\nStatus code complete, sending response");
-    SYSTEM_BUS.iwm_send_packet(id(), iwm_packet_type_t::data, 0, data_buffer, data_len);
+    SYSTEM_BUS.iwm_send_packet(id(), iwm_packet_type_t::data, SP_ERR::NOERROR, data_buffer, data_len);
 }
 
 void iwmCPM::iwm_read(iwm_decoded_cmd_t cmd)
@@ -202,7 +202,7 @@ void iwmCPM::iwm_read(iwm_decoded_cmd_t cmd)
     }
 
     Debug_printf("\r\nsending CPM read data packet ...");
-    SYSTEM_BUS.iwm_send_packet(id(), iwm_packet_type_t::data, 0, data_buffer, data_len);
+    SYSTEM_BUS.iwm_send_packet(id(), iwm_packet_type_t::data, SP_ERR::NOERROR, data_buffer, data_len);
     data_len = 0;
     memset(data_buffer, 0, sizeof(data_buffer));
 }
@@ -230,12 +230,12 @@ void iwmCPM::iwm_write(iwm_decoded_cmd_t cmd)
 #endif
     }
 
-    send_reply_packet(SP_ERR_NOERROR);
+    send_reply_packet(SP_ERR::NOERROR);
 }
 
 void iwmCPM::iwm_ctrl(iwm_decoded_cmd_t cmd)
 {
-    uint8_t err_result = SP_ERR_NOERROR;
+    spError_t err_result = SP_ERR::NOERROR;
 
     // uint8_t source = cmd.dest;                                                 // we are the destination and will become the source // data_buffer[6];
     Debug_printf("\r\nCPM Device %02x Control Code %02x", id(), cmd.control_status.fuji.command);
@@ -252,7 +252,7 @@ void iwmCPM::iwm_ctrl(iwm_decoded_cmd_t cmd)
 #ifdef ESP_PLATFORM // OS
             if (!fnSystem.hasbuffer())
             {
-                err_result = SP_ERR_OFFLINE;
+                err_result = SP_ERR::OFFLINE;
                 Debug_printf("FujiApple HASBUFFER Missing, not starting CP/M\n");
             }
             else
@@ -269,11 +269,11 @@ void iwmCPM::iwm_ctrl(iwm_decoded_cmd_t cmd)
             }
             break;
         default:
-            send_reply_packet(SP_ERR_BADCMD);
+            send_reply_packet(SP_ERR::BADCMD);
             return;
         }
     else
-        err_result = SP_ERR_IOERROR;
+        err_result = SP_ERR::IOERROR;
 
     send_reply_packet(err_result);
 }

--- a/lib/device/iwm/disk.cpp
+++ b/lib/device/iwm/disk.cpp
@@ -118,7 +118,7 @@ void iwmDisk::send_status_reply_packet()
   std::vector<uint8_t> data;
   data.push_back(status);
   data.insert(data.end(), block_size.begin(), block_size.end());
-  SYSTEM_BUS.iwm_send_packet(id(), iwm_packet_type_t::status,SP_ERR_NOERROR, data.data(), data.size());
+  SYSTEM_BUS.iwm_send_packet(id(), iwm_packet_type_t::status,SP_ERR::NOERROR, data.data(), data.size());
 }
 
 //*****************************************************************************
@@ -146,7 +146,7 @@ void iwmDisk::send_extended_status_reply_packet() //XXX! Currently unused
   std::vector<uint8_t> data;
   data.push_back(status);
   data.insert(data.end(), block_size.begin(), block_size.end());
-  SYSTEM_BUS.iwm_send_packet(id(), iwm_packet_type_t::ext_status, SP_ERR_NOERROR, data.data(), data.size());
+  SYSTEM_BUS.iwm_send_packet(id(), iwm_packet_type_t::ext_status, SP_ERR::NOERROR, data.data(), data.size());
 }
 
 //*****************************************************************************
@@ -173,7 +173,7 @@ void iwmDisk::send_status_dib_reply_packet() // to do - abstract this out with p
     { smartport_device_type(), smartport_device_subtype() },    // type, subtype
     { 0x01, 0x0f }                                              // version.
   );
-        SYSTEM_BUS.iwm_send_packet(id(), iwm_packet_type_t::status, SP_ERR_NOERROR, data.data(), data.size());
+        SYSTEM_BUS.iwm_send_packet(id(), iwm_packet_type_t::status, SP_ERR::NOERROR, data.data(), data.size());
 }
 
 //*****************************************************************************
@@ -207,12 +207,12 @@ void iwmDisk::send_extended_status_dib_reply_packet() //XXX! currently unused
     switched = false;
   }
 
-  SYSTEM_BUS.iwm_send_packet(id(), iwm_packet_type_t::ext_status, SP_ERR_NOERROR, data.data(), data.size());
+  SYSTEM_BUS.iwm_send_packet(id(), iwm_packet_type_t::ext_status, SP_ERR::NOERROR, data.data(), data.size());
 }
 
 void iwmDisk::iwm_ctrl(iwm_decoded_cmd_t cmd)
 {
-  err_result = SP_ERR_NOERROR;
+  err_result = SP_ERR::NOERROR;
   Debug_printf("\nDisk Device %02x Control Code %02x", id(), cmd.control_status.fuji.command);
   Debug_printf("\nDecoding Control Data Packet:");
   SYSTEM_BUS.iwm_decode_data_packet((uint8_t *)data_buffer, data_len);
@@ -227,7 +227,7 @@ void iwmDisk::iwm_ctrl(iwm_decoded_cmd_t cmd)
     platformFuji.handle_ctl_eject(_devnum);
     break;
   default:
-    err_result = SP_ERR_BADCTL;
+    err_result = SP_ERR::BADCTL;
     break;
   }
   send_reply_packet(err_result);
@@ -288,17 +288,17 @@ void iwmDisk::iwm_readblock(iwm_decoded_cmd_t cmd)
   if (!(_disk != nullptr))
   {
     Debug_printf(" - ERROR - No image mounted");
-    send_reply_packet(SP_ERR_OFFLINE);
+    send_reply_packet(SP_ERR::OFFLINE);
     return;
   }
   if((!device_active)) {
     Debug_printf("iwm_readblock while device offline!\r\n");
-    send_reply_packet(SP_ERR_OFFLINE);
+    send_reply_packet(SP_ERR::OFFLINE);
     return;
   }
   if((switched) && (cmd.block_rw.num > 2)){
     Debug_printf("iwm_readblock() returning disk switched error\r\n");
-    send_reply_packet(SP_ERR_OFFLINE);
+    send_reply_packet(SP_ERR::OFFLINE);
     switched = false;
     return;
   }
@@ -309,19 +309,19 @@ void iwmDisk::iwm_readblock(iwm_decoded_cmd_t cmd)
   if (_disk->read(cmd.block_rw.num, &sdstato, data_buffer))
   {
     Debug_printf("\r\nFile Seek or Read err: %d bytes", sdstato);
-    send_reply_packet(SP_ERR_IOERROR);
+    send_reply_packet(SP_ERR::IOERROR);
     return; // todo - true or false?
   }
 
   // send_data_packet();
   Debug_printf("\r\nsending block packet ...");
-  if (SYSTEM_BUS.iwm_send_packet(id(), iwm_packet_type_t::data, 0, data_buffer, BLOCK_DATA_LEN))
+  if (SYSTEM_BUS.iwm_send_packet(id(), iwm_packet_type_t::data, SP_ERR::NOERROR, data_buffer, BLOCK_DATA_LEN))
    ((MediaTypePO*)_disk)->reset_seek_opto();  // force seek next time if send error
 }
 
 void iwmDisk::iwm_writeblock(iwm_decoded_cmd_t cmd)
 {
-  uint8_t status = 0;
+  spError_t err = SP_ERR::NOERROR;
 
 
   Debug_printf("\r\nDrive %02x ", id());
@@ -339,24 +339,24 @@ void iwmDisk::iwm_writeblock(iwm_decoded_cmd_t cmd)
 
       if((!device_active)) {
         Debug_printf("iwm_writeblock while device offline!\r\n");
-        send_reply_packet(SP_ERR_OFFLINE);
+        send_reply_packet(SP_ERR::OFFLINE);
         return;
       }
       if(switched && readonly) {
         Debug_printf("iwm_writeblock while readonly and disk switched\r\n");
-        send_reply_packet(SP_ERR_NOWRITE);
+        send_reply_packet(SP_ERR::NOWRITE);
         switched = false;
         return;
       }
       if(switched) {
         Debug_printf("iwm_writeblock while disk switched = true\r\nn");
-        send_reply_packet(SP_ERR_OFFLINE);
+        send_reply_packet(SP_ERR::OFFLINE);
         switched = false;
         return;
       }
       if(readonly) {
         Debug_printf("\r\niwm_writeblock tried to write while readonly = true!");
-        send_reply_packet(SP_ERR_NOWRITE);
+        send_reply_packet(SP_ERR::NOWRITE);
         return;
       }
 
@@ -367,13 +367,13 @@ void iwmDisk::iwm_writeblock(iwm_decoded_cmd_t cmd)
       {
         Debug_printf("\r\nFile Write err: %d bytes", sdstato);
         if (sdstato == 0)
-          status = 0x2B; // write protected todo: we should probably have a read-only flag that gets set and tested up top
+          err = SP_ERR::NOWRITE; // write protected todo: we should probably have a read-only flag that gets set and tested up top
         else
-          status = 0x27; // 6;
+          err = SP_ERR::IOERROR; // 6;
         //return;
       }
       //now return status code to host
-      send_reply_packet(status);
+      send_reply_packet(err);
     }
 }
 

--- a/lib/device/iwm/disk.h
+++ b/lib/device/iwm/disk.h
@@ -9,7 +9,7 @@
 class iwmDisk : public virtualDevice
 {
 private:
-    uint8_t err_result = SP_ERR_NOERROR;
+    spError_t err_result = SP_ERR::NOERROR;
     void prodos_encode_datetime(unsigned short *date_out, unsigned short *time_out);
     int prodos_write_block(fnFile *f, const unsigned char *buf);
     error_is_true prodos_write_boot_block(fnFile *f);

--- a/lib/device/iwm/iwmFuji.cpp
+++ b/lib/device/iwm/iwmFuji.cpp
@@ -83,16 +83,16 @@ iwmFuji::iwmFuji() : fujiDevice(MAX_A2DISK_DEVICES, IMAGE_EXTENSION, LOBBY_URL)
              this->fujicmd_reset();
          }},   // 0x00
 #ifdef DEV_RELAY_SLIP
-        { SP_CTRL_CLEAR_DISKII_SEEN, [this]()              { err_result = SP_ERR_NODRIVE; }},
+        { SP_CTRL_CLEAR_DISKII_SEEN, [this]()              { err_result = SP_ERR::NODRIVE; }},
 #else
-        { SP_CTRL_CLEAR_DISKII_SEEN, [this]()              { diskii_xface.d2_enable_seen = 0; err_result = SP_ERR_NOERROR; }},
+        { SP_CTRL_CLEAR_DISKII_SEEN, [this]()              { diskii_xface.d2_enable_seen = 0; err_result = SP_ERR::NOERROR; }},
 #endif
 
         { FUJICMD_MOUNT_ALL, [&]()                     {
-             err_result = fujicmd_mount_all_success() ? SP_ERR_NOERROR : SP_ERR_IOERROR;
+             err_result = fujicmd_mount_all_success() ? SP_ERR::NOERROR : SP_ERR::IOERROR;
          }},          // 0xD7
-        { FUJICMD_MOUNT_IMAGE, [&]()                   { err_result = fujicmd_mount_disk_image_success(data_buffer[0], (disk_access_flags_t) data_buffer[1]) ? SP_ERR_NOERROR : SP_ERR_NODRIVE; }},  // 0xF8
-        { FUJICMD_OPEN_DIRECTORY, [&]()                { err_result = fujicore_open_directory_success(data_buffer[0], std::string((char *) &data_buffer[1], sizeof(data_buffer) - 1)) ? SP_ERR_NOERROR : SP_ERR_IOERROR; }}     // 0xF7
+        { FUJICMD_MOUNT_IMAGE, [&]()                   { err_result = fujicmd_mount_disk_image_success(data_buffer[0], (disk_access_flags_t) data_buffer[1]) ? SP_ERR::NOERROR : SP_ERR::NODRIVE; }},  // 0xF8
+        { FUJICMD_OPEN_DIRECTORY, [&]()                { err_result = fujicore_open_directory_success(data_buffer[0], std::string((char *) &data_buffer[1], sizeof(data_buffer) - 1)) ? SP_ERR::NOERROR : SP_ERR::IOERROR; }}     // 0xF7
     };
 
     status_handlers = {
@@ -304,7 +304,7 @@ void iwmFuji::send_status_reply_packet()
         data[1] = 0; // block size 1
         data[2] = 0; // block size 2
         data[3] = 0; // block size 3
-        SYSTEM_BUS.iwm_send_packet(id(), iwm_packet_type_t::status, SP_ERR_NOERROR, data, 4);
+        SYSTEM_BUS.iwm_send_packet(id(), iwm_packet_type_t::status, SP_ERR::NOERROR, data, 4);
 }
 
 void iwmFuji::send_status_dib_reply_packet()
@@ -317,7 +317,7 @@ void iwmFuji::send_status_dib_reply_packet()
                 { SP_TYPE_BYTE_FUJINET, SP_SUBTYPE_BYTE_FUJINET },      // type, subtype
                 { 0x00, 0x01 }                                          // version.
         );
-        SYSTEM_BUS.iwm_send_packet(id(), iwm_packet_type_t::status, SP_ERR_NOERROR, data.data(), data.size());
+        SYSTEM_BUS.iwm_send_packet(id(), iwm_packet_type_t::status, SP_ERR::NOERROR, data.data(), data.size());
 }
 
 void iwmFuji::send_stat_get_enable()
@@ -352,14 +352,14 @@ void iwmFuji::iwm_status(iwm_decoded_cmd_t cmd)
         if (status_completed) return;
 
         Debug_printf("\nStatus code complete, sending response");
-        SYSTEM_BUS.iwm_send_packet(id(), iwm_packet_type_t::data, 0, data_buffer, data_len);
+        SYSTEM_BUS.iwm_send_packet(id(), iwm_packet_type_t::data, SP_ERR::NOERROR, data_buffer, data_len);
 }
 
 void iwmFuji::iwm_ctrl(iwm_decoded_cmd_t cmd)
 {
         Debug_printf("\ntheFuji Device %02x Control Code %02x", id(), cmd.control_status.fuji.command);
 
-        err_result = SP_ERR_NOERROR;
+        err_result = SP_ERR::NOERROR;
         data_len = 512;
 
         Debug_printf("\nDecoding Control Data Packet for code: 0x%02x\r\n", cmd.control_status.fuji.command);
@@ -371,7 +371,7 @@ void iwmFuji::iwm_ctrl(iwm_decoded_cmd_t cmd)
         it->second();
     } else {
                 Debug_printf("ERROR: Unhandled control code: %02X\n", cmd.control_status.fuji.command);
-        err_result = SP_ERR_BADCTL;
+        err_result = SP_ERR::BADCTL;
     }
 
         send_reply_packet(err_result);

--- a/lib/device/iwm/iwmFuji.h
+++ b/lib/device/iwm/iwmFuji.h
@@ -116,7 +116,7 @@ protected:
     void send_extended_status_dib_reply_packet() override {};
 
 public:
-    uint8_t err_result = SP_ERR_NOERROR;
+    spError_t err_result = SP_ERR::NOERROR;
     bool status_completed = false;
     fujiCommandID_t active_fuji_command;
 

--- a/lib/device/iwm/modem.cpp
+++ b/lib/device/iwm/modem.cpp
@@ -1357,7 +1357,7 @@ void iwmModem::send_status_reply_packet()
     data[1] = 0; // block size 1
     data[2] = 0; // block size 2
     data[3] = 0; // block size 3
-    SYSTEM_BUS.iwm_send_packet(id(), iwm_packet_type_t::status, SP_ERR_NOERROR, data, 4);
+    SYSTEM_BUS.iwm_send_packet(id(), iwm_packet_type_t::status, SP_ERR::NOERROR, data, 4);
 }
 
 void iwmModem::send_status_dib_reply_packet()
@@ -1370,13 +1370,13 @@ void iwmModem::send_status_dib_reply_packet()
 		{ SP_TYPE_BYTE_FUJINET_MODEM, SP_SUBTYPE_BYTE_FUJINET_MODEM },  // type, subtype
 		{ 0x00, 0x01 }                                                  // version.
 	);
-	SYSTEM_BUS.iwm_send_packet(id(), iwm_packet_type_t::status, SP_ERR_NOERROR, data.data(), data.size());
+	SYSTEM_BUS.iwm_send_packet(id(), iwm_packet_type_t::status, SP_ERR::NOERROR, data.data(), data.size());
 }
 
 void iwmModem::iwm_open(iwm_decoded_cmd_t cmd)
 {
     Debug_printf("\nModem: Open\n");
-    send_reply_packet(SP_ERR_NOERROR);
+    send_reply_packet(SP_ERR::NOERROR);
 }
 
 void iwmModem::iwm_close(iwm_decoded_cmd_t cmd)
@@ -1389,7 +1389,7 @@ void iwmModem::iwm_close(iwm_decoded_cmd_t cmd)
         tcpClient.stop();
     }
     
-    send_reply_packet(SP_ERR_NOERROR);
+    send_reply_packet(SP_ERR::NOERROR);
 }
 
 void iwmModem::iwm_read(iwm_decoded_cmd_t cmd)
@@ -1430,7 +1430,7 @@ void iwmModem::iwm_read(iwm_decoded_cmd_t cmd)
     }
 
     Debug_printf("\r\nsending Modem read data packet ...");
-    SYSTEM_BUS.iwm_send_packet(id(), iwm_packet_type_t::data, 0, data_buffer, data_len);
+    SYSTEM_BUS.iwm_send_packet(id(), iwm_packet_type_t::data, SP_ERR::NOERROR, data_buffer, data_len);
     data_len = 0;
     memset(data_buffer, 0, sizeof(data_buffer));
 }
@@ -1452,23 +1452,16 @@ void iwmModem::iwm_write(iwm_decoded_cmd_t cmd)
 #endif
     }
 
-    send_reply_packet(SP_ERR_NOERROR);
+    send_reply_packet(SP_ERR::NOERROR);
 }
 
 void iwmModem::iwm_ctrl(iwm_decoded_cmd_t cmd)
 {
-    uint8_t err_result = SP_ERR_NOERROR;
+    spError_t err_result = SP_ERR::NOERROR;
 
     Debug_printf("\r\nModem Device %02x Control Code %02x", id(), cmd.control_status.fuji.command);
     SYSTEM_BUS.iwm_decode_data_packet(data_buffer, data_len);
     print_packet(data_buffer,data_len);
-
-    // if (data_len > 0)
-    //     switch (control_code)
-    //     {
-    //     }
-    // else
-    //     err_result = SP_ERR_IOERROR;
 
     Debug_printf("\nSending Control Reply");
     send_reply_packet(err_result);
@@ -1512,12 +1505,12 @@ void iwmModem::iwm_status(iwm_decoded_cmd_t cmd)
         iwm_modem_status();
         break;
     default:
-        send_reply_packet(SP_ERR_BADCMD);
+        send_reply_packet(SP_ERR::BADCMD);
         return;
     }
 
     Debug_printf("\r\nStatus code complete, sending response");
-    SYSTEM_BUS.iwm_send_packet(id(), iwm_packet_type_t::data, 0, data_buffer, data_len);
+    SYSTEM_BUS.iwm_send_packet(id(), iwm_packet_type_t::data, SP_ERR::NOERROR, data_buffer, data_len);
 }
 
 void iwmModem::process(iwm_decoded_cmd_t cmd)

--- a/lib/device/iwm/network.cpp
+++ b/lib/device/iwm/network.cpp
@@ -53,7 +53,7 @@ void iwmNetwork::send_status_reply_packet()
     data[1] = 0; // block size 1
     data[2] = 0; // block size 2
     data[3] = 0; // block size 3
-    SYSTEM_BUS.iwm_send_packet(id(), iwm_packet_type_t::status, SP_ERR_NOERROR, data, 4);
+    SYSTEM_BUS.iwm_send_packet(id(), iwm_packet_type_t::status, SP_ERR::NOERROR, data, 4);
 }
 
 void iwmNetwork::send_status_dib_reply_packet()
@@ -66,7 +66,7 @@ void iwmNetwork::send_status_dib_reply_packet()
         { SP_TYPE_BYTE_FUJINET_NETWORK, SP_SUBTYPE_BYTE_FUJINET_NETWORK },  // type, subtype
         { 0x00, 0x01 }                                                      // version.
     );
-    SYSTEM_BUS.iwm_send_packet(id(), iwm_packet_type_t::status, SP_ERR_NOERROR, data.data(), data.size());
+    SYSTEM_BUS.iwm_send_packet(id(), iwm_packet_type_t::status, SP_ERR::NOERROR, data.data(), data.size());
 }
 
 /**
@@ -102,7 +102,7 @@ void iwmNetwork::open()
         current_network_data.urlParser.reset();
     }
 
-    err = SP_ERR_NOERROR;
+    err = SP_ERR::NOERROR;
 
     Debug_printf("\nopen()\n");
 
@@ -134,7 +134,7 @@ void iwmNetwork::open()
 void iwmNetwork::close()
 {
     Debug_printf("iwmNetwork::close()\n");
-    err = SP_ERR_NOERROR;
+    err = SP_ERR::NOERROR;
     if (network_data_map.find(current_network_unit) == network_data_map.end()) {
         Debug_printf("No network_data for unit: %d, exiting close\r\n", current_network_unit);
         return;
@@ -280,13 +280,13 @@ void iwmNetwork::json_parse()
 void iwmNetwork::iwm_open(iwm_decoded_cmd_t cmd)
 {
     // nothing in fujinet-lib calls this, it does a control with open command. This is used only by the Apple/// as it has no fn-lib support yet
-    send_reply_packet(SP_ERR_NOERROR);
+    send_reply_packet(SP_ERR::NOERROR);
 }
 
 void iwmNetwork::iwm_close(iwm_decoded_cmd_t cmd)
 {
     // nothing in fujinet-lib calls this, it does a control with close command. This is used only by the Apple/// as it has no fn-lib support yet
-    send_reply_packet(SP_ERR_NOERROR);
+    send_reply_packet(SP_ERR::NOERROR);
     close();
 }
 
@@ -302,16 +302,16 @@ void iwmNetwork::status()
     case CHANNEL_MODE::PROTOCOL:
         if (!current_network_data.protocol) {
             Debug_printf("ERROR: Calling status on a null protocol.\r\n");
-            err = SP_ERR_BADCMD;
+            err = SP_ERR::BADCMD;
             s.error = NDEV_STATUS::INVALID_COMMAND;
         } else {
             err = current_network_data.protocol->status(&s) == FUJI_ERROR::NONE
-                ? SP_ERR_NOERROR : SP_ERR_BADCMD;
+                ? SP_ERR::NOERROR : SP_ERR::BADCMD;
             avail = current_network_data.protocol->available();
         }
         break;
     case CHANNEL_MODE::JSON:
-        err = (current_network_data.json->status(&s) == false) ? SP_ERR_NOERROR : SP_ERR_IOERROR;
+        err = (current_network_data.json->status(&s) == false) ? SP_ERR::NOERROR : SP_ERR::IOERROR;
         avail = current_network_data.json->available();
         break;
     }
@@ -363,13 +363,13 @@ void iwmNetwork::iwm_status(iwm_decoded_cmd_t cmd)
         status();
         break;
     default:
-        send_reply_packet(SP_ERR_BADCMD);
+        send_reply_packet(SP_ERR::BADCMD);
         return;
     }
 
     Debug_printf("\r\nStatus code complete, sending response");
     //send_data_packet(data_len);
-    SYSTEM_BUS.iwm_send_packet(id(), iwm_packet_type_t::data, 0, data_buffer, data_len);
+    SYSTEM_BUS.iwm_send_packet(id(), iwm_packet_type_t::data, SP_ERR::NOERROR, data_buffer, data_len);
     data_len = 0;
     memset(data_buffer, 0, sizeof(data_buffer));
 }
@@ -434,7 +434,7 @@ bool iwmNetwork::read_channel(unsigned short num_bytes, iwm_decoded_cmd_t cmd)
 
     if (current_network_data.protocol->read(data_len) != FUJI_ERROR::NONE) // protocol adapter returned error
     {
-        err = current_network_data.protocol->error == NDEV_STATUS::SUCCESS ? SP_ERR_NOERROR : SP_ERR_BADCMD;
+        err = current_network_data.protocol->error == NDEV_STATUS::SUCCESS ? SP_ERR::NOERROR : SP_ERR::BADCMD;
         return true;
     }
     else // everything ok
@@ -495,7 +495,7 @@ void iwmNetwork::iwm_read(iwm_decoded_cmd_t cmd)
     else
     {
         Debug_printf("\r\nsending Network read data packet (%04x bytes)...", data_len);
-        SYSTEM_BUS.iwm_send_packet(id(), iwm_packet_type_t::data, 0, data_buffer, data_len);
+        SYSTEM_BUS.iwm_send_packet(id(), iwm_packet_type_t::data, SP_ERR::NOERROR, data_buffer, data_len);
         data_len = 0;
         memset(data_buffer, 0, sizeof(data_buffer));
     }
@@ -534,11 +534,11 @@ void iwmNetwork::iwm_write(iwm_decoded_cmd_t cmd)
         current_network_data.transmitBuffer += string((char *)data_buffer, cmd.char_rw.length);
         if (write_channel(cmd.char_rw.length))
         {
-            send_reply_packet(SP_ERR_IOERROR);
+            send_reply_packet(SP_ERR::IOERROR);
         }
         else
         {
-            send_reply_packet(SP_ERR_NOERROR);
+            send_reply_packet(SP_ERR::NOERROR);
         }
     }
 
@@ -548,7 +548,7 @@ void iwmNetwork::iwm_write(iwm_decoded_cmd_t cmd)
 
 void iwmNetwork::iwm_ctrl(iwm_decoded_cmd_t cmd)
 {
-    uint8_t err_result = SP_ERR_NOERROR;
+    spError_t err_result = SP_ERR::NOERROR;
 
     // TODO: remove this in the future when we decide to drop support of the deprecated fujinet-lib (with unit-id support)
     // We have moved to a separate control command that sets the active channel for all subsequent commands
@@ -637,12 +637,12 @@ void iwmNetwork::iwm_ctrl(iwm_decoded_cmd_t cmd)
         break;
 
     default:
-        err = SP_ERR_IOERROR;
+        err = SP_ERR::IOERROR;
         break;
     }
 
-    if (err != 0)
-        err_result = SP_ERR_IOERROR;
+    if (err != SP_ERR::NOERROR)
+        err_result = SP_ERR::IOERROR;
 
     send_reply_packet(err_result);
 
@@ -735,7 +735,7 @@ void iwmNetwork::parse_and_instantiate_protocol(string d)
     if (!current_network_data.urlParser->isValidUrl())
     {
         Debug_printf("Invalid devicespec: %s\n", current_network_data.deviceSpec.c_str());
-        err = SP_ERR_BADCTLPARM;
+        err = SP_ERR::BADCTLPARM;
         return;
     }
 
@@ -747,7 +747,7 @@ void iwmNetwork::parse_and_instantiate_protocol(string d)
     if (!instantiate_protocol())
     {
         Debug_printf("Could not open protocol. spec: >%s<, url: >%s<\n", current_network_data.deviceSpec.c_str(), current_network_data.urlParser->mRawUrl.c_str());
-        err = SP_ERR_BADCMD;
+        err = SP_ERR::BADCMD;
         return;
     }
 }
@@ -775,7 +775,7 @@ void iwmNetwork::process_fs(fujiCommandID_t fuji_command)
     NetworkProtocolFS *fs = dynamic_cast<NetworkProtocolFS *>(current_network_data.protocol.get());
     if (!fs)
     {
-        err = SP_ERR_IOERROR;
+        err = SP_ERR::IOERROR;
         return;
     }
 
@@ -807,7 +807,7 @@ void iwmNetwork::process_fs(fujiCommandID_t fuji_command)
     }
 
     if (cmd_err != FUJI_ERROR::NONE)
-        err = SP_ERR_IOERROR;
+        err = SP_ERR::IOERROR;
 }
 
 void iwmNetwork::process_tcp(fujiCommandID_t fuji_command)
@@ -817,7 +817,7 @@ void iwmNetwork::process_tcp(fujiCommandID_t fuji_command)
     NetworkProtocolTCP *tcp = dynamic_cast<NetworkProtocolTCP *>(current_network_data.protocol.get());
     if (!tcp)
     {
-        err = SP_ERR_IOERROR;
+        err = SP_ERR::IOERROR;
         return;
     }
 
@@ -836,7 +836,7 @@ void iwmNetwork::process_tcp(fujiCommandID_t fuji_command)
     }
 
     if (cmd_err != FUJI_ERROR::NONE)
-        err = SP_ERR_IOERROR;
+        err = SP_ERR::IOERROR;
 }
 
 void iwmNetwork::process_http(fujiCommandID_t fuji_command)
@@ -846,7 +846,7 @@ void iwmNetwork::process_http(fujiCommandID_t fuji_command)
     NetworkProtocolHTTP *http = dynamic_cast<NetworkProtocolHTTP *>(current_network_data.protocol.get());
     if (!http)
     {
-        err = SP_ERR_IOERROR;
+        err = SP_ERR::IOERROR;
         return;
     }
 
@@ -862,7 +862,7 @@ void iwmNetwork::process_http(fujiCommandID_t fuji_command)
     }
 
     if (cmd_err != FUJI_ERROR::NONE)
-        err = SP_ERR_IOERROR;
+        err = SP_ERR::IOERROR;
 }
 
 void iwmNetwork::process_udp(fujiCommandID_t fuji_command)
@@ -872,7 +872,7 @@ void iwmNetwork::process_udp(fujiCommandID_t fuji_command)
     NetworkProtocolUDP *udp = dynamic_cast<NetworkProtocolUDP *>(current_network_data.protocol.get());
     if (!udp)
     {
-        err = SP_ERR_IOERROR;
+        err = SP_ERR::IOERROR;
         return;
     }
 
@@ -882,7 +882,7 @@ void iwmNetwork::process_udp(fujiCommandID_t fuji_command)
 #ifndef ESP_PLATFORM
     case NETCMD_GET_REMOTE:
         cmd_err = udp->get_remote(data_buffer, SPECIAL_BUFFER_SIZE);
-        SYSTEM_BUS.iwm_send_packet(id(), iwm_packet_type_t::data, 0,
+        SYSTEM_BUS.iwm_send_packet(id(), iwm_packet_type_t::data, SP_ERR::NOERROR,
                                    data_buffer, SPECIAL_BUFFER_SIZE);
         break;
 #endif /* ESP_PLATFORM */
@@ -890,11 +890,11 @@ void iwmNetwork::process_udp(fujiCommandID_t fuji_command)
         {
             cmd_err = udp->set_destination(data_buffer, data_len);
             if (cmd_err != FUJI_ERROR::NONE)
-                err = SP_ERR_IOERROR;
+                err = SP_ERR::IOERROR;
         }
         break;
     default:
-        err = SP_ERR_IOERROR;
+        err = SP_ERR::IOERROR;
         break;
     }
 }

--- a/lib/device/iwm/network.h
+++ b/lib/device/iwm/network.h
@@ -157,7 +157,7 @@ private:
     /**
      * SP_ERR number when there's an ... error!
      */
-    uint8_t err = SP_ERR_NOERROR;
+    spError_t err = SP_ERR::NOERROR;
 
     /**
      * ESP timer handle for the Interrupt rate limiting timer

--- a/lib/device/iwm/printer.cpp
+++ b/lib/device/iwm/printer.cpp
@@ -28,7 +28,7 @@ void iwmPrinter::send_status_reply_packet()
     data[0] = 0b01110000;
     data[1] = data[2] = data[3] = 0;
 
-    SYSTEM_BUS.iwm_send_packet(id(), iwm_packet_type_t::ext_status, SP_ERR_NOERROR, data, 4);
+    SYSTEM_BUS.iwm_send_packet(id(), iwm_packet_type_t::ext_status, SP_ERR::NOERROR, data, 4);
 }
 
 void iwmPrinter::send_extended_status_reply_packet()
@@ -38,7 +38,7 @@ void iwmPrinter::send_extended_status_reply_packet()
     data[0] = 0b01110000;
     data[1] = data[2] = data[3] = data[4] = 0;
 
-    SYSTEM_BUS.iwm_send_packet(id(), iwm_packet_type_t::ext_status, SP_ERR_NOERROR, data, 5);
+    SYSTEM_BUS.iwm_send_packet(id(), iwm_packet_type_t::ext_status, SP_ERR::NOERROR, data, 5);
 }
 
 void iwmPrinter::send_status_dib_reply_packet()
@@ -51,7 +51,7 @@ void iwmPrinter::send_status_dib_reply_packet()
         { SP_TYPE_BYTE_FUJINET_PRINTER, SP_SUBTYPE_BYTE_FUJINET_PRINTER },  // type, subtype
         { 0x00, 0x01 }                                                      // version.
     );
-    SYSTEM_BUS.iwm_send_packet(id(), iwm_packet_type_t::status, SP_ERR_NOERROR, data.data(), data.size());
+    SYSTEM_BUS.iwm_send_packet(id(), iwm_packet_type_t::status, SP_ERR::NOERROR, data.data(), data.size());
 }
 
 void iwmPrinter::send_extended_status_dib_reply_packet()
@@ -71,7 +71,7 @@ void iwmPrinter::iwm_status(iwm_decoded_cmd_t cmd)
         send_status_dib_reply_packet();
         break;
     default:
-      send_reply_packet(SP_ERR_BADCMD);
+      send_reply_packet(SP_ERR::BADCMD);
       break;
     }
 }
@@ -79,13 +79,13 @@ void iwmPrinter::iwm_status(iwm_decoded_cmd_t cmd)
 void iwmPrinter::iwm_open(iwm_decoded_cmd_t cmd)
 {
     Debug_printf("\nPrinter: Open\n");
-    send_reply_packet(SP_ERR_NOERROR);
+    send_reply_packet(SP_ERR::NOERROR);
 }
 
 void iwmPrinter::iwm_close(iwm_decoded_cmd_t cmd)
 {
     Debug_printf("\nPrinter: Close\n");
-    send_reply_packet(SP_ERR_NOERROR);
+    send_reply_packet(SP_ERR::NOERROR);
 }
 
 void iwmPrinter::iwm_write(iwm_decoded_cmd_t cmd)
@@ -112,7 +112,7 @@ void iwmPrinter::iwm_write(iwm_decoded_cmd_t cmd)
     }
 
     _last_ms = fnSystem.millis();
-    send_reply_packet(SP_ERR_NOERROR);
+    send_reply_packet(SP_ERR::NOERROR);
 }
 
 /**


### PR DESCRIPTION
Changed `spError_t` to an `enum class` so the compiler would enforce that the correct error types were being used in the right places.