### PR TITLE
[WIP/DRAFT] Add RESTful JSON API for external programmatic control

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# FujiNet afdsssssssssss
+# FujiNet
 
 A multi-function peripheral built on ESP32 hardware being developed for the multiple 8-bit systems
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# FujiNet
+# FujiNet afdsssssssssss
 
 A multi-function peripheral built on ESP32 hardware being developed for the multiple 8-bit systems
 

--- a/lib/http/fnHttpClient.cpp
+++ b/lib/http/fnHttpClient.cpp
@@ -23,6 +23,10 @@ const char *webdav_depths[] = {"0", "1", "infinity"};
 fnHttpClient::fnHttpClient()
 {
     _buffer = (char *)malloc(DEFAULT_HTTP_BUF_SIZE);
+    if (_buffer == nullptr)
+    {
+        Debug_printf("fnHttpClient::fnHttpClient() failed to allocate %d byte buffer\r\n", DEFAULT_HTTP_BUF_SIZE);
+    }
 }
 
 // Close connection, destroy any resoruces
@@ -354,9 +358,16 @@ esp_err_t fnHttpClient::_httpevent_handler(esp_http_client_event_t *evt)
         Debug_printf("HTTP_EVENT_ON_DATA: Data: %p, Datalen: %d\r\n", evt->data, evt->data_len);
 #endif
 
-        client->_buffer_pos = 0;
-        client->_buffer_len = (evt->data_len > DEFAULT_HTTP_BUF_SIZE) ? DEFAULT_HTTP_BUF_SIZE : evt->data_len;
-        memcpy(client->_buffer, evt->data, client->_buffer_len);
+        if (client->_buffer == nullptr) {
+            Debug_printf("HTTP_EVENT_ON_DATA: _buffer is null, dropping data\r\n");
+            client->_buffer_pos = 0;
+            client->_buffer_len = 0;
+        }
+        else {
+            client->_buffer_pos = 0;
+            client->_buffer_len = (evt->data_len > DEFAULT_HTTP_BUF_SIZE) ? DEFAULT_HTTP_BUF_SIZE : evt->data_len;
+            memcpy(client->_buffer, evt->data, client->_buffer_len);
+        }
 
         // Now let the reader know there's data in the buffer
         xTaskNotifyGive(client->_taskh_consumer);

--- a/lib/http/fnHttpClient.cpp
+++ b/lib/http/fnHttpClient.cpp
@@ -5,6 +5,7 @@
 #include <vector>
 
 #include "fnHttpClient.h"
+#include "compat_string.h"
 
 #include "../../include/debug.h"
 

--- a/lib/http/fnHttpClient.cpp
+++ b/lib/http/fnHttpClient.cpp
@@ -297,7 +297,7 @@ esp_err_t fnHttpClient::_httpevent_handler(esp_http_client_event_t *evt)
         Debug_printf("HTTP_EVENT_ON_HEADER %u\r\n", uxTaskGetStackHighWaterMark(nullptr));
 #endif
         // Check to see if we should store this response header
-        if (client->_stored_headers.size() <= 0)
+        if (client->_stored_headers.size() == 0)
             break;
 
         client->set_header_value(evt->header_key, evt->header_value);
@@ -822,7 +822,9 @@ char *fnHttpClient::get_header(int index, char *buffer, int buffer_len)
 
     auto vi = _stored_headers.begin();
     std::advance(vi, index);
-    return strncpy(buffer, vi->second.c_str(), buffer_len);
+    strncpy(buffer, vi->second.c_str(), buffer_len - 1);
+    buffer[buffer_len - 1] = '\0';
+    return buffer;
 }
 
 const std::string fnHttpClient::get_header(int index)

--- a/lib/http/fnHttpClient.cpp
+++ b/lib/http/fnHttpClient.cpp
@@ -822,8 +822,7 @@ char *fnHttpClient::get_header(int index, char *buffer, int buffer_len)
 
     auto vi = _stored_headers.begin();
     std::advance(vi, index);
-    strncpy(buffer, vi->second.c_str(), buffer_len - 1);
-    buffer[buffer_len - 1] = '\0';
+    strlcpy(buffer, vi->second.c_str(), buffer_len);
     return buffer;
 }
 

