### PR TITLE
[coco] Move common device methods to virtualDevice

### DIFF
--- a/include/global_types.h
+++ b/include/global_types.h
@@ -8,20 +8,13 @@
 #include "fuji_endian.h"
 #include <cstdint>
 #include <cstring>
+#include <vector>
 
-/**
- * byte array for buffers
- */
+using ByteBuffer = std::vector<std::uint8_t>;
+
+// Obsolete, do not use
 typedef uint8_t* Buffer;
-
-/**
- * Used for specifying buffer lengths
- */
 typedef uint16_t BufferLength;
-
-/**
- * Used to specify both aux1/aux2 values
- */
 typedef uint16_t AuxWord;
 
 typedef enum class FUJI_ERROR {

--- a/lib/bus/drivewire/drivewire.cpp
+++ b/lib/bus/drivewire/drivewire.cpp
@@ -950,6 +950,35 @@ void systemBus::writeBusPacket(FujiBusPacket &packet)
 }
 #endif /* PINMAP_FUJIVERSAL_DRIVEWIRE */
 
+void virtualDevice::ready()
+{
+    SYSTEM_BUS.write(0x01); // yes, ready.
+}
+
+void virtualDevice::send_response()
+{
+    uint16_t len = be16toh(cmdFrame.aux12);
+
+    // Pad to requested response length. Thanks apc!
+    if (_response.size() < len)
+        _response.resize(std::max<size_t>(_response.size(), len), 0);
+
+    // Send body
+    SYSTEM_BUS.write(_response.data(), _response.size());
+
+    // Clear the response
+    _response.clear();
+    _response.shrink_to_fit();
+}
+
+void virtualDevice::send_error()
+{
+    Debug_printf("drivewire device error = %s\n",
+                 _errorCode == NDEV_STATUS::SUCCESS
+                 ? "NONE" : std::to_string(static_cast<int>(_errorCode)).c_str());
+    SYSTEM_BUS.write(static_cast<uint8_t>(_errorCode));
+}
+
 void virtualDevice::transaction_begin(transState_t expectMoreData)
 {
     assert(_transaction_state == TRANS_STATE::INVALID);
@@ -960,11 +989,15 @@ void virtualDevice::transaction_complete()
 {
     assert(_transaction_state == TRANS_STATE::NO_GET
            || _transaction_state == TRANS_STATE::DID_GET);
+    _errorCode = NDEV_STATUS::SUCCESS;
+    _response.clear();
+    _response.shrink_to_fit();
     _transaction_state = TRANS_STATE::INVALID;
 }
 
 void virtualDevice::transaction_error()
 {
+    _errorCode = NDEV_STATUS::GENERAL;
     _transaction_state = TRANS_STATE::INVALID;
 }
 
@@ -978,9 +1011,11 @@ success_is_true virtualDevice::transaction_get(void *data, size_t len)
 void virtualDevice::transaction_put(const void *data, size_t len, bool err)
 {
     assert(_transaction_state == TRANS_STATE::NO_GET);
-    transaction_complete();
     if (err)
         transaction_error();
+    _response.insert(_response.end(), static_cast<const uint8_t *>(data),
+                     static_cast<const uint8_t *>(data) + len);
+    _transaction_state = TRANS_STATE::INVALID;
 }
 
 #endif               /* BUILD_COCO */

--- a/lib/bus/drivewire/drivewire.h
+++ b/lib/bus/drivewire/drivewire.h
@@ -25,6 +25,7 @@
 #include "UARTChannel.h"
 #include "ACMChannel.h"
 #include "fujiDeviceID.h"
+#include "status_error_codes.h"
 #ifdef PINMAP_FUJIVERSAL_DRIVEWIRE
 #include "../rs232/FujiBusPacket.h"
 #include <deque>
@@ -148,18 +149,32 @@ class virtualDevice
     friend systemBus;
     friend fujiDevice;
 
+private:
+    ByteBuffer _response;
+    transState_t _transaction_state = TRANS_STATE::INVALID;
+
 protected:
+    nDevStatus_t _errorCode;
     fujiDeviceID_t _devnum;
 
     cmdFrame_t cmdFrame;
     bool listen_to_type3_polls = false;
 
-    transState_t _transaction_state = TRANS_STATE::INVALID;
     virtual void transaction_begin(transState_t expectMoreData);
     virtual void transaction_complete();
     virtual void transaction_error();
     virtual success_is_true transaction_get(void *data, size_t len);
     virtual void transaction_put(const void *data, size_t len, bool err=false);
+    inline void transaction_put(std::string data) {
+        transaction_put(data.data(), data.size());
+    }
+    inline void transaction_put(ByteBuffer data) {
+        transaction_put(data.data(), data.size());
+    }
+
+    void send_error();             // 0x02
+    void send_response();          // 0x01
+    void ready();                  // 0x00
 
     // Optional shutdown/reboot cleanup routine
     virtual void shutdown(){};

--- a/lib/device/drivewire/cpm.cpp
+++ b/lib/device/drivewire/cpm.cpp
@@ -78,9 +78,7 @@ void drivewireCPM::read()
     if (!mw)
         return;
 
-    response.clear();
-    response.shrink_to_fit();
-
+    ByteBuffer buffer(len);
     for (uint16_t i=0; i<len; i++)
     {
         char b;
@@ -88,8 +86,10 @@ void drivewireCPM::read()
 #ifdef ESP_PLATFORM
         xQueueReceive(rxq, &b, portMAX_DELAY);
 #endif /* ESP_PLATFORM */
-        response += b;
+        buffer[i] = b;
     }
+
+    transaction_put(buffer);
 }
 
 void drivewireCPM::write()
