### PR TITLE
My first change

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# FujiNet afdsssssssssss
+# FujiNet
 
 A multi-function peripheral built on ESP32 hardware being developed for the multiple 8-bit systems
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# FujiNet
+# FujiNet afdsssssssssss
 
 A multi-function peripheral built on ESP32 hardware being developed for the multiple 8-bit systems
 

--- a/lib/http/fnHttpClient.cpp
+++ b/lib/http/fnHttpClient.cpp
@@ -23,6 +23,10 @@ const char *webdav_depths[] = {"0", "1", "infinity"};
 fnHttpClient::fnHttpClient()
 {
     _buffer = (char *)malloc(DEFAULT_HTTP_BUF_SIZE);
+    if (_buffer == nullptr)
+    {
+        Debug_printf("fnHttpClient::fnHttpClient() failed to allocate %d byte buffer\r\n", DEFAULT_HTTP_BUF_SIZE);
+    }
 }
 
 // Close connection, destroy any resoruces
@@ -354,9 +358,16 @@ esp_err_t fnHttpClient::_httpevent_handler(esp_http_client_event_t *evt)
         Debug_printf("HTTP_EVENT_ON_DATA: Data: %p, Datalen: %d\r\n", evt->data, evt->data_len);
 #endif
 
-        client->_buffer_pos = 0;
-        client->_buffer_len = (evt->data_len > DEFAULT_HTTP_BUF_SIZE) ? DEFAULT_HTTP_BUF_SIZE : evt->data_len;
-        memcpy(client->_buffer, evt->data, client->_buffer_len);
+        if (client->_buffer == nullptr) {
+            Debug_printf("HTTP_EVENT_ON_DATA: _buffer is null, dropping data\r\n");
+            client->_buffer_pos = 0;
+            client->_buffer_len = 0;
+        }
+        else {
+            client->_buffer_pos = 0;
+            client->_buffer_len = (evt->data_len > DEFAULT_HTTP_BUF_SIZE) ? DEFAULT_HTTP_BUF_SIZE : evt->data_len;
+            memcpy(client->_buffer, evt->data, client->_buffer_len);
+        }
 
         // Now let the reader know there's data in the buffer
         xTaskNotifyGive(client->_taskh_consumer);

--- a/lib/http/fnHttpClient.cpp
+++ b/lib/http/fnHttpClient.cpp
@@ -5,6 +5,7 @@
 #include <vector>
 
 #include "fnHttpClient.h"
+#include "compat_string.h"
 
 #include "../../include/debug.h"
 

--- a/lib/http/fnHttpClient.cpp
+++ b/lib/http/fnHttpClient.cpp
@@ -297,7 +297,7 @@ esp_err_t fnHttpClient::_httpevent_handler(esp_http_client_event_t *evt)
         Debug_printf("HTTP_EVENT_ON_HEADER %u\r\n", uxTaskGetStackHighWaterMark(nullptr));
 #endif
         // Check to see if we should store this response header
-        if (client->_stored_headers.size() <= 0)
+        if (client->_stored_headers.size() == 0)
             break;
 
         client->set_header_value(evt->header_key, evt->header_value);
@@ -822,7 +822,9 @@ char *fnHttpClient::get_header(int index, char *buffer, int buffer_len)
 
     auto vi = _stored_headers.begin();
     std::advance(vi, index);
-    return strncpy(buffer, vi->second.c_str(), buffer_len);
+    strncpy(buffer, vi->second.c_str(), buffer_len - 1);
+    buffer[buffer_len - 1] = '\0';
+    return buffer;
 }
 
 const std::string fnHttpClient::get_header(int index)

--- a/lib/http/fnHttpClient.cpp
+++ b/lib/http/fnHttpClient.cpp
@@ -822,8 +822,7 @@ char *fnHttpClient::get_header(int index, char *buffer, int buffer_len)
 
     auto vi = _stored_headers.begin();
     std::advance(vi, index);
-    strncpy(buffer, vi->second.c_str(), buffer_len - 1);
-    buffer[buffer_len - 1] = '\0';
+    strlcpy(buffer, vi->second.c_str(), buffer_len);
     return buffer;
 }
 

