### PR TITLE
Fix: check malloc() result in fnHttpClient to prevent null pointer crash

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# FujiNet afdsssssssssss
+# FujiNet
 
 A multi-function peripheral built on ESP32 hardware being developed for the multiple 8-bit systems
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# FujiNet
+# FujiNet afdsssssssssss
 
 A multi-function peripheral built on ESP32 hardware being developed for the multiple 8-bit systems
 

--- a/lib/http/fnHttpClient.cpp
+++ b/lib/http/fnHttpClient.cpp
@@ -23,6 +23,10 @@ const char *webdav_depths[] = {"0", "1", "infinity"};
 fnHttpClient::fnHttpClient()
 {
     _buffer = (char *)malloc(DEFAULT_HTTP_BUF_SIZE);
+    if (_buffer == nullptr)
+    {
+        Debug_printf("fnHttpClient::fnHttpClient() failed to allocate %d byte buffer\r\n", DEFAULT_HTTP_BUF_SIZE);
+    }
 }
 
 // Close connection, destroy any resoruces
@@ -354,9 +358,16 @@ esp_err_t fnHttpClient::_httpevent_handler(esp_http_client_event_t *evt)
         Debug_printf("HTTP_EVENT_ON_DATA: Data: %p, Datalen: %d\r\n", evt->data, evt->data_len);
 #endif
 
-        client->_buffer_pos = 0;
-        client->_buffer_len = (evt->data_len > DEFAULT_HTTP_BUF_SIZE) ? DEFAULT_HTTP_BUF_SIZE : evt->data_len;
-        memcpy(client->_buffer, evt->data, client->_buffer_len);
+        if (client->_buffer == nullptr) {
+            Debug_printf("HTTP_EVENT_ON_DATA: _buffer is null, dropping data\r\n");
+            client->_buffer_pos = 0;
+            client->_buffer_len = 0;
+        }
+        else {
+            client->_buffer_pos = 0;
+            client->_buffer_len = (evt->data_len > DEFAULT_HTTP_BUF_SIZE) ? DEFAULT_HTTP_BUF_SIZE : evt->data_len;
+            memcpy(client->_buffer, evt->data, client->_buffer_len);
+        }
 
         // Now let the reader know there's data in the buffer
         xTaskNotifyGive(client->_taskh_consumer);


### PR DESCRIPTION
## What this fixes

`fnHttpClient`'s constructor calls `malloc()` to allocate the response buffer but never checks if the allocation succeeded. If `malloc()` fails (e.g. low memory on the ESP32), `_buffer` stays `nullptr`.

Later, in `_httpevent_handler` (HTTP_EVENT_ON_DATA), the code does:
```cpp
memcpy(client->_buffer, evt->data, client->_buffer_len);
```
without checking for null, which would crash on the first data received over HTTP.

## Changes

- Added a null check after `malloc()` in the constructor, with a debug log if allocation fails.
- Added a guard in the `HTTP_EVENT_ON_DATA` handler to safely drop incoming data (instead of crashing) if `_buffer` is null.

## Testing

Built and tested using FujiNet-PC on Windows (MSYS2/CLANG64). Build succeeds with no errors, all existing tests pass.