@@ -115,13 +115,10 @@ void drivewireCPM::status()
     unsigned short mw = uxQueueMessagesWaiting(rxq);
     unsigned char status_response[2] = {0,0};
 
-    response.clear();
-    response.shrink_to_fit();
-
     status_response[0] = mw >> 8;
     status_response[1] = mw & 0xFF;
 
-    response = std::string((const char *)status_response, 2);
+    transaction_put(&status_response, sizeof(status_response));
 }
 
 void drivewireCPM::process()

--- a/lib/device/drivewire/cpm.cpp
+++ b/lib/device/drivewire/cpm.cpp
@@ -52,32 +52,6 @@ drivewireCPM::drivewireCPM()
     txq = xQueueCreate(2048, sizeof(char));
 }
 
-// drivewireCPM::~drivewireCPM()
-// {
-//     if (cpmTaskHandle != NULL)
-//     {
-//         vTaskDelete(cpmTaskHandle);
-//     }
-
-//     vQueueDelete(rxq);
-//     vQueueDelete(txq);
-// }
-
-void drivewireCPM::ready()
-{
-    SYSTEM_BUS.write(0x01);
-}
-
-void drivewireCPM::send_response()
-{
-    // Send body
-    SYSTEM_BUS.write((uint8_t *)response.c_str(),response.length());
-
-    // Clear the response
-    response.clear();
-    response.shrink_to_fit();
-}
-
 void drivewireCPM::boot()
 {
 #ifdef ESP_PLATFORM

--- a/lib/device/drivewire/cpm.h
+++ b/lib/device/drivewire/cpm.h
@@ -17,8 +17,6 @@ typedef unsigned int    uint32;
 class drivewireCPM : public virtualDevice
 {
 private:
-    std::string response;
-
 #ifdef ESP_PLATFORM
     TaskHandle_t cpmTaskHandle = NULL;
 #endif /* ESP_PLATFORM */
@@ -26,13 +24,11 @@ private:
 public:
     drivewireCPM();
     // virtual ~drivewireCPM();
-    virtual void process();
-    virtual void ready();
-    virtual void send_response();
-    virtual void boot();
-    virtual void read();
-    virtual void write();
-    virtual void status();
+    void process();
+    void boot();
+    void read();
+    void write();
+    void status();
 };
 
 extern drivewireCPM theCPM;

--- a/lib/device/drivewire/drivewireFuji.cpp
+++ b/lib/device/drivewire/drivewireFuji.cpp
@@ -179,6 +179,7 @@ void drivewireFuji::base64_encode_input()
     }
 
     std::vector<unsigned char> p(len);
+    transaction_begin(TRANS_STATE::WILL_GET);
     transaction_get(p.data(), len);
     base64.base64_buffer += std::string((const char *)p.data(), len);
     transaction_complete();
