### PR TITLE
Convert RS232 bus to SystemBusBase transaction interface

### DIFF
--- a/fujinet_pc.cmake
+++ b/fujinet_pc.cmake
@@ -269,7 +269,7 @@ set(SOURCES src/main.cpp
     lib/network-protocol/SD.h lib/network-protocol/SD.cpp
     lib/fuji/fujiHost.h lib/fuji/fujiHost.cpp
     lib/fuji/fujiDisk.h lib/fuji/fujiDisk.cpp
-    lib/bus/bus.h
+    lib/bus/bus.h lib/bus/bus.cpp
     lib/device/device.h
     lib/device/disk.h
     lib/device/printer.h

--- a/lib/bus/bus.cpp
+++ b/lib/bus/bus.cpp
@@ -1,0 +1,32 @@
+#include "bus.h"
+
+// Temporary migration wrappers. Remove after all buses have been
+// converted to inherit from SystemBusBase.
+#if defined(BUILD_RS232)
+
+void VDevMigrationWrapper::transaction_begin(transState_t expectMoreData)
+{
+    SYSTEM_BUS.transaction_accept(expectMoreData);
+}
+
+void VDevMigrationWrapper::transaction_complete()
+{
+    SYSTEM_BUS.transaction_success();
+}
+
+void VDevMigrationWrapper::transaction_error()
+{
+    SYSTEM_BUS.transaction_error();
+}
+
+success_is_true VDevMigrationWrapper::transaction_get(void *data, size_t len)
+{
+    return SYSTEM_BUS.transaction_get(data, len);
+}
+
+void VDevMigrationWrapper::transaction_put(const void *data, size_t len, bool is_error)
+{
+    SYSTEM_BUS.transaction_send(data, len, is_error);
+}
+
+#endif

--- a/lib/bus/bus.h
+++ b/lib/bus/bus.h
@@ -58,6 +58,20 @@ public:
     }
 };
 
+// Temporary migration wrappers. Remove after all buses have been
+// converted to inherit from SystemBusBase.
+class VDevMigrationWrapper
+{
+#if defined(BUILD_RS232)
+protected:
+    void transaction_begin(transState_t expectMoreData);
+    void transaction_complete();
+    void transaction_error();
+    success_is_true transaction_get(void *data, size_t len);
+    void transaction_put(const void *data, size_t len, bool is_error=false);
+#endif
+};
+
 #ifdef BUILD_ATARI
 #include "sio/sio.h"
 #ifdef ESP_PLATFORM

--- a/lib/bus/rs232/rs232.cpp
+++ b/lib/bus/rs232/rs232.cpp
@@ -36,26 +36,27 @@ uint8_t rs232_checksum(uint8_t *buf, unsigned short len)
     return chk;
 }
 
-void virtualDevice::transaction_begin(transState_t expectMoreData)
+void systemBus::transaction_accept(transState_t expectMoreData)
 {
     assert(_transaction_state == TRANS_STATE::INVALID);
+    _activePacketDataPosition = 0;
     _transaction_state = expectMoreData;
 }
 
-void virtualDevice::transaction_complete()
+void systemBus::transaction_success()
 {
     assert(_transaction_state == TRANS_STATE::NO_GET || _transaction_state == TRANS_STATE::DID_GET);
-    SYSTEM_BUS.sendReplyPacket(_devnum, true, nullptr, 0);
+    sendReplyPacket(_activeDev->_devnum, true, nullptr, 0);
     _transaction_state = TRANS_STATE::INVALID;
 }
 
-void virtualDevice::transaction_error()
+void systemBus::transaction_error()
 {
-    SYSTEM_BUS.sendReplyPacket(_devnum, false, nullptr, 0);
+    sendReplyPacket(_activeDev->_devnum, false, nullptr, 0);
     _transaction_state = TRANS_STATE::INVALID;
 }
 
-success_is_true virtualDevice::transaction_get(void *data, size_t len)
+success_is_true systemBus::transaction_get(void *data, size_t len)
 {
     assert(_transaction_state == TRANS_STATE::WILL_GET);
     _transaction_state = TRANS_STATE::DID_GET;
@@ -63,26 +64,23 @@ success_is_true virtualDevice::transaction_get(void *data, size_t len)
     if (!len)
         RETURN_SUCCESS_AS_TRUE();
 
-    // FIXME - This is a terrible hack to allow devices to continue to
-    // use the pattern of fetching data on their own instead of
-    // upgrading them fully to work with packets.
-    auto optional_data = _legacyPacketData->data();
+    auto optional_data = _activePacket->data();
     if (!optional_data.has_value())
         RETURN_ERROR_AS_FALSE();
-    size_t avail = optional_data.value().size() - _legacyDataPosition;
+    size_t avail = optional_data.value().size() - _activePacketDataPosition;
     avail = std::min(avail, (size_t) len);
-    memcpy(data, optional_data.value().data() + _legacyDataPosition, avail);
-    _legacyDataPosition += avail;
+    memcpy(data, optional_data.value().data() + _activePacketDataPosition, avail);
+    _activePacketDataPosition += avail;
 
     if (avail != len)
         RETURN_ERROR_AS_FALSE();
     RETURN_SUCCESS_AS_TRUE();
 }
 
-void virtualDevice::transaction_put(const void *data, size_t len, bool err)
+void systemBus::transaction_send(const void *data, size_t len, bool is_error)
 {
     assert(_transaction_state == TRANS_STATE::NO_GET);
-    SYSTEM_BUS.sendReplyPacket(_devnum, !err, data, len);
+    sendReplyPacket(_activeDev->_devnum, !is_error, data, len);
     _transaction_state = TRANS_STATE::INVALID;
 }
 
@@ -128,14 +126,15 @@ void systemBus::_rs232_process_cmd()
                  tempFrame->device(), tempFrame->command(),
                  tempFrame->data() ? tempFrame->data()->size() : -1);
 
+
+    _activePacket = tempFrame.get();
+    _activeDev = nullptr;
+
     if (tempFrame->device() == FUJI_DEVICEID_DISK && _fujiDev != nullptr
         && _fujiDev->boot_config)
     {
         _activeDev = &_fujiDev->bootdisk;
-
         Debug_println("FujiNet CONFIG boot");
-        // handle command
-        _activeDev->rs232_process(*tempFrame);
     }
     else
     {
@@ -146,19 +145,13 @@ void systemBus::_rs232_process_cmd()
             if (tempFrame->device() == devicep->_devnum)
             {
                 _activeDev = devicep;
-
-                // FIXME - This is a terrible hack to allow devices to continue to
-                // use the pattern of fetching data on their own instead of
-                // upgrading them fully to work with packets.
-                _activeDev->_legacyPacketData = tempFrame.get();
-                _activeDev->_legacyDataPosition = 0;
-
-                // handle command
-                _activeDev->rs232_process(*tempFrame);
                 break;
             }
         }
     }
+
+    if (_activeDev != nullptr)
+        _activeDev->rs232_process(*tempFrame);
 
     fnLedManager.set(eLed::LED_BUS, false);
 }

--- a/lib/bus/rs232/rs232.h
+++ b/lib/bus/rs232/rs232.h
@@ -54,34 +54,13 @@ class virtualDevice
     friend systemBus;
     friend fujiDevice;
 
-private:
-    transState_t _transaction_state = TRANS_STATE::INVALID;
-
 protected:
     fujiDeviceID_t _devnum;
 
     bool listen_to_type3_polls = false;
 
-    virtual void transaction_begin(transState_t expectMoreData);
-    virtual void transaction_complete();
-    virtual void transaction_error();
-    virtual success_is_true transaction_get(void *data, size_t len);
-    virtual void transaction_put(const void *data, size_t len, bool err=false);
-    inline void transaction_put(std::string data) {
-        transaction_put(data.data(), data.size());
-    }
-    inline void transaction_put(ByteBuffer data) {
-        transaction_put(data.data(), data.size());
-    }
-
-    // FIXME - This is a terrible hack to allow devices to continue to
-    // use the pattern of fetching data on their own instead of
-    // upgrading them fully to work with packets.
-    FujiBusPacket *_legacyPacketData;
-    size_t _legacyDataPosition;
-
     /**
-     * @brief All RS232 commands by convention should return a status command, using bus_to_computer() to return
+     * @brief All RS232 commands by convention should return a status command to return
      * four bytes of status information to be put into DVSTAT ($02EA)
      */
     virtual void rs232_status(FujiStatusReq reqType) = 0;
