### PR TITLE
[adam] migrate ADAM media/disk I/O to fnFile (TNFS-capable on PC)

### DIFF
--- a/lib/FileSystem/fnio.h
+++ b/lib/FileSystem/fnio.h
@@ -3,8 +3,9 @@
 
 #include <cstddef>
 
-#if defined(BUILD_ATARI) || defined(BUILD_APPLE) || defined(BUILD_COCO) || defined(BUILD_RS232)
+#if defined(BUILD_ATARI) || defined(BUILD_APPLE) || defined(BUILD_COCO) || defined(BUILD_RS232) || (defined(BUILD_ADAM) && !defined(ESP_PLATFORM))
   // ATARI and APPLE was already ported to use fnio
+  // ADAM uses fnio on PC only (TNFS needs FileHandler); ESP ADAM keeps stdio.
   // set FNIO_IS_STDIO to force stdio
 
   // for testing/debugging, it is possible to switch to stdio

--- a/lib/device/adamnet/adamFuji.cpp
+++ b/lib/device/adamnet/adamFuji.cpp
@@ -13,6 +13,7 @@
 #include "fnConfig.h"
 #include "fnWiFi.h"
 #include "fsFlash.h"
+#include "fnio.h"
 #include "led.h"
 
 #include "utils.h"
@@ -139,13 +140,13 @@ void adamFuji::adamnet_new_disk()
     disk.access_mode = DISK_ACCESS_MODE_WRITE;
     strlcpy(disk.filename, (const char *)p, 256);
 
-    disk.fileh = host.file_open(disk.filename, disk.filename, sizeof(disk.filename), "w");
+    disk.fileh = host.fnfile_open(disk.filename, disk.filename, sizeof(disk.filename), "w");
 
     Debug_printf("Creating file %s on host slot %u mounting in disk slot %u numblocks: %lu\n", disk.filename, hs, ds, numBlocks);
 
     disk.disk_dev.write_blank(disk.fileh, numBlocks);
 
-    fclose(disk.fileh);
+    fnio::fclose(disk.fileh);
 
     new_disk_completed = true;
 }
@@ -155,17 +156,17 @@ void adamFuji::insert_boot_device(uint8_t d)
 {
     const char *config_atr = "/autorun.ddp";
     const char *mount_all_atr = "/mount-and-boot.ddp";
-    FILE *fBoot;
+    fnFile *fBoot;
 
     switch (d)
     {
     case 0:
-        fBoot = fsFlash.file_open(config_atr);
+        fBoot = fsFlash.fnfile_open(config_atr);
         _fnDisks[0].disk_dev.mount(fBoot, config_atr, 262144, DISK_ACCESS_MODE_READ, MEDIATYPE_DDP);
         break;
     case 1:
 
-        fBoot = fsFlash.file_open(mount_all_atr);
+        fBoot = fsFlash.fnfile_open(mount_all_atr);
         _fnDisks[0].disk_dev.mount(fBoot, mount_all_atr, 262144, DISK_ACCESS_MODE_READ, MEDIATYPE_DDP);
         break;
     }
@@ -272,13 +273,13 @@ void adamFuji::setup()
         Debug_printf("Config General Boot Mode: %u\n", Config.get_general_boot_mode());
         if (Config.get_general_boot_mode() == 0)
         {
-            FILE *f = fsFlash.file_open("/autorun.ddp");
+            fnFile *f = fsFlash.fnfile_open("/autorun.ddp");
             _fnDisks[0].disk_dev.mount(f, "/autorun.ddp", 262144, DISK_ACCESS_MODE_READ, MEDIATYPE_DDP);
             _fnDisks[0].disk_dev.is_config_device = true;
         }
         else
         {
-            FILE *f = fsFlash.file_open("/mount-and-boot.ddp");
+            fnFile *f = fsFlash.fnfile_open("/mount-and-boot.ddp");
             _fnDisks[0].disk_dev.mount(f, "/mount-and-boot.ddp", 262144, DISK_ACCESS_MODE_READ, MEDIATYPE_DDP);
         }
     }

--- a/lib/device/adamnet/disk.cpp
+++ b/lib/device/adamnet/disk.cpp
@@ -40,7 +40,7 @@ void adamDisk::reset()
     }
 }
 
-mediatype_t adamDisk::mount(FILE *f, const char *filename, uint32_t disksize,
+mediatype_t adamDisk::mount(fnFile *f, const char *filename, uint32_t disksize,
                             disk_access_flags_t access_mode, mediatype_t disk_type)
 {
     mediatype_t mt = MEDIATYPE_UNKNOWN;
@@ -96,7 +96,7 @@ void adamDisk::unmount()
     }
 }
 