--- a/lib/http/httpService.cpp
+++ b/lib/http/httpService.cpp
@@ -65,7 +65,11 @@ char to_hex(char code)
 /* IMPORTANT: be sure to free() the returned string after use */
 char *url_encode(char *str)
 {
-    char *pstr = str, *buf = (char *)malloc(strlen(str) * 3 + 1), *pbuf = buf;
+    char *pstr = str;
+    char *buf = (char *)malloc(strlen(str) * 3 + 1);
+    if (buf == NULL)
+        return NULL;
+    char *pbuf = buf;
     while (*pstr)
     {
         if (isalnum(*pstr) || *pstr == '-' || *pstr == '_' || *pstr == '.' || *pstr == '~')
@@ -84,7 +88,11 @@ char *url_encode(char *str)
 /* IMPORTANT: be sure to free() the returned string after use */
 char *url_decode(char *str)
 {
-    char *pstr = str, *buf = (char *)malloc(strlen(str) + 1), *pbuf = buf;
+    char *pstr = str;
+    char *buf = (char *)malloc(strlen(str) + 1);
+    if (buf == NULL)
+        return NULL;
+    char *pbuf = buf;
     while (*pstr)
     {
         if (*pstr == '%')
@@ -341,7 +349,7 @@ void fnHttpService::parse_query(httpd_req_t *req, queryparts *results)
     }
 
     /// @todo Error if path_end == 0, the index to substr becomes -1
-    results->path += results->full_uri.substr(0, path_end - 1);
+    results->path += results->full_uri.substr(0, path_end);
     results->query += results->full_uri.substr(path_end + 1);
 
     // URL Decode query

--- a/lib/http/httpServiceParser.cpp
+++ b/lib/http/httpServiceParser.cpp
@@ -652,7 +652,7 @@ const string fnHttpServiceParser::substitute_tag(const string &tag)
                 {
                     strncat(result, "<option value=\"", MAX_PRINTER_LIST_BUFFER-1);
                     strncat(result, PRINTER_CLASS::printer_model_str[i], MAX_PRINTER_LIST_BUFFER-1);
-                    strncat(result, "\">", MAX_PRINTER_LIST_BUFFER);
+                    strncat(result, "\">", MAX_PRINTER_LIST_BUFFER - strlen(result) - 1);
                     strncat(result, PRINTER_CLASS::printer_model_str[i], MAX_PRINTER_LIST_BUFFER-1);
                     strncat(result, "</option>\n", MAX_PRINTER_LIST_BUFFER-1);
                 }

--- a/lib/http/mgHttpClient.cpp
+++ b/lib/http/mgHttpClient.cpp
@@ -984,7 +984,7 @@ int mgHttpClient::COPY(const char *destination, bool overwrite, bool move)
     _flush_response();
 
     // Set method
-    _method = HTTP_MOVE;
+    _method = move ? HTTP_MOVE : HTTP_COPY;
     // Set detination
     set_header("Destination", destination);
     // Set overwrite
@@ -1110,7 +1110,9 @@ char *mgHttpClient::get_header(int index, char *buffer, int buffer_len)
 
     auto vi = _stored_headers.begin();
     std::advance(vi, index);
-    return strncpy(buffer, vi->second.c_str(), buffer_len);
+    strncpy(buffer, vi->second.c_str(), buffer_len - 1);
+    buffer[buffer_len - 1] = '\0';
+    return buffer;
 }
 
 const std::string mgHttpClient::get_header(int index)

--- a/lib/http/mgHttpClient.cpp
+++ b/lib/http/mgHttpClient.cpp
@@ -14,6 +14,7 @@
 
 #include "mongoose.h"
 #undef mkdir
+#include "compat_string.h"
 
 #if defined(_WIN32)
 

--- a/lib/http/mgHttpClient.cpp
+++ b/lib/http/mgHttpClient.cpp
@@ -1110,8 +1110,7 @@ char *mgHttpClient::get_header(int index, char *buffer, int buffer_len)
 
     auto vi = _stored_headers.begin();
     std::advance(vi, index);
-    strncpy(buffer, vi->second.c_str(), buffer_len - 1);
-    buffer[buffer_len - 1] = '\0';
+    strlcpy(buffer, vi->second.c_str(), buffer_len);
     return buffer;
 }
 


### PR DESCRIPTION
# Fix: 7 Bugs in lib/http/

## Summary

This PR fixes 7 bugs found in the `lib/http/` folder. All bugs are small and safe to merge.

---

## Bug 1: Buffer not null-terminated

**Files:**
- `lib/http/fnHttpClient.cpp` line 825
- `lib/http/mgHttpClient.cpp` line 1113

**Problem:**
`strncpy()` does not add `\0` at the end when the source string is longer than the buffer. Any code reading this buffer will read garbage memory.

**Example:**
```
buffer_len = 10
Header value = "very long header value" (22 chars)
Result: "very long " + garbage...
```

**Fix:**
```cpp
// Before
return strncpy(buffer, vi->second.c_str(), buffer_len);

// After
strncpy(buffer, vi->second.c_str(), buffer_len - 1);
buffer[buffer_len - 1] = '\0';
return buffer;
```

---

## Bug 2: url_encode() crashes on low memory

**File:** `lib/http/httpService.cpp` line 68

**Problem:**
`malloc()` can return `NULL` when memory is low. The code does not check and writes to `NULL` pointer, causing crash.

**Fix:**
```cpp
char *buf = (char *)malloc(strlen(str) * 3 + 1);
if (buf == NULL)
    return NULL;
```

---

## Bug 3: url_decode() crashes on low memory

**File:** `lib/http/httpService.cpp` line 87

**Problem:**
Same as Bug 2. `malloc()` without NULL check.

**Fix:**
```cpp
char *buf = (char *)malloc(strlen(str) + 1);
if (buf == NULL)
    return NULL;
```

---

## Bug 4: Off-by-one in query parsing

**File:** `lib/http/httpService.cpp` line 344

**Problem:**
Using `path_end - 1` instead of `path_end` cuts one character from the path.

**Example:**
```
URI: /mount?hostslot=1
Before: path = "/moun"  (wrong)
After:  path = "/mount" (correct)
```

**Fix:**
```cpp
// Before
results->path += results->full_uri.substr(0, path_end - 1);

// After
results->path += results->full_uri.substr(0, path_end);
```

---

## Bug 5: COPY() always sends MOVE request

**File:** `lib/http/mgHttpClient.cpp` line 987

**Problem:**
The `COPY()` function ignores the `move` parameter. It always sets `HTTP_MOVE`, even when copying.

**Fix:**
```cpp
// Before
_method = HTTP_MOVE;

// After
_method = move ? HTTP_MOVE : HTTP_COPY;
```

---

## Bug 6: strncat() can overflow buffer

**File:** `lib/http/httpServiceParser.cpp` line 655

**Problem:**
`strncat()` receives the total buffer size instead of remaining space. Can write past the buffer.

**Fix:**
```cpp
// Before
strncat(result, "\">", MAX_PRINTER_LIST_BUFFER);

// After
strncat(result, "\">", MAX_PRINTER_LIST_BUFFER - strlen(result) - 1);
```

---

## Bug 7: Wrong unsigned comparison

**File:** `lib/http/fnHttpClient.cpp` line 300

**Problem:**
`size()` returns `unsigned`. Comparing with `<= 0` is meaningless because unsigned can never be negative.

**Fix:**
```cpp
// Before
if (client->_stored_headers.size() <= 0)

// After
if (client->_stored_headers.size() == 0)
```

---

## Files Changed

| File | Bugs Fixed |
|------|------------|
| lib/http/fnHttpClient.cpp | Bug 1, Bug 7 |
| lib/http/mgHttpClient.cpp | Bug 1, Bug 5 |
| lib/http/httpService.cpp | Bug 2, Bug 3, Bug 4 |
| lib/http/httpServiceParser.cpp | Bug 6 |

---

## Testing

All fixes are small and focused:
- Bug 1: Prevents buffer read overflow
- Bug 2-3: Prevents NULL pointer crash
- Bug 4: Fixes path parsing
- Bug 5: Fixes HTTP method selection
- Bug 6: Prevents buffer write overflow
- Bug 7: Code clarity fix

---

## Related

All bugs are in the HTTP library (`lib/http/`). They affect:
- HTTP client header reading
- URL encoding/decoding
- Query string parsing
- WebDAV COPY/MOVE operations
- Printer list HTML generation
