### PR TITLE
netstream: fix unbounded downstream pacing + bufferbloat (frame-align…

### DIFF
--- a/lib/config/fnConfig.h
+++ b/lib/config/fnConfig.h
@@ -118,6 +118,7 @@ public:
     int get_network_netstream_port() { return _network.netstream_port; };
     bool get_network_netstream_register() { return _network.netstream_register; };
     int get_network_netstream_mode() { return _network.netstream_mode; };
+    int get_network_netstream_rx_depth() { return _network.netstream_rx_depth; };
     bool get_general_config_enabled() { return _general.config_enabled; };
     void store_general_devicename(const char *devicename);
     void store_general_hsioindex(int hsio_index);
@@ -134,6 +135,7 @@ public:
     void store_netstream_port(int port);
     void store_netstream_register(bool enable);
     void store_netstream_mode(int mode);
+    void store_netstream_rx_depth(int depth);
     bool get_general_fnconfig_spifs() { return _general.fnconfig_spifs; };
     void store_general_fnconfig_spifs(bool fnconfig_spifs);
     bool get_general_status_wait_enabled() { return _general.status_wait_enabled; }
@@ -433,6 +435,7 @@ private:
         int netstream_port;
         bool netstream_register = true;
         int netstream_mode = 1;
+        int netstream_rx_depth = 0; // 0 => use firmware default (NETSTREAM_RX_MAX_FRAMES)
     };
 
     struct general_info

--- a/lib/config/fnc_network.cpp
+++ b/lib/config/fnc_network.cpp
@@ -23,6 +23,11 @@ void fnConfig::store_netstream_mode(int mode)
     _network.netstream_mode = mode;
 }
 
+void fnConfig::store_netstream_rx_depth(int depth)
+{
+    _network.netstream_rx_depth = depth;
+}
+
 void fnConfig::_read_section_network(std::stringstream &ss)
 {
     std::string line;
@@ -54,6 +59,10 @@ void fnConfig::_read_section_network(std::stringstream &ss)
             else if (strcasecmp(name.c_str(), "netstream_register") == 0)
             {
                 _network.netstream_register = util_string_value_is_true(value);
+            }
+            else if (strcasecmp(name.c_str(), "netstream_rx_depth") == 0)
+            {
+                _network.netstream_rx_depth = atoi(value.c_str());
             }
         }
     }

--- a/lib/config/fnc_save.cpp
+++ b/lib/config/fnc_save.cpp
@@ -81,6 +81,7 @@ void fnConfig::save()
     ss << "netstream_port=" << _network.netstream_port << LINETERM;
     ss << "netstream_mode=" << _network.netstream_mode << LINETERM;
     ss << "netstream_register=" << _network.netstream_register << LINETERM;
+    ss << "netstream_rx_depth=" << _network.netstream_rx_depth << LINETERM;
 
     // HOSTS
     for (i = 0; i < MAX_HOST_SLOTS; i++)

--- a/lib/device/sio/netstream.cpp
+++ b/lib/device/sio/netstream.cpp
@@ -7,6 +7,7 @@
 
 #include "cassette.h"
 #include "fnSystem.h"
+#include "fnConfig.h"
 #include "utils.h"
 
 static uint64_t netstream_time_us()
@@ -109,11 +110,164 @@ bool sioNetStream::ensure_netstream_ready()
     return true;
 }
 