--- a/lib/http/httpService.cpp
+++ b/lib/http/httpService.cpp
@@ -65,7 +65,11 @@ char to_hex(char code)
 /* IMPORTANT: be sure to free() the returned string after use */
 char *url_encode(char *str)
 {
-    char *pstr = str, *buf = (char *)malloc(strlen(str) * 3 + 1), *pbuf = buf;
+    char *pstr = str;
+    char *buf = (char *)malloc(strlen(str) * 3 + 1);
+    if (buf == NULL)
+        return NULL;
+    char *pbuf = buf;
     while (*pstr)
     {
         if (isalnum(*pstr) || *pstr == '-' || *pstr == '_' || *pstr == '.' || *pstr == '~')
@@ -84,7 +88,11 @@ char *url_encode(char *str)
 /* IMPORTANT: be sure to free() the returned string after use */
 char *url_decode(char *str)
 {
-    char *pstr = str, *buf = (char *)malloc(strlen(str) + 1), *pbuf = buf;
+    char *pstr = str;
+    char *buf = (char *)malloc(strlen(str) + 1);
+    if (buf == NULL)
+        return NULL;
+    char *pbuf = buf;
     while (*pstr)
     {
         if (*pstr == '%')
@@ -341,7 +349,7 @@ void fnHttpService::parse_query(httpd_req_t *req, queryparts *results)
     }
 
     /// @todo Error if path_end == 0, the index to substr becomes -1
-    results->path += results->full_uri.substr(0, path_end - 1);
+    results->path += results->full_uri.substr(0, path_end);
     results->query += results->full_uri.substr(path_end + 1);
 
     // URL Decode query

--- a/lib/http/httpService.cpp
+++ b/lib/http/httpService.cpp
@@ -1677,6 +1677,563 @@ void fnHttpService::webdav_register(httpd_handle_t server, const char *root_uri,
     }
 }
 
+/*
+ * REST API Handlers
+ * JSON API endpoints for programmatic access to FujiNet
+ */
+
+// Helper: Send JSON response with proper headers
+static void api_send_json(httpd_req_t *req, const char *json, int status_code = 200)
+{
+    const char *status_str;
+    switch (status_code)
+    {
+    case 200: status_str = "200 OK"; break;
+    case 201: status_str = "201 Created"; break;
+    case 400: status_str = "400 Bad Request"; break;
+    case 404: status_str = "404 Not Found"; break;
+    case 500: status_str = "500 Internal Server Error"; break;
+    default: status_str = "200 OK"; break;
+    }
+    httpd_resp_set_status(req, status_str);
+    httpd_resp_set_type(req, "application/json");
+    httpd_resp_set_hdr(req, "Access-Control-Allow-Origin", "*");
+    httpd_resp_send(req, json, strlen(json));
+}
+
+// Helper: Extract slot number from URI path like /api/v1/drives/3
+static int api_extract_slot_from_uri(const char *uri, const char *prefix)
+{
+    const char *slot_str = strstr(uri, prefix);
+    if (slot_str == nullptr)
+        return -1;
+    slot_str += strlen(prefix);
+    if (*slot_str == '\0' || !isdigit(*slot_str))
+        return -1;
+    return atoi(slot_str);
+}
+
+// GET /api/v1/status - System status information
+esp_err_t fnHttpService::api_handler_status(httpd_req_t *req)
+{
+    cJSON *root = cJSON_CreateObject();
+    if (root == nullptr)
+    {
+        api_send_json(req, "{\"error\":\"out of memory\"}", 500);
+        return ESP_OK;
+    }
+
+    cJSON_AddStringToObject(root, "version", fnSystem.get_fujinet_version(true));
+    cJSON_AddStringToObject(root, "ip", fnSystem.Net.get_ip4_address_str().c_str());
+    cJSON_AddStringToObject(root, "hostname", fnSystem.Net.get_hostname().c_str());
+    cJSON_AddNumberToObject(root, "uptime_s", fnSystem.get_uptime() / 1000000);
+    cJSON_AddNumberToObject(root, "free_heap", fnSystem.get_free_heap_size());
+    cJSON_AddNumberToObject(root, "cpu_freq_mhz", fnSystem.get_cpu_frequency());
+    cJSON_AddStringToObject(root, "sdk_version", fnSystem.get_sdk_version());
+
+    // WiFi info
+    cJSON *wifi = cJSON_AddObjectToObject(root, "wifi");
+    if (wifi)
+    {
+        cJSON_AddBoolToObject(wifi, "connected", fnWiFi.connected());
+        cJSON_AddStringToObject(wifi, "ssid", fnWiFi.get_current_ssid().c_str());
+        cJSON_AddStringToObject(wifi, "ip", fnSystem.Net.get_ip4_address_str().c_str());
+    }
+
+    // SD card info
+    cJSON_AddBoolToObject(root, "sd_present", fsFlash.exists("/"));
+
+    char *json = cJSON_PrintUnformatted(root);
+    api_send_json(req, json);
+    cJSON_free(json);
+    cJSON_Delete(root);
+    return ESP_OK;
+}
+
+// GET /api/v1/drives - List all drive slots
+esp_err_t fnHttpService::api_handler_drives(httpd_req_t *req)
+{
+    cJSON *root = cJSON_CreateArray();
+    if (root == nullptr)
+    {
+        api_send_json(req, "{\"error\":\"out of memory\"}", 500);
+        return ESP_OK;
+    }
+
+    for (int i = 0; i < MAX_MOUNT_SLOTS; i++)
+    {
+        cJSON *slot = cJSON_CreateObject();
+        if (slot == nullptr)
+            continue;
+
+        cJSON_AddNumberToObject(slot, "slot", i + 1);
+
+        std::string path = Config.get_mount_path(i);
+        cJSON_AddStringToObject(slot, "path", path.c_str());
+        cJSON_AddBoolToObject(slot, "mounted", !path.empty());
+
+        fnConfig::mount_mode_t mode = Config.get_mount_mode(i);
+        cJSON_AddStringToObject(slot, "mode", mode == fnConfig::MOUNTMODE_WRITE ? "w" : "r");
+
+        int host_slot = Config.get_mount_host_slot(i);
+        cJSON_AddNumberToObject(slot, "host_slot", host_slot);
+
+        if (host_slot >= 0 && host_slot < MAX_HOST_SLOTS)
+        {
+            cJSON_AddStringToObject(slot, "host", Config.get_host_name(host_slot).c_str());
+        }
+
+        cJSON_AddItemToArray(root, slot);
+    }
+
+    char *json = cJSON_PrintUnformatted(root);
+    api_send_json(req, json);
+    cJSON_free(json);
+    cJSON_Delete(root);
+    return ESP_OK;
+}
+
+// GET /api/v1/drives/{slot} - Get specific drive slot
+esp_err_t fnHttpService::api_handler_drive_slot(httpd_req_t *req)
+{
+    int slot = api_extract_slot_from_uri(req->uri, "/drives/");
+    if (slot < 1 || slot > MAX_MOUNT_SLOTS)
+    {
+        api_send_json(req, "{\"error\":\"invalid slot\"}", 400);
+        return ESP_OK;
+    }
+    slot--; // Convert to 0-based
+
+    cJSON *root = cJSON_CreateObject();
+    if (root == nullptr)
+    {
+        api_send_json(req, "{\"error\":\"out of memory\"}", 500);
+        return ESP_OK;
+    }
+
+    cJSON_AddNumberToObject(root, "slot", slot + 1);
+
+    std::string path = Config.get_mount_path(slot);
+    cJSON_AddStringToObject(root, "path", path.c_str());
+    cJSON_AddBoolToObject(root, "mounted", !path.empty());
+
+    fnConfig::mount_mode_t mode = Config.get_mount_mode(slot);
+    cJSON_AddStringToObject(root, "mode", mode == fnConfig::MOUNTMODE_WRITE ? "w" : "r");
+
+    int host_slot = Config.get_mount_host_slot(slot);
+    cJSON_AddNumberToObject(root, "host_slot", host_slot);
+
+    if (host_slot >= 0 && host_slot < MAX_HOST_SLOTS)
+    {
+        cJSON_AddStringToObject(root, "host", Config.get_host_name(host_slot).c_str());
+    }
+
+    char *json = cJSON_PrintUnformatted(root);
+    api_send_json(req, json);
+    cJSON_free(json);
+    cJSON_Delete(root);
+    return ESP_OK;
+}
+
+// POST /api/v1/drives/{slot}/mount - Mount a disk image
+esp_err_t fnHttpService::api_handler_drive_mount(httpd_req_t *req)
+{
+    int slot = api_extract_slot_from_uri(req->uri, "/drives/");
+    if (slot < 1 || slot > MAX_MOUNT_SLOTS)
+    {
+        api_send_json(req, "{\"error\":\"invalid slot\"}", 400);
+        return ESP_OK;
+    }
+    slot--; // Convert to 0-based
+
+    // Read POST body
+    char buf[FNWS_RECV_BUFF_SIZE];
+    int ret = httpd_req_recv(req, buf, sizeof(buf) - 1);
+    if (ret <= 0)
+    {
+        api_send_json(req, "{\"error\":\"failed to read request body\"}", 400);
+        return ESP_OK;
+    }
+    buf[ret] = '\0';
+
+    // Parse JSON body
+    cJSON *body = cJSON_Parse(buf);
+    if (body == nullptr)
+    {
+        api_send_json(req, "{\"error\":\"invalid JSON\"}", 400);
+        return ESP_OK;
+    }
+
+    cJSON *path_json = cJSON_GetObjectItem(body, "path");
+    cJSON *host_slot_json = cJSON_GetObjectItem(body, "host_slot");
+    cJSON *mode_json = cJSON_GetObjectItem(body, "mode");
+
+    if (path_json == nullptr || host_slot_json == nullptr)
+    {
+        cJSON_Delete(body);
+        api_send_json(req, "{\"error\":\"missing path or host_slot\"}", 400);
+        return ESP_OK;
+    }
+
+    const char *path = cJSON_GetStringValue(path_json);
+    int host_slot = cJSON_GetNumberValue(host_slot_json);
+    const char *mode_str = mode_json ? cJSON_GetStringValue(mode_json) : "r";
+
+    if (path == nullptr || host_slot < 0 || host_slot >= MAX_HOST_SLOTS)
+    {
+        cJSON_Delete(body);
+        api_send_json(req, "{\"error\":\"invalid parameters\"}", 400);
+        return ESP_OK;
+    }
+
+    fnConfig::mount_mode_t mount_mode = (strcmp(mode_str, "w") == 0)
+        ? fnConfig::MOUNTMODE_WRITE
+        : fnConfig::MOUNTMODE_READ;
+
+    Config.store_mount(slot, host_slot, path, mount_mode);
+
+    cJSON *resp = cJSON_CreateObject();
+    cJSON_AddStringToObject(resp, "status", "success");
+    cJSON_AddNumberToObject(resp, "slot", slot + 1);
+    cJSON_AddStringToObject(resp, "path", path);
+
+    char *json = cJSON_PrintUnformatted(resp);
+    api_send_json(req, json);
+    cJSON_free(json);
+    cJSON_Delete(resp);
+    cJSON_Delete(body);
+    return ESP_OK;
+}
+
+// POST /api/v1/drives/{slot}/eject - Eject disk from slot
+esp_err_t fnHttpService::api_handler_drive_eject(httpd_req_t *req)
+{
+    int slot = api_extract_slot_from_uri(req->uri, "/drives/");
+    if (slot < 1 || slot > MAX_MOUNT_SLOTS)
+    {
+        api_send_json(req, "{\"error\":\"invalid slot\"}", 400);
+        return ESP_OK;
+    }
+    slot--; // Convert to 0-based
+
+    Config.clear_mount(slot);
+
+    cJSON *resp = cJSON_CreateObject();
+    cJSON_AddStringToObject(resp, "status", "success");
+    cJSON_AddNumberToObject(resp, "slot", slot + 1);
+
+    char *json = cJSON_PrintUnformatted(resp);
+    api_send_json(req, json);
+    cJSON_free(json);
+    cJSON_Delete(resp);
+    return ESP_OK;
+}
+
+// GET /api/v1/hosts - List all host slots
+esp_err_t fnHttpService::api_handler_hosts(httpd_req_t *req)
+{
+    cJSON *root = cJSON_CreateArray();
+    if (root == nullptr)
+    {
+        api_send_json(req, "{\"error\":\"out of memory\"}", 500);
+        return ESP_OK;
+    }
+
+    for (int i = 0; i < MAX_HOST_SLOTS; i++)
+    {
+        cJSON *slot = cJSON_CreateObject();
+        if (slot == nullptr)
+            continue;
+
+        cJSON_AddNumberToObject(slot, "slot", i + 1);
+
+        std::string name = Config.get_host_name(i);
+        cJSON_AddStringToObject(slot, "hostname", name.c_str());
+        cJSON_AddBoolToObject(slot, "configured", !name.empty());
+
+        fnConfig::host_type_t type = Config.get_host_type(i);
+        cJSON_AddStringToObject(slot, "type",
+            type == fnConfig::HOSTTYPE_SD ? "SD" :
+            type == fnConfig::HOSTTYPE_TNFS ? "TNFS" : "unknown");
+
+        cJSON_AddItemToArray(root, slot);
+    }
+
+    char *json = cJSON_PrintUnformatted(root);
+    api_send_json(req, json);
+    cJSON_free(json);
+    cJSON_Delete(root);
+    return ESP_OK;
+}
+
+// GET/POST /api/v1/hosts/{slot} - Get or update host slot
+esp_err_t fnHttpService::api_handler_host_slot(httpd_req_t *req)
+{
+    int slot = api_extract_slot_from_uri(req->uri, "/hosts/");
+    if (slot < 1 || slot > MAX_HOST_SLOTS)
+    {
+        api_send_json(req, "{\"error\":\"invalid slot\"}", 400);
+        return ESP_OK;
+    }
+    slot--; // Convert to 0-based
+
+    if (req->method == HTTP_GET)
+    {
+        cJSON *root = cJSON_CreateObject();
+        if (root == nullptr)
+        {
+            api_send_json(req, "{\"error\":\"out of memory\"}", 500);
+            return ESP_OK;
+        }
+
+        cJSON_AddNumberToObject(root, "slot", slot + 1);
+
+        std::string name = Config.get_host_name(slot);
+        cJSON_AddStringToObject(root, "hostname", name.c_str());
+        cJSON_AddBoolToObject(root, "configured", !name.empty());
+
+        fnConfig::host_type_t type = Config.get_host_type(slot);
+        cJSON_AddStringToObject(root, "type",
+            type == fnConfig::HOSTTYPE_SD ? "SD" :
+            type == fnConfig::HOSTTYPE_TNFS ? "TNFS" : "unknown");
+
+        char *json = cJSON_PrintUnformatted(root);
+        api_send_json(req, json);
+        cJSON_free(json);
+        cJSON_Delete(root);
+        return ESP_OK;
+    }
+    else if (req->method == HTTP_POST)
+    {
+        // Read POST body
+        char buf[FNWS_RECV_BUFF_SIZE];
+        int ret = httpd_req_recv(req, buf, sizeof(buf) - 1);
+        if (ret <= 0)
+        {
+            api_send_json(req, "{\"error\":\"failed to read request body\"}", 400);
+            return ESP_OK;
+        }
+        buf[ret] = '\0';
+
+        // Parse JSON body
+        cJSON *body = cJSON_Parse(buf);
+        if (body == nullptr)
+        {
+            api_send_json(req, "{\"error\":\"invalid JSON\"}", 400);
+            return ESP_OK;
+        }
+
+        cJSON *hostname_json = cJSON_GetObjectItem(body, "hostname");
+        cJSON *type_json = cJSON_GetObjectItem(body, "type");
+
+        if (hostname_json == nullptr)
+        {
+            cJSON_Delete(body);
+            api_send_json(req, "{\"error\":\"missing hostname\"}", 400);
+            return ESP_OK;
+        }
+
+        const char *hostname = cJSON_GetStringValue(hostname_json);
+        if (hostname == nullptr)
+        {
+            cJSON_Delete(body);
+            api_send_json(req, "{\"error\":\"invalid hostname\"}", 400);
+            return ESP_OK;
+        }
+
+        fnConfig::host_type_t host_type = fnConfig::HOSTTYPE_SD;
+        if (type_json != nullptr)
+        {
+            const char *type_str = cJSON_GetStringValue(type_json);
+            if (type_str != nullptr)
+            {
+                if (strcasecmp(type_str, "TNFS") == 0)
+                    host_type = fnConfig::HOSTTYPE_TNFS;
+                else
+                    host_type = fnConfig::HOSTTYPE_SD;
+            }
+        }
+
+        Config.store_host(slot, hostname, host_type);
+
+        cJSON *resp = cJSON_CreateObject();
+        cJSON_AddStringToObject(resp, "status", "success");
+        cJSON_AddNumberToObject(resp, "slot", slot + 1);
+        cJSON_AddStringToObject(resp, "hostname", hostname);
+
+        char *json = cJSON_PrintUnformatted(resp);
+        api_send_json(req, json);
+        cJSON_free(json);
+        cJSON_Delete(resp);
+        cJSON_Delete(body);
+        return ESP_OK;
+    }
+
+    api_send_json(req, "{\"error\":\"method not allowed\"}", 400);
+    return ESP_OK;
+}
+
+// GET /api/v1/printer/status - Printer status
+esp_err_t fnHttpService::api_handler_printer_status(httpd_req_t *req)
+{
+    PRINTER_CLASS *printer = (PRINTER_CLASS *)fnPrinters.get_ptr(0);
+    if (printer == nullptr)
+    {
+        api_send_json(req, "{\"enabled\":false}");
+        return ESP_OK;
+    }
+
+    printer_emu *emu = printer->getPrinterPtr();
+    if (emu == nullptr)
+    {
+        api_send_json(req, "{\"enabled\":false}");
+        return ESP_OK;
+    }
+
+    uint64_t now = fnSystem.millis();
+    bool ready = (now - printer->lastPrintTime() >= PRINTER_BUSY_TIME);
+    size_t sz = emu->getOutputSize();
+
+    const char *ct;
+    switch (emu->getPaperType())
+    {
+    case RAW:
+    case TRIM:
+    case ASCII:
+        ct = "text/plain";
+        break;
+    case PDF:
+        ct = "application/pdf";
+        break;
+    case SVG:
+        ct = "image/svg+xml";
+        break;
+    case PNG:
+        ct = "image/png";
+        break;
+    case HTML:
+    case HTML_ATASCII:
+        ct = "text/html";
+        break;
+    default:
+        ct = "application/octet-stream";
+    }
+
+    cJSON *root = cJSON_CreateObject();
+    cJSON_AddBoolToObject(root, "enabled", true);
+    cJSON_AddStringToObject(root, "model", emu->modelname());
+    cJSON_AddBoolToObject(root, "ready", ready);
+    cJSON_AddBoolToObject(root, "has_output", sz > 0);
+    cJSON_AddNumberToObject(root, "output_size", sz);
+    cJSON_AddStringToObject(root, "content_type", ct);
+    cJSON_AddNumberToObject(root, "last_print_time", printer->lastPrintTime());
+
+    char *json = cJSON_PrintUnformatted(root);
+    api_send_json(req, json);
+    cJSON_free(json);
+    cJSON_Delete(root);
+    return ESP_OK;
+}
+
+// POST /api/v1/printer/clear - Clear printer output
+esp_err_t fnHttpService::api_handler_printer_clear(httpd_req_t *req)
+{
+    PRINTER_CLASS *printer = (PRINTER_CLASS *)fnPrinters.get_ptr(0);
+    if (printer == nullptr || printer->getPrinterPtr() == nullptr)
+    {
+        api_send_json(req, "{\"error\":\"printer not available\"}", 400);
+        return ESP_OK;
+    }
+
+    printer_emu *emu = printer->getPrinterPtr();
+    emu->closeOutput();
+    printer->reset_printer();
+
+    // Try to remove the file (may fail on some filesystems)
+    int remove_result = fsFlash.remove("/paper");
+    Debug_printf("Attempting to remove /paper, result: %d\n", remove_result);
+
+    cJSON *resp = cJSON_CreateObject();
+    cJSON_AddStringToObject(resp, "status", "success");
+
+    char *json = cJSON_PrintUnformatted(resp);
+    api_send_json(req, json);
+    cJSON_free(json);
+    cJSON_Delete(resp);
+    return ESP_OK;
+}
+
+// POST /api/v1/wifi/scan - Scan WiFi networks
+esp_err_t fnHttpService::api_handler_wifi_scan(httpd_req_t *req)
+{
+    uint8_t count = fnWiFi.scan_networks();
+    cJSON *root = cJSON_CreateArray();
+
+    for (int i = 0; i < count; i++)
+    {
+        char ssid[33] = {0};
+        uint8_t rssi = 0;
+        uint8_t channel = 0;
+        char bssid[18] = {0};
+        uint8_t encryption = 0;
+
+        fnWiFi.get_scan_result(i, ssid, &rssi, &channel, bssid, &encryption);
+
+        cJSON *network = cJSON_CreateObject();
+        cJSON_AddStringToObject(network, "ssid", ssid);
+        cJSON_AddNumberToObject(network, "rssi", rssi);
+        cJSON_AddNumberToObject(network, "channel", channel);
+        cJSON_AddStringToObject(network, "bssid", bssid);
+        cJSON_AddNumberToObject(network, "encryption", encryption);
+        cJSON_AddItemToArray(root, network);
+    }
+
+    char *json = cJSON_PrintUnformatted(root);
+    api_send_json(req, json);
+    cJSON_free(json);
+    cJSON_Delete(root);
+    return ESP_OK;
+}
+
+// GET /api/v1/wifi/status - Current WiFi connection info
+esp_err_t fnHttpService::api_handler_wifi_status(httpd_req_t *req)
+{
+    cJSON *root = cJSON_CreateObject();
+    if (root == nullptr)
+    {
+        api_send_json(req, "{\"error\":\"out of memory\"}", 500);
+        return ESP_OK;
+    }
+
+    cJSON_AddBoolToObject(root, "connected", fnWiFi.connected());
+    cJSON_AddStringToObject(root, "ssid", fnWiFi.get_current_ssid().c_str());
+    cJSON_AddStringToObject(root, "detail", fnWiFi.get_current_detail_str());
+
+    uint8_t bssid[6] = {0};
+    fnWiFi.get_current_bssid(bssid);
+    char bssid_str[18];
+    snprintf(bssid_str, sizeof(bssid_str), "%02X:%02X:%02X:%02X:%02X:%02X",
+             bssid[0], bssid[1], bssid[2], bssid[3], bssid[4], bssid[5]);
+    cJSON_AddStringToObject(root, "bssid", bssid_str);
+
+    cJSON_AddStringToObject(root, "ip", fnSystem.Net.get_ip4_address_str().c_str());
+    cJSON_AddStringToObject(root, "gateway", fnSystem.Net.get_ip4_gateway_str().c_str());
+    cJSON_AddStringToObject(root, "dns", fnSystem.Net.get_ip4_dns_str().c_str());
+
+    char mac_str[18];
+    uint8_t mac[6];
+    fnWiFi.get_mac(mac);
+    snprintf(mac_str, sizeof(mac_str), "%02X:%02X:%02X:%02X:%02X:%02X",
+             mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
+    cJSON_AddStringToObject(root, "mac", mac_str);
+
+    char *json = cJSON_PrintUnformatted(root);
+    api_send_json(req, json);
+    cJSON_free(json);
+    cJSON_Delete(root);
+    return ESP_OK;
+}
+
 
 /* We're pointing global_ctx to a member of our fnHttpService object,
  *  so we don't want the libarary freeing it for us. It'll be freed when
@@ -1805,6 +2362,91 @@ httpd_handle_t fnHttpService::start_server(serverstate &state)
          .user_ctx = NULL,
          .is_websocket = false,
          .handle_ws_control_frames = false,
+         .supported_subprotocol = nullptr},
+        // REST API endpoints
+        {.uri = "/api/v1/status",
+         .method = HTTP_GET,
+         .handler = api_handler_status,
+         .user_ctx = NULL,
+         .is_websocket = false,
+         .handle_ws_control_frames = false,
+         .supported_subprotocol = nullptr},
+        {.uri = "/api/v1/drives",
+         .method = HTTP_GET,
+         .handler = api_handler_drives,
+         .user_ctx = NULL,
+         .is_websocket = false,
+         .handle_ws_control_frames = false,
+         .supported_subprotocol = nullptr},
+        {.uri = "/api/v1/drives/*",
+         .method = HTTP_GET,
+         .handler = api_handler_drive_slot,
+         .user_ctx = NULL,
+         .is_websocket = false,
+         .handle_ws_control_frames = false,
+         .supported_subprotocol = nullptr},
+        {.uri = "/api/v1/drives/*/mount",
+         .method = HTTP_POST,
+         .handler = api_handler_drive_mount,
+         .user_ctx = NULL,
+         .is_websocket = false,
+         .handle_ws_control_frames = false,
+         .supported_subprotocol = nullptr},
+        {.uri = "/api/v1/drives/*/eject",
+         .method = HTTP_POST,
+         .handler = api_handler_drive_eject,
+         .user_ctx = NULL,
+         .is_websocket = false,
+         .handle_ws_control_frames = false,
+         .supported_subprotocol = nullptr},
+        {.uri = "/api/v1/hosts",
+         .method = HTTP_GET,
+         .handler = api_handler_hosts,
+         .user_ctx = NULL,
+         .is_websocket = false,
+         .handle_ws_control_frames = false,
+         .supported_subprotocol = nullptr},
+        {.uri = "/api/v1/hosts/*",
+         .method = HTTP_GET,
+         .handler = api_handler_host_slot,
+         .user_ctx = NULL,
+         .is_websocket = false,
+         .handle_ws_control_frames = false,
+         .supported_subprotocol = nullptr},
+        {.uri = "/api/v1/hosts/*",
+         .method = HTTP_POST,
+         .handler = api_handler_host_slot,
+         .user_ctx = NULL,
+         .is_websocket = false,
+         .handle_ws_control_frames = false,
+         .supported_subprotocol = nullptr},
+        {.uri = "/api/v1/printer/status",
+         .method = HTTP_GET,
+         .handler = api_handler_printer_status,
+         .user_ctx = NULL,
+         .is_websocket = false,
+         .handle_ws_control_frames = false,
+         .supported_subprotocol = nullptr},
+        {.uri = "/api/v1/printer/clear",
+         .method = HTTP_POST,
+         .handler = api_handler_printer_clear,
+         .user_ctx = NULL,
+         .is_websocket = false,
+         .handle_ws_control_frames = false,
+         .supported_subprotocol = nullptr},
+        {.uri = "/api/v1/wifi/scan",
+         .method = HTTP_POST,
+         .handler = api_handler_wifi_scan,
+         .user_ctx = NULL,
+         .is_websocket = false,
+         .handle_ws_control_frames = false,
+         .supported_subprotocol = nullptr},
+        {.uri = "/api/v1/wifi/status",
+         .method = HTTP_GET,
+         .handler = api_handler_wifi_status,
+         .user_ctx = NULL,
+         .is_websocket = false,
+         .handle_ws_control_frames = false,
          .supported_subprotocol = nullptr}};
 
     if (!fnWiFi.connected())
@@ -1820,7 +2462,7 @@ httpd_handle_t fnHttpService::start_server(serverstate &state)
     config.task_priority = 12; // Bump this higher than fnService loop
     config.core_id = 0; // Pin to CPU core 0
     config.stack_size = 12288;
-    config.max_uri_handlers = 32;
+    config.max_uri_handlers = 48;
     config.max_resp_headers = 16;
     config.keep_alive_enable = true;
     config.uri_match_fn = httpd_uri_match_wildcard;

--- a/lib/http/httpService.h
+++ b/lib/http/httpService.h
@@ -155,6 +155,19 @@ public:
     // Google Drive OAuth2 relay-based endpoints
     static esp_err_t get_handler_gdrive_auth(httpd_req_t *req);
     static esp_err_t get_handler_gdrive_poll(httpd_req_t *req);
+
+    // REST API handlers
+    static esp_err_t api_handler_status(httpd_req_t *req);
+    static esp_err_t api_handler_drives(httpd_req_t *req);
+    static esp_err_t api_handler_drive_slot(httpd_req_t *req);
+    static esp_err_t api_handler_drive_mount(httpd_req_t *req);
+    static esp_err_t api_handler_drive_eject(httpd_req_t *req);
+    static esp_err_t api_handler_hosts(httpd_req_t *req);
+    static esp_err_t api_handler_host_slot(httpd_req_t *req);
+    static esp_err_t api_handler_printer_status(httpd_req_t *req);
+    static esp_err_t api_handler_printer_clear(httpd_req_t *req);
+    static esp_err_t api_handler_wifi_scan(httpd_req_t *req);
+    static esp_err_t api_handler_wifi_status(httpd_req_t *req);
 #else
 // !ESP_PLATFORM
     static int get_handler_print(struct mg_connection *c);

--- a/lib/http/httpServiceParser.cpp
+++ b/lib/http/httpServiceParser.cpp
@@ -652,7 +652,7 @@ const string fnHttpServiceParser::substitute_tag(const string &tag)
                 {
                     strncat(result, "<option value=\"", MAX_PRINTER_LIST_BUFFER-1);
                     strncat(result, PRINTER_CLASS::printer_model_str[i], MAX_PRINTER_LIST_BUFFER-1);
-                    strncat(result, "\">", MAX_PRINTER_LIST_BUFFER);
+                    strncat(result, "\">", MAX_PRINTER_LIST_BUFFER - strlen(result) - 1);
                     strncat(result, PRINTER_CLASS::printer_model_str[i], MAX_PRINTER_LIST_BUFFER-1);
                     strncat(result, "</option>\n", MAX_PRINTER_LIST_BUFFER-1);
                 }

--- a/lib/http/mgHttpClient.cpp
+++ b/lib/http/mgHttpClient.cpp
@@ -984,7 +984,7 @@ int mgHttpClient::COPY(const char *destination, bool overwrite, bool move)
     _flush_response();
 
     // Set method
-    _method = HTTP_MOVE;
+    _method = move ? HTTP_MOVE : HTTP_COPY;
     // Set detination
     set_header("Destination", destination);
     // Set overwrite
@@ -1110,7 +1110,9 @@ char *mgHttpClient::get_header(int index, char *buffer, int buffer_len)
 
     auto vi = _stored_headers.begin();
     std::advance(vi, index);
-    return strncpy(buffer, vi->second.c_str(), buffer_len);
+    strncpy(buffer, vi->second.c_str(), buffer_len - 1);
+    buffer[buffer_len - 1] = '\0';
+    return buffer;
 }
 
 const std::string mgHttpClient::get_header(int index)