@@ -132,9 +111,12 @@ struct rs232_message_t
 
 // typedef rs232_message_t rs232_message_t;
 
-class systemBus
+class systemBus : public SystemBusBase
 {
 private:
+    FujiBusPacket *_activePacket;
+    size_t _activePacketDataPosition;
+
     std::forward_list<virtualDevice *> _daisyChain;
 
     int _command_frame_counter = 0;
@@ -182,6 +164,12 @@ public:
 
     bool shuttingDown = false;                                  // TRUE if we are in shutdown process
     bool getShuttingDown() { return shuttingDown; };
+
+    void transaction_accept(transState_t expectMoreData) override;
+    void transaction_success() override;
+    void transaction_error() override;
+    success_is_true transaction_get(void *data, size_t len) override;
+    void transaction_send(const void *data, size_t len, bool is_error=false) override;
 
     std::unique_ptr<FujiBusPacket> readBusPacket(int first=-1);
     void writeBusPacket(FujiBusPacket &packet);

--- a/lib/device/fujiDevice.h
+++ b/lib/device/fujiDevice.h
@@ -121,7 +121,7 @@ enum DET_file_flags_t {
     DET_FF_TRUNC = 0x02,
 };
 
-class fujiDevice : public virtualDevice
+class fujiDevice : public virtualDevice, public VDevMigrationWrapper
 {
 private:
     bool hostMounted[MAX_HOSTS];

--- a/lib/device/rs232/apetime.cpp
+++ b/lib/device/rs232/apetime.cpp
@@ -25,98 +25,98 @@ std::optional<std::string> rs232ApeTime::_read_tz(const FujiBusPacket &packet)
 
 void rs232ApeTime::_set_alternate_tz(const FujiBusPacket &packet)
 {
-    transaction_begin(TRANS_STATE::NO_GET);
+    SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
     auto tz = _read_tz(packet);
     if (tz) {
         alternate_tz = tz.value();
         Debug_printf("Alt TZ set to <%s>\n", alternate_tz.c_str());
     }
-    transaction_complete();
+    SYSTEM_BUS.transaction_success();
 }
 
 void rs232ApeTime::_set_fn_tz(const FujiBusPacket &packet)
 {
-    transaction_begin(TRANS_STATE::NO_GET);
+    SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
     auto tz = _read_tz(packet);
     if (tz)
         Config.store_general_timezone(tz->c_str());
-    transaction_complete();
+    SYSTEM_BUS.transaction_success();
 }
 
 void rs232ApeTime::_get_time_apetime(const FujiBusPacket &packet, bool force_alt)
 {
-    transaction_begin(TRANS_STATE::NO_GET);
+    SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
     bool use_alt = force_alt ||
                    (packet.paramCount() > 0 && packet.param(0) == 0x01);
     auto t = Clock::get_current_time_apetime(
         Clock::tz_to_use(use_alt, alternate_tz, Config.get_general_timezone()));
-    transaction_put(t.data(), t.size(), false);
+    SYSTEM_BUS.transaction_send(t.data(), t.size(), false);
 }
 
 void rs232ApeTime::_get_time_simple(const FujiBusPacket &packet)
 {
-    transaction_begin(TRANS_STATE::NO_GET);
+    SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
     bool use_alt = packet.paramCount() > 0 && packet.param(0) == 0x01;
     auto t = Clock::get_current_time_simple(
         Clock::tz_to_use(use_alt, alternate_tz, Config.get_general_timezone()));
-    transaction_put(t.data(), t.size(), false);
+    SYSTEM_BUS.transaction_send(t.data(), t.size(), false);
 }
 
 void rs232ApeTime::_get_time_simple_hundredths(const FujiBusPacket &packet)
 {
-    transaction_begin(TRANS_STATE::NO_GET);
+    SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
     bool use_alt = packet.paramCount() > 0 && packet.param(0) == 0x01;
     auto t = Clock::get_current_time_simple_hundredths(
         Clock::tz_to_use(use_alt, alternate_tz, Config.get_general_timezone()));
-    transaction_put(t.data(), t.size(), false);
+    SYSTEM_BUS.transaction_send(t.data(), t.size(), false);
 }
 
 void rs232ApeTime::_get_time_prodos(const FujiBusPacket &packet)
 {
-    transaction_begin(TRANS_STATE::NO_GET);
+    SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
     bool use_alt = packet.paramCount() > 0 && packet.param(0) == 0x01;
     auto t = Clock::get_current_time_prodos(
         Clock::tz_to_use(use_alt, alternate_tz, Config.get_general_timezone()));
-    transaction_put(t.data(), t.size(), false);
+    SYSTEM_BUS.transaction_send(t.data(), t.size(), false);
 }
 
 void rs232ApeTime::_get_time_sos(const FujiBusPacket &packet)
 {
-    transaction_begin(TRANS_STATE::NO_GET);
+    SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
     bool use_alt = packet.paramCount() > 0 && packet.param(0) == 0x01;
     std::string s = Clock::get_current_time_sos(
         Clock::tz_to_use(use_alt, alternate_tz, Config.get_general_timezone()));
-    transaction_put(s.c_str(), s.size() + 1, false);
+    SYSTEM_BUS.transaction_send(s.c_str(), s.size() + 1, false);
 }
 
 void rs232ApeTime::_get_time_iso_local(const FujiBusPacket &packet)
 {
-    transaction_begin(TRANS_STATE::NO_GET);
+    SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
     bool use_alt = packet.paramCount() > 0 && packet.param(0) == 0x01;
     std::string s = Clock::get_current_time_iso(
         Clock::tz_to_use(use_alt, alternate_tz, Config.get_general_timezone()));
-    transaction_put(s.c_str(), s.size() + 1, false);
+    SYSTEM_BUS.transaction_send(s.c_str(), s.size() + 1, false);
 }
 
 void rs232ApeTime::_get_time_iso_utc()
 {
-    transaction_begin(TRANS_STATE::NO_GET);
+    SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
     std::string s = Clock::get_current_time_iso("UTC+0");
-    transaction_put(s.c_str(), s.size() + 1, false);
+    SYSTEM_BUS.transaction_send(s.c_str(), s.size() + 1, false);
 }
 
 void rs232ApeTime::_get_general_tz()
 {
-    transaction_begin(TRANS_STATE::NO_GET);
+    SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
     const std::string tz = Config.get_general_timezone();
-    transaction_put(tz.c_str(), tz.size() + 1, false);
+    SYSTEM_BUS.transaction_send(tz.c_str(), tz.size() + 1, false);
 }
 
 void rs232ApeTime::_get_general_tz_len()
 {
-    transaction_begin(TRANS_STATE::NO_GET);
+    SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
     uint8_t len = Config.get_general_timezone().size() + 1;
-    transaction_put(&len, 1, false);
+    SYSTEM_BUS.transaction_send(&len, 1, false);
 }
 
 void rs232ApeTime::rs232_process(FujiBusPacket &packet)
@@ -161,7 +161,7 @@ void rs232ApeTime::rs232_process(FujiBusPacket &packet)
         break;
     default:
         Debug_printv("Unknown rs232 clock cmd: %02x", packet.command());
-        transaction_error();
+        SYSTEM_BUS.transaction_error();
         break;
     }
 }

--- a/lib/device/rs232/disk.cpp
+++ b/lib/device/rs232/disk.cpp
@@ -19,13 +19,13 @@ rs232Disk::rs232Disk()
 // Read disk data and send to computer
 void rs232Disk::rs232_read(uint32_t sector)
 {
-    transaction_begin(TRANS_STATE::NO_GET);
+    SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
 
     Debug_printf("disk READ %lu\n", sector);
 
     if (_disk == nullptr)
     {
-        transaction_error();
+        SYSTEM_BUS.transaction_error();
         return;
     }
 
@@ -34,7 +34,7 @@ void rs232Disk::rs232_read(uint32_t sector)
     bool err = _disk->read(sector, &readcount);
 
     // Send result to Atari
-    transaction_put(_disk->_disk_sectorbuff, readcount, err);
+    SYSTEM_BUS.transaction_send(_disk->_disk_sectorbuff, readcount, err);
 }
 
 // Write disk data from computer