@@ -200,6 +201,7 @@ void drivewireFuji::base64_encode_compute()
     base64.base64_buffer.clear();
     base64.base64_buffer = std::string(p.get(), out_len);
 
+    transaction_begin(TRANS_STATE::NO_GET);
     transaction_complete();
 }
 
@@ -214,6 +216,7 @@ void drivewireFuji::base64_encode_length()
         (uint8_t)(l)
     };
 
+    transaction_begin(TRANS_STATE::NO_GET);
     transaction_put(&o, 4);
 }
 
@@ -230,12 +233,13 @@ void drivewireFuji::base64_encode_output()
         return;
     }
 
-    std::vector<unsigned char> p(len);
-    std::memcpy(p.data(), base64.base64_buffer.data(), len);
+    std::vector<unsigned char> p(base64.base64_buffer.data(),
+                                 base64.base64_buffer.data() + len);
     base64.base64_buffer.erase(0, len);
     base64.base64_buffer.shrink_to_fit();
 
-    transaction_put(p.data(), len);
+    transaction_begin(TRANS_STATE::NO_GET);
+    transaction_put(p);
 }
 
 void drivewireFuji::base64_decode_input()
@@ -251,6 +255,7 @@ void drivewireFuji::base64_decode_input()
         return;
     }
 
+    transaction_begin(TRANS_STATE::WILL_GET);
     std::vector<unsigned char> p(len);
     transaction_get(p.data(), len);
     base64.base64_buffer += std::string((const char *)p.data(), len);
@@ -276,6 +281,7 @@ void drivewireFuji::base64_decode_compute()
     base64.base64_buffer = std::string((const char *)p.get(), out_len);
 
     Debug_printf("Resulting BASE64 encoded data is: %u bytes\n", out_len);
+    transaction_begin(TRANS_STATE::NO_GET);
     transaction_complete();
 }
 
@@ -293,6 +299,7 @@ void drivewireFuji::base64_decode_length()
 
     Debug_printf("base64 buffer length: %u bytes\n", len);
 
+    transaction_begin(TRANS_STATE::NO_GET);
     transaction_put(_response, 4);
 }
 
@@ -325,6 +332,7 @@ void drivewireFuji::base64_decode_output()
     memcpy(p.data(), base64.base64_buffer.data(), len);
     base64.base64_buffer.erase(0, len);
     base64.base64_buffer.shrink_to_fit();
+    transaction_begin(TRANS_STATE::NO_GET);
     transaction_put(p.data(), len);
 }
 
@@ -343,6 +351,7 @@ void drivewireFuji::hash_input()
         return;
     }
 
+    transaction_begin(TRANS_STATE::WILL_GET);
     std::vector<uint8_t> p(len);
     transaction_get(p.data(), len);
     hasher.add_data(p);
@@ -354,6 +363,7 @@ void drivewireFuji::hash_compute(bool clear_data)
     Debug_printf("FUJI: HASH COMPUTE\n");
     algorithm = Hash::to_algorithm(SYSTEM_BUS.read());
     hasher.compute(algorithm, clear_data);
+    transaction_begin(TRANS_STATE::NO_GET);
     transaction_complete();
 }
 
@@ -362,6 +372,7 @@ void drivewireFuji::hash_length()
     Debug_printf("FUJI: HASH LENGTH\n");
     uint8_t is_hex = SYSTEM_BUS.read() == 1;
     uint8_t r = hasher.hash_length(algorithm, is_hex);
+    transaction_begin(TRANS_STATE::NO_GET);
     transaction_put(&r, 1);
 }
 