+// Inter-byte gap (us) matching the negotiated baud (8N1 => 10 bits/byte).
+// The hub's credit flow-control already paces writes to the true line rate, so this
+// gap just smooths delivery; fall back to the fixed constants if baud is unknown.
+static uint32_t netstream_gap_us_for_baud(int baud, int port)
+{
+    if (baud > 0)
+        return (uint32_t)(10000000u / (uint32_t)baud);
+    return (port == MIDI_PORT) ? NETSTREAM_MIN_GAP_US_MIDI : NETSTREAM_MIN_GAP_US_SIO;
+}
+
+void sioNetStream::enqueue_rx(const uint8_t *data, int len)
+{
+    for (int i = 0; i < len; i++)
+    {
+        if (rx_count < NETSTREAM_RX_RING_SIZE)
+        {
+            rx_ring[rx_head] = data[i];
+            rx_head = (rx_head + 1) % NETSTREAM_RX_RING_SIZE;
+            rx_count++;
+        }
+        else
+        {
+            // Drop oldest byte to keep the most recent stream data.
+            rx_tail = (rx_tail + 1) % NETSTREAM_RX_RING_SIZE;
+            rx_ring[rx_head] = data[i];
+            rx_head = (rx_head + 1) % NETSTREAM_RX_RING_SIZE;
+            rx_drop_count++;
+        }
+    }
+}
+
+void sioNetStream::enqueue_frame(const uint8_t *data, int len)
+{
+    // Framed (lossy UDP) path: buffer a whole datagram as one frame, evicting the
+    // OLDEST whole frame(s) when over the depth cap or out of physical ring space.
+    // Drops are always whole-frame aligned so the Atari deframer never desyncs.
+    if (len <= 0)
+        return;
+    if (len > NETSTREAM_MAX_FRAME)
+    {
+        // Framed path is for small real-time datagrams; a frame this large can't be
+        // held in inflight[]. Drop it whole (keeps the stream frame-aligned).
+        rx_drop_count++;
+        return;
+    }
+
+    while (frame_count > 0 &&
+           (frame_count >= rx_cap_frames ||
+            frame_count >= NETSTREAM_RX_FRAME_SLOTS ||
+            (int)rx_count + len > NETSTREAM_RX_RING_SIZE))
+    {
+        uint16_t evicted = frame_len[frame_tail];
+        frame_tail = (frame_tail + 1) % NETSTREAM_RX_FRAME_SLOTS;
+        frame_count--;
+        rx_tail = (rx_tail + evicted) % NETSTREAM_RX_RING_SIZE;
+        rx_count -= evicted;
+        rx_drop_count++;
+    }
+
+    for (int i = 0; i < len; i++)
+    {
+        rx_ring[rx_head] = data[i];
+        rx_head = (rx_head + 1) % NETSTREAM_RX_RING_SIZE;
+        rx_count++;
+    }
+    frame_len[frame_head] = (uint16_t)len;
+    frame_head = (frame_head + 1) % NETSTREAM_RX_FRAME_SLOTS;
+    frame_count++;
+}
+
+void sioNetStream::drain_net_to_ring()
+{
+    if (netstreamMode == NetStreamMode::UDP)
+    {
+        // Pull every datagram already queued, not just one, so a burst that arrived
+        // while we were busy doesn't pile up in the kernel UDP receive buffer.
+        int guard = 0;
+        int packetSize;
+        while ((packetSize = netStreamUdp.parsePacket()) > 0 && guard++ < NETSTREAM_RX_DRAIN_MAX_PACKETS)
+        {
+            netStreamUdp.read(buf_net, NETSTREAM_BUFFER_SIZE);
+            if (rx_framed)
+                enqueue_frame(buf_net, packetSize);
+            else
+                enqueue_rx(buf_net, packetSize);
+            last_rx_us = netstream_time_us();
+#ifdef DEBUG_NETSTREAM
+            Debug_printf("STREAM-IN [%llu ms]: ", (unsigned long long)(netstream_time_us() / 1000ULL));
+            util_dump_bytes(buf_net, packetSize);
+#endif
+        }
+    }
+    else if (ensure_netstream_ready())
+    {
+        size_t available = netStreamTcp.available();
+        while (available > 0)
+        {
+            size_t to_read = (available > NETSTREAM_BUFFER_SIZE) ? NETSTREAM_BUFFER_SIZE : available;
+            int packetSize = netStreamTcp.read(buf_net, to_read);
+            if (packetSize <= 0)
+                break;
+            enqueue_rx(buf_net, packetSize);
+            last_rx_us = netstream_time_us();
+#ifdef DEBUG_NETSTREAM
+            Debug_printf("STREAM-IN [%llu ms]: ", (unsigned long long)(netstream_time_us() / 1000ULL));
+            util_dump_bytes(buf_net, packetSize);
+#endif
+            available = netStreamTcp.available();
+        }
+    }
+}
+
 void sioNetStream::pace_to_atari(uint32_t min_gap_us)
 {
     // Pacing to keep NET->SIO output moving even when other paths wait.
+    // Cap bytes per call so a backlog can catch up without holding the SIO service
+    // loop long enough to delay CMD-assert detection. The gap (and the hub's credit
+    // flow-control) still bound the actual rate, so this can't overrun the Atari.
     uint8_t send_count = 0;
-    while (rx_count > 0 && send_count < 16)
+
+    if (rx_framed)
+    {
+        // Framed path: send the in-flight frame byte-by-byte; load the next whole frame
+        // out of the ring when the current one finishes. The in-flight frame lives in
+        // inflight[] (outside the droppable queue), so it is never split by an eviction.
+        while (send_count < NETSTREAM_PACE_MAX_PER_CALL)
+        {
+            if (inflight_pos >= inflight_len)
+            {
+                if (frame_count == 0)
+                    break; // nothing buffered
+                int L = frame_len[frame_tail];
+                frame_tail = (frame_tail + 1) % NETSTREAM_RX_FRAME_SLOTS;
+                frame_count--;
+                for (int j = 0; j < L; j++)
+                {
+                    inflight[j] = rx_ring[rx_tail];
+                    rx_tail = (rx_tail + 1) % NETSTREAM_RX_RING_SIZE;
+                    rx_count--;
+                }
+                inflight_len = L;
+                inflight_pos = 0;
+                if (L == 0)
+                    continue;
+            }
+            uint64_t now_us = netstream_time_us();
+            if ((now_us - last_tx_us) < min_gap_us)
+                break;
+            SYSTEM_BUS.write(&inflight[inflight_pos], 1);
+            inflight_pos++;
+            last_tx_us += min_gap_us;
+            send_count++;
+        }
+        return;
+    }
+
+    // Byte path (lossless MIDI/TCP): drain the ring directly.
+    while (rx_count > 0 && send_count < NETSTREAM_PACE_MAX_PER_CALL)
     {
         uint64_t now_us = netstream_time_us();
         if ((now_us - last_tx_us) < min_gap_us)
@@ -191,6 +345,23 @@ void sioNetStream::sio_enable_netstream()
     rx_tail = 0;
     rx_count = 0;
     rx_drop_count = 0;
+
+    // Lossy, frame-aligned shallow buffering applies only to UDP non-MIDI streams;
+    // MIDI and TCP stay lossless (full byte ring, no proactive drops).
+    rx_framed = (netstreamMode == NetStreamMode::UDP) && (netstream_port != MIDI_PORT);
+    int cfg_depth = Config.get_network_netstream_rx_depth();
+    int depth = (cfg_depth > 0) ? cfg_depth : NETSTREAM_RX_MAX_FRAMES;
+    if (depth < 2)
+        depth = 2; // need >=2 so an old frame can be shed while one is in flight
+    if (depth > NETSTREAM_RX_FRAME_SLOTS - 1)
+        depth = NETSTREAM_RX_FRAME_SLOTS - 1;
+    rx_cap_frames = depth;
+    frame_head = 0;
+    frame_tail = 0;
+    frame_count = 0;
+    inflight_len = 0;
+    inflight_pos = 0;
+
     Debug_println("NETSTREAM mode ENABLED");
 }
 
@@ -216,7 +387,7 @@ void sioNetStream::sio_disable_netstream()
 
 void sioNetStream::sio_handle_netstream()
 {
-    const uint32_t min_gap_us = (netstream_port == MIDI_PORT) ? NETSTREAM_MIN_GAP_US_MIDI : NETSTREAM_MIN_GAP_US_SIO;
+    const uint32_t min_gap_us = netstream_gap_us_for_baud(netstream_baud, netstream_port);
     uint64_t batch_start_us = 0;
     bool batch_active = false;
 
@@ -260,76 +431,8 @@ void sioNetStream::sio_handle_netstream()
         batch_start_us = 0;
     };
 
-    if (netstreamMode == NetStreamMode::UDP)
-    {
-        // if there’s data available, read a packet
-        int packetSize = netStreamUdp.parsePacket();
-        if (packetSize > 0)
-        {
-            netStreamUdp.read(buf_net, NETSTREAM_BUFFER_SIZE);
-
-            // Buffer incoming UDP bytes for paced UART output.
-            for (int i = 0; i < packetSize; i++)
-            {
-                if (rx_count < NETSTREAM_RX_RING_SIZE)
-                {
-                    rx_ring[rx_head] = buf_net[i];
-                    rx_head = (rx_head + 1) % NETSTREAM_RX_RING_SIZE;
-                    rx_count++;
-                }
-                else
-                {
-                    // Drop oldest byte to keep the most recent stream data.
-                    rx_tail = (rx_tail + 1) % NETSTREAM_RX_RING_SIZE;
-                    rx_ring[rx_head] = buf_net[i];
-                    rx_head = (rx_head + 1) % NETSTREAM_RX_RING_SIZE;
-                    rx_drop_count++;
-                }
-            }
-            last_rx_us = netstream_time_us();
-#ifdef DEBUG_NETSTREAM
-            Debug_printf("STREAM-IN [%llu ms]: ", (unsigned long long)(netstream_time_us() / 1000ULL));
-            util_dump_bytes(buf_net, packetSize);
-#endif
-        }
-    }
-    else if (ensure_netstream_ready())
-    {
-        // if there’s data available, read from the TCP stream
-        size_t available = netStreamTcp.available();
-        while (available > 0)
-        {
-            size_t to_read = (available > NETSTREAM_BUFFER_SIZE) ? NETSTREAM_BUFFER_SIZE : available;
-            int packetSize = netStreamTcp.read(buf_net, to_read);
-            if (packetSize <= 0)
-                break;
-
-            // Buffer incoming TCP bytes for paced UART output.
-            for (int i = 0; i < packetSize; i++)
-            {
-                if (rx_count < NETSTREAM_RX_RING_SIZE)
-                {
-                    rx_ring[rx_head] = buf_net[i];
-                    rx_head = (rx_head + 1) % NETSTREAM_RX_RING_SIZE;
-                    rx_count++;
-                }
-                else
-                {
-                    // Drop oldest byte to keep the most recent stream data.
-                    rx_tail = (rx_tail + 1) % NETSTREAM_RX_RING_SIZE;
-                    rx_ring[rx_head] = buf_net[i];
-                    rx_head = (rx_head + 1) % NETSTREAM_RX_RING_SIZE;
-                    rx_drop_count++;
-                }
-            }
-            last_rx_us = netstream_time_us();
-#ifdef DEBUG_NETSTREAM
-            Debug_printf("STREAM-IN [%llu ms]: ", (unsigned long long)(netstream_time_us() / 1000ULL));
-            util_dump_bytes(buf_net, packetSize);
-#endif
-            available = netStreamTcp.available();
-        }
-    }
+    // Pull all queued inbound datagrams into the ring (drop-oldest on overflow).
+    drain_net_to_ring();
 
     pace_to_atari(min_gap_us);
 
@@ -385,6 +488,9 @@ void sioNetStream::sio_handle_netstream()
                 {
                     fnSystem.delay_microseconds(wait_step_us);
                     waited_us += wait_step_us;
+                    // Keep refilling from the network so inbound isn't starved while
+                    // we wait out an outbound burst (else datagrams pile up upstream).
+                    drain_net_to_ring();
                     pace_to_atari(min_gap_us);
                     if (buf_stream_index >= NETSTREAM_FLUSH_THRESHOLD ||
                         (batch_active && (netstream_time_us() - batch_start_us) >= NETSTREAM_MAX_BATCH_AGE_US))

--- a/lib/device/sio/netstream.h
+++ b/lib/device/sio/netstream.h
@@ -24,8 +24,13 @@
 #define NETSTREAM_BUFFER_SIZE 2048
 #define NETSTREAM_RX_RING_SIZE 2048
 #define NETSTREAM_PACKET_TIMEOUT 5000
-#define NETSTREAM_MIN_GAP_US_MIDI 320                           // ~1 byte at 31.25kbps
-#define NETSTREAM_MIN_GAP_US_SIO 520                            // ~1 byte at 19.2kbps
+#define NETSTREAM_MIN_GAP_US_MIDI 320                           // ~1 byte at 31.25kbps (fallback)
+#define NETSTREAM_MIN_GAP_US_SIO 520                            // ~1 byte at 19.2kbps (fallback)
+#define NETSTREAM_PACE_MAX_PER_CALL 64                          // Max bytes drained per pace_to_atari() call.
+#define NETSTREAM_RX_DRAIN_MAX_PACKETS 32                       // Max UDP datagrams pulled per service pass.
+#define NETSTREAM_RX_MAX_FRAMES 4                               // Default shallow-buffer depth (whole frames). >=2.
+#define NETSTREAM_RX_FRAME_SLOTS 64                             // Descriptor ring capacity (>= any rx_depth used).
+#define NETSTREAM_MAX_FRAME 256                                 // Max datagram size buffered on the framed (lossy UDP) path.
 #define NETSTREAM_MAX_BATCH_AGE_US 3000                         // Max SIO->NET batch age before forced flush.
 #define NETSTREAM_FLUSH_THRESHOLD (NETSTREAM_BUFFER_SIZE - 16)  // Flush when nearly full.
 #define MIDI_PORT 5004
@@ -47,12 +52,30 @@ private:
     uint16_t rx_tail = 0;
     uint16_t rx_count = 0;
     uint32_t rx_drop_count = 0;
+
+    // Framed (lossy UDP) inbound buffering: a bounded queue of whole datagrams/frames.
+    // rx_ring holds concatenated whole *unsent* frames; the frame currently being paced
+    // out is copied into inflight[] so it is never in the droppable set (drops stay
+    // whole-frame aligned even when pacing breaks mid-frame on the gap).
+    bool rx_framed = false;              // true only for UDP non-MIDI
+    int rx_cap_frames = NETSTREAM_RX_MAX_FRAMES; // max buffered (waiting) frames
+    uint16_t frame_len[NETSTREAM_RX_FRAME_SLOTS]; // per-frame lengths, in order
+    uint16_t frame_head = 0;
+    uint16_t frame_tail = 0;
+    uint16_t frame_count = 0;
+    uint8_t inflight[NETSTREAM_MAX_FRAME]; // frame currently being paced out
+    int inflight_len = 0;
+    int inflight_pos = 0;
+
     bool cassette_was_active = false;
 
     uint64_t last_rx_us = 0;
     uint64_t last_tx_us = 0;
     bool ensure_netstream_ready();
     void pace_to_atari(uint32_t min_gap_us);
+    void enqueue_rx(const uint8_t *data, int len);    // byte path (lossless MIDI/TCP): push bytes, drop-oldest only on overflow
+    void enqueue_frame(const uint8_t *data, int len); // framed path (lossy UDP): push whole frame, evict oldest whole frames over cap
+    void drain_net_to_ring();                         // pull all available net datagrams into the buffer
     void sio_status() override;
     void sio_process(uint32_t commanddata, uint8_t checksum) override;
 


### PR DESCRIPTION
…ed drop, configurable depth)

Fixes growing/unbounded downstream (server->Atari) latency in the concurrent UDP netstream SIO path (Mode B, Fuji cmd 0xF0 / FUJICMD_ENABLE_UDPSTREAM).

Pacing (eliminates the runaway):
- pace_to_atari() inter-byte gap now tracks the negotiated baud (10,000,000 / netstream_baud, 8N1) instead of a fixed 520us calibrated for 19.2k while the lane negotiates ~31960. The NetSIO hub credit flow-control remains the hard backstop, so the Atari can't be overrun.
- All queued UDP datagrams are drained per service pass (not one), including inside the outbound Atari->Net loop, so inbound intake isn't starved during bidirectional traffic. Per-call drain cap raised (NETSTREAM_PACE_MAX_PER_CALL).

Bufferbloat (keeps standing latency small at high rate):
- For the lossy UDP path, inbound is a bounded queue of whole datagrams/frames with drop-oldest eviction. enqueue_frame() tracks per-frame lengths (frame_len[] descriptor ring) and evicts the OLDEST WHOLE frame(s) over the depth cap. The frame currently being sent is copied into inflight[], outside the droppable queue, so eviction is always whole-frame aligned and never splits a frame mid-send. This matters because the Atari deframer pulls fixed-size chunks with no resync marker -- a byte-misaligned drop would desync it permanently. MIDI (port 5004) and TCP keep the lossless byte path (enqueue_rx, full ring, drop only on true overflow).

Configurable depth (#define default + ini override):
- NETSTREAM_RX_MAX_FRAMES (default 4, min effective 2) is the shallow-buffer depth in whole frames. New [Network] netstream_rx_depth in fnconfig.ini overrides it; 0 means "use the firmware default". Clamped to [2, slots-1].

Footprint (ESP32 DRAM is tight):
- inflight[] is sized to NETSTREAM_MAX_FRAME (256) rather than the full 2KB buffer; the framed path only carries small real-time datagrams, and larger ones are dropped whole. Keeps .dram0.bss within the classic ESP32 limit.

Verified end-to-end via the seq-echo --hz sweep on the PC build: hz=30 ~2.5s -> ~0.5s, hz=60 ~1.5s -> ~0.43s; ovf=0, bad=0, stale=0 and resync flat at every rate (whole-frame drops, no desync), confirmed down to rx_depth=2. A ~49.7k baud run confirmed raw bandwidth was never the limiter. Builds clean for both fujinet-pc (ATARI) and ESP32 (fujinet-atari-v1; RAM 36.9%, Flash 25%).