### PR TITLE
[iwm] close the SLIP connection on shutdown (fd leak across in-process restart)

### DIFF
--- a/lib/bus/iwm/iwm.cpp
+++ b/lib/bus/iwm/iwm.cpp
@@ -1011,5 +1011,10 @@ void systemBus::shutdown()
     devicep->shutdown();
   }
   Debug_printf("All devices shut down.\n");
+
+#ifdef DEV_RELAY_SLIP
+  // Close the SLIP connection so its socket/thread aren't leaked on restart.
+  smartport.end_request_thread();
+#endif
 }
 #endif /* BUILD_APPLE */


### PR DESCRIPTION
`systemBus::setup()` opens the SLIP socket + reader thread via `smartport.setup_spi()`, but `systemBus::shutdown()` never tore down the global `smartport`. `TCPConnection` has no destructor, so only `end_request_thread()` closes the socket.

The in-process Android runtime restarts by re-running `main_setup()` without killing the process, so each cycle strands the previous socket. Eventually the open-fd count crosses `FD_SETSIZE` (1024) and the next `select()`/`FD_SET` trips Android FORTIFY.

Fix: call `smartport.end_request_thread()` from `shutdown()` (guarded by `DEV_RELAY_SLIP`) — the same teardown `restart()` already uses. Inert on real hardware/PC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