@@ -48,17 +48,17 @@ void rs232Disk::rs232_write(uint32_t sector, bool verify)
 
         memset(_disk->_disk_sectorbuff, 0, DISK_SECTORBUF_SIZE);
 
-        if (transaction_get(_disk->_disk_sectorbuff, sectorSize))
+        if (SYSTEM_BUS.transaction_get(_disk->_disk_sectorbuff, sectorSize))
         {
             if (_disk->write(sector, verify) == false)
             {
-                transaction_complete();
+                SYSTEM_BUS.transaction_success();
                 return;
             }
         }
     }
 
-    transaction_error();
+    SYSTEM_BUS.transaction_error();
 }
 
 // Status
@@ -111,18 +111,18 @@ void rs232Disk::rs232_status(FujiStatusReq reqType)
 
     Debug_printf("response: 0x%02x, 0x%02x, 0x%02x\n", _status[0], _status[1], _status[2]);
 
-    transaction_put(_status, sizeof(_status), false);
+    SYSTEM_BUS.transaction_send(_status, sizeof(_status), false);
 }
 
 // Disk format
 void rs232Disk::rs232_format()
 {
-    transaction_begin(TRANS_STATE::NO_GET);
+    SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
     Debug_print("disk FORMAT\n");
 
     if (_disk == nullptr)
     {
-        transaction_error();
+        SYSTEM_BUS.transaction_error();
         return;
     }
 
@@ -130,44 +130,44 @@ void rs232Disk::rs232_format()
     bool err = _disk->format(&responsesize);
 
     // Send to computer
-    transaction_put(_disk->_disk_sectorbuff, responsesize, err);
+    SYSTEM_BUS.transaction_send(_disk->_disk_sectorbuff, responsesize, err);
 }
 
 // Read percom block
 void rs232Disk::rs232_read_percom_block()
 {
-    transaction_begin(TRANS_STATE::NO_GET);
+    SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
     Debug_print("disk READ PERCOM BLOCK\n");
 
     if (_disk == nullptr)
     {
-        transaction_error();
+        SYSTEM_BUS.transaction_error();
         return;
     }
 
 #ifdef VERBOSE_DISK
     _disk->dump_percom_block();
 #endif
-    transaction_put((uint8_t *)&_disk->_percomBlock, sizeof(_disk->_percomBlock), false);
+    SYSTEM_BUS.transaction_send((uint8_t *)&_disk->_percomBlock, sizeof(_disk->_percomBlock), false);
 }
 
 // Write percom block
 void rs232Disk::rs232_write_percom_block()
 {
-    transaction_begin(TRANS_STATE::WILL_GET);
+    SYSTEM_BUS.transaction_accept(TRANS_STATE::WILL_GET);
     Debug_print("disk WRITE PERCOM BLOCK\n");
 
     if (_disk == nullptr)
     {
-        transaction_error();
+        SYSTEM_BUS.transaction_error();
         return;
     }
 
-    transaction_get((uint8_t *)&_disk->_percomBlock, sizeof(_disk->_percomBlock));
+    SYSTEM_BUS.transaction_get((uint8_t *)&_disk->_percomBlock, sizeof(_disk->_percomBlock));
 #ifdef VERBOSE_DISK
     _disk->dump_percom_block();
 #endif
-    transaction_complete();
+    SYSTEM_BUS.transaction_success();
 }
 
 /* Mount Disk
@@ -313,7 +313,7 @@ void rs232Disk::rs232_process(FujiBusPacket &packet)
         break;
     }
 
-    transaction_error();
+    SYSTEM_BUS.transaction_error();
 }
 
 #endif /* BUILD_RS232 */

--- a/lib/device/rs232/modem.cpp
+++ b/lib/device/rs232/modem.cpp
@@ -160,7 +160,7 @@ void rs232Modem::rs232_status(FujiStatusReq reqType)
 
     Debug_printf("rs232Modem::rs232_status(%02x,%02x)\n", mdmStatus[0], mdmStatus[1]);
 
-    transaction_put(mdmStatus, sizeof(mdmStatus), false);
+    SYSTEM_BUS.transaction_send(mdmStatus, sizeof(mdmStatus), false);
 }
 
 // 0x41 / 'A' - CONTROL
@@ -214,7 +214,7 @@ void rs232Modem::rs232_control()
     }
 #endif /* OBSOLETE */
     // for now, just complete
-    transaction_complete();
+    SYSTEM_BUS.transaction_success();
 }
 
 // 0x42 / 'B' - CONFIGURE
@@ -245,7 +245,7 @@ void rs232Modem::rs232_config()
          0: Watch CRX line
     */
     // Complete and then set newbaud
-    transaction_complete();
+    SYSTEM_BUS.transaction_success();
 
 #ifdef OBSOLETE
     uint8_t newBaud = 0x0F & cmdFrame.aux1; // Get baud rate
@@ -296,7 +296,7 @@ void rs232Modem::rs232_config()
 void rs232Modem::rs232_set_dump(bool enable)
 {
     modemSniffer->setEnable(enable);
-    transaction_complete();
+    SYSTEM_BUS.transaction_success();
 }
 
 // 0x58 / 'X' - STREAM
@@ -350,7 +350,7 @@ void rs232Modem::rs232_stream()
         break;
     }
 
-    transaction_put((uint8_t *)response, sizeof(response), false);
+    SYSTEM_BUS.transaction_send((uint8_t *)response, sizeof(response), false);
 
     SYSTEM_BUS.setBaudrate(modemBaud);
     modemActive = true;
@@ -370,14 +370,14 @@ void rs232Modem::rs232_listen(unsigned short newPort)
     }
 
     if (listenPort < 1)
-        transaction_error();
+        SYSTEM_BUS.transaction_error();
     else
-        transaction_begin(TRANS_STATE::NO_GET);
+        SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
 
     tcpServer.setMaxClients(1);
     tcpServer.begin(listenPort);
 
-    transaction_complete();
+    SYSTEM_BUS.transaction_success();
 }
 
 /**
@@ -385,10 +385,10 @@ void rs232Modem::rs232_listen(unsigned short newPort)
  */
 void rs232Modem::rs232_unlisten()
 {
-    transaction_begin(TRANS_STATE::NO_GET);
+    SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
     tcpClient.stop();
     tcpServer.stop();
-    transaction_complete();
+    SYSTEM_BUS.transaction_success();
 }
 
 /**
@@ -396,13 +396,13 @@ void rs232Modem::rs232_unlisten()
  */
 void rs232Modem::rs232_baudlock(bool enable, unsigned int newBaud)
 {
-    transaction_begin(TRANS_STATE::NO_GET);
+    SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
     baudLock = enable;
     modemBaud = newBaud;
 
     Debug_printf("baudLock: %d\n", baudLock);
 
-    transaction_complete();
+    SYSTEM_BUS.transaction_success();
 }
 
 /**
@@ -410,12 +410,12 @@ void rs232Modem::rs232_baudlock(bool enable, unsigned int newBaud)
  */
 void rs232Modem::rs232_autoanswer(bool enable)
 {
-    transaction_begin(TRANS_STATE::NO_GET);
+    SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
     autoAnswer = enable;
 
     Debug_printf("autoanswer: %d\n", autoAnswer);
 
-    transaction_complete();
+    SYSTEM_BUS.transaction_success();
 }
 
 void rs232Modem::at_connect_resultCode(int modemBaud)