@@ -369,6 +380,7 @@ void drivewireFuji::hash_output()
 {
     Debug_printf("FUJI: HASH OUTPUT\n");
 
+    transaction_begin(TRANS_STATE::NO_GET);
     uint8_t is_hex = SYSTEM_BUS.read() == 1;
     if (is_hex) {
         std::string output = hasher.output_hex();
@@ -383,6 +395,7 @@ void drivewireFuji::hash_clear()
 {
     Debug_printf("FUJI: HASH INIT\n");
     hasher.clear();
+    transaction_begin(TRANS_STATE::NO_GET);
     transaction_complete();
 }
 
@@ -405,12 +418,6 @@ void drivewireFuji::setup()
 #endif /* OBSOLETE */
 }
 
-void drivewireFuji::send_error()
-{
-    Debug_printf("drivewireFuji::send_error(%u)\n",_errorCode);
-    SYSTEM_BUS.write(_errorCode);
-}
-
 void drivewireFuji::random()
 {
     int r = rand();
@@ -418,26 +425,11 @@ void drivewireFuji::random()
     transaction_put(&r, sizeof(r));
 }
 
-void drivewireFuji::send_response()
-{
-    // Send body
-    SYSTEM_BUS.write((uint8_t *)_response.c_str(),_response.length());
-
-    // Clear the response
-    _response.clear();
-    _response.shrink_to_fit();
-}
-
-void drivewireFuji::ready()
-{
-    SYSTEM_BUS.write(0x01); // Yes, ready.
-}
-
 void drivewireFuji::process()
 {
     fujiCommandID_t c = (fujiCommandID_t) SYSTEM_BUS.read();
 
-    _errorCode = 1;
+    _errorCode = NDEV_STATUS::SUCCESS;
     switch (c)
     {
     case FUJICMD_SEND_ERROR:
@@ -629,8 +621,12 @@ void drivewireFuji::process()
             uint8_t source = SYSTEM_BUS.read();
             uint8_t dest = SYSTEM_BUS.read();
             char dirpath[256];
+            transaction_begin(TRANS_STATE::WILL_GET);
             transaction_get(dirpath, sizeof(dirpath));
-            fujicmd_copy_file_success(source, dest, dirpath);
+            if (fujicore_copy_file_success(source, dest, dirpath).is_error())
+                transaction_error();
+            else
+                transaction_complete();
         }
         break;
     case FUJICMD_GENERATE_GUID:

--- a/lib/device/drivewire/drivewireFuji.h
+++ b/lib/device/drivewire/drivewireFuji.h
@@ -10,10 +10,6 @@
 class drivewireFuji : public fujiDevice
 {
 private:
-    std::string _response;
-
-    uint8_t _errorCode;
-
 #ifdef ESP_PLATFORM
     drivewireCassette _cassetteDev;
 #endif
@@ -25,20 +21,16 @@ protected:
     }
     void transaction_complete() override {
         virtualDevice::transaction_complete();
-        _errorCode = 1;
-        _response.clear();
-        _response.shrink_to_fit();
     }
     void transaction_error() override {
         virtualDevice::transaction_error();
-        _errorCode = 144;
     }
     success_is_true transaction_get(void *data, size_t len) override {
         return virtualDevice::transaction_get(data, len);
     }
+    using virtualDevice::transaction_put;
     void transaction_put(const void *data, size_t len, bool err=false) override {
         virtualDevice::transaction_put(data, len, err);
-        _response.append((char *) data, len);
     }
 
     size_t set_additional_direntry_details(fsdir_entry_t *f, uint8_t *dest,
@@ -60,9 +52,6 @@ protected:
     void hash_output();            // 0xC5
     void hash_clear();             // 0xC2
 
-    void send_error();             // 0x02
-    void send_response();          // 0x01
-    void ready();                  // 0x00
     void shutdown() override;
 
 public:

--- a/lib/device/drivewire/network.cpp
+++ b/lib/device/drivewire/network.cpp
@@ -64,11 +64,6 @@ drivewireNetwork::~drivewireNetwork()
 
 /** DRIVEWIRE COMMANDS ***************************************************************/
 
-void drivewireNetwork::ready()
-{
-    SYSTEM_BUS.write(0x01); // yes, ready.
-}
-
 /**
  * DRIVEWIRE Open command
  * Called in response to 'O' command. Instantiate a protocol, pass URL to it, call its open
@@ -115,9 +110,6 @@ void drivewireNetwork::open()
         protocolParser = nullptr;
     }
 
-    // Reset status buffer
-    ns.reset();
-
     // Parse and instantiate protocol
     parse_and_instantiate_protocol();
 
@@ -139,8 +131,8 @@ void drivewireNetwork::open()
     // Attempt protocol open
     if (protocol->open(urlParser.get(), (fileAccessMode_t) cmdFrame.aux1, (netProtoTranslation_t) cmdFrame.aux2) != FUJI_ERROR::NONE)
     {
-        ns.error = protocol->error;
-        Debug_printf("Protocol unable to make connection. Error: %d\n", ns.error);
+        _errorCode = protocol->error;
+        Debug_printf("Protocol unable to make connection. Error: %d\n", _errorCode);
         delete protocol;
         protocol = nullptr;
         if (protocolParser != nullptr)
@@ -148,7 +140,6 @@ void drivewireNetwork::open()
             delete protocolParser;
             protocolParser = nullptr;
         }
-        //SYSTEM_BUS.write(ns.error);
         return;
     }
 
@@ -158,10 +149,8 @@ void drivewireNetwork::open()
     json->setProtocol(protocol);
     channelMode = PROTOCOL;
 
-    // And signal complete!
-    ns.error = NDEV_STATUS::SUCCESS;
-    //SYSTEM_BUS.write(ns.error);
-    Debug_printf("ns.error = %u\n",ns.error);
+    transaction_begin(TRANS_STATE::NO_GET);
+    transaction_complete();
 }
 
 /**
@@ -171,8 +160,6 @@ void drivewireNetwork::open()
 void drivewireNetwork::close()
 {
     Debug_printf("drivewireNetwork::close()\n");
-
-    ns.reset();
 
     if (protocolParser != nullptr)
     {
@@ -207,9 +194,8 @@ void drivewireNetwork::close()
     Debug_printv("After protocol delete %lu\n",esp_get_free_internal_heap_size());
 #endif
 
-    // And signal complete!
-    ns.error = NDEV_STATUS::SUCCESS;
-    //SYSTEM_BUS.write(ns.error);
+    transaction_begin(TRANS_STATE::NO_GET);
+    transaction_complete();
 }
 
 /**
@@ -238,7 +224,8 @@ void drivewireNetwork::read()
     // Check for rx buffer. If NULL, then tell caller we could not allocate buffers.
     if (receiveBuffer == nullptr)
     {
-        ns.error = NDEV_STATUS::COULD_NOT_ALLOCATE_BUFFERS;
+        transaction_error();
+        _errorCode = NDEV_STATUS::COULD_NOT_ALLOCATE_BUFFERS;
         return;
     }
 
@@ -251,15 +238,16 @@ void drivewireNetwork::read()
             protocolParser = nullptr;
         }
 
-        ns.error = NDEV_STATUS::NOT_CONNECTED;
+        transaction_error();
+        _errorCode = NDEV_STATUS::NOT_CONNECTED;
         return;
     }
 
     // Do the channel read
     read_channel(num_bytes);
 
-    // And set response buffer.
-    response += *receiveBuffer;
+    transaction_begin(TRANS_STATE::NO_GET);
+    transaction_put(*receiveBuffer);
 
     // Remove from receive buffer and shrink.
     receiveBuffer->erase(0, num_bytes);
@@ -342,7 +330,7 @@ void drivewireNetwork::write()
             delete protocolParser;
             protocolParser = nullptr;
         }
-        ns.error = NDEV_STATUS::NOT_CONNECTED;
+        _errorCode = NDEV_STATUS::NOT_CONNECTED;
         return;
     }
 
@@ -430,13 +418,12 @@ void drivewireNetwork::status_local()
         memcpy(&status,ipDNS,sizeof(status));
         break;
     default:
-        status.conn = ns.connected;
-        status.err = ns.error;
+        status.conn = true;
+        status.err = _errorCode;
         break;
     }
 
-    response.clear();
-    response.append((char *) &status, sizeof(status));
+    transaction_put(&status, sizeof(status));
 }
 
 bool drivewireNetwork::status_channel_json(NetworkStatus *ns)
@@ -451,6 +438,7 @@ bool drivewireNetwork::status_channel_json(NetworkStatus *ns)
  */
 void drivewireNetwork::status_channel()
 {
+    NetworkStatus ns;
     NDeviceStatus status;
     size_t avail = 0;
 
@@ -485,10 +473,8 @@ void drivewireNetwork::status_channel()
                  avail, ns.connected, ns.error);
 #endif /* TOO_MUCH_DEBUG */
 
-    // and fill response.
-    response.clear();
-    response.shrink_to_fit();
-    response.append((char *) &status, sizeof(status));
+    transaction_begin(TRANS_STATE::NO_GET);
+    transaction_put(&status, sizeof(status));
 }
 
 /**
@@ -500,7 +486,7 @@ void drivewireNetwork::get_prefix()
     Debug_printf("drivewireNetwork::get_prefix(%s)\n",prefix.c_str());
     memset(out,0,sizeof(out));
     strcpy(out,prefix.c_str());
-    response = std::string(out,256);
+    transaction_put(out, sizeof(out));
 }
 
 /**
@@ -686,30 +672,6 @@ bool drivewireNetwork::poll_interrupt()
     return protocol->available() > 0;
 }
 
-void drivewireNetwork::send_error()
-{
-    Debug_printf("drivewireNetwork::send_error(%u)\n",ns.error);
-    SYSTEM_BUS.write((uint8_t) ns.error);
-}
-
-void drivewireNetwork::send_response()
-{
-    uint16_t len = cmdFrame.aux1 << 8 | cmdFrame.aux2; // big endian
-
-    // Pad to requested response length. Thanks apc!
-    if (response.length() < len)
-        response.insert(response.length(), len - response.length(), '\0');
-
-    // Send body
-    SYSTEM_BUS.write((uint8_t *)response.c_str(), len);
-
-    Debug_printf("drivewireNetwork::send_response[%d]:%s\n", len, response.c_str());
-
-    // Clear the response
-    response.clear();
-    response.shrink_to_fit();
-}
-
 /**
  * Preprocess deviceSpec given aux1 open mode. This is used to work around various assumptions that different
  * disk utility packages do when opening a device, such as adding wildcards for directory opens.
@@ -740,7 +702,7 @@ void drivewireNetwork::parse_and_instantiate_protocol()
     if (!urlParser->isValidUrl())
     {
         Debug_printf("Invalid devicespec: >%s<\n", deviceSpec.c_str());
-        ns.error = NDEV_STATUS::INVALID_DEVICESPEC;
+        _errorCode = NDEV_STATUS::INVALID_DEVICESPEC;
         return;
     }
 
@@ -752,7 +714,7 @@ void drivewireNetwork::parse_and_instantiate_protocol()
     if (!instantiate_protocol())
     {
         Debug_printf("Could not open protocol. spec: >%s<, url: >%s<\n", deviceSpec.c_str(), urlParser->mRawUrl.c_str());
-        ns.error = NDEV_STATUS::GENERAL;
+        _errorCode = NDEV_STATUS::GENERAL;
         return;
     }
 }
@@ -869,13 +831,13 @@ void drivewireNetwork::parse_json()
 {
     bool success = json->parse();
 
-    ns.error = NDEV_STATUS::SUCCESS;
+    _errorCode = NDEV_STATUS::SUCCESS;
 #ifdef UNUSED
     // Atari doesn't check for errors and blindly returns that
     // everything is fine. This causes the httpbin test to pass when
     // it probably shouldn't. However we'll just do what Atari does.
     if (!success)
-        ns.error = NDEV_STATUS::COULD_NOT_PARSE_JSON;
+        _errorCode = NDEV_STATUS::COULD_NOT_PARSE_JSON;
 #endif /* UNUSED */
 }
 
@@ -1015,8 +977,7 @@ void drivewireNetwork::process()
         break;
 
     default:
-        ns.reset();
-        ns.error = NDEV_STATUS::GENERAL;
+        transaction_error();
         break;
     }
 }
