### PR TITLE
[fuji] guard fujiHost::cleanup() against a null filesystem

### DIFF
--- a/lib/fuji/fujiHost.cpp
+++ b/lib/fuji/fujiHost.cpp
@@ -24,13 +24,15 @@ void fujiHost::unmount()
 void fujiHost::cleanup()
 {
     if (_fs != nullptr)
+    {
         _fs->dir_close();
 
-    // Delete the filesystem if it's not one of the global ones
-    if (_fs->is_global() == false)
-        delete _fs;
+        // Delete the filesystem if it's not one of the global ones
+        if (_fs->is_global() == false)
+            delete _fs;
 
-    _fs = nullptr;
+        _fs = nullptr;
+    }
 
     _hostname[0] = '\0';
 }


### PR DESCRIPTION
`fujiHost::cleanup()` null-checks `_fs` before `_fs->dir_close()`, but then calls `_fs->is_global()` outside that guard, so a call with `_fs == nullptr` crashes (reachable via `set_type()` on a host whose `_fs` was already released).

Fix: move `dir_close()` / `delete` / `_fs = nullptr` inside the existing null check; `_hostname` is still cleared unconditionally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
