### PR TITLE
Convert Drivewire bus to SystemBusBase transaction interface

### DIFF
--- a/lib/bus/bus.cpp
+++ b/lib/bus/bus.cpp
@@ -2,7 +2,7 @@
 
 // Temporary migration wrappers. Remove after all buses have been
 // converted to inherit from SystemBusBase.
-#if defined(BUILD_RS232)
+#if defined(BUILD_RS232) || defined(BUILD_COCO)
 
 void VDevMigrationWrapper::transaction_begin(transState_t expectMoreData)
 {

--- a/lib/bus/bus.h
+++ b/lib/bus/bus.h
@@ -62,13 +62,19 @@ public:
 // converted to inherit from SystemBusBase.
 class VDevMigrationWrapper
 {
-#if defined(BUILD_RS232)
+#if defined(BUILD_RS232) || defined(BUILD_COCO)
 protected:
     void transaction_begin(transState_t expectMoreData);
     void transaction_complete();
     void transaction_error();
     success_is_true transaction_get(void *data, size_t len);
     void transaction_put(const void *data, size_t len, bool is_error=false);
+    inline void transaction_put(std::string data) {
+        transaction_put(data.data(), data.size());
+    }
+    inline void transaction_put(ByteBuffer data) {
+        transaction_put(data.data(), data.size());
+    }
 #endif
 };
 

--- a/lib/bus/drivewire/drivewire.cpp
+++ b/lib/bus/drivewire/drivewire.cpp
@@ -335,6 +335,8 @@ bool systemBus::_transaction_handle_command(dwOpcode_t opcode, fujiCommandID_t c
 {
     u16be_t len;
 
+    _activeDev = &device;
+
     switch (cmd)
     {
     case FUJICMD_DEVICE_READY:
@@ -354,12 +356,12 @@ bool systemBus::_transaction_handle_command(dwOpcode_t opcode, fujiCommandID_t c
             read(&len, sizeof(len));
 
         // Pad to requested response length. Thanks apc!
-        if (device._response.size() < len)
-            device._response.resize(std::max<size_t>(device._response.size(), len), 0);
+        if (_transaction_response.size() < len)
+            _transaction_response.resize(std::max<size_t>(_transaction_response.size(), len), 0);
 
-        write(device._response.data(), device._response.size());
-        device._response.clear();
-        device._response.shrink_to_fit();
+        write(_transaction_response.data(), _transaction_response.size());
+        _transaction_response.clear();
+        _transaction_response.shrink_to_fit();
         return true;
 
     default:
@@ -1001,42 +1003,43 @@ void systemBus::writeBusPacket(FujiBusPacket &packet)
 }
 #endif /* PINMAP_FUJIVERSAL_DRIVEWIRE */
 
-void virtualDevice::transaction_begin(transState_t expectMoreData)
+void systemBus::transaction_accept(transState_t expectMoreData)
 {
     assert(_transaction_state == TRANS_STATE::INVALID);
     _transaction_state = expectMoreData;
 }
 
-void virtualDevice::transaction_complete()
+void systemBus::transaction_success()
 {
     assert(_transaction_state == TRANS_STATE::NO_GET
            || _transaction_state == TRANS_STATE::DID_GET);
-    _errorCode = NDEV_STATUS::SUCCESS;
-    _response.clear();
-    _response.shrink_to_fit();
+    _activeDev->_errorCode = NDEV_STATUS::SUCCESS;
+    _transaction_response.clear();
+    _transaction_response.shrink_to_fit();
     _transaction_state = TRANS_STATE::INVALID;
 }
 
-void virtualDevice::transaction_error()
+void systemBus::transaction_error()
 {
-    _errorCode = NDEV_STATUS::GENERAL;
+    _activeDev->_errorCode = NDEV_STATUS::GENERAL;
     _transaction_state = TRANS_STATE::INVALID;
 }
 
-success_is_true virtualDevice::transaction_get(void *data, size_t len)
+success_is_true systemBus::transaction_get(void *data, size_t len)
 {
     assert(_transaction_state == TRANS_STATE::WILL_GET);
     _transaction_state = TRANS_STATE::DID_GET;
     RETURN_SUCCESS_IF(SYSTEM_BUS.read((uint8_t *) data, len) == len);
 }
 
-void virtualDevice::transaction_put(const void *data, size_t len, bool err)
+void systemBus::transaction_send(const void *data, size_t len, bool is_error)
 {
     assert(_transaction_state == TRANS_STATE::NO_GET);
-    if (err)
+    if (is_error)
         transaction_error();
-    _response.insert(_response.end(), static_cast<const uint8_t *>(data),
-                     static_cast<const uint8_t *>(data) + len);
+    _transaction_response.insert(_transaction_response.end(),
+                                 static_cast<const uint8_t *>(data),
+                                 static_cast<const uint8_t *>(data) + len);
     _transaction_state = TRANS_STATE::INVALID;
 }
 

--- a/lib/bus/drivewire/drivewire.h
+++ b/lib/bus/drivewire/drivewire.h
@@ -66,14 +66,14 @@
                          FEATURE_PRINTER
 
 // class def'ns
-class drivewireModem;          // declare here so can reference it, but define in modem.h
-class drivewireFuji;        // declare here so can reference it, but define in fuji.h
-class systemBus;      // declare early so can be friend
-class drivewireNetwork;     // declare here so can reference it, but define in network.h
-class drivewireNetStream;   // declare here so can reference it, but define in netstream.h
-class drivewireCassette;    // Cassette forward-declaration.
-class drivewireCPM;         // CPM device.
-class drivewirePrinter;     // Printer device
+class drivewireModem;     // declare here so can reference it, but define in modem.h
+class drivewireFuji;      // declare here so can reference it, but define in fuji.h
+class systemBus;          // declare early so can be friend
+class drivewireNetwork;   // declare here so can reference it, but define in network.h
+class drivewireNetStream; // declare here so can reference it, but define in netstream.h
+class drivewireCassette;  // Cassette forward-declaration.
+class drivewireCPM;       // CPM device.
+class drivewirePrinter;   // Printer device
 class fujiDevice;
 
 class virtualDevice
@@ -81,29 +81,9 @@ class virtualDevice
     friend systemBus;
     friend fujiDevice;
 
-private:
-    ByteBuffer _response;
-    transState_t _transaction_state = TRANS_STATE::INVALID;
-
 protected:
     nDevStatus_t _errorCode;
     fujiDeviceID_t _devnum;
-
-    virtual void transaction_begin(transState_t expectMoreData);
-    virtual void transaction_complete();
-    virtual void transaction_error();
-    virtual success_is_true transaction_get(void *data, size_t len);
-    virtual void transaction_put(const void *data, size_t len, bool err=false);
-    inline void transaction_put(std::string data) {
-        transaction_put(data.data(), data.size());
-    }
-    inline void transaction_put(ByteBuffer data) {
-        transaction_put(data.data(), data.size());
-    }
-
-    void send_error();                // 0x02
-    void send_response(uint16_t len); // 0x01
-    void ready();                     // 0x00
 
     // Optional shutdown/reboot cleanup routine
     virtual void shutdown(){};
@@ -131,7 +111,7 @@ struct drivewire_message_t
 
 // typedef drivewire_message_t drivewire_message_t;
 
-class systemBus
+class systemBus : public SystemBusBase
 {
 private:
     IOChannel *_port = nullptr;
@@ -157,6 +137,10 @@ private:
     FILE *pNamedObjFp;
     uint8_t szNamedMount[256];
     uint8_t bDragon;
+
+    ByteBuffer _transaction_response;
+    bool _transaction_handle_command(dwOpcode_t opcode, fujiCommandID_t cmd,
+                                     virtualDevice &device);
 
     void _drivewire_process_cmd();
     void _drivewire_process_queue();
@@ -185,9 +169,6 @@ private:
      * @brief Sector data (256 bytes)
      */
     uint8_t sector_data[MEDIA_BLOCK_SIZE];
-
-    bool _transaction_handle_command(dwOpcode_t opcode, fujiCommandID_t cmd,
-                                     virtualDevice &device);
 
     /**
      * @brief NOP command (do nothing)
@@ -222,6 +203,13 @@ public:
     void setup();
     void service();
     void shutdown();
+
+    void transaction_accept(transState_t expectMoreData) override;
+    void transaction_success() override;
+    void transaction_error() override;
+    success_is_true transaction_get(void *data, size_t len) override;
+    using SystemBusBase::transaction_send;
+    void transaction_send(const void *data, size_t len, bool is_error=false) override;
 
     int getBaudrate();                                          // Gets current DRIVEWIRE baud rate setting
     void setBaudrate(int baud);                                 // Sets DRIVEWIRE to specific baud rate

--- a/lib/device/drivewire/cpm.cpp
+++ b/lib/device/drivewire/cpm.cpp
@@ -90,7 +90,7 @@ void drivewireCPM::read()
         buffer[i] = b;
     }
 
-    transaction_put(buffer);
+    SYSTEM_BUS.transaction_send(buffer);
 }
 
 void drivewireCPM::write()
@@ -119,7 +119,7 @@ void drivewireCPM::status()
     status_response[0] = mw >> 8;
     status_response[1] = mw & 0xFF;
 
-    transaction_put(&status_response, sizeof(status_response));
+    SYSTEM_BUS.transaction_send(&status_response, sizeof(status_response));
 }
 
 void drivewireCPM::process(fujiCommandID_t cmd)

--- a/lib/device/drivewire/network.cpp
+++ b/lib/device/drivewire/network.cpp
@@ -143,8 +143,8 @@ void drivewireNetwork::open(fileAccessMode_t access, netProtoTranslation_t trans
     json->setProtocol(protocol);
     channelMode = PROTOCOL;
 
-    transaction_begin(TRANS_STATE::NO_GET);
-    transaction_complete();
+    SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
+    SYSTEM_BUS.transaction_success();
 }
 
 /**
@@ -188,8 +188,8 @@ void drivewireNetwork::close()
     Debug_printv("After protocol delete %lu\n",esp_get_free_internal_heap_size());
 #endif
 
-    transaction_begin(TRANS_STATE::NO_GET);
-    transaction_complete();
+    SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
+    SYSTEM_BUS.transaction_success();
 }
 
 /**
@@ -214,7 +214,7 @@ void drivewireNetwork::read(uint16_t num_bytes)
     // Check for rx buffer. If NULL, then tell caller we could not allocate buffers.
     if (receiveBuffer == nullptr)
     {
-        transaction_error();
+        SYSTEM_BUS.transaction_error();
         _errorCode = NDEV_STATUS::COULD_NOT_ALLOCATE_BUFFERS;
         return;
     }
@@ -228,7 +228,7 @@ void drivewireNetwork::read(uint16_t num_bytes)
             protocolParser = nullptr;
         }
 
-        transaction_error();
+        SYSTEM_BUS.transaction_error();
         _errorCode = NDEV_STATUS::NOT_CONNECTED;
         return;
     }
@@ -236,8 +236,8 @@ void drivewireNetwork::read(uint16_t num_bytes)
     // Do the channel read
     read_channel(num_bytes);
 
-    transaction_begin(TRANS_STATE::NO_GET);
-    transaction_put(*receiveBuffer);
+    SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
+    SYSTEM_BUS.transaction_send(*receiveBuffer);
 
     // Remove from receive buffer and shrink.
     receiveBuffer->erase(0, num_bytes);
@@ -412,7 +412,7 @@ void drivewireNetwork::status_local(uint8_t req)
         break;
     }
 
-    transaction_put(&status, sizeof(status));
+    SYSTEM_BUS.transaction_send(&status, sizeof(status));
 }
 
 bool drivewireNetwork::status_channel_json(NetworkStatus *ns)
@@ -462,8 +462,8 @@ void drivewireNetwork::status_channel()
                  avail, ns.connected, ns.error);
 #endif /* TOO_MUCH_DEBUG */
 
-    transaction_begin(TRANS_STATE::NO_GET);
-    transaction_put(&status, sizeof(status));
+    SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
+    SYSTEM_BUS.transaction_send(&status, sizeof(status));
 }
 
 /**
@@ -475,7 +475,7 @@ void drivewireNetwork::get_prefix()
     Debug_printf("drivewireNetwork::get_prefix(%s)\n",prefix.c_str());
     memset(out,0,sizeof(out));
     strcpy(out,prefix.c_str());
-    transaction_put(out, sizeof(out));
+    SYSTEM_BUS.transaction_send(out, sizeof(out));
 }
 
 /**
@@ -858,7 +858,7 @@ void drivewireNetwork::process(fujiCommandID_t cmd)
         break;
 
     default:
-        transaction_error();
+        SYSTEM_BUS.transaction_error();
         break;
     }
 }
@@ -871,7 +871,7 @@ void drivewireNetwork::process_fs(fujiCommandID_t cmd, bool is_dir)
     NetworkProtocolFS *fs = dynamic_cast<NetworkProtocolFS *>(protocol);
     if (!fs)
     {
-        transaction_error();
+        SYSTEM_BUS.transaction_error();
         return;
     }
 
@@ -904,7 +904,7 @@ void drivewireNetwork::process_fs(fujiCommandID_t cmd, bool is_dir)
 
     if (err != FUJI_ERROR::NONE)
     {
-        transaction_error();
+        SYSTEM_BUS.transaction_error();
     }
 }
 
@@ -914,7 +914,7 @@ void drivewireNetwork::process_tcp(fujiCommandID_t cmd)
     NetworkProtocolTCP *tcp = dynamic_cast<NetworkProtocolTCP *>(protocol);
     if (!tcp)
     {
-        transaction_error();
+        SYSTEM_BUS.transaction_error();
         return;
     }
 
@@ -934,7 +934,7 @@ void drivewireNetwork::process_tcp(fujiCommandID_t cmd)
 
     if (err != FUJI_ERROR::NONE)
     {
-        transaction_error();
+        SYSTEM_BUS.transaction_error();
     }
 }
 
@@ -944,7 +944,7 @@ void drivewireNetwork::process_http(fujiCommandID_t cmd, uint8_t chan_mode)
     NetworkProtocolHTTP *http = dynamic_cast<NetworkProtocolHTTP *>(protocol);
     if (!http)
     {
-        transaction_error();
+        SYSTEM_BUS.transaction_error();
         return;
     }
 
@@ -961,7 +961,7 @@ void drivewireNetwork::process_http(fujiCommandID_t cmd, uint8_t chan_mode)
 
     if (err != FUJI_ERROR::NONE)
     {
-        transaction_error();
+        SYSTEM_BUS.transaction_error();
     }
 }
 
@@ -971,7 +971,7 @@ void drivewireNetwork::process_udp(fujiCommandID_t cmd)
     NetworkProtocolUDP *udp = dynamic_cast<NetworkProtocolUDP *>(protocol);
     if (!udp)
     {
-        transaction_error();
+        SYSTEM_BUS.transaction_error();
         return;
     }
 
@@ -982,7 +982,7 @@ void drivewireNetwork::process_udp(fujiCommandID_t cmd)
     case NETCMD_GET_REMOTE:
         receiveBuffer->resize(SPECIAL_BUFFER_SIZE);
         err = udp->get_remote(receiveBuffer->data(), receiveBuffer->size());
-        transaction_put(*receiveBuffer);
+        SYSTEM_BUS.transaction_send(*receiveBuffer);
         break;
 #endif /* ESP_PLATFORM */
     case NETCMD_SET_DESTINATION:
@@ -992,12 +992,12 @@ void drivewireNetwork::process_udp(fujiCommandID_t cmd)
             err = udp->set_destination(spData, bytes_read);
             if (err != FUJI_ERROR::NONE)
             {
-                transaction_error();
+                SYSTEM_BUS.transaction_error();
             }
         }
         break;
     default:
-        transaction_error();
+        SYSTEM_BUS.transaction_error();
         break;
     }
 }


### PR DESCRIPTION
Move transaction state and handling from the device layer into Drivewire systemBus class, making the bus responsible for implementing the SystemBusBase contract.