@@ -1029,8 +990,7 @@ void drivewireNetwork::process_fs()
     NetworkProtocolFS *fs = dynamic_cast<NetworkProtocolFS *>(protocol);
     if (!fs)
     {
-        ns.reset();
-        ns.error = NDEV_STATUS::GENERAL;
+        transaction_error();
         return;
     }
 
@@ -1063,8 +1023,7 @@ void drivewireNetwork::process_fs()
 
     if (err != FUJI_ERROR::NONE)
     {
-        ns.reset();
-        ns.error = NDEV_STATUS::GENERAL;
+        transaction_error();
     }
 }
 
@@ -1074,8 +1033,7 @@ void drivewireNetwork::process_tcp()
     NetworkProtocolTCP *tcp = dynamic_cast<NetworkProtocolTCP *>(protocol);
     if (!tcp)
     {
-        ns.reset();
-        ns.error = NDEV_STATUS::GENERAL;
+        transaction_error();
         return;
     }
 
@@ -1095,8 +1053,7 @@ void drivewireNetwork::process_tcp()
 
     if (err != FUJI_ERROR::NONE)
     {
-        ns.reset();
-        ns.error = NDEV_STATUS::GENERAL;
+        transaction_error();
     }
 }
 
@@ -1106,8 +1063,7 @@ void drivewireNetwork::process_http()
     NetworkProtocolHTTP *http = dynamic_cast<NetworkProtocolHTTP *>(protocol);
     if (!http)
     {
-        ns.reset();
-        ns.error = NDEV_STATUS::GENERAL;
+        transaction_error();
         return;
     }
 
