### PR TITLE
DriveWire/CoCo high score information support.

### DIFF
--- a/lib/device/drivewire/disk.cpp
+++ b/lib/device/drivewire/disk.cpp
@@ -59,6 +59,7 @@ mediatype_t drivewireDisk::mount(fnFile *f, const char *filename, uint32_t disks
     if (_media)
     {
         strcpy(_media->_disk_filename,filename);
+        _media->_media_read_only = !(access_mode & DISK_ACCESS_MODE_WRITE);
         mt = _media->mount(f, disksize);
         if (mt == MEDIATYPE_UNKNOWN)
         {
@@ -77,6 +78,12 @@ mediatype_t drivewireDisk::mount(fnFile *f, const char *filename, uint32_t disks
 
 void drivewireDisk::unmount()
 {
+}
+
+void drivewireDisk::set_media_host(fujiHost *host)
+{
+    if (_media)
+        _media->_media_host = host;
 }
 
 error_is_true drivewireDisk::read(uint32_t lsn, uint8_t *buf)

--- a/lib/device/drivewire/disk.h
+++ b/lib/device/drivewire/disk.h
@@ -20,6 +20,8 @@ public:
                       mediatype_t disk_type = MEDIATYPE_UNKNOWN);
     void unmount();
 
+    void set_media_host(fujiHost *host);
+
     success_is_true write_blank(fnFile *f, uint8_t numDisks);
 
     error_is_true read(uint32_t sector, uint8_t *buf);

--- a/lib/device/drivewire/drivewireFuji.cpp
+++ b/lib/device/drivewire/drivewireFuji.cpp
@@ -647,6 +647,19 @@ void drivewireFuji::process()
     }
 }
 
+success_is_true drivewireFuji::fujicore_mount_disk_image_success(uint8_t deviceSlot,
+                                                                   disk_access_flags_t access_mode)
+{
+    if (!fujiDevice::fujicore_mount_disk_image_success(deviceSlot, access_mode))
+        RETURN_ERROR_AS_FALSE();
+
+    fujiDisk &disk = *get_disk(deviceSlot);
+    fujiHost &host = _fnHosts[disk.host_slot];
+    get_disk_dev(deviceSlot)->set_media_host(&host);
+
+    RETURN_SUCCESS_AS_TRUE();
+}
+
 std::optional<std::vector<uint8_t>> drivewireFuji::fujicore_read_app_key()
 {
     auto result = fujiDevice::fujicore_read_app_key();

--- a/lib/device/drivewire/drivewireFuji.h
+++ b/lib/device/drivewire/drivewireFuji.h
@@ -80,6 +80,8 @@ public:
     // ============ Wrapped Fuji commands ============
     std::optional<std::vector<uint8_t>> fujicore_read_app_key() override;
     void fujicmd_open_app_key() override;
+    success_is_true fujicore_mount_disk_image_success(uint8_t deviceSlot,
+                                                      disk_access_flags_t access_mode) override;
 
 };
 

--- a/lib/device/fujiDevice.cpp
+++ b/lib/device/fujiDevice.cpp
@@ -503,11 +503,6 @@ success_is_true fujiDevice::fujicore_mount_disk_image_success(uint8_t deviceSlot
     disk.disk_type = disk_dev->mount(disk.fileh, disk.filename, disk.disk_size, access_mode);
     disk_dev->is_config_device = false;
 
-#ifdef BUILD_COCO
-    // the media layer needs the host to reopen high-score sectors read-write
-    disk_dev->set_media_host(&host);
-#endif
-
     RETURN_SUCCESS_AS_TRUE();
 }
 

--- a/lib/device/fujiDevice.cpp
+++ b/lib/device/fujiDevice.cpp
@@ -503,6 +503,11 @@ success_is_true fujiDevice::fujicore_mount_disk_image_success(uint8_t deviceSlot
     disk.disk_type = disk_dev->mount(disk.fileh, disk.filename, disk.disk_size, access_mode);
     disk_dev->is_config_device = false;
 
+#ifdef BUILD_COCO
+    // the media layer needs the host to reopen high-score sectors read-write
+    disk_dev->set_media_host(&host);
+#endif
+
     RETURN_SUCCESS_AS_TRUE();
 }
 

--- a/lib/media/drivewire/mediaType.h
+++ b/lib/media/drivewire/mediaType.h
@@ -50,6 +50,7 @@ public:
     uint8_t _media_controller_status = DISK_CTRL_STATUS_CLEAR;
     fujiHost *_media_host = nullptr;
     char _disk_filename[256];
+    bool _media_read_only = false;
 
 
     mediatype_t _mediatype = MEDIATYPE_UNKNOWN;

--- a/lib/media/drivewire/mediaTypeDSK.cpp
+++ b/lib/media/drivewire/mediaTypeDSK.cpp
@@ -59,40 +59,117 @@ error_is_true MediaTypeDSK::write(uint32_t blockNum, bool verify)
 {
     // Debug_printf("DSK WRITE\n", blockNum, _media_num_blocks);
 
+    fnFile *hsFileh = nullptr;
+    fnFile *oldFileh = nullptr;
+
+    if (_media_read_only)
+    {
+        // High-score marked sectors are writable even on a read-only mount,
+        // via a temporary read-write handle (see the Atari ATR equivalent).
+        if (!_high_score_block(blockNum) || _media_host == nullptr)
+        {
+            Debug_printf("DSK::write block %lu rejected (read-only)\n", blockNum);
+            _media_controller_status = 2;
+            RETURN_ERROR_AS_TRUE();
+        }
+
+        Debug_printf("DSK::write high score block %lu, opening read-write\n", blockNum);
+        hsFileh = _media_host->fnfile_open(_disk_filename, _disk_filename,
+                                           strlen(_disk_filename) + 1, "rb+");
+        if (hsFileh == nullptr)
+        {
+            Debug_printf("DSK::write high score open failed\n");
+            _media_controller_status = 2;
+            RETURN_ERROR_AS_TRUE();
+        }
+        oldFileh = _media_fileh;
+        _media_fileh = hsFileh;
+    }
+
     uint32_t offset = _block_to_offset(blockNum);
 
     _media_last_block = INVALID_SECTOR_VALUE;
 
-    // Perform a seek if we're writing to the sector after the last one
-    int e;
-    e = fnio::fseek(_media_fileh, offset, SEEK_SET);
-    if (e != 0)
-    {
+    int e = fnio::fseek(_media_fileh, offset, SEEK_SET);
+    bool err = (e != 0);
+    if (err)
         Debug_printf("::write seek error %d\n", e);
+
+    if (!err)
+    {
+        e = fnio::fwrite(&_media_blockbuff, 1, MEDIA_BLOCK_SIZE, _media_fileh);
+        err = (e != MEDIA_BLOCK_SIZE);
+        if (err)
+            Debug_printf("::write error %d, %d\n", e, errno);
+    }
+
+    if (!err)
+    {
+        int ret = fnio::fflush(_media_fileh);    // This doesn't seem to be connected to anything in ESP-IDF VF, so it may not do anything
+
+        // This next line is commented out because there's no fsync in the
+        // fnio class. In a discussion with @apc from the following discussion:
+        // https://discord.com/channels/655893677146636301/1209535440915406848/1231880068528214026
+        // fnio::fflush() should be sufficient for syncing as well.
+//      ret = fsync(fileno(_media_fileh)); // Since we might get reset at any moment, go ahead and sync the file (not clear if fflush does this)
+        Debug_printf("DSK::write fsync:%d\n", ret);
+    }
+
+    if (hsFileh != nullptr)
+    {
+        fnio::fclose(hsFileh);
+        _media_fileh = oldFileh;
+    }
+
+    _media_last_block = INVALID_SECTOR_VALUE;
+
+    if (err)
+    {
         _media_controller_status = 2;
         RETURN_ERROR_AS_TRUE();
     }
-    // Write the data
-    e = fnio::fwrite(&_media_blockbuff, 1, MEDIA_BLOCK_SIZE, _media_fileh);
 
-    if (e != MEDIA_BLOCK_SIZE)
-    {
-        Debug_printf("::write error %d, %d\n", e, errno);
-        RETURN_ERROR_AS_TRUE();
-    }
-
-    int ret = fnio::fflush(_media_fileh);    // This doesn't seem to be connected to anything in ESP-IDF VF, so it may not do anything
-    
-    // This next line is commented out because there's no fsync in the 
-    // fnio class. In a discussion with @apc from the following discussion:
-    // https://discord.com/channels/655893677146636301/1209535440915406848/1231880068528214026
-    // fnio::fflush() should be sufficient for syncing as well.
-//    ret = fsync(fileno(_media_fileh)); // Since we might get reset at any moment, go ahead and sync the file (not clear if fflush does this)
-    Debug_printf("DSK::write fsync:%d\n", ret);
-
-    _media_last_block = INVALID_SECTOR_VALUE;
     _media_controller_status = 0;
     RETURN_SUCCESS_AS_FALSE();
+}
+
+void MediaTypeDSK::_parse_high_score_marker()
+{
+    uint8_t buf[MEDIA_BLOCK_SIZE];
+
+    _hs_num_ranges = 0;
+
+    if (_media_num_blocks <= HS_MARKER_BLOCK)
+        return;
+
+    if (fnio::fseek(_media_fileh, _block_to_offset(HS_MARKER_BLOCK), SEEK_SET) != 0)
+        return;
+    if (fnio::fread(buf, 1, MEDIA_BLOCK_SIZE, _media_fileh) != MEDIA_BLOCK_SIZE)
+        return;
+
+    if (memcmp(buf, "FNHS", 4) != 0 || buf[4] != 1)
+        return;
+
+    uint8_t n = buf[5];
+    if (n > HS_MAX_RANGES)
+        n = HS_MAX_RANGES;
+
+    for (uint8_t i = 0; i < n; i++)
+    {
+        _hs_start[i] = (buf[6 + i * 4] << 8) | buf[7 + i * 4];
+        _hs_count[i] = (buf[8 + i * 4] << 8) | buf[9 + i * 4];
+        Debug_printf("DSK high score sectors: LSN %u, count %u\n",
+                     _hs_start[i], _hs_count[i]);
+    }
+    _hs_num_ranges = n;
+}
+
+bool MediaTypeDSK::_high_score_block(uint32_t blockNum)
+{
+    for (uint8_t i = 0; i < _hs_num_ranges; i++)
+        if (blockNum >= _hs_start[i] && blockNum < (uint32_t)(_hs_start[i] + _hs_count[i]))
+            return true;
+    return false;
 }
 
 uint8_t MediaTypeDSK::status()
@@ -113,6 +190,8 @@ mediatype_t MediaTypeDSK::mount(fnFile *f, uint32_t disksize)
     _media_fileh = f;
     _mediatype = MEDIATYPE_DSK;
     _media_num_blocks = disksize / MEDIA_BLOCK_SIZE;
+
+    _parse_high_score_marker();
 
     return _mediatype;
 }

--- a/lib/media/drivewire/mediaTypeDSK.h
+++ b/lib/media/drivewire/mediaTypeDSK.h
@@ -5,10 +5,18 @@
 
 #include "mediaType.h"
 
+#define HS_MARKER_BLOCK 323     // track 17, sector 18: unused by Disk BASIC
+#define HS_MAX_RANGES 4
+
 class MediaTypeDSK : public MediaType
 {
 private:
     uint32_t _block_to_offset(uint32_t blockNum);
+    void _parse_high_score_marker();
+    bool _high_score_block(uint32_t blockNum);
+    uint8_t _hs_num_ranges = 0;
+    uint16_t _hs_start[HS_MAX_RANGES];
+    uint16_t _hs_count[HS_MAX_RANGES];
 
 public:
     error_is_true read(uint32_t blockNum, uint16_t *readcount) override;


### PR DESCRIPTION
High-score sectors for CoCo DSK images

Allows a DSK image to be mounted read-only while still permitting writes to a designated set of "high-score" sectors — so game code is protected but scores can still be saved.

How it works:

- A marker block at LSN 323 (track 17, sector 18 — unused by CoCo Disk BASIC) identifies up to 4 ranges of writable sectors. The format is the 4-byte magic FNHS, a version byte (0x01), a count, then pairs of (start LSN, count) as big-endian 16-bit values.
- On mount, MediaTypeDSK reads and parses this marker, storing the ranges. The _media_read_only flag is now set from the access mode before mount() is called.
- On a write to a read-only disk, the media layer checks whether the target block falls in a high-score range. If not, the write is rejected. If it is, the firmware temporarily reopens the file read-write via the fujiHost, performs the write and flush, then closes that handle and restores the original read-only one.
- fujiDevice passes the fujiHost pointer down to the disk device via the new set_media_host() call after a successful mount (CoCo only), so the media layer has what it needs to do the reopen.