### PR TITLE
[iwm][network] preserve error code on failed opens.

### DIFF
--- a/lib/device/iwm/network.cpp
+++ b/lib/device/iwm/network.cpp
@@ -100,6 +100,7 @@ void iwmNetwork::open()
     }
 
     err = SP_ERR::NOERROR;
+    current_network_data.open_error = NDEV_STATUS::SUCCESS;
 
     Debug_printf("\nopen()\n");
 
@@ -108,13 +109,21 @@ void iwmNetwork::open()
 
     if (!current_network_data.protocol)
     {
+        current_network_data.open_error = NDEV_STATUS::INVALID_DEVICESPEC;
         return;
     }
 
     // Attempt protocol open
     if (current_network_data.protocol->open(current_network_data.urlParser.get(), (fileAccessMode_t) data_buffer[0], (netProtoTranslation_t) data_buffer[1]) != FUJI_ERROR::NONE)
     {
-        Debug_printf("Protocol unable to make connection. Error: %d\n", err);
+        // Remember the failure before the protocol (and its error) is destroyed,
+        // so a subsequent STATUS can report the real code (e.g. FILE_NOT_FOUND).
+        current_network_data.open_error =
+            current_network_data.protocol->error != NDEV_STATUS::SUCCESS
+                ? current_network_data.protocol->error
+                : NDEV_STATUS::GENERAL;
+        Debug_printf("Protocol unable to make connection. Error: %d\n",
+                     (int)current_network_data.open_error);
         current_network_data.protocol.reset();
         return;
     }
@@ -300,7 +309,12 @@ void iwmNetwork::status()
         if (!current_network_data.protocol) {
             Debug_printf("ERROR: Calling status on a null protocol.\r\n");
             err = SP_ERR::BADCMD;
-            s.error = NDEV_STATUS::INVALID_COMMAND;
+            s.connected = 0;
+            // A failed OPEN destroyed the protocol; report the remembered
+            // open error (e.g. FILE_NOT_FOUND) rather than a generic code.
+            s.error = current_network_data.open_error != NDEV_STATUS::SUCCESS
+                        ? current_network_data.open_error
+                        : NDEV_STATUS::INVALID_COMMAND;
         } else {
             err = current_network_data.protocol->status(&s) == FUJI_ERROR::NONE
                 ? SP_ERR::NOERROR : SP_ERR::BADCMD;

--- a/lib/network-protocol/network_data.h
+++ b/lib/network-protocol/network_data.h
@@ -7,6 +7,8 @@
 #include <memory>
 #include <string>
 
+#include "status_error_codes.h"
+
 class NetworkProtocol;
 class FNJSON;
 class PeoplesUrlParser;
@@ -29,6 +31,10 @@ struct NetworkData {
     uint8_t translationMode = 0;
     std::string login;
     std::string password;
+    // Result of the last OPEN on this channel.  A failed protocol open
+    // destroys the protocol instance, so the specific error (e.g.
+    // FILE_NOT_FOUND) must be remembered here for a later STATUS to report.
+    nDevStatus_t open_error = NDEV_STATUS::SUCCESS;
 };
 
 #endif // NETWORK_DATA_H


### PR DESCRIPTION
The error code was being swallowed on an N: open if it failed. So we need to preserve it so that it can be retrieved via the status command.