### PR TITLE
[fuji] reset host mounts on shutdown so an in-process restart re-mounts fresh

### DIFF
--- a/lib/device/fujiDevice.cpp
+++ b/lib/device/fujiDevice.cpp
@@ -201,11 +201,7 @@ void fujiDevice::shutdown()
     for (int i = 0; i < _totalDiskDevices; i++)
         _fnDisks[i].disk_dev.unmount();
 
-    // Release host mounts so the next startup re-mounts them fresh. The Android
-    // "FujiNet Go" runtime restarts in-process (re-runs main_setup() without
-    // killing the process), so these process-global fujiHost objects otherwise
-    // survive with a dead TNFS session that mount() reuses -- garbage directory
-    // listings and failed mounts until a Force Stop.
+    // Make sure we clean the mounts, to prevent a leak.
     for (int i = 0; i < MAX_HOSTS; i++)
     {
         fujiHostType htype = _fnHosts[i].get_type();

--- a/lib/device/fujiDevice.cpp
+++ b/lib/device/fujiDevice.cpp
@@ -200,6 +200,18 @@ void fujiDevice::shutdown()
 {
     for (int i = 0; i < _totalDiskDevices; i++)
         _fnDisks[i].disk_dev.unmount();
+
+    // Release host mounts so the next startup re-mounts them fresh. The Android
+    // "FujiNet Go" runtime restarts in-process (re-runs main_setup() without
+    // killing the process), so these process-global fujiHost objects otherwise
+    // survive with a dead TNFS session that mount() reuses -- garbage directory
+    // listings and failed mounts until a Force Stop.
+    for (int i = 0; i < MAX_HOSTS; i++)
+    {
+        fujiHostType htype = _fnHosts[i].get_type();
+        if (htype != HOSTTYPE_UNINITIALIZED && htype != HOSTTYPE_LOCAL)
+            _fnHosts[i].unmount_success();
+    }
 }
 
 // Disk Image Rotate

--- a/lib/device/fujiDevice.cpp
+++ b/lib/device/fujiDevice.cpp
@@ -201,13 +201,15 @@ void fujiDevice::shutdown()
     for (int i = 0; i < _totalDiskDevices; i++)
         _fnDisks[i].disk_dev.unmount();
 
-    // Make sure we clean the mounts, to prevent a leak.
+    // Clean the mounts and mount tracking, so they re-mount after a restart.
     for (int i = 0; i < MAX_HOSTS; i++)
     {
         fujiHostType htype = _fnHosts[i].get_type();
         if (htype != HOSTTYPE_UNINITIALIZED && htype != HOSTTYPE_LOCAL)
             _fnHosts[i].unmount_success();
+        hostMounted[i] = false;
     }
+    _startup_mount_lock.store(false);
 }
 
 // Disk Image Rotate


### PR DESCRIPTION
The Android FujiNet Go siblings embed libfujinet in-process and restart by re-running `main_setup()` **without killing the process**, so firmware globals survive.

`fujiDevice::shutdown()` unmounted disks but not host filesystems, so a `fujiHost` kept `HOSTTYPE_TNFS` and a `FileSystemTNFS` with a dead session. On restart `set_hostname()` keeps the unchanged host and `mount()` short-circuits on `_fs->running()`, so directory reads and disk mounts run over the dead session — garbage listings and failed mounts (cleared only by a Force Stop).

Fix: release host mounts in `shutdown()`, symmetric with the disk teardown, so the next `mount()` reconnects. SD hosts are skipped. Inert on ESP32/PC, where shutdown precedes a real process exit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