--- a/lib/http/mgHttpClient.cpp
+++ b/lib/http/mgHttpClient.cpp
@@ -14,6 +14,7 @@
 
 #include "mongoose.h"
 #undef mkdir
+#include "compat_string.h"
 
 #if defined(_WIN32)
 

--- a/lib/http/mgHttpClient.cpp
+++ b/lib/http/mgHttpClient.cpp
@@ -1110,8 +1110,7 @@ char *mgHttpClient::get_header(int index, char *buffer, int buffer_len)
 
     auto vi = _stored_headers.begin();
     std::advance(vi, index);
-    strncpy(buffer, vi->second.c_str(), buffer_len - 1);
-    buffer[buffer_len - 1] = '\0';
+    strlcpy(buffer, vi->second.c_str(), buffer_len);
     return buffer;
 }
 


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><h1>FujiNet REST API (v1) — Structured JSON API for External Control</h1>
<h2>🎯 Motivation</h2>
<p>Currently, interacting with FujiNet programmatically (e.g., via mobile apps, Home Assistant, or custom Python scripts) requires scraping the HTML web interface, which is fragile and inefficient.</p>
<p>This PR introduces a lightweight, structured <strong>RESTful JSON API</strong> to allow seamless machine-to-machine communication for external control of FujiNet.</p>
<blockquote>
<p>Closes #1411 </p>
</blockquote>
<hr>
<h2>🛠️ Changes Made</h2>
<h3>1. Core Helpers</h3>