@@ -1620,15 +1620,15 @@ void rs232Modem::rs232_process(FujiBusPacket &packet)
         switch (packet.command())
         {
         case MODEMCMD_CONTROL:
-            transaction_begin(TRANS_STATE::NO_GET);
+            SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
             rs232_control();
             break;
         case MODEMCMD_CONFIGURE:
-            transaction_begin(TRANS_STATE::NO_GET);
+            SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
             rs232_config();
             break;
         case MODEMCMD_SET_DUMP:
-            transaction_begin(TRANS_STATE::NO_GET);
+            SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
             rs232_set_dump(packet.param(0));
             break;
         case MODEMCMD_LISTEN:
@@ -1644,20 +1644,20 @@ void rs232Modem::rs232_process(FujiBusPacket &packet)
             rs232_autoanswer(packet.param(0));
             break;
         case MODEMCMD_STATUS:
-            transaction_begin(TRANS_STATE::NO_GET);
+            SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
             rs232_status(static_cast<FujiStatusReq>(packet.param(0)));
             break;
         case MODEMCMD_WRITE:
-            transaction_begin(TRANS_STATE::NO_GET);
+            SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
             rs232_write(packet.data());
-            transaction_complete();
+            SYSTEM_BUS.transaction_success();
             break;
         case MODEMCMD_STREAM:
-            transaction_begin(TRANS_STATE::NO_GET);
+            SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
             rs232_stream();
             break;
         default:
-            transaction_error();
+            SYSTEM_BUS.transaction_error();
         }
     }
 }