-error_is_true adamDisk::write_blank(FILE *fileh, uint32_t numBlocks)
+error_is_true adamDisk::write_blank(fnFile *fileh, uint32_t numBlocks)
 {
     uint8_t buf[256];
 
@@ -104,10 +104,10 @@ error_is_true adamDisk::write_blank(FILE *fileh, uint32_t numBlocks)
     {
         memset(buf, 0xE5, 256);
 
-        fwrite(buf, 1, 256, fileh);
-        fwrite(buf, 1, 256, fileh);
-        fwrite(buf, 1, 256, fileh);
-        fwrite(buf, 1, 256, fileh);
+        fnio::fwrite(buf, 1, 256, fileh);
+        fnio::fwrite(buf, 1, 256, fileh);
+        fnio::fwrite(buf, 1, 256, fileh);
+        fnio::fwrite(buf, 1, 256, fileh);
     }
 
     RETURN_SUCCESS_AS_FALSE();

--- a/lib/device/adamnet/disk.h
+++ b/lib/device/adamnet/disk.h
@@ -36,11 +36,11 @@ private:
 
 public:
     adamDisk();
-    mediatype_t mount(FILE *f, const char *filename, uint32_t disksize,
+    mediatype_t mount(fnFile *f, const char *filename, uint32_t disksize,
                       disk_access_flags_t access_mode,
                       mediatype_t disk_type = MEDIATYPE_UNKNOWN);
     void unmount();
-    error_is_true write_blank(FILE *f, uint32_t numBlocks);
+    error_is_true write_blank(fnFile *f, uint32_t numBlocks);
     virtual void reset() override;
     MediaType *get_media() { return  _media; }
     void set_media(MediaType *__media) { _media = __media; }

--- a/lib/device/adamnet/network.cpp
+++ b/lib/device/adamnet/network.cpp
@@ -1004,10 +1004,14 @@ void adamNetwork::process_udp(fujiCommandID_t cmd)
     {
 #ifndef ESP_PLATFORM
     case NETCMD_GET_REMOTE:
+    {
         receiveBuffer->resize(SPECIAL_BUFFER_SIZE);
         cmd_err = udp->get_remote(receiveBuffer->data(), receiveBuffer->size());
-        response += *receiveBuffer;
+        size_t n = receiveBuffer->size() < sizeof(response) ? receiveBuffer->size() : sizeof(response);
+        memcpy(response, receiveBuffer->data(), n);
+        response_len = n;
         break;
+    }
 #endif /* ESP_PLATFORM */
     case NETCMD_SET_DESTINATION:
         {

--- a/lib/media/adam/mediaType.cpp
+++ b/lib/media/adam/mediaType.cpp
@@ -30,7 +30,7 @@ void MediaType::unmount()
 {
     if (_media_fileh != nullptr)
     {
-        fclose(_media_fileh);
+        fnio::fclose(_media_fileh);
         _media_fileh = nullptr;
     }
 }

--- a/lib/media/adam/mediaType.h
+++ b/lib/media/adam/mediaType.h
@@ -3,6 +3,7 @@
 
 #include <stdio.h>
 #include <fujiHost.h>
+#include "fnio.h"
 
 #define INVALID_SECTOR_VALUE 0xFFFFFFFF
 
@@ -26,9 +27,9 @@ enum mediatype_t
 class MediaType
 {
 protected:
-    FILE *_media_fileh = nullptr;
-    FILE *oldFileh = nullptr;
-    FILE *hsFileh = nullptr;
+    fnFile *_media_fileh = nullptr;
+    fnFile *oldFileh = nullptr;
+    fnFile *hsFileh = nullptr;
 
     uint32_t _media_image_size = 0;
     uint32_t _media_num_blocks = 256;
@@ -58,12 +59,12 @@ public:
     uint8_t _media_controller_status = DISK_CTRL_STATUS_CLEAR;
 
     fujiHost *_media_host = nullptr;
-    FILE *_media_hsfileh = nullptr;
+    fnFile *_media_hsfileh = nullptr;
 
     mediatype_t _mediatype = MEDIATYPE_UNKNOWN;
     bool _allow_hsio = true;
 
-    virtual mediatype_t mount(FILE *f, uint32_t disksize) = 0;
+    virtual mediatype_t mount(fnFile *f, uint32_t disksize) = 0;
     virtual void unmount();
 
     // Returns TRUE if an error condition occurred

--- a/lib/media/adam/mediaTypeDDP.cpp
+++ b/lib/media/adam/mediaTypeDDP.cpp
@@ -27,6 +27,12 @@ error_is_true MediaTypeDDP::read(uint32_t blockNum, uint16_t *readcount)
 
     Debug_print("DDP READ\r\n");
 
+    if (_media_fileh == nullptr)
+    {
+        _media_controller_status = 2;
+        RETURN_ERROR_AS_TRUE();
+    }
+
     // Return an error if we're trying to read beyond the end of the disk
     if (blockNum > _media_num_blocks-1)
     {
@@ -42,12 +48,12 @@ error_is_true MediaTypeDDP::read(uint32_t blockNum, uint16_t *readcount)
     // if (blockNum != _media_last_block + 1)
     // {
         uint32_t offset = _block_to_offset(blockNum);
-        err = fseek(_media_fileh, offset, SEEK_SET) != 0;
+        err = fnio::fseek(_media_fileh, offset, SEEK_SET) != 0;
         _media_last_block = INVALID_SECTOR_VALUE;
     // }
 
     if (err == false)
-        err = fread(_media_blockbuff, 1, 1024, _media_fileh) != 1024;
+        err = fnio::fread(_media_blockbuff, 1, 1024, _media_fileh) != 1024;
 
     if (err == false)
     {
@@ -74,13 +80,17 @@ error_is_true MediaTypeDDP::write(uint32_t blockNum, bool verify)
 
     _media_last_block = INVALID_SECTOR_VALUE;
 
+#ifdef FNIO_IS_STDIO
     bool hs_mode = (_media_fileh->_flags == 0x1484);
+#else
+    bool hs_mode = false; // FileHandler (PC) doesn't expose stdio flags
+#endif
     if (hs_mode)
     {
         Debug_printf("High score mode activated, attempting write open\r\n");
 
         oldFileh = _media_fileh;
-        hsFileh = fsFlash.file_open(_disk_filename, "r+");
+        hsFileh = fsFlash.fnfile_open(_disk_filename, "r+");
         if (hsFileh == nullptr)
         {
             Debug_printf("HS write open failed for %s; leaving read-only\r\n", _disk_filename);
@@ -95,40 +105,40 @@ error_is_true MediaTypeDDP::write(uint32_t blockNum, bool verify)
     int e;
 //    if (blockNum != _media_last_block + 1)
 //    {
-        e = fseek(_media_fileh, offset, SEEK_SET);
+        e = fnio::fseek(_media_fileh, offset, SEEK_SET);
         if (e != 0)
         {
             Debug_printf("::write seek error %d\r\n", e);
             _media_controller_status=2;
-            if (hs_mode) { fclose(hsFileh); _media_fileh = oldFileh; }
+            if (hs_mode) { fnio::fclose(hsFileh); _media_fileh = oldFileh; }
             RETURN_ERROR_AS_TRUE();
         }
 //    }
     // Write the data
-    e = fwrite(&_media_blockbuff[0], 1, 256, _media_fileh);
-    e += fwrite(&_media_blockbuff[256], 1, 256, _media_fileh);
-    e += fwrite(&_media_blockbuff[512], 1, 256, _media_fileh);
-    e += fwrite(&_media_blockbuff[768], 1, 256, _media_fileh);
+    e = fnio::fwrite(&_media_blockbuff[0], 1, 256, _media_fileh);
+    e += fnio::fwrite(&_media_blockbuff[256], 1, 256, _media_fileh);
+    e += fnio::fwrite(&_media_blockbuff[512], 1, 256, _media_fileh);
+    e += fnio::fwrite(&_media_blockbuff[768], 1, 256, _media_fileh);
 
     if (e != 1024)
     {
         Debug_printf("::write error %d, %d\r\n", e, errno);
-        if (hs_mode) { fclose(hsFileh); _media_fileh = oldFileh; }
+        if (hs_mode) { fnio::fclose(hsFileh); _media_fileh = oldFileh; }
         RETURN_ERROR_AS_TRUE();
     }
 
-    int ret = fflush(_media_fileh);    // This doesn't seem to be connected to anything in ESP-IDF VF, so it may not do anything
-    ret = fsync(fileno(_media_fileh)); // Since we might get reset at any moment, go ahead and sync the file (not clear if fflush does this)
+    int ret = fnio::fflush(_media_fileh);
+#ifdef FNIO_IS_STDIO
+    ret = fsync(fileno(_media_fileh)); // sync now in case we get reset at any moment
+#endif
     Debug_printf("DDP::write fsync:%d\r\n", ret);
-
-    Debug_printv("media flags %x\n",_media_fileh->_flags);
 
     if (hs_mode)
     {
         Debug_printf("Closing high score sector.\r\n");
 
         if (hsFileh != nullptr)
-            fclose(hsFileh);
+            fnio::fclose(hsFileh);
 
         _media_fileh = oldFileh;
         _media_last_block = INVALID_SECTOR_VALUE; // force a cache invalidate.
@@ -152,20 +162,27 @@ error_is_true MediaTypeDDP::format(uint16_t *responsesize)
     RETURN_ERROR_AS_TRUE();
 }
 
-mediatype_t MediaTypeDDP::mount(FILE *f, uint32_t disksize)
+mediatype_t MediaTypeDDP::mount(fnFile *f, uint32_t disksize)
 {
     Debug_print("DDP MOUNT\r\n");
+
+    // f can be NULL (e.g. /autorun.ddp absent on PC); don't dereference it.
+    if (f == nullptr)
+    {
+        Debug_printf("DDP MOUNT failed: null file handle\r\n");
+        _media_fileh = nullptr;
+        return MEDIATYPE_UNKNOWN;
+    }
 
     _media_fileh = f;
     _mediatype = MEDIATYPE_DDP;
     _media_num_blocks = disksize / 1024;
 
-    Debug_printv("FLAGS: %x\n",_media_fileh->_flags);
     return _mediatype;
 }
 
 // Returns FALSE on error
-success_is_true MediaTypeDDP::create(FILE *f, uint32_t numBlocks)
+success_is_true MediaTypeDDP::create(fnFile *f, uint32_t numBlocks)
 {
     Debug_print("DDP CREATE\r\n");
 

--- a/lib/media/adam/mediaTypeDDP.h
+++ b/lib/media/adam/mediaTypeDDP.h
@@ -16,11 +16,11 @@ public:
 
     error_is_true format(uint16_t *responsesize) override;
 
-    mediatype_t mount(FILE *f, uint32_t disksize) override;
+    mediatype_t mount(fnFile *f, uint32_t disksize) override;
 
     uint8_t status() override;
 
-    static success_is_true create(FILE *f, uint32_t numBlock);
+    static success_is_true create(fnFile *f, uint32_t numBlock);
 };
 
 

--- a/lib/media/adam/mediaTypeDSK.cpp
+++ b/lib/media/adam/mediaTypeDSK.cpp
@@ -50,17 +50,17 @@ error_is_true MediaTypeDSK::read(uint32_t blockNum, uint16_t *readcount)
 
     // Read lower part of block
     std::pair<uint32_t, uint32_t> offsets = _block_to_offsets(blockNum);
-    err = fseek(_media_fileh, offsets.first, SEEK_SET) != 0;
+    err = fnio::fseek(_media_fileh, offsets.first, SEEK_SET) != 0;
 
     if (err == false)
-        err = fread(_media_blockbuff, 1, 512, _media_fileh) != 512;
+        err = fnio::fread(_media_blockbuff, 1, 512, _media_fileh) != 512;
 
     // Read upper part of block
     if (err == false)
-        err = fseek(_media_fileh, offsets.second, SEEK_SET) != 0;
+        err = fnio::fseek(_media_fileh, offsets.second, SEEK_SET) != 0;
 
     if (err == false)
-        err = fread(&_media_blockbuff[512], 1, 512, _media_fileh) != 512;
+        err = fnio::fread(&_media_blockbuff[512], 1, 512, _media_fileh) != 512;
 
     if (err == false)
         _media_last_block = blockNum;
@@ -92,13 +92,17 @@ error_is_true MediaTypeDSK::write(uint32_t blockNum, bool verify)
     // game saving a high score) reopen it read/write on the flash filesystem
     // where those images live. (_media_host was never wired up, so the old
     // reopen via it dereferenced null.)
+#ifdef FNIO_IS_STDIO
     bool hs_mode = (_media_fileh->_flags == 0x1484);
+#else
+    bool hs_mode = false; // FileHandler (PC) doesn't expose stdio flags
+#endif
     if (hs_mode)
     {
         Debug_printf("High score mode activated, attempting write open\r\n");
 
         oldFileh = _media_fileh;
-        hsFileh = fsFlash.file_open(_disk_filename, "r+");
+        hsFileh = fsFlash.fnfile_open(_disk_filename, "r+");
         if (hsFileh == nullptr)
         {
             Debug_printf("HS write open failed for %s; leaving read-only\r\n", _disk_filename);
@@ -110,18 +114,20 @@ error_is_true MediaTypeDSK::write(uint32_t blockNum, bool verify)
     }
 
     // Write lower part of block
-    err = fseek(_media_fileh, offsets.first, SEEK_SET) != 0;
+    err = fnio::fseek(_media_fileh, offsets.first, SEEK_SET) != 0;
     if (err == false)
-        err = fwrite(_media_blockbuff, 1, 512, _media_fileh) != 512;
+        err = fnio::fwrite(_media_blockbuff, 1, 512, _media_fileh) != 512;
 
     // Write upper part of block
     if (err == false)
-        err = fseek(_media_fileh, offsets.second, SEEK_SET) != 0;
+        err = fnio::fseek(_media_fileh, offsets.second, SEEK_SET) != 0;
     if (err == false)
-        err = fwrite(&_media_blockbuff[512], 1, 512, _media_fileh) != 512;
+        err = fnio::fwrite(&_media_blockbuff[512], 1, 512, _media_fileh) != 512;
 
-    int ret = fflush(_media_fileh);    // This doesn't seem to be connected to anything in ESP-IDF VF, so it may not do anything
-    ret = fsync(fileno(_media_fileh)); // Since we might get reset at any moment, go ahead and sync the file (not clear if fflush does this)
+    int ret = fnio::fflush(_media_fileh);
+#ifdef FNIO_IS_STDIO
+    ret = fsync(fileno(_media_fileh)); // sync now in case we get reset at any moment
+#endif
     Debug_printf("DSK::write fsync:%d\r\n", ret);
 
     if (hs_mode)
@@ -129,7 +135,7 @@ error_is_true MediaTypeDSK::write(uint32_t blockNum, bool verify)
         Debug_printf("Closing high score sector.\r\n");
 
         if (hsFileh != nullptr)
-            fclose(hsFileh);
+            fnio::fclose(hsFileh);
 
         _media_fileh = oldFileh;
         _media_last_block = INVALID_SECTOR_VALUE; // force a cache invalidate.
@@ -160,7 +166,7 @@ error_is_true MediaTypeDSK::format(uint16_t *responsesize)
     RETURN_SUCCESS_AS_FALSE();
 }
 
-mediatype_t MediaTypeDSK::mount(FILE *f, uint32_t disksize)
+mediatype_t MediaTypeDSK::mount(fnFile *f, uint32_t disksize)
 {
     Debug_print("DSK MOUNT\r\n");
 
@@ -174,7 +180,7 @@ mediatype_t MediaTypeDSK::mount(FILE *f, uint32_t disksize)
 }
 
 // Returns FALSE on error
-success_is_true MediaTypeDSK::create(FILE *f, uint32_t numBlocks)
+success_is_true MediaTypeDSK::create(fnFile *f, uint32_t numBlocks)
 {
     Debug_print("DSK CREATE\r\n");
     uint8_t buf[1024];
@@ -183,7 +189,7 @@ success_is_true MediaTypeDSK::create(FILE *f, uint32_t numBlocks)
     
     for (uint32_t b = 0; b < numBlocks; b++)
     {
-        fwrite(buf, 1024, 1, f);
+        fnio::fwrite(buf, 1024, 1, f);
     }
 
     RETURN_SUCCESS_AS_TRUE();

--- a/lib/media/adam/mediaTypeDSK.h
+++ b/lib/media/adam/mediaTypeDSK.h
@@ -18,11 +18,11 @@ public:
 
     error_is_true format(uint16_t *responsesize) override;
 
-    mediatype_t mount(FILE *f, uint32_t disksize) override;
+    mediatype_t mount(fnFile *f, uint32_t disksize) override;
 
     uint8_t status() override;
 
-    static success_is_true create(FILE *f, uint32_t numBlock);
+    static success_is_true create(fnFile *f, uint32_t numBlock);
 };
 
 

--- a/lib/media/adam/mediaTypeROM.cpp
+++ b/lib/media/adam/mediaTypeROM.cpp
@@ -57,11 +57,11 @@ error_is_true MediaTypeROM::read(uint32_t blockNum, uint16_t *readcount)
     {
         // // Perform a seek if we're not reading the sector after the last one we read
         uint32_t offset = _block_to_offset(blockNum - 2); // minus the two boot blocks
-        err = fseek(_media_fileh, offset, SEEK_SET) != 0;
+        err = fnio::fseek(_media_fileh, offset, SEEK_SET) != 0;
         _media_last_block = INVALID_SECTOR_VALUE;
 
         if (err == false)
-            err = fread(_media_blockbuff, 1, 1024, _media_fileh) != 1024;
+            err = fnio::fread(_media_blockbuff, 1, 1024, _media_fileh) != 1024;
 
         if (err == false)
         {
@@ -114,7 +114,7 @@ error_is_true MediaTypeROM::format(uint16_t *responsesize)
     RETURN_ERROR_AS_TRUE();
 }
 
-mediatype_t MediaTypeROM::mount(FILE *f, uint32_t disksize)
+mediatype_t MediaTypeROM::mount(fnFile *f, uint32_t disksize)
 {
     Debug_print("ROM MOUNT\r\n");
 
@@ -123,12 +123,11 @@ mediatype_t MediaTypeROM::mount(FILE *f, uint32_t disksize)
     _media_num_blocks = disksize / 1024;
     _media_num_blocks += 2; // to account for the two boot blocks.
 
-    Debug_printv("FLAGS: %x\n", _media_fileh->_flags);
     return _mediatype;
 }
 
 // Returns FALSE on error
-success_is_true MediaTypeROM::create(FILE *f, uint32_t numBlocks)
+success_is_true MediaTypeROM::create(fnFile *f, uint32_t numBlocks)
 {
     RETURN_ERROR_AS_FALSE();
 }

--- a/lib/media/adam/mediaTypeROM.h
+++ b/lib/media/adam/mediaTypeROM.h
@@ -12,10 +12,10 @@ private:
     // Block 0 and 1 data borrowed from Sean Myers' AdamNet Drive Emulator
     // https://github.com/Kalidomra/AdamNet-Drive-Emulator/blob/master/AdamNet_Drive_Emulator/SDLoadBlock.ino#L95
 
-    const char block0[1024]={0x3A,0x6F,0xFD,0x01,0x00,0x00,0x11,0x01,    // This is the boot block it just loads block 1 into 0x2000 and then jumps to 0x2000
+    const uint8_t block0[1024]={0x3A,0x6F,0xFD,0x01,0x00,0x00,0x11,0x01,    // This is the boot block it just loads block 1 into 0x2000 and then jumps to 0x2000
                              0x00,0x21,0x00,0x20,0xCD,0xF3,0xFC,0xC3,
                              0x00,0x20};
-    const char block1[1024]={0x11,0x02,0x00,0x21,0x00,0x40,0x3A,0x6F,  // This code will load the rom file from block 2 and above into 0x4000
+    const uint8_t block1[1024]={0x11,0x02,0x00,0x21,0x00,0x40,0x3A,0x6F,  // This code will load the rom file from block 2 and above into 0x4000
                              0xFD,0x01,0x00,0x00,0xCD,0xF3,0xFC,0x3E,  // Then the PCB's are move to 0x2100 and the AdamNet scanned
                              0x21,0xBB,0xCA,0x1D,0x20,0x01,0x00,0x04,  // (Thanks to Milli for this information)
                              0x09,0x13,0xC3,0x06,0x20,0x21,0x00,0x21,  // It will then bank switch in OS7 and move the rom code to 0x8000.
@@ -36,11 +36,11 @@ public:
 
     error_is_true format(uint16_t *responsesize) override;
 
-    mediatype_t mount(FILE *f, uint32_t disksize) override;
+    mediatype_t mount(fnFile *f, uint32_t disksize) override;
 
     uint8_t status() override;
 
-    static success_is_true create(FILE *f, uint32_t numBlock);
+    static success_is_true create(fnFile *f, uint32_t numBlock);
 };
 
 


### PR DESCRIPTION
Split from #1344. Base of the ADAM PC stack: **#1381 → #1379 → #1380**.

Migrate the ADAM media/disk layer from raw `FILE*` to `fnFile`/`FileHandler` so
TNFS works on PC, scoped to `BUILD_ADAM && !ESP_PLATFORM`. ESP ADAM unchanged
(`fnFile` maps to `FILE*`). Also fixes three issues found during PC bring-up: DDP
NULL-`fileh` crash, mediaTypeROM char-narrowing init, network `GET_REMOTE` buffer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