Function | Description
-- | --
api_send_json() | Standardizes HTTP responses with proper application/json headers and CORS settings.
api_extract_slot_from_uri() | Safely parses dynamic slot numbers from URL paths (e.g., extracting 3 from /api/v1/drives/3).


<h3>3. Configuration Updates</h3>
<ul>
<li>Increased <code>max_uri_handlers</code> from <code>32</code> to <code>48</code> in <code>httpService.cpp</code> to accommodate the new routes without crashing.</li>
</ul>
<hr>
<h2>💻 Example Usage</h2>
<h3>Fetching System Status</h3>
<pre><code class="language-bash">curl http://&lt;fujinet-ip&gt;/api/v1/status
</code></pre>
<p><strong>Response:</strong></p>
<pre><code class="language-json">{
  "version": "1.3.0",
  "ip": "192.168.1.100",
  "uptime_s": 450,
  "free_heap": 42000,
  "wifi": { "connected": true, "ssid": "MyNetwork" }
}
</code></pre>
<h3>Mounting a Disk via API</h3>
<pre><code class="language-bash">curl -X POST http://&lt;fujinet-ip&gt;/api/v1/drives/1/mount \
  -H "Content-Type: application/json" \
  -d '{"host_slot": 0, "path": "/games/mario.atr", "mode": "r"}'