--- a/lib/device/rs232/network.cpp
+++ b/lib/device/rs232/network.cpp
@@ -98,7 +98,7 @@ void rs232Network::rs232_open(fileAccessMode_t access, netProtoTranslation_t tra
 {
     Debug_println("rs232Network::rs232_open()\n");
 
-    transaction_begin(TRANS_STATE::WILL_GET);
+    SYSTEM_BUS.transaction_accept(TRANS_STATE::WILL_GET);
 
     channelMode = CHANNEL_MODE::PROTOCOL;
 
@@ -131,7 +131,7 @@ void rs232Network::rs232_open(fileAccessMode_t access, netProtoTranslation_t tra
     if (protocol == nullptr)
     {
         // invalid devicespec error already passed in.
-        transaction_error();
+        SYSTEM_BUS.transaction_error();
         return;
     }
 
@@ -147,7 +147,7 @@ void rs232Network::rs232_open(fileAccessMode_t access, netProtoTranslation_t tra
             delete protocolParser;
             protocolParser = nullptr;
         }
-        transaction_error();
+        SYSTEM_BUS.transaction_error();
         return;
     }
 
@@ -166,7 +166,7 @@ void rs232Network::rs232_open(fileAccessMode_t access, netProtoTranslation_t tra
     channelMode = CHANNEL_MODE::PROTOCOL;
 
     // And signal complete!
-    transaction_complete();
+    SYSTEM_BUS.transaction_success();
 }
 
 /**
@@ -177,7 +177,7 @@ void rs232Network::rs232_close()
 {
     Debug_printf("rs232Network::rs232_close()\n");
 
-    transaction_begin(TRANS_STATE::NO_GET);
+    SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
 
     status.reset();
 
@@ -189,15 +189,15 @@ void rs232Network::rs232_close()
     // If no protocol enabled, we just signal complete, and return.
     if (protocol == nullptr)
     {
-        transaction_complete();
+        SYSTEM_BUS.transaction_success();
         return;
     }
 
     // Ask the protocol to close
     if (protocol->close() != FUJI_ERROR::NONE)
-        transaction_error();
+        SYSTEM_BUS.transaction_error();
     else
-        transaction_complete();
+        SYSTEM_BUS.transaction_success();
 
     // Delete the protocol object
     delete protocol;
@@ -217,13 +217,13 @@ void rs232Network::rs232_read(uint16_t length)
 
     Debug_printf("rs232Network::rs232_read( %d bytes)\n", length);
 
-    transaction_begin(TRANS_STATE::NO_GET);
+    SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
 
     // Check for rx buffer. If NULL, then tell caller we could not allocate buffers.
     if (receiveBuffer == nullptr)
     {
         status.error = NDEV_STATUS::COULD_NOT_ALLOCATE_BUFFERS;
-        transaction_error();
+        SYSTEM_BUS.transaction_error();
         return;
     }
 
@@ -231,7 +231,7 @@ void rs232Network::rs232_read(uint16_t length)
     if (protocol == nullptr)
     {
         status.error = NDEV_STATUS::NOT_CONNECTED;
-        transaction_error();
+        SYSTEM_BUS.transaction_error();
         return;
     }
 
@@ -239,7 +239,7 @@ void rs232Network::rs232_read(uint16_t length)
     err = rs232_read_channel(length);
 
     // And send off to the computer
-    transaction_put((uint8_t *)receiveBuffer->data(), length, err != FUJI_ERROR::NONE);
+    SYSTEM_BUS.transaction_send((uint8_t *)receiveBuffer->data(), length, err != FUJI_ERROR::NONE);
     receiveBuffer->erase(0, length);
 }
 
@@ -260,7 +260,7 @@ fujiError_t rs232Network::rs232_read_channel_json(uint16_t num_bytes)
 /**
  * Perform the channel read based on the channelMode
  * @param num_bytes - number of bytes to read from channel.
- * @return TRUE on error, FALSE on success. Passed directly to transaction_put().
+ * @return TRUE on error, FALSE on success. Passed directly to SYSTEM_BUS.transaction_send().
  */
 fujiError_t rs232Network::rs232_read_channel(uint16_t num_bytes)
 {
@@ -294,23 +294,23 @@ void rs232Network::rs232_write(uint16_t length)
     if (newData == nullptr)
     {
         Debug_printf("Could not allocate %u bytes.\n", length);
-        transaction_error();
+        SYSTEM_BUS.transaction_error();
         return;
     }
 
-    transaction_begin(TRANS_STATE::WILL_GET);
+    SYSTEM_BUS.transaction_accept(TRANS_STATE::WILL_GET);
 
     // If protocol isn't connected, then return not connected.
     if (protocol == nullptr)
     {
         status.error = NDEV_STATUS::NOT_CONNECTED;
-        transaction_error();
+        SYSTEM_BUS.transaction_error();
         free(newData);
         return;
     }
 
     // Get the data from the Atari
-    transaction_get(newData, length);
+    SYSTEM_BUS.transaction_get(newData, length);
     *transmitBuffer += string((char *)newData, length);
     free(newData);
 
@@ -320,16 +320,16 @@ void rs232Network::rs232_write(uint16_t length)
     // Acknowledge to Atari of channel outcome.
     if (err == FUJI_ERROR::NONE)
     {
-        transaction_complete();
+        SYSTEM_BUS.transaction_success();
     }
     else
-        transaction_error();
+        SYSTEM_BUS.transaction_error();
 }
 
 /**
  * Perform the correct write based on value of channelMode
  * @param num_bytes Number of bytes to write.
- * @return TRUE on error, FALSE on success. Used to emit transaction_error or transaction_complete().
+ * @return TRUE on error, FALSE on success. Used to emit SYSTEM_BUS.transaction_error or SYSTEM_BUS.transaction_success().
  */
 fujiError_t rs232Network::rs232_write_channel(uint16_t num_bytes)
 {
@@ -356,7 +356,7 @@ fujiError_t rs232Network::rs232_write_channel(uint16_t num_bytes)
 void rs232Network::rs232_status(FujiStatusReq reqType) // was aux2
 {
     // Acknowledge
-    transaction_begin(TRANS_STATE::NO_GET);
+    SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
 
     if (protocol == nullptr)
         rs232_status_local(reqType);
@@ -385,24 +385,24 @@ void rs232Network::rs232_status_local(FujiStatusReq reqType)
     {
     case 1: // IP Address
         Debug_printf("IP Address: %u.%u.%u.%u\n", ipAddress[0], ipAddress[1], ipAddress[2], ipAddress[3]);
-        transaction_put(ipAddress, 4, false);
+        SYSTEM_BUS.transaction_send(ipAddress, 4, false);
         break;
     case 2: // Netmask
         Debug_printf("Netmask: %u.%u.%u.%u\n", ipNetmask[0], ipNetmask[1], ipNetmask[2], ipNetmask[3]);
-        transaction_put(ipNetmask, 4, false);
+        SYSTEM_BUS.transaction_send(ipNetmask, 4, false);
         break;
     case 3: // Gateway
         Debug_printf("Gateway: %u.%u.%u.%u\n", ipGateway[0], ipGateway[1], ipGateway[2], ipGateway[3]);
-        transaction_put(ipGateway, 4, false);
+        SYSTEM_BUS.transaction_send(ipGateway, 4, false);
         break;
     case 4: // DNS
         Debug_printf("DNS: %u.%u.%u.%u\n", ipDNS[0], ipDNS[1], ipDNS[2], ipDNS[3]);
-        transaction_put(ipDNS, 4, false);
+        SYSTEM_BUS.transaction_send(ipDNS, 4, false);
         break;
     default:
         default_status[2] = status.connected;
         default_status[3] = (uint8_t) status.error;
-        transaction_put(default_status, 4, false);
+        SYSTEM_BUS.transaction_send(default_status, 4, false);
     }
 }
 
@@ -452,7 +452,7 @@ void rs232Network::rs232_status_channel()
                  nstatus.avail, nstatus.conn, (uint8_t) nstatus.err);
 
     // and send to computer
-    transaction_put((uint8_t *) &nstatus, sizeof(nstatus), err != FUJI_ERROR::NONE);
+    SYSTEM_BUS.transaction_send((uint8_t *) &nstatus, sizeof(nstatus), err != FUJI_ERROR::NONE);
 }
 
 /**
@@ -463,12 +463,12 @@ void rs232Network::rs232_get_prefix()
     uint8_t prefixSpec[256];
     string prefixSpec_str;
 
-    transaction_begin(TRANS_STATE::NO_GET);
+    SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
     memcpy(prefixSpec, prefix.data(), prefix.size());
 
     prefixSpec[prefix.size()] = 0x9B; // add EOL.
 
-    transaction_put(prefixSpec, sizeof(prefixSpec), false);
+    SYSTEM_BUS.transaction_send(prefixSpec, sizeof(prefixSpec), false);
 }
 
 /**
@@ -479,8 +479,8 @@ void rs232Network::rs232_set_prefix()
     uint8_t prefixSpec[256];
     string prefixSpec_str;
 
-    transaction_begin(TRANS_STATE::WILL_GET);
-    transaction_get(prefixSpec, sizeof(prefixSpec)); // TODO test checksum
+    SYSTEM_BUS.transaction_accept(TRANS_STATE::WILL_GET);
+    SYSTEM_BUS.transaction_get(prefixSpec, sizeof(prefixSpec)); // TODO test checksum
     util_devicespec_fix_9b(prefixSpec, sizeof(prefixSpec));
 
     prefixSpec_str = string((const char *)prefixSpec);
@@ -549,7 +549,7 @@ void rs232Network::rs232_set_prefix()
 #endif
 
     // We are okay, signal complete.
-    transaction_complete();
+    SYSTEM_BUS.transaction_success();
 }
 
 /**
@@ -562,10 +562,10 @@ void rs232Network::rs232_set_channel_mode(channelMode_t newMode) // was aux2
     case CHANNEL_MODE::PROTOCOL:
     case CHANNEL_MODE::JSON:
         channelMode = newMode;
-        transaction_complete();
+        SYSTEM_BUS.transaction_success();
         break;
     default:
-        transaction_error();
+        SYSTEM_BUS.transaction_error();
     }
 }
 
@@ -576,12 +576,12 @@ void rs232Network::rs232_set_login()
 {
     uint8_t loginSpec[256];
 
-    transaction_begin(TRANS_STATE::WILL_GET);
-    transaction_get(loginSpec, sizeof(loginSpec));
+    SYSTEM_BUS.transaction_accept(TRANS_STATE::WILL_GET);
+    SYSTEM_BUS.transaction_get(loginSpec, sizeof(loginSpec));
     util_devicespec_fix_9b(loginSpec, sizeof(loginSpec));
 
     login = string((char *)loginSpec);
-    transaction_complete();
+    SYSTEM_BUS.transaction_success();
 }
 
 /**
@@ -591,12 +591,12 @@ void rs232Network::rs232_set_password()
 {
     uint8_t passwordSpec[256];
 
-    transaction_begin(TRANS_STATE::WILL_GET);
-    transaction_get(passwordSpec, sizeof(passwordSpec));
+    SYSTEM_BUS.transaction_accept(TRANS_STATE::WILL_GET);
+    SYSTEM_BUS.transaction_get(passwordSpec, sizeof(passwordSpec));
     util_devicespec_fix_9b(passwordSpec, sizeof(passwordSpec));
 
     password = string((char *)passwordSpec);
-    transaction_complete();
+    SYSTEM_BUS.transaction_success();
 }
 
 void rs232Network::process_tcp(FujiBusPacket &packet)
@@ -605,7 +605,7 @@ void rs232Network::process_tcp(FujiBusPacket &packet)
     NetworkProtocolTCP *tcp = dynamic_cast<NetworkProtocolTCP *>(protocol);
     if (!tcp)
     {
-        transaction_error();
+        SYSTEM_BUS.transaction_error();
         return;
     }
 
@@ -613,22 +613,22 @@ void rs232Network::process_tcp(FujiBusPacket &packet)
     switch (packet.command())
     {
     case NETCMD_CONTROL:
-        transaction_begin(TRANS_STATE::NO_GET);
+        SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
         err = tcp->accept_connection();
         break;
     case NETCMD_CLOSE_CLIENT:
-        transaction_begin(TRANS_STATE::NO_GET);
+        SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
         err = tcp->close_client_connection();
         break;
     default:
-        transaction_error();
+        SYSTEM_BUS.transaction_error();
         return;
     }
 
     if (err != FUJI_ERROR::NONE)
-        transaction_error();
+        SYSTEM_BUS.transaction_error();
     else
-        transaction_complete();
+        SYSTEM_BUS.transaction_success();
 }
 
 void rs232Network::process_http(FujiBusPacket &packet)
@@ -637,7 +637,7 @@ void rs232Network::process_http(FujiBusPacket &packet)
     NetworkProtocolHTTP *http = dynamic_cast<NetworkProtocolHTTP *>(protocol);
     if (!http)
     {
-        transaction_error();
+        SYSTEM_BUS.transaction_error();
         return;
     }
 
@@ -645,18 +645,18 @@ void rs232Network::process_http(FujiBusPacket &packet)
     switch (packet.command())
     {
     case NETCMD_SET_CHANNEL_MODE:
-        transaction_begin(TRANS_STATE::NO_GET);
+        SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
         err = http->set_channel_mode((netProtoHTTPChannelMode_t) packet.param(1));
         break;
     default:
-        transaction_error();
+        SYSTEM_BUS.transaction_error();
         return;
     }
 
     if (err != FUJI_ERROR::NONE)
-        transaction_error();
+        SYSTEM_BUS.transaction_error();
     else
-        transaction_complete();
+        SYSTEM_BUS.transaction_success();
 }
 
 void rs232Network::process_udp(FujiBusPacket &packet)
@@ -665,7 +665,7 @@ void rs232Network::process_udp(FujiBusPacket &packet)
     NetworkProtocolUDP *udp = dynamic_cast<NetworkProtocolUDP *>(protocol);
     if (!udp)
     {
-        transaction_error();
+        SYSTEM_BUS.transaction_error();
         return;
     }
 
@@ -674,34 +674,34 @@ void rs232Network::process_udp(FujiBusPacket &packet)
     {
 #ifndef ESP_PLATFORM
     case NETCMD_GET_REMOTE:
-        transaction_begin(TRANS_STATE::NO_GET);
+        SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
         err = udp->get_remote(receiveBuffer->data(), SPECIAL_BUFFER_SIZE);
-        transaction_put((uint8_t *)receiveBuffer->data(), SPECIAL_BUFFER_SIZE, err != FUJI_ERROR::NONE);
+        SYSTEM_BUS.transaction_send((uint8_t *)receiveBuffer->data(), SPECIAL_BUFFER_SIZE, err != FUJI_ERROR::NONE);
         break;
 #endif /* ESP_PLATFORM */
     case NETCMD_SET_DESTINATION:
         {
             uint8_t spData[SPECIAL_BUFFER_SIZE];
-            transaction_begin(TRANS_STATE::WILL_GET);
-            transaction_get(spData, sizeof(spData));
+            SYSTEM_BUS.transaction_accept(TRANS_STATE::WILL_GET);
+            SYSTEM_BUS.transaction_get(spData, sizeof(spData));
             err = udp->set_destination(spData, sizeof(spData));
             if (err != FUJI_ERROR::NONE)
-                transaction_error();
+                SYSTEM_BUS.transaction_error();
             else
-                transaction_complete();
+                SYSTEM_BUS.transaction_success();
         }
         break;
     default:
-        transaction_error();
+        SYSTEM_BUS.transaction_error();
         return;
     }
 }
 
 void rs232Network::rs232_seek(uint32_t offset)
 {
-    transaction_begin(TRANS_STATE::NO_GET);
+    SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
     protocol->seek(offset, SEEK_SET);
-    transaction_complete();
+    SYSTEM_BUS.transaction_success();
     return;
 }
 