@@ -1124,8 +1080,7 @@ void drivewireNetwork::process_http()
 
     if (err != FUJI_ERROR::NONE)
     {
-        ns.reset();
-        ns.error = NDEV_STATUS::GENERAL;
+        transaction_error();
     }
 }
 
@@ -1135,8 +1090,7 @@ void drivewireNetwork::process_udp()
     NetworkProtocolUDP *udp = dynamic_cast<NetworkProtocolUDP *>(protocol);
     if (!udp)
     {
-        ns.reset();
-        ns.error = NDEV_STATUS::GENERAL;
+        transaction_error();
         return;
     }
 
@@ -1147,7 +1101,7 @@ void drivewireNetwork::process_udp()
     case NETCMD_GET_REMOTE:
         receiveBuffer->resize(SPECIAL_BUFFER_SIZE);
         err = udp->get_remote(receiveBuffer->data(), receiveBuffer->size());
-        response += *receiveBuffer;
+        transaction_put(*receiveBuffer);
         break;
 #endif /* ESP_PLATFORM */
     case NETCMD_SET_DESTINATION:
@@ -1157,14 +1111,12 @@ void drivewireNetwork::process_udp()
             err = udp->set_destination(spData, bytes_read);
             if (err != FUJI_ERROR::NONE)
             {
-                ns.reset();
-                ns.error = NDEV_STATUS::GENERAL;
+                transaction_error();
             }
         }
         break;
     default:
