### PR TITLE
[fuji] build per-platform device topology once per process (in-process restart)

### DIFF
--- a/lib/device/adamnet/adamFuji.cpp
+++ b/lib/device/adamnet/adamFuji.cpp
@@ -292,12 +292,17 @@ void adamFuji::setup()
         Debug_printf("Not mounting config disk\n");
     }
 
-    theNetwork = new adamNetwork();
-    theNetwork2 = new adamNetwork();
-    theSerial = new adamSerial();
-    SYSTEM_BUS.addDevice(theNetwork, FUJI_DEVICEID_NETWORK);  // temporary.
-    SYSTEM_BUS.addDevice(theNetwork2, FUJI_DEVICEID_NETWORK + 1); // temporary
-    SYSTEM_BUS.addDevice(theFuji, FUJI_DEVICEID_FUJINET);    // Fuji becomes the gateway device.
+    // Create these once, to avoid leaking them when setup() re-runs on an
+    // in-process restart.
+    if (theNetwork == nullptr)
+    {
+        theNetwork = new adamNetwork();
+        theNetwork2 = new adamNetwork();
+        theSerial = new adamSerial();
+        SYSTEM_BUS.addDevice(theNetwork, FUJI_DEVICEID_NETWORK);  // temporary.
+        SYSTEM_BUS.addDevice(theNetwork2, FUJI_DEVICEID_NETWORK + 1); // temporary
+        SYSTEM_BUS.addDevice(theFuji, FUJI_DEVICEID_FUJINET);    // Fuji becomes the gateway device.
+    }
 }
 
 void adamFuji::adamnet_random_number()

--- a/lib/device/iwm/iwmFuji.cpp
+++ b/lib/device/iwm/iwmFuji.cpp
@@ -247,23 +247,28 @@ void iwmFuji::setup()
         // Disable booting from CONFIG if our settings say to turn it off
         boot_config = Config.get_general_config_enabled();
 
-        // add ourselves as a device
-        SYSTEM_BUS.addDevice(this, iwm_fujinet_type_t::FujiNet);
-
-        theNetwork = new iwmNetwork();
-        SYSTEM_BUS.addDevice(theNetwork, iwm_fujinet_type_t::Network);
-
-        theClock = new iwmClock();
-        SYSTEM_BUS.addDevice(theClock, iwm_fujinet_type_t::Clock);
-
-        theCPM = new iwmCPM();
-        SYSTEM_BUS.addDevice(theCPM, iwm_fujinet_type_t::CPM);
-
-        for (int i = MAX_SPDISK_DEVICES - 1; i >= 0; i--)
+        // Build the device topology once, to avoid duplicating the daisy chain
+        // and leaking the devices when setup() re-runs on an in-process restart.
+        if (theNetwork == nullptr)
         {
-                DISK_DEVICE *disk_dev = get_disk_dev(i);
-                disk_dev->set_disk_number('0' + i);
-                SYSTEM_BUS.addDevice(disk_dev, iwm_fujinet_type_t::BlockDisk);
+                // add ourselves as a device
+                SYSTEM_BUS.addDevice(this, iwm_fujinet_type_t::FujiNet);
+
+                theNetwork = new iwmNetwork();
+                SYSTEM_BUS.addDevice(theNetwork, iwm_fujinet_type_t::Network);
+
+                theClock = new iwmClock();
+                SYSTEM_BUS.addDevice(theClock, iwm_fujinet_type_t::Clock);
+
+                theCPM = new iwmCPM();
+                SYSTEM_BUS.addDevice(theCPM, iwm_fujinet_type_t::CPM);
+
+                for (int i = MAX_SPDISK_DEVICES - 1; i >= 0; i--)
+                {
+                        DISK_DEVICE *disk_dev = get_disk_dev(i);
+                        disk_dev->set_disk_number('0' + i);
+                        SYSTEM_BUS.addDevice(disk_dev, iwm_fujinet_type_t::BlockDisk);
+                }
         }
 
         if (boot_config)

--- a/lib/device/rs232/rs232Fuji.cpp
+++ b/lib/device/rs232/rs232Fuji.cpp
@@ -40,14 +40,21 @@ void rs232Fuji::setup()
     // Disable booting from CONFIG if our settings say to turn it off
     boot_config = Config.get_general_config_enabled();
 
-    // Add our devices to the RS232 bus
-    for (int i = 0; i < MAX_DISK_DEVICES; i++)
-        SYSTEM_BUS.addDevice(&_fnDisks[i].disk_dev,
-                             static_cast<fujiDeviceID_t>(FUJI_DEVICEID_DISK + i));
+    // Add our devices once, to avoid duplicating the bus chain when setup()
+    // re-runs on an in-process restart.
+    static bool devices_added = false;
+    if (!devices_added)
+    {
+        devices_added = true;
 
-    for (int i = 0; i < MAX_NETWORK_DEVICES; i++)
-        SYSTEM_BUS.addDevice(&rs232NetDevs[i],
-                             static_cast<fujiDeviceID_t>(FUJI_DEVICEID_NETWORK + i));
+        for (int i = 0; i < MAX_DISK_DEVICES; i++)
+            SYSTEM_BUS.addDevice(&_fnDisks[i].disk_dev,
+                                 static_cast<fujiDeviceID_t>(FUJI_DEVICEID_DISK + i));
+
+        for (int i = 0; i < MAX_NETWORK_DEVICES; i++)
+            SYSTEM_BUS.addDevice(&rs232NetDevs[i],
+                                 static_cast<fujiDeviceID_t>(FUJI_DEVICEID_NETWORK + i));
+    }
 }
 
 // Status


### PR DESCRIPTION
Follow-up to #1396, same environment: the in-process Android runtime re-runs `setup()` without killing the process, so the bus daisy chain and device objects survive. Re-running each platform's `Fuji::setup()` then rebuilds the topology:

- **iwm (Apple)** — list-based chain → duplicate entries corrupt SmartPort device-number enumeration, plus leaks network/clock/cpm.
- **adamnet (Adam)** — map keyed by device id → only leaks adamNetwork×2/adamSerial.
- **rs232 (MSX)** — forward_list → duplicate entries for member disk/net devices.
- **drivewire (CoCo)** — adds nothing in setup → no change.

Fix: guard each platform's device construction so it runs once per process (`theNetwork == nullptr` for iwm/adam; a static flag for rs232). `populate_slots_from_config()` and boot-device insertion still run every restart. Inert on ESP32/PC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