@@ -712,17 +712,17 @@ void rs232Network::rs232_tell()
 
 
     // Acknowledge
-    transaction_begin(TRANS_STATE::NO_GET);
+    SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
 
     offset = protocol->seek(0, SEEK_CUR);
     if (offset == -1) {
         status.error = NDEV_STATUS::SERVER_GENERAL;
-        transaction_error();
+        SYSTEM_BUS.transaction_error();
         return;
     }
 
     retval = htole32(offset);
-    transaction_put((unsigned char *) &retval, 4, false);
+    SYSTEM_BUS.transaction_send((unsigned char *) &retval, 4, false);
     return;
 }
 
@@ -739,7 +739,7 @@ void rs232Network::rs232_process(FujiBusPacket &packet)
     case NETCMD_OPEN:
         if (packet.paramCount() < 2) {
             Debug_printv("Insufficient open paramaters: %d", packet.paramCount());
-            transaction_error();
+            SYSTEM_BUS.transaction_error();
         }
         else
             rs232_open((fileAccessMode_t) packet.param(0),
@@ -751,7 +751,7 @@ void rs232Network::rs232_process(FujiBusPacket &packet)
     case NETCMD_READ:
         if (packet.paramCount() < 1) {
             Debug_printv("Insufficient read paramaters: %d", packet.paramCount());
-            transaction_error();
+            SYSTEM_BUS.transaction_error();
         }
         else
             rs232_read(packet.param(0));
@@ -759,7 +759,7 @@ void rs232Network::rs232_process(FujiBusPacket &packet)
     case NETCMD_WRITE:
         if (packet.paramCount() < 1 || !packet.data().has_value()) {
             Debug_printv("Insufficient write paramaters: %d", packet.paramCount());
-            transaction_error();
+            SYSTEM_BUS.transaction_error();
         }
         else
             rs232_write(packet.param(0));
@@ -773,7 +773,7 @@ void rs232Network::rs232_process(FujiBusPacket &packet)
         }
         break;
     case NETCMD_PARSE:
-        transaction_begin(TRANS_STATE::NO_GET);
+        SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
         rs232_parse_json();
         break;
     case NETCMD_QUERY:
@@ -782,18 +782,18 @@ void rs232Network::rs232_process(FujiBusPacket &packet)
     case NETCMD_CHANNEL_MODE:
         if (packet.paramCount() < 2) {
             Debug_printv("Insufficient mode paramaters: %d", packet.paramCount());
-            transaction_error();
+            SYSTEM_BUS.transaction_error();
         }
         else
         {
-            transaction_begin(TRANS_STATE::NO_GET);
+            SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
             rs232_set_channel_mode((channelMode_t) packet.param(1));
         }
         break;
     case NETCMD_SEEK:
         if (packet.paramCount() < 1) {
             Debug_printv("Insufficient seek paramaters: %d", packet.paramCount());
-            transaction_error();
+            SYSTEM_BUS.transaction_error();
         }
         else
             rs232_seek(packet.param(0));
@@ -804,7 +804,7 @@ void rs232Network::rs232_process(FujiBusPacket &packet)
     case NETCMD_TRANSLATION:
         if (packet.paramCount() < 2) {
             Debug_printv("Insufficient translation paramaters: %d", packet.paramCount());
-            transaction_error();
+            SYSTEM_BUS.transaction_error();
         }
         else
             rs232_set_translation((netProtoTranslation_t) packet.param(1));
@@ -812,7 +812,7 @@ void rs232Network::rs232_process(FujiBusPacket &packet)
     case NETCMD_SET_INT_RATE:
         if (packet.paramCount() < 2) {
             Debug_printv("Insufficient rate paramaters: %d", packet.paramCount());
-            transaction_error();
+            SYSTEM_BUS.transaction_error();
         }
         else
             rs232_set_timer_rate(packet.param(1));
@@ -854,7 +854,7 @@ void rs232Network::rs232_process(FujiBusPacket &packet)
         break;
 
     default:
-        transaction_error();
+        SYSTEM_BUS.transaction_error();
         break;
     }
 }
@@ -917,7 +917,7 @@ success_is_true rs232Network::instantiate_protocol()
 void rs232Network::create_devicespec(fileAccessMode_t access)
 {
     // Get Devicespec from buffer, and put into primary devicespec string
-    transaction_get(devicespecBuf, sizeof(devicespecBuf));
+    SYSTEM_BUS.transaction_get(devicespecBuf, sizeof(devicespecBuf));
     util_devicespec_fix_9b(devicespecBuf, sizeof(devicespecBuf));
     deviceSpec = string((char *)devicespecBuf);
 
@@ -951,7 +951,7 @@ void rs232Network::parse_and_instantiate_protocol(fileAccessMode_t access)
     {
         Debug_printf("Invalid devicespec: >%s<\n", deviceSpec.c_str());
         status.error = NDEV_STATUS::INVALID_DEVICESPEC;
-        transaction_error();
+        SYSTEM_BUS.transaction_error();
         return;
     }
 
@@ -964,7 +964,7 @@ void rs232Network::parse_and_instantiate_protocol(fileAccessMode_t access)
     {
         Debug_printf("Could not open protocol. spec: >%s<, url: >%s<\n", deviceSpec.c_str(), urlParser->mRawUrl.c_str());
         status.error = NDEV_STATUS::GENERAL;
-        transaction_error();
+        SYSTEM_BUS.transaction_error();
         return;
     }
 }
@@ -1054,13 +1054,13 @@ void rs232Network::rs232_assert_interrupt()
 void rs232Network::rs232_set_translation(netProtoTranslation_t mode)
 {
     trans_mode = mode;
-    transaction_complete();
+    SYSTEM_BUS.transaction_success();
 }
 
 void rs232Network::rs232_parse_json()
 {
     json.parse();
-    transaction_complete();
+    SYSTEM_BUS.transaction_success();
 }
 
 void rs232Network::rs232_set_json_query()
@@ -1068,8 +1068,8 @@ void rs232Network::rs232_set_json_query()
     uint8_t in[256];
     uint8_t *tmp;
 
-    transaction_begin(TRANS_STATE::WILL_GET);
-    transaction_get(in, sizeof(in));
+    SYSTEM_BUS.transaction_accept(TRANS_STATE::WILL_GET);
+    SYSTEM_BUS.transaction_get(in, sizeof(in));
 
     // strip away line endings from input spec.
     for (int i = 0; i < 256; i++)
@@ -1086,7 +1086,7 @@ void rs232Network::rs232_set_json_query()
     *receiveBuffer += string((const char *)tmp,json_bytes_remaining);
     free(tmp);
     Debug_printf("Query set to %s\n",in);
-    transaction_complete();
+    SYSTEM_BUS.transaction_success();
 }
 
 void rs232Network::rs232_set_timer_rate(int newRate)
@@ -1102,7 +1102,7 @@ void rs232Network::rs232_set_timer_rate(int newRate)
         timer_start();
 #endif /* ESP_PLATFORM */
 