-        ns.reset();
-        ns.error = NDEV_STATUS::GENERAL;
+        transaction_error();
         break;
     }
 }

--- a/lib/device/drivewire/network.h
+++ b/lib/device/drivewire/network.h
@@ -55,21 +55,6 @@ public:
     bool poll_interrupt();
 
     /**
-     * @brief Ready?
-     */
-    void ready();
-
-    /**
-     * @brief Get last error
-     */
-    void send_error();
-
-    /**
-     * @brief send response
-     */
-    void send_response();
-
-    /**
      * Called for DRIVEWIRE Command 'O' to open a connection to a network protocol, allocate all buffers,
      */
     virtual void open();
@@ -131,11 +116,6 @@ public:
 private:
 
     /**
-     * @brief the response buffer
-     */
-    std::string response;
-
-    /**
      * Buffer for holding devicespec
      */
     uint8_t devicespecBuf[256];
@@ -169,11 +149,6 @@ private:
      * @brief Factory that creates protocol from urls
     */
     ProtocolParser *protocolParser = nullptr;
-
-    /**
-     * Network Status object
-     */
-    NetworkStatus ns;
 
     /**
      * Devicespec passed to us, e.g. N:HTTP://WWW.GOOGLE.COM:80/

--- a/lib/device/fujiDevice.cpp
+++ b/lib/device/fujiDevice.cpp
@@ -954,8 +954,8 @@ dirEntryDetails fujiDevice::_additional_direntry_details(fsdir_entry_t *f)
     return details;
 }
 
-success_is_true fujiDevice::fujicmd_copy_file_success(uint8_t sourceSlot, uint8_t destSlot,
-                                                      std::string copySpec)
+success_is_true fujiDevice::fujicore_copy_file_success(uint8_t sourceSlot, uint8_t destSlot,
+                                                       std::string copySpec)
 {
     std::string sourcePath;
     std::string destPath;
@@ -963,31 +963,20 @@ success_is_true fujiDevice::fujicmd_copy_file_success(uint8_t sourceSlot, uint8_
     fnFile *destFile;
     char *dataBuf;
 
-    transaction_begin(TRANS_STATE::NO_GET);
-    Debug_printf("copySpec: %s\n", copySpec.c_str());
-
     // Check for malformed copyspec.
     if (copySpec.empty() || copySpec.find_first_of("|") == std::string::npos)
-    {
-        transaction_error();
         RETURN_ERROR_AS_FALSE();
-    }
 
     // Protocol sends 1-based slot numbers; convert to 0-based array indices.
     if (sourceSlot == 0 || destSlot == 0)
-    {
-        transaction_error();
         RETURN_ERROR_AS_FALSE();
-    }
+
     sourceSlot--;
     destSlot--;
 
     if (!validate_host_slot(sourceSlot, "copy_file_source")
         || !validate_host_slot(destSlot, "copy_file_dest"))
-    {
-        transaction_error();
         RETURN_ERROR_AS_FALSE();
-    }
 
     // Chop up copyspec.
     sourcePath = copySpec.substr(0, copySpec.find_first_of("|"));
@@ -1009,16 +998,12 @@ success_is_true fujiDevice::fujicmd_copy_file_success(uint8_t sourceSlot, uint8_
     sourceFile = _fnHosts[sourceSlot].fnfile_open(
         sourcePath.c_str(), (char *)sourcePath.c_str(), sourcePath.size() + 1, "rb");
     if (sourceFile == nullptr)
-    {
-        transaction_error();
         RETURN_ERROR_AS_FALSE();
-    }
 
     destFile = _fnHosts[destSlot].fnfile_open(destPath.c_str(), (char *)destPath.c_str(),
                                               destPath.size() + 1, "wb");
     if (destFile == nullptr)
     {
-        transaction_error();
         fnio::fclose(sourceFile);
         RETURN_ERROR_AS_FALSE();
     }
@@ -1026,7 +1011,6 @@ success_is_true fujiDevice::fujicmd_copy_file_success(uint8_t sourceSlot, uint8_
     dataBuf = (char *)malloc(532);
     if (dataBuf == nullptr)
     {
-        transaction_error();
         fnio::fclose(sourceFile);
         RETURN_ERROR_AS_FALSE();
     }
@@ -1038,12 +1022,24 @@ success_is_true fujiDevice::fujicmd_copy_file_success(uint8_t sourceSlot, uint8_
         fnio::fwrite(dataBuf, 1, count, destFile);
     } while (count > 0);
 
-    transaction_complete();
-
     // copyEnd:
     fnio::fclose(sourceFile);
     fnio::fclose(destFile);
     free(dataBuf);
+    RETURN_SUCCESS_AS_TRUE();
+}
+
+success_is_true fujiDevice::fujicmd_copy_file_success(uint8_t sourceSlot, uint8_t destSlot,
+                                                      std::string copySpec)
+{
+    transaction_begin(TRANS_STATE::NO_GET);
+
+    if (!fujicore_copy_file_success(sourceSlot, destSlot, copySpec)) {
+        transaction_error();
+        RETURN_ERROR_AS_FALSE();
+    }
+
+    transaction_complete();
     RETURN_SUCCESS_AS_TRUE();
 }
 

--- a/lib/device/fujiDevice.h
+++ b/lib/device/fujiDevice.h
@@ -204,6 +204,7 @@ public:
     virtual void fujicmd_read_directory_entry(size_t maxlen, uint8_t addtl);
     void fujicmd_get_directory_position();
     void fujicmd_set_directory_position(uint16_t pos);
+    success_is_true fujicore_copy_file_success(uint8_t sourceSlot, uint8_t destSlot, std::string copySpec);
     success_is_true fujicmd_copy_file_success(uint8_t sourceSlot, uint8_t destSlot, std::string copySpec);
     virtual void fujicmd_get_adapter_config();
     virtual void fujicmd_get_adapter_config_extended();


### PR DESCRIPTION
Moved `ready()`, `send_error()`, `send_response()` to virtualDevice instead of duplicating in each device class.
    
Added transaction_state tracking to virtualDevice `transaction_*` methods.