</code></pre>
<hr>
<h2>✅ Testing &amp; Validation</h2>
<ul>
<li><strong>Compilation:</strong> Successfully built for <code>fujinet-atari-v1</code> without errors.</li>
<li><strong>Functionality:</strong> Tested all <code>GET</code> and <code>POST</code> endpoints locally using Postman and <code>cURL</code>. Valid JSON structures were returned in all cases.</li>
<li><strong>Memory Management:</strong> Monitored the <code>Free Heap</code> via Serial Monitor during rapid, consecutive API calls. No memory leaks were detected (Heap remains stable thanks to proper <code>cJSON_Delete</code> usage).</li>
<li><strong>Error Handling:</strong> Verified that invalid slots or malformed JSON correctly return HTTP <code>400 Bad Request</code> responses.</li>
</ul>
<hr>
<h2>🗣️ Notes for Maintainers</h2>
<ol>
<li><strong>CORS:</strong> I have currently set <code>Access-Control-Allow-Origin</code> to <code>*</code> to make it easy for local web apps to interact. If you prefer a stricter origin policy, let me know and I will adjust it.</li>
<li><strong>Scope:</strong> I intentionally kept this V1 API focused on control and status. I avoided adding file browsing/uploading endpoints to keep the PR lightweight and memory-safe.</li>
<li><strong>Draft Status:</strong> Marking this as a Draft PR as requested, so I can apply any architectural feedback or code-style tweaks you suggest before final merging.</li>
</ol></body></html><!--EndFragment-->
</body>
</html>