-    transaction_complete();
+    SYSTEM_BUS.transaction_success();
 }
 
 void rs232Network::process_fs(FujiBusPacket &packet)
@@ -1111,7 +1111,7 @@ void rs232Network::process_fs(FujiBusPacket &packet)
     NetworkProtocolFS *fs = dynamic_cast<NetworkProtocolFS *>(protocol);
     if (!fs)
     {
-        transaction_error();
+        SYSTEM_BUS.transaction_error();
         return;
     }
 
@@ -1138,14 +1138,14 @@ void rs232Network::process_fs(FujiBusPacket &packet)
         err = fs->rmdir(url);
         break;
     default:
-        transaction_error();
+        SYSTEM_BUS.transaction_error();
         return;
     }
 
     if (err != FUJI_ERROR::NONE)
-        transaction_error();
+        SYSTEM_BUS.transaction_error();
     else
-        transaction_complete();
+        SYSTEM_BUS.transaction_success();
 }
 
 #endif /* BUILD_RS232 */

--- a/lib/device/rs232/printer.cpp
+++ b/lib/device/rs232/printer.cpp
@@ -44,7 +44,7 @@ void rs232Printer::rs232_write(const std::optional<ByteBuffer>& data)
 {
     if (!data || data->empty())
     {
-        transaction_error();
+        SYSTEM_BUS.transaction_error();
         return;
     }
 
@@ -52,9 +52,9 @@ void rs232Printer::rs232_write(const std::optional<ByteBuffer>& data)
     memcpy(_pptr->provideBuffer(), data->data(), len);
 
     if (_pptr->process(len, 0, 0))
-        transaction_complete();
+        SYSTEM_BUS.transaction_success();
     else
-        transaction_error();
+        SYSTEM_BUS.transaction_error();
 }
 
 /**
@@ -103,7 +103,7 @@ void rs232Printer::rs232_status(FujiStatusReq reqType)
     status[2] = 5;
     status[3] = 0;
 
-    transaction_put(status, sizeof(status), false);
+    SYSTEM_BUS.transaction_send(status, sizeof(status), false);
 }
 
 void rs232Printer::set_printer_type(rs232Printer::printer_type printer_type)
@@ -240,23 +240,23 @@ void rs232Printer::rs232_process(FujiBusPacket &packet)
         case RS232_PRINTERCMD_PUT: // Needed by A822 for graphics mode printing
         case RS232_PRINTERCMD_WRITE:
             _last_ms = fnSystem.millis();
-            transaction_begin(TRANS_STATE::NO_GET);
+            SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
             rs232_write(packet.data());
             break;
         case RS232_PRINTERCMD_STATUS:
             if (packet.paramCount() < 1) {
                 Debug_printv("Insufficient status paramaters: %d", packet.paramCount());
-                transaction_error();
+                SYSTEM_BUS.transaction_error();
             }
             else
             {
                 _last_ms = fnSystem.millis();
-                transaction_begin(TRANS_STATE::NO_GET);
+                SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
                 rs232_status(static_cast<FujiStatusReq>(packet.param(0)));
             }
             break;
         default:
-            transaction_error();
+            SYSTEM_BUS.transaction_error();
         }
     }
 }

--- a/lib/device/rs232/rs232Fuji.cpp
+++ b/lib/device/rs232/rs232Fuji.cpp
@@ -60,7 +60,7 @@ void rs232Fuji::setup()
 // Status
 void rs232Fuji::rs232_status(FujiStatusReq reqType)
 {
-    transaction_begin(TRANS_STATE::NO_GET);
+    SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
     Debug_println("Fuji cmd: STATUS");
 
     if (reqType == STATUS_MOUNT_TIME)
@@ -75,14 +75,14 @@ void rs232Fuji::rs232_status(FujiStatusReq reqType)
         if (boot_config)
             mount_status[0] = bootdisk.mount_time();
 
-        transaction_put((uint8_t *) mount_status, sizeof(mount_status), false);
+        SYSTEM_BUS.transaction_send((uint8_t *) mount_status, sizeof(mount_status), false);
     }
     else
     {
         char ret[4] = {0};
 
         Debug_printf("Status for what? %08x\n", reqType);
-        transaction_put((uint8_t *)ret, sizeof(ret), false);
+        SYSTEM_BUS.transaction_send((uint8_t *)ret, sizeof(ret), false);
     }
     return;
 }
@@ -91,21 +91,21 @@ void rs232Fuji::rs232_status(FujiStatusReq reqType)
 void rs232Fuji::rs232_net_set_ssid(bool save) // was aux1
 {
     SSIDConfig cfg;
-    transaction_begin(TRANS_STATE::WILL_GET);
-    if (!transaction_get((uint8_t *)&cfg, sizeof(cfg)) ||
+    SYSTEM_BUS.transaction_accept(TRANS_STATE::WILL_GET);
+    if (!SYSTEM_BUS.transaction_get((uint8_t *)&cfg, sizeof(cfg)) ||
         !fujicore_net_set_ssid_success(cfg.ssid, cfg.password, save))
     {
-        transaction_error();
+        SYSTEM_BUS.transaction_error();
         return;
     }
 
-    transaction_complete();
+    SYSTEM_BUS.transaction_success();
 }
 
 //  Make new disk and shove into device slot
 void rs232Fuji::rs232_new_disk()
 {
-    transaction_begin(TRANS_STATE::WILL_GET);
+    SYSTEM_BUS.transaction_accept(TRANS_STATE::WILL_GET);
     Debug_println("Fuji cmd: NEW DISK");
 
     struct
@@ -118,16 +118,16 @@ void rs232Fuji::rs232_new_disk()
     } newDisk;
 
     // Ask for details on the new disk to create
-    if (!transaction_get((uint8_t *)&newDisk, sizeof(newDisk)))
+    if (!SYSTEM_BUS.transaction_get((uint8_t *)&newDisk, sizeof(newDisk)))
     {
         Debug_print("rs232_new_disk Bad checksum\n");
-        transaction_error();
+        SYSTEM_BUS.transaction_error();
         return;
     }
     if (newDisk.deviceSlot >= MAX_DISK_DEVICES || newDisk.hostSlot >= MAX_HOSTS)
     {
         Debug_print("rs232_new_disk Bad disk or host slot parameter\n");
-        transaction_error();
+        SYSTEM_BUS.transaction_error();
         return;
     }
     // A couple of reference variables to make things much easier to read...
@@ -141,7 +141,7 @@ void rs232Fuji::rs232_new_disk()
     if (host.file_exists(disk.filename))
     {
         Debug_printf("rs232_new_disk File exists: \"%s\"\n", disk.filename);
-        transaction_error();
+        SYSTEM_BUS.transaction_error();
         return;
     }
 
@@ -149,7 +149,7 @@ void rs232Fuji::rs232_new_disk()
     if (disk.fileh == nullptr)
     {
         Debug_printf("rs232_new_disk Couldn't open file for writing: \"%s\"\n", disk.filename);
-        transaction_error();
+        SYSTEM_BUS.transaction_error();
         return;
     }
 
@@ -159,22 +159,22 @@ void rs232Fuji::rs232_new_disk()
     if (ok == false)
     {
         Debug_print("rs232_new_disk Data write failed\n");
-        transaction_error();
+        SYSTEM_BUS.transaction_error();
         return;
     }
 
     Debug_print("rs232_new_disk succeeded\n");
-    transaction_complete();
+    SYSTEM_BUS.transaction_success();
 }
 
 void rs232Fuji::rs232_test()
 {
     uint8_t buf[512];
 
-    transaction_begin(TRANS_STATE::NO_GET);
+    SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
     Debug_printf("rs232_test()\n");
     memset(buf, 'A', 512);
-    transaction_put(buf, 512, false);
+    SYSTEM_BUS.transaction_send(buf, 512, false);
 }
 
 size_t rs232Fuji::set_additional_direntry_details(fsdir_entry_t *f, uint8_t *dest, uint8_t maxlen)
@@ -214,7 +214,7 @@ void rs232Fuji::rs232_process(FujiBusPacket &packet)
     case FUJICMD_STATUS:
         if (packet.paramCount() < 1) {
             Debug_printv("Insufficient status paramaters: %d", packet.paramCount());
-            transaction_error();
+            SYSTEM_BUS.transaction_error();
         }
         else
             rs232_status(static_cast<FujiStatusReq>(packet.param(0)));
@@ -228,7 +228,7 @@ void rs232Fuji::rs232_process(FujiBusPacket &packet)
     case FUJICMD_GET_SCAN_RESULT:
         if (packet.paramCount() < 1) {
             Debug_printv("Insufficient scan paramaters: %d", packet.paramCount());
-            transaction_error();
+            SYSTEM_BUS.transaction_error();
         }
         else
             fujicmd_net_scan_result(packet.param(0));
@@ -236,7 +236,7 @@ void rs232Fuji::rs232_process(FujiBusPacket &packet)
     case FUJICMD_SET_SSID:
         if (packet.paramCount() < 1) {
             Debug_printv("Insufficient SSID paramaters: %d", packet.paramCount());
-            transaction_error();
+            SYSTEM_BUS.transaction_error();
         }
         else
             rs232_net_set_ssid(true);
@@ -250,7 +250,7 @@ void rs232Fuji::rs232_process(FujiBusPacket &packet)
     case FUJICMD_MOUNT_HOST:
         if (packet.paramCount() < 1) {
             Debug_printv("Insufficient mount host paramaters: %d", packet.paramCount());
-            transaction_error();
+            SYSTEM_BUS.transaction_error();
         }
         else
             fujicmd_mount_host_success(packet.param(0));
@@ -258,7 +258,7 @@ void rs232Fuji::rs232_process(FujiBusPacket &packet)
     case FUJICMD_MOUNT_IMAGE:
         if (packet.paramCount() < 2) {
             Debug_printv("Insufficient mount image paramaters: %d", packet.paramCount());
-            transaction_error();
+            SYSTEM_BUS.transaction_error();
         }
         else
             fujicmd_mount_disk_image_success(packet.param(0), (disk_access_flags_t) packet.param(1));
@@ -266,7 +266,7 @@ void rs232Fuji::rs232_process(FujiBusPacket &packet)
     case FUJICMD_OPEN_DIRECTORY:
         if (packet.paramCount() < 1) {
             Debug_printv("Insufficient open dir paramaters: %d", packet.paramCount());
-            transaction_error();
+            SYSTEM_BUS.transaction_error();
         }
         else
             fujicmd_open_directory_success(packet.param(0));
@@ -274,7 +274,7 @@ void rs232Fuji::rs232_process(FujiBusPacket &packet)
     case FUJICMD_READ_DIR_ENTRY:
         if (packet.paramCount() < 2) {
             Debug_printv("Insufficient read dir paramaters: %d", packet.paramCount());
-            transaction_error();
+            SYSTEM_BUS.transaction_error();
         }
         else
             fujicmd_read_directory_entry(packet.param(0), packet.param(1));
@@ -288,7 +288,7 @@ void rs232Fuji::rs232_process(FujiBusPacket &packet)
     case FUJICMD_SET_DIRECTORY_POSITION:
         if (packet.paramCount() < 1) {
             Debug_printv("Insufficient set dir position paramaters: %d", packet.paramCount());
-            transaction_error();
+            SYSTEM_BUS.transaction_error();
         }
         else
             fujicmd_set_directory_position(packet.param(0));
@@ -311,7 +311,7 @@ void rs232Fuji::rs232_process(FujiBusPacket &packet)
     case FUJICMD_UNMOUNT_IMAGE:
         if (packet.paramCount() < 1) {
             Debug_printv("Insufficient unmount image paramaters: %d", packet.paramCount());
-            transaction_error();
+            SYSTEM_BUS.transaction_error();
         }
         else
             fujicmd_unmount_disk_image_success(packet.param(0));
@@ -328,7 +328,7 @@ void rs232Fuji::rs232_process(FujiBusPacket &packet)
     case FUJICMD_SET_DEVICE_FULLPATH:
         if (packet.paramCount() < 3) {
             Debug_printv("Insufficient set device fullpath paramaters: %d", packet.paramCount());
-            transaction_error();
+            SYSTEM_BUS.transaction_error();
         }
         else
             fujicmd_set_device_filename_success(packet.param(0), packet.param(1),
@@ -337,7 +337,7 @@ void rs232Fuji::rs232_process(FujiBusPacket &packet)
     case FUJICMD_SET_HOST_PREFIX:
         if (packet.paramCount() < 1) {
             Debug_printv("Insufficient set host prefix paramaters: %d", packet.paramCount());
-            transaction_error();
+            SYSTEM_BUS.transaction_error();
         }
         else
             fujicmd_set_host_prefix(packet.param(0));
@@ -345,7 +345,7 @@ void rs232Fuji::rs232_process(FujiBusPacket &packet)
     case FUJICMD_GET_HOST_PREFIX:
         if (packet.paramCount() < 1) {
             Debug_printv("Insufficient get host prefix paramaters: %d", packet.paramCount());
-            transaction_error();
+            SYSTEM_BUS.transaction_error();
         }
         else
             fujicmd_get_host_prefix(packet.param(0));
@@ -365,7 +365,7 @@ void rs232Fuji::rs232_process(FujiBusPacket &packet)
     case FUJICMD_GET_DEVICE_FULLPATH:
         if (packet.paramCount() < 1) {
             Debug_printv("Insufficient get device fullpath paramaters: %d", packet.paramCount());
-            transaction_error();
+            SYSTEM_BUS.transaction_error();
         }
         else
             fujicmd_get_device_filename(packet.param(0));
@@ -373,7 +373,7 @@ void rs232Fuji::rs232_process(FujiBusPacket &packet)
     case FUJICMD_CONFIG_BOOT:
         if (packet.paramCount() < 1) {
             Debug_printv("Insufficient config boot paramaters: %d", packet.paramCount());
-            transaction_error();
+            SYSTEM_BUS.transaction_error();
         }
         else
             fujicmd_set_boot_config(packet.param(0));
@@ -381,7 +381,7 @@ void rs232Fuji::rs232_process(FujiBusPacket &packet)
     case FUJICMD_COPY_FILE:
         if (packet.paramCount() < 2 || !packet.data().has_value()) {
             Debug_printv("Insufficient copy files paramaters: %d", packet.paramCount());
-            transaction_error();
+            SYSTEM_BUS.transaction_error();
         }
         else
             fujicmd_copy_file_success(packet.param(0), packet.param(1),
@@ -393,7 +393,7 @@ void rs232Fuji::rs232_process(FujiBusPacket &packet)
     case FUJICMD_SET_BOOT_MODE:
         if (packet.paramCount() < 1) {
             Debug_printv("Insufficient set boot mode paramaters: %d", packet.paramCount());
-            transaction_error();
+            SYSTEM_BUS.transaction_error();
         }
         else
             fujicmd_set_boot_mode(packet.param(0), MEDIATYPE_UNKNOWN, &bootdisk);
@@ -406,7 +406,7 @@ void rs232Fuji::rs232_process(FujiBusPacket &packet)
         fujicmd_generate_guid();
         break;
     default:
-        transaction_error();
+        SYSTEM_BUS.transaction_error();
     }
 }
 

--- a/lib/device/rs232/rs232cpm.cpp
+++ b/lib/device/rs232/rs232cpm.cpp
@@ -75,15 +75,15 @@ void rs232CPM::rs232_process(FujiBusPacket &packet)
     switch (packet.command())
     {
     case CPMCMD_INIT:
-        transaction_begin(TRANS_STATE::NO_GET);
+        SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
         fnSystem.delay(10);
-        transaction_complete();
+        SYSTEM_BUS.transaction_success();
         fnSystem.delay(5000);
         init_cpm(9600);
         cpmActive = true;
         break;
     default:
-        transaction_error();
+        SYSTEM_BUS.transaction_error();
         break;
     }
 }


### PR DESCRIPTION
Move transaction state and handling from the device layer into rs232 systemBus class, making the bus responsible for implementing the SystemBusBase contract.