### PR TITLE
[coco] Decouple virtualDevices from the transport layer

### DIFF
--- a/fujinet_pc.cmake
+++ b/fujinet_pc.cmake
@@ -389,6 +389,7 @@ if(FUJINET_TARGET STREQUAL "COCO")
     list(APPEND SOURCES
 
     lib/bus/drivewire/drivewire.h lib/bus/drivewire/drivewire.cpp
+    lib/bus/drivewire/FujiDWPacket.h lib/bus/drivewire/FujiDWPacket.cpp
     lib/hardware/BoIPChannel.h lib/hardware/BoIPChannel.cpp
 
     lib/media/drivewire/mediaType.h lib/media/drivewire/mediaType.cpp

--- a/lib/bus/drivewire/FujiDWPacket.cpp
+++ b/lib/bus/drivewire/FujiDWPacket.cpp
@@ -1,0 +1,100 @@
+#ifdef BUILD_COCO
+
+#include "FujiDWPacket.h"
+
+#include "bus.h"
+
+uint32_t FujiDWPacket::getParam(size_t index, size_t psize)
+{
+    size_t count;
+
+    assert(psize == 1 || psize == 2 || psize == 4);
+    assert(_params.size() == 0 || _paramSize == psize);
+    if (!_command.has_value()) {
+        // Need to read command byte before reading params
+        command();
+    }
+    if (index >= _params.size()) {
+        assert(!_data.has_value());
+        _paramSize = psize;
+        count = index - _params.size() + 1;
+        if (_opcode == OP::NET && _params.size() == 0 && count * psize < 2) {
+            // Need to make sure we get both parameter bytes on network packets
+            count = 2 / psize;
+        }
+        fillParams(count, psize);
+    }
+    return _params[index];
+}
+
+void FujiDWPacket::fillParams(size_t count, size_t psize)
+{
+    uint32_t val;
+    size_t idx;
+
+    for (idx = 0; idx < count; idx++)
+    {
+        switch (psize) {
+        case 1:
+            val = SYSTEM_BUS.read();
+            break;
+        case 2:
+            {
+                uint16_t ev;
+                SYSTEM_BUS.read(&ev, sizeof(ev));
+                val = be16toh(ev);
+            }
+            break;
+        case 4:
+            {
+                uint32_t ev;
+                SYSTEM_BUS.read(&ev, sizeof(ev));
+                val = be32toh(ev);
+            }
+            break;
+        }
+        _params.push_back(val);
+    }
+}
+
+fujiCommandID_t FujiDWPacket::command()
+{
+    if (!_command.has_value()) {
+        assert(!_data.has_value() && _params.size() == 0);
+        if (_opcode == OP::NET && !_unit.has_value()) {
+            // Need to read unit before command
+            unit();
+        }
+        _command = static_cast<fujiCommandID_t>(SYSTEM_BUS.read());
+    }
+    return *_command;
+}
+
+uint8_t FujiDWPacket::unit()
+{
+    if (!_unit.has_value()) {
+        assert(_opcode == OP::NET && !_command.has_value());
+        _unit = SYSTEM_BUS.read();
+    }
+    return *_unit;
+}
+
+void FujiDWPacket::setDataLength(const size_t len)
+{
+    size_t rlen;
+
+
+    assert(!_data.has_value());
+
+    if (_opcode == OP::NET && _params.size() == 0) {
+        // Read off the parameter bytes that occur before data
+        fillParams(2, 1);
+    }
+
+    _data.emplace(len, 0);
+    rlen = SYSTEM_BUS.read(_data->data(), _data->size());
+    if (rlen != len)
+        _data->resize(rlen);
+}
+
+#endif /* BUILD_COCO */

--- a/lib/bus/drivewire/FujiDWPacket.h
+++ b/lib/bus/drivewire/FujiDWPacket.h
@@ -1,0 +1,186 @@
+#ifdef BUILD_COCO
+
+#ifndef DRIVEWIREPACKET_H
+#define DRIVEWIREPACKET_H
+
+#include "opcode.h"
+#include "fujiCommandID.h"
+#include "global_types.h"
+
+#include <optional>
+#include <vector>
+#include <cassert>
+#include <string>
+
+/**
+ * DriveWire implementation of the RS232 FujiBusPacket interface.
+ *
+ * This class provides the same logical interface as FujiBusPacket
+ * (command(), param(), data(), and dataAsString()) so device handlers
+ * can process DriveWire packets using the same abstractions as other
+ * buses.
+ *
+ * Unlike other packet formats, DriveWire does not encode enough
+ * structural information to deserialize a complete packet up front.
+ * Parameters and data are therefore deserialized lazily as they are
+ * requested. Parameter values are read from the bus on first access
+ * and cached for subsequent accesses.
+ *
+ * The only API difference from FujiBusPacket is setDataLength(). The
+ * trailing data field has no self-describing length, so its size must
+ * be supplied before data() or dataAsString() can be used. Code using
+ * the transaction_* helpers does not need to call setDataLength()
+ * directly, as those helpers determine the length automatically.
+ */
+
+class FujiDWPacket
+{
+private:
+    dwOpcode_t _opcode;
+    std::optional<uint8_t> _unit;
+    std::optional<fujiCommandID_t> _command;
+    std::vector<uint32_t> _params;
+    unsigned _paramSize;
+    std::optional<ByteBuffer> _data;
+
+    struct PacketParamProxy
+    {
+        /**
+         * Proxy object returned by param().
+         *
+         * The proxy exists because parameter decoding requires two pieces of
+         * information that are not available at the same time:
+         *
+         *   - param(index) knows which parameter is being requested, but not
+         *     the integer width the caller expects.
+         *   - The conversion operator knows the requested integer width, but
+         *     would otherwise have no way to identify which parameter to decode.
+         *
+         * The proxy preserves the parameter index until the compiler selects
+         * the appropriate conversion operator. At that point the packet knows
+         * both the parameter index and the requested width, allowing it to:
+         *
+         *   - Read the correct number of bytes from the bus.
+         *   - Convert DriveWire's big-endian encoding to native byte order.
+         *   - Cache the decoded value for subsequent accesses.
+         *
+         * Example:
+         *
+         *   uint16_t length = packet.param(0);
+         *   uint8_t  mode   = packet.param(1);
+         *
+         * The compiler selects the conversion operator based on the destination
+         * type (or an explicit cast). Subsequent accesses return the cached
+         * value rather than reading from the bus again.
+         *
+         * The param8(), param16(), and param32() methods provide explicit
+         * alternatives when the implicit conversion is undesirable or the
+         * destination type is not obvious.
+         */
+
+        size_t index;
+        FujiDWPacket *packet;
+
+        // These tell the compiler: "Run this code if the destination matches my type"
+        operator bool() const {
+            return static_cast<uint8_t>(*this) != 0;
+        }
+
+        // These tell the compiler exactly how to handle direct equality checks
+        // against any integer type without triggering conversion rule debates.
+
+        bool operator==(uint8_t val) const {
+            return static_cast<uint8_t>(*this) == val;
+        }
+
+        bool operator==(uint16_t val) const {
+            return static_cast<uint16_t>(*this) == val;
+        }
+
+        inline operator uint8_t() const {
+            return packet->getParam(index, sizeof(uint8_t));
+        }
+
+        inline operator uint16_t() const {
+            return packet->getParam(index, sizeof(uint16_t));
+        }
+
+        inline operator uint32_t() const {
+            return packet->getParam(index, sizeof(uint32_t));
+        }
+    };
+
+    friend PacketParamProxy;
+
+    uint32_t getParam(size_t index, size_t psize);
+    void fillParams(size_t count, size_t psize);
+
+public:
+    FujiDWPacket(dwOpcode_t opcode) : _opcode(opcode) {};
+    ~FujiDWPacket() {
+        if (_opcode == OP::NET && _params.size() == 0) {
+            // Read off the parameter bytes that were never consumed
+            fillParams(2, 1);
+        }
+    }
+
+    dwOpcode_t device() const { return _opcode; }
+    fujiCommandID_t command();
+
+    uint8_t unit();
+
+    PacketParamProxy param(size_t index) {
+        return PacketParamProxy{ index, this };
+    }
+
+    // Completes deserialization by reading the trailing data field once its
+    // length has been determined from command-specific context.
+    void setDataLength(const size_t len);
+
+    const std::optional<ByteBuffer>& data() const {
+        assert(_data.has_value());
+        return _data;
+    }
+
+    std::optional<std::string> dataAsString() const
+    {
+        if (!_data) return std::nullopt;
+        return std::string(_data->begin(), _data->end());
+    }
+
+    // Explicit alternatives to the implicit PacketParamProxy conversions.
+    // These may be preferred where the destination type is not obvious.
+    uint8_t  param8(int idx)  { return (uint8_t)param(idx); }
+    uint16_t param16(int idx) { return (uint16_t)param(idx); }
+    uint32_t param32(int idx) { return (uint32_t)param(idx); }
+};
+
+/**
+ * Design notes:
+ *
+ * - Parameters are decoded lazily and cached on first access. Parameters
+ *   may be requested in any order prior to calling data(). If a later
+ *   parameter is requested first, all preceding parameters are
+ *   automatically decoded and cached as needed.
+ *
+ * - This allows parameters to be passed directly to a function without
+ *   first storing them in temporary variables, e.g.
+ *
+ *       device_method(frame.param(0), frame.param(1), frame.param(2));
+ *
+ *   The packet guarantees that parameters are read from the bus in
+ *   protocol order regardless of the compiler's argument evaluation
+ *   order.
+ *
+ * - Protocol-specific packet variations are handled transparently. For
+ *   example, packet types that include a unit byte before the command
+ *   byte are decoded correctly regardless of whether unit() or
+ *   command() is accessed first.
+ *
+ * - Multi-byte parameters are automatically converted from DriveWire's
+ *   big-endian encoding to the native host byte order.
+ */
+
+#endif /* DRIVEWIREPACKET_H */
+
+#endif /* BUILD_COCO */

--- a/lib/bus/drivewire/drivewire.cpp
+++ b/lib/bus/drivewire/drivewire.cpp
@@ -330,12 +330,16 @@ void systemBus::op_write()
     _port->write(0x00); // success
 }
 
-bool systemBus::_transaction_handle_command(dwOpcode_t opcode, fujiCommandID_t cmd,
-                                            virtualDevice &device)
+bool systemBus::_transaction_handle_command(FujiDWPacket &packet, virtualDevice &device)
 {
-    u16be_t len;
+    uint16_t len;
+    fujiCommandID_t cmd = packet.command();
 
     _activeDev = &device;
+    _activeFrame = &packet;
+
+    if (packet.device() == OP::CLOCK)
+        cmd = FUJICMD_SEND_RESPONSE;
 
     switch (cmd)
     {
@@ -352,8 +356,8 @@ bool systemBus::_transaction_handle_command(dwOpcode_t opcode, fujiCommandID_t c
 
     case FUJICMD_SEND_RESPONSE:
         len = 0;
-        if (opcode == OP::NET)
-            read(&len, sizeof(len));
+        if (packet.device() == OP::NET)
+            len = packet.param(0);
 
         // Pad to requested response length. Thanks apc!
         if (_transaction_response.size() < len)
@@ -371,52 +375,53 @@ bool systemBus::_transaction_handle_command(dwOpcode_t opcode, fujiCommandID_t c
     return false;
 }
 
-void systemBus::op_fuji()
+void systemBus::op_fuji(dwOpcode_t opcode)
 {
-    fujiCommandID_t cmd = static_cast<fujiCommandID_t>(read());
+    FujiDWPacket packet(opcode);
 
-    if (_transaction_handle_command(OP::FUJI, cmd, platformFuji))
+    if (_transaction_handle_command(packet, platformFuji))
         return;
-    platformFuji.process(cmd);
+
+    platformFuji.processCommand(packet);
 }
 
-void systemBus::op_cpm()
+void systemBus::op_cpm(dwOpcode_t opcode)
 {
-    fujiCommandID_t cmd = static_cast<fujiCommandID_t>(read());
+    FujiDWPacket packet(opcode);
 
 #ifdef ESP_PLATFORM
-    if (_transaction_handle_command(OP::CPM, cmd, theCPM))
+    if (_transaction_handle_command(packet, theCPM))
         return;
-    theCPM.process(cmd);
+
+    theCPM.processCommand(packet);
 #endif /* ESP_PLATFORM */
 }
 
-void systemBus::op_clock()
+void systemBus::op_clock(dwOpcode_t opcode)
 {
-    fujiCommandID_t cmd = static_cast<fujiCommandID_t>(read());
+    FujiDWPacket packet(opcode);
 
-    platformClock.process(cmd);
-    _transaction_handle_command(OP::CLOCK, FUJICMD_SEND_RESPONSE, platformClock);
+    platformClock.processCommand(packet);
+    _transaction_handle_command(packet, platformClock);
 }
 
-void systemBus::op_net()
+void systemBus::op_net(dwOpcode_t opcode)
 {
-    uint8_t unit = (uint8_t)_port->read();
-    fujiCommandID_t cmd = static_cast<fujiCommandID_t>(read());
+    FujiDWPacket packet(opcode);
 
     // If device doesn't exist, create it.
-    if (!_netDev.contains(unit))
+    if (!_netDev.contains(packet.unit()))
     {
-        Debug_printf("Opening new network device %u\n",unit);
-        _netDev[unit] = new drivewireNetwork();
+        Debug_printf("Opening new network device %u\n", packet.unit());
+        _netDev[packet.unit()] = new drivewireNetwork();
     }
 
-    if (_transaction_handle_command(OP::NET, cmd, *_netDev[unit]))
+    if (_transaction_handle_command(packet, platformFuji))
         return;
 
     // And pass control to it
-    Debug_printf("OP_NET: %u\n",unit);
-    _netDev[unit]->process(cmd);
+    Debug_printf("OP_NET: %u\n", packet.unit());
+    _netDev[packet.unit()]->processCommand(packet);
 }
 
 void systemBus::op_unhandled(dwOpcode_t opcode)
@@ -685,16 +690,16 @@ void systemBus::_drivewire_process_cmd()
             op_serterm();
             break;
         case OP::FUJI:
-            op_fuji();
+            op_fuji(opcode);
             break;
         case OP::NET:
-            op_net();
+            op_net(opcode);
             break;
         case OP::CPM:
-            op_cpm();
+            op_cpm(opcode);
             break;
         case OP::CLOCK:
-            op_clock();
+            op_clock(opcode);
             break;
         default:
             op_unhandled(opcode);
@@ -941,28 +946,6 @@ void systemBus::shutdown()
     Debug_printf("All devices shut down.\n");
 }
 
-void systemBus::toggleBaudrate()
-{
-}
-
-int systemBus::getBaudrate()
-{
-    return _drivewireBaud;
-}
-
-void systemBus::setBaudrate(int baud)
-{
-    if (_drivewireBaud == baud)
-    {
-        Debug_printf("Baudrate already at %d - nothing to do\n", baud);
-        return;
-    }
-
-    Debug_printf("Changing baudrate from %d to %d\n", _drivewireBaud, baud);
-    _drivewireBaud = baud;
-    //_modemDev->get_uart()->set_baudrate(baud); // TODO COME BACK HERE.
-}
-
 #ifdef PINMAP_FUJIVERSAL_DRIVEWIRE
 std::unique_ptr<FujiBusPacket> systemBus::readBusPacket(int first)
 {
@@ -1029,7 +1012,12 @@ success_is_true systemBus::transaction_get(void *data, size_t len)
 {
     assert(_transaction_state == TRANS_STATE::WILL_GET);
     _transaction_state = TRANS_STATE::DID_GET;
-    RETURN_SUCCESS_IF(SYSTEM_BUS.read((uint8_t *) data, len) == len);
+    _activeFrame->setDataLength(len);
+    if (_activeFrame->data()->size() != len)
+        RETURN_ERROR_AS_FALSE();
+    std::copy(_activeFrame->data()->begin(), _activeFrame->data()->end(),
+              static_cast<uint8_t *>(data));
+    RETURN_SUCCESS_AS_TRUE();
 }
 
 void systemBus::transaction_send(const void *data, size_t len, bool is_error)

--- a/lib/bus/drivewire/drivewire.h
+++ b/lib/bus/drivewire/drivewire.h
@@ -20,6 +20,7 @@
 #define COCO_H
 
 #include "bus.h"
+#include "FujiDWPacket.h"
 #include "opcode.h"
 #include "BoIPChannel.h"
 #include "UARTChannel.h"
@@ -76,7 +77,7 @@ class drivewireCPM;       // CPM device.
 class drivewirePrinter;   // Printer device
 class fujiDevice;
 
-class virtualDevice
+class drivewireDevice
 {
     friend systemBus;
     friend fujiDevice;
@@ -97,6 +98,12 @@ public:
     fujiDeviceID_t id() { return _devnum; };
 };
 
+class virtualDevice : public drivewireDevice
+{
+public:
+    virtual void processCommand(FujiDWPacket &packet) = 0;
+};
+
 enum drivewire_message : uint16_t
 {
     DRIVEWIREMSG_DISKSWAP,  // Rotate disk
@@ -113,6 +120,8 @@ struct drivewire_message_t
 
 class systemBus : public SystemBusBase
 {
+    friend FujiDWPacket;
+
 private:
     IOChannel *_port = nullptr;
 #if FUJINET_OVER_USB
@@ -126,7 +135,8 @@ private:
     std::deque<uint8_t> _dbc_pushback;
 #endif
 
-    virtualDevice *_activeDev = nullptr;
+    FujiDWPacket *_activeFrame;
+    drivewireDevice *_activeDev = nullptr;
     drivewireModem *_modemDev = nullptr;
     drivewireFuji *_fujiDev = nullptr;
     //drivewireNetwork *_netDev[8] = {nullptr};
@@ -139,8 +149,7 @@ private:
     uint8_t bDragon;
 
     ByteBuffer _transaction_response;
-    bool _transaction_handle_command(dwOpcode_t opcode, fujiCommandID_t cmd,
-                                     virtualDevice &device);
+    bool _transaction_handle_command(FujiDWPacket &packet, virtualDevice &device);
 
     void _drivewire_process_cmd();
     void _drivewire_process_queue();
@@ -177,10 +186,10 @@ private:
     void op_nop();
     void op_reset();
     void op_readex();
-    void op_fuji();
-    void op_net();
-    void op_cpm();
-    void op_clock();
+    void op_fuji(dwOpcode_t opcode);
+    void op_net(dwOpcode_t opcode);
+    void op_cpm(dwOpcode_t opcode);
+    void op_clock(dwOpcode_t opcode);
     void op_write();
     void op_time();
     void op_init();
@@ -199,37 +208,6 @@ private:
     void op_print();
     void op_namedobj_mnt();
 
-public:
-    void setup();
-    void service();
-    void shutdown();
-
-    void transaction_accept(transState_t expectMoreData) override;
-    void transaction_success() override;
-    void transaction_error() override;
-    success_is_true transaction_get(void *data, size_t len) override;
-    using SystemBusBase::transaction_send;
-    void transaction_send(const void *data, size_t len, bool is_error=false) override;
-
-    int getBaudrate();                                          // Gets current DRIVEWIRE baud rate setting
-    void setBaudrate(int baud);                                 // Sets DRIVEWIRE to specific baud rate
-    void toggleBaudrate();                                      // Toggle between standard and high speed DRIVEWIRE baud rate
-
-    bool shuttingDown = false;                                  // TRUE if we are in shutdown process
-    bool getShuttingDown() { return shuttingDown; };
-    bool motorActive = false;
-
-    drivewireCassette *getCassette() { return _cassetteDev; }
-    drivewirePrinter *getPrinter() { return _printerdev; }
-    void setPrinter(drivewirePrinter *_p) { _printerdev = _p; }
-    drivewireCPM *getCPM() { return _cpmDev; }
-    std::map<uint8_t,drivewireNetwork *> _netDev;
-
-    // I wish this codebase would make up its mind to use camel or snake casing.
-    drivewireModem *get_modem() { return _modemDev; }
-
-    // Everybody thinks "oh I know how a serial port works, I'll just
-    // access it directly and bypass the bus!" ಠ_ಠ
     size_t read(void *buffer, size_t length) {
 #ifdef PINMAP_FUJIVERSAL_DRIVEWIRE
         size_t n = 0;
@@ -258,6 +236,31 @@ public:
 #endif
     }
     void flushOutput() { _port->flushOutput(); }
+
+public:
+    void setup();
+    void service();
+    void shutdown();
+
+    void transaction_accept(transState_t expectMoreData) override;
+    void transaction_success() override;
+    void transaction_error() override;
+    success_is_true transaction_get(void *data, size_t len) override;
+    using SystemBusBase::transaction_send;
+    void transaction_send(const void *data, size_t len, bool is_error=false) override;
+
+    bool shuttingDown = false;                                  // TRUE if we are in shutdown process
+    bool getShuttingDown() { return shuttingDown; };
+    bool motorActive = false;
+
+    drivewireCassette *getCassette() { return _cassetteDev; }
+    drivewirePrinter *getPrinter() { return _printerdev; }
+    void setPrinter(drivewirePrinter *_p) { _printerdev = _p; }
+    drivewireCPM *getCPM() { return _cpmDev; }
+    std::map<uint8_t,drivewireNetwork *> _netDev;
+
+    // I wish this codebase would make up its mind to use camel or snake casing.
+    drivewireModem *get_modem() { return _modemDev; }
 
 #ifdef PINMAP_FUJIVERSAL_DRIVEWIRE
     std::unique_ptr<FujiBusPacket> readBusPacket(int first = -1);

--- a/lib/device/drivewire/cassette.h
+++ b/lib/device/drivewire/cassette.h
@@ -6,7 +6,7 @@
 #include "bus.h"
 #include "fnSystem.h"
 
-class drivewireCassette : public virtualDevice
+class drivewireCassette : public drivewireDevice
 {
 protected:
 

--- a/lib/device/drivewire/clock.cpp
+++ b/lib/device/drivewire/clock.cpp
@@ -13,120 +13,124 @@
 
 drivewireClock platformClock;
 
-std::optional<std::string> drivewireClock::read_tz_from_host()
+std::optional<std::string> drivewireClock::read_tz_from_host(uint16_t bufsz)
 {
-    uint8_t lenl = SYSTEM_BUS.read();
-    uint8_t lenh = SYSTEM_BUS.read();
-    uint16_t bufsz = ((uint16_t)lenh << 8) | lenl;
-
     if (bufsz == 0) {
         Debug_printv("ERROR: No timezone sent");
         return std::nullopt;
     }
 
-    std::string timezone;
-    timezone.reserve(bufsz);
-    for (uint16_t i = 0; i < bufsz; i++)
-        timezone.push_back((char)SYSTEM_BUS.read());
-    while (!timezone.empty() && timezone.back() == '\0')
-        timezone.pop_back();
+    std::string timezone(bufsz, 0);
+    SYSTEM_BUS.transaction_accept(TRANS_STATE::WILL_GET);
+    SYSTEM_BUS.transaction_get(timezone.data(), timezone.size());
+    timezone.resize(std::min(timezone.find('\0'), timezone.size()));
+    SYSTEM_BUS.transaction_success();
     return timezone;
 }
 
-void drivewireClock::set_fn_tz()
+void drivewireClock::set_fn_tz(uint16_t bufsz)
 {
-    auto result = read_tz_from_host();
+    auto result = read_tz_from_host(bufsz);
     if (result)
         Config.store_general_timezone(result->c_str());
 }
 
-void drivewireClock::set_alternate_tz()
+void drivewireClock::set_alternate_tz(uint16_t bufsz)
 {
-    auto result = read_tz_from_host();
+    auto result = read_tz_from_host(bufsz);
     if (result)
         alternate_tz = result.value();
 }
 
-void drivewireClock::process(fujiCommandID_t cmd)
+void drivewireClock::processCommand(FujiDWPacket &packet)
 {
     uint8_t aux1;
     bool use_alt;
 
-    switch (cmd)
+    switch (packet.command())
     {
     case APETIMECMD_GETTZTIME:
     case APETIMECMD_GETTIME: {
-        aux1 = SYSTEM_BUS.read();
-        use_alt = (cmd == APETIMECMD_GETTZTIME) || (aux1 == 0x01);
+        aux1 = packet.param(0);
+        use_alt = (packet.command() == APETIMECMD_GETTZTIME) || (aux1 == 0x01);
         auto t = Clock::get_current_time_apetime(
             Clock::tz_to_use(use_alt, alternate_tz, Config.get_general_timezone()));
-        SYSTEM_BUS.write(t.data(), t.size());
+        SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
+        SYSTEM_BUS.transaction_send(t);
         break;
     }
     case APETIMECMD_SETTZ_ALT2: {
-        aux1 = SYSTEM_BUS.read();
+        aux1 = packet.param(0);
         use_alt = (aux1 == 0x01);
         auto t = Clock::get_current_time_simple(
             Clock::tz_to_use(use_alt, alternate_tz, Config.get_general_timezone()));
-        SYSTEM_BUS.write(t.data(), t.size());
+        SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
+        SYSTEM_BUS.transaction_send(t);
         break;
     }
     case APETIMECMD_GET_SIMPLE_HUNDREDTHS: {
-        aux1 = SYSTEM_BUS.read();
+        aux1 = packet.param(0);
         use_alt = (aux1 == 0x01);
         auto t = Clock::get_current_time_simple_hundredths(
             Clock::tz_to_use(use_alt, alternate_tz, Config.get_general_timezone()));
-        SYSTEM_BUS.write(t.data(), t.size());
+        SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
+        SYSTEM_BUS.transaction_send(t);
         break;
     }
     case APETIMECMD_GET_PRODOS: {
-        aux1 = SYSTEM_BUS.read();
+        aux1 = packet.param(0);
         use_alt = (aux1 == 0x01);
         auto t = Clock::get_current_time_prodos(
             Clock::tz_to_use(use_alt, alternate_tz, Config.get_general_timezone()));
-        SYSTEM_BUS.write(t.data(), t.size());
+        SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
+        SYSTEM_BUS.transaction_send(t);
         break;
     }
     case APETIMECMD_GET_SOS: {
-        aux1 = SYSTEM_BUS.read();
+        aux1 = packet.param(0);
         use_alt = (aux1 == 0x01);
         std::string s = Clock::get_current_time_sos(
-            Clock::tz_to_use(use_alt, alternate_tz, Config.get_general_timezone()));
-        SYSTEM_BUS.write((const uint8_t *)s.c_str(), s.size() + 1);
+            Clock::tz_to_use(use_alt, alternate_tz, Config.get_general_timezone())) + '\0';
+        SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
+        SYSTEM_BUS.transaction_send(s);
         break;
     }
     case APETIMECMD_GET_ISO_LOCAL: {
-        aux1 = SYSTEM_BUS.read();
+        aux1 = packet.param(0);
         use_alt = (aux1 == 0x01);
         std::string s = Clock::get_current_time_iso(
-            Clock::tz_to_use(use_alt, alternate_tz, Config.get_general_timezone()));
-        SYSTEM_BUS.write((const uint8_t *)s.c_str(), s.size() + 1);
+            Clock::tz_to_use(use_alt, alternate_tz, Config.get_general_timezone())) + '\0';
+        SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
+        SYSTEM_BUS.transaction_send(s);
         break;
     }
     case APETIMECMD_GET_ISO_UTC: {
-        SYSTEM_BUS.read();
-        std::string s = Clock::get_current_time_iso("UTC+0");
-        SYSTEM_BUS.write((const uint8_t *)s.c_str(), s.size() + 1);
+        aux1 = packet.param(0);
+        std::string s = Clock::get_current_time_iso("UTC+0") + '\0';
+        SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
+        SYSTEM_BUS.transaction_send(s);
         break;
     }
     case APETIMECMD_SETTZ:
-        set_alternate_tz();
+        set_alternate_tz(be16toh(packet.param(0)));
         break;
     case APETIMECMD_SETTZ_ALT:
-        set_fn_tz();
+        set_fn_tz(be16toh(packet.param(0)));
         break;
     case APETIMECMD_GET_GENERAL: {
-        const std::string &tz = Config.get_general_timezone();
-        SYSTEM_BUS.write((const uint8_t *)tz.c_str(), tz.size() + 1);
+        const std::string &tz = Config.get_general_timezone() + '\0';
+        SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
+        SYSTEM_BUS.transaction_send(tz);
         break;
     }
     case APETIMECMD_GETTZ_LEN: {
         uint8_t len = Config.get_general_timezone().size() + 1;
-        SYSTEM_BUS.write(len);
+        SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
+        SYSTEM_BUS.transaction_send(&len, sizeof(len));
         break;
     }
     default:
-        Debug_printv("Unknown drivewire clock cmd: %02x", cmd);
+        Debug_printv("Unknown drivewire clock cmd: %02x", packet.command());
         break;
     }
 }

--- a/lib/device/drivewire/clock.h
+++ b/lib/device/drivewire/clock.h
@@ -11,12 +11,12 @@ class drivewireClock : public virtualDevice
 {
 private:
     std::string alternate_tz = "";
-    std::optional<std::string> read_tz_from_host();
-    void set_fn_tz();
-    void set_alternate_tz();
+    std::optional<std::string> read_tz_from_host(uint16_t bufsz);
+    void set_fn_tz(uint16_t bufsz);
+    void set_alternate_tz(uint16_t bufsz);
 
 public:
-    void process(fujiCommandID_t cmd);
+    void processCommand(FujiDWPacket &packet) override;
 };
 
 extern drivewireClock platformClock;

--- a/lib/device/drivewire/cpm.cpp
+++ b/lib/device/drivewire/cpm.cpp
@@ -66,11 +66,8 @@ void drivewireCPM::boot()
 #endif /* ESP_PLATFORM */
 }
 
-void drivewireCPM::read()
+void drivewireCPM::read(uint16_t len)
 {
-    uint8_t lenh = SYSTEM_BUS.read();
-    uint8_t lenl = SYSTEM_BUS.read();
-    uint16_t len = (lenh * 256) + lenl;
     uint16_t mw = uxQueueMessagesWaiting(rxq);
 
     if (!len)
@@ -93,20 +90,18 @@ void drivewireCPM::read()
     SYSTEM_BUS.transaction_send(buffer);
 }
 
-void drivewireCPM::write()
+void drivewireCPM::write(uint16_t len)
 {
-    uint8_t lenh = SYSTEM_BUS.read();
-    uint8_t lenl = SYSTEM_BUS.read();
-    uint16_t len = (lenh * 256) + lenl;
-
     if (!len)
         return;
 
-    for (uint16_t i=0;i<len;i++)
+    SYSTEM_BUS.transaction_accept(TRANS_STATE::WILL_GET);
+    ByteBuffer data(len, 0);
+    SYSTEM_BUS.transaction_get(data.data(), data.size());
+    for (uint16_t i=0;i<data.size();i++)
     {
-        char b = SYSTEM_BUS.read();
 #ifdef ESP_PLATFORM
-        xQueueSend(txq, &b, portMAX_DELAY);
+        xQueueSend(txq, &data[i], portMAX_DELAY);
 #endif /* ESP_PLATFORM */
     }
 }
@@ -122,18 +117,18 @@ void drivewireCPM::status()
     SYSTEM_BUS.transaction_send(&status_response, sizeof(status_response));
 }
 
-void drivewireCPM::process(fujiCommandID_t cmd)
+void drivewireCPM::processCommand(FujiDWPacket &packet)
 {
-    switch(cmd)
+    switch(packet.command())
     {
     case CPMCMD_BOOT:
         boot();
         break;
     case CPMCMD_READ:
-        read();
+        read(packet.param(0));
         break;
     case CPMCMD_WRITE:
-        write();
+        write(packet.param(0));
         break;
     case CPMCMD_STATUS:
         status();

--- a/lib/device/drivewire/cpm.h
+++ b/lib/device/drivewire/cpm.h
@@ -24,10 +24,10 @@ private:
 public:
     drivewireCPM();
     // virtual ~drivewireCPM();
-    void process(fujiCommandID_t cmd);
+    void processCommand(FujiDWPacket &packet) override;
     void boot();
-    void read();
-    void write();
+    void read(uint16_t len);
+    void write(uint16_t len);
     void status();
 };
 

--- a/lib/device/drivewire/disk.h
+++ b/lib/device/drivewire/disk.h
@@ -5,7 +5,7 @@
 #include "bus.h"
 #include "media.h"
 
-class drivewireDisk : public virtualDevice
+class drivewireDisk : public drivewireDevice
 {
 private:
     MediaType *_media = nullptr;

--- a/lib/device/drivewire/drivewireFuji.cpp
+++ b/lib/device/drivewire/drivewireFuji.cpp
@@ -19,8 +19,6 @@ fujiDevice *theFuji = &platformFuji; // Global fuji object.
 // drivewireDisk drivewireDiskDevs[MAX_HOSTS];
 drivewireNetwork drivewireNetDevs[MAX_NETWORK_DEVICES];
 
-#define SYS_BUS_READ16BE() ({ u16be_t val; SYSTEM_BUS.read(&val, sizeof(val)); val; })
-
 /**
  * Say the numbers 1-8 using phonetic tweaks.
  * @param n The number to say.
@@ -405,10 +403,10 @@ void drivewireFuji::random()
     transaction_put(&r, sizeof(r));
 }
 
-void drivewireFuji::process(fujiCommandID_t cmd)
+void drivewireFuji::processCommand(FujiDWPacket &packet)
 {
     _errorCode = NDEV_STATUS::SUCCESS;
-    switch (cmd)
+    switch (packet.command())
     {
     case FUJICMD_RESET:
         fnSystem.reboot();
@@ -420,7 +418,7 @@ void drivewireFuji::process(fujiCommandID_t cmd)
         fujicmd_get_adapter_config_extended();
         break;
     case FUJICMD_GET_SCAN_RESULT:
-        fujicmd_net_scan_result(SYSTEM_BUS.read());
+        fujicmd_net_scan_result(packet.param(0));
         break;
     case FUJICMD_SCAN_NETWORKS:
         fujicmd_net_scan_networks();
@@ -456,47 +454,36 @@ void drivewireFuji::process(fujiCommandID_t cmd)
         fujicmd_net_get_wifi_status();
         break;
     case FUJICMD_MOUNT_HOST:
-        fujicmd_mount_host_success(SYSTEM_BUS.read());
+        fujicmd_mount_host_success(packet.param8(0));
         break;
     case FUJICMD_OPEN_DIRECTORY:
-        fujicmd_open_directory_success(SYSTEM_BUS.read());
+        fujicmd_open_directory_success(packet.param(0));
         break;
     case FUJICMD_CLOSE_DIRECTORY:
         fujicmd_close_directory();
         break;
     case FUJICMD_READ_DIR_ENTRY:
-        {
-            uint8_t maxlen = SYSTEM_BUS.read();
-            uint8_t addtl = SYSTEM_BUS.read();
-            fujicmd_read_directory_entry(maxlen, addtl);
-        }
+        fujicmd_read_directory_entry(packet.param8(0), packet.param(1));
         break;
     case FUJICMD_SET_DIRECTORY_POSITION:
-        fujicmd_set_directory_position(SYS_BUS_READ16BE());
+        fujicmd_set_directory_position(packet.param(0));
         break;
     case FUJICMD_SET_DEVICE_FULLPATH:
-        {
-            uint8_t slot = SYSTEM_BUS.read();
-            uint8_t host = SYSTEM_BUS.read();
-            uint8_t mode = SYSTEM_BUS.read();
-            fujicmd_set_device_filename_success(slot, host, (disk_access_flags_t) mode);
-        }
+        fujicmd_set_device_filename_success(packet.param(0), packet.param(1),
+                                            (disk_access_flags_t) packet.param8(2));
         break;
     case FUJICMD_GET_DEVICE_FULLPATH:
-        fujicmd_get_device_filename(SYSTEM_BUS.read());
+        fujicmd_get_device_filename(packet.param(0));
         break;
     case FUJICMD_MOUNT_IMAGE:
-        {
-            uint8_t slot = SYSTEM_BUS.read();
-            uint8_t mode = SYSTEM_BUS.read();
-            fujicmd_mount_disk_image_success(slot, (disk_access_flags_t) mode);
-        }
+        fujicmd_mount_disk_image_success(packet.param(0),
+                                         (disk_access_flags_t) packet.param8(1));
         break;
     case FUJICMD_UNMOUNT_HOST:
-        fujicmd_unmount_host_success(SYSTEM_BUS.read());
+        fujicmd_unmount_host_success(packet.param(0));
         break;
     case FUJICMD_UNMOUNT_IMAGE:
-        fujicmd_unmount_disk_image_success(SYSTEM_BUS.read());
+        fujicmd_unmount_disk_image_success(packet.param(0));
         break;
     case FUJICMD_NEW_DISK:
         new_disk();
@@ -514,13 +501,13 @@ void drivewireFuji::process(fujiCommandID_t cmd)
         // fujinet-lib always sends MAX_APPKEY_LEN data bytes
         // regardless of len. Drain the full payload so leftover
         // bytes don't get interpreted as bus opcodes.
-        fujicmd_write_app_key(SYS_BUS_READ16BE(), MAX_APPKEY_LEN);
+        fujicmd_write_app_key(packet.param(0), MAX_APPKEY_LEN);
         break;
     case FUJICMD_RANDOM_NUMBER:
         random();
         break;
     case FUJICMD_BASE64_ENCODE_INPUT:
-        base64_encode_input(SYS_BUS_READ16BE());
+        base64_encode_input(packet.param(0));
         break;
     case FUJICMD_BASE64_ENCODE_COMPUTE:
         base64_encode_compute();
@@ -529,10 +516,10 @@ void drivewireFuji::process(fujiCommandID_t cmd)
         base64_encode_length();
         break;
     case FUJICMD_BASE64_ENCODE_OUTPUT:
-        base64_encode_output(SYS_BUS_READ16BE());
+        base64_encode_output(packet.param(0));
         break;
     case FUJICMD_BASE64_DECODE_INPUT:
-        base64_decode_input(SYS_BUS_READ16BE());
+        base64_decode_input(packet.param(0));
         break;
     case FUJICMD_BASE64_DECODE_COMPUTE:
         base64_decode_compute();
@@ -541,42 +528,42 @@ void drivewireFuji::process(fujiCommandID_t cmd)
         base64_decode_length();
         break;
     case FUJICMD_BASE64_DECODE_OUTPUT:
-        base64_decode_output(SYS_BUS_READ16BE());
+        base64_decode_output(packet.param(0));
         break;
     case FUJICMD_HASH_INPUT:
-        hash_input(SYS_BUS_READ16BE());
+        hash_input(packet.param(0));
         break;
     case FUJICMD_HASH_COMPUTE:
-        hash_compute(true, SYSTEM_BUS.read());
+        hash_compute(true, packet.param(0));
         break;
     case FUJICMD_HASH_COMPUTE_NO_CLEAR:
-        hash_compute(false, SYSTEM_BUS.read());
+        hash_compute(false, packet.param(0));
         break;
     case FUJICMD_HASH_LENGTH:
-        hash_length(SYSTEM_BUS.read() == 1);
+        hash_length(packet.param8(0) == 1);
         break;
     case FUJICMD_HASH_OUTPUT:
-        hash_output(SYSTEM_BUS.read() == 1);
+        hash_output(packet.param8(0) == 1);
         break;
     case FUJICMD_HASH_CLEAR:
         hash_clear();
         break;
     case FUJICMD_SET_BOOT_MODE:
-        fujicmd_set_boot_mode(SYSTEM_BUS.read(), MEDIATYPE_UNKNOWN, &bootdisk);
+        fujicmd_set_boot_mode(packet.param(0), MEDIATYPE_UNKNOWN, &bootdisk);
         break;
     case FUJICMD_MOUNT_ALL:
         fujicmd_mount_all_success();
         break;
     case FUJICMD_GET_HOST_PREFIX:
-        fujicmd_get_host_prefix(SYSTEM_BUS.read());
+        fujicmd_get_host_prefix(packet.param(0));
         break;
     case FUJICMD_SET_HOST_PREFIX:
-        fujicmd_set_host_prefix(SYSTEM_BUS.read());
+        fujicmd_set_host_prefix(packet.param(0));
         break;
     case FUJICMD_COPY_FILE:
         {
-            uint8_t source = SYSTEM_BUS.read();
-            uint8_t dest = SYSTEM_BUS.read();
+            uint8_t source = packet.param(0);
+            uint8_t dest = packet.param(1);
             char dirpath[256];
             transaction_begin(TRANS_STATE::WILL_GET);
             transaction_get(dirpath, sizeof(dirpath));

--- a/lib/device/drivewire/drivewireFuji.h
+++ b/lib/device/drivewire/drivewireFuji.h
@@ -45,7 +45,7 @@ public:
     void debug_tape();
 
     void setup() override;
-    void process(fujiCommandID_t cmd);
+    void processCommand(FujiDWPacket &packet) override;
     drivewireFuji();
 
     // ============ Wrapped Fuji commands ============

--- a/lib/device/drivewire/modem.cpp
+++ b/lib/device/drivewire/modem.cpp
@@ -466,7 +466,9 @@ void drivewireModem::at_handle_answer()
         CRX = true;
 
         cmdMode = false;
+#ifdef OBSOLETE
         SYSTEM_BUS.flushOutput();
+#endif /* OBSOLETE */
         answerHack = false;
     }
 }

--- a/lib/device/drivewire/modem.h
+++ b/lib/device/drivewire/modem.h
@@ -70,7 +70,7 @@
 
 #define ANSWER_TIMER_MS 1000 // milliseconds to wait before issuing CONNECT command, to simulate carrier negotiation.
 
-class drivewireModem : public virtualDevice
+class drivewireModem : public drivewireDevice
 {
 private:
     static constexpr int TX_BUF_SIZE = 256;

--- a/lib/device/drivewire/network.cpp
+++ b/lib/device/drivewire/network.cpp
@@ -75,16 +75,16 @@ void drivewireNetwork::open(fileAccessMode_t access, netProtoTranslation_t trans
 
     char tmp[256];
 
-    size_t bytes_read = SYSTEM_BUS.read((uint8_t *)tmp, 256);
-    tmp[sizeof(tmp)-1] = '\0';
-
-    Debug_printf("tmp = %s\n",tmp);
-
-    if (bytes_read != 256)
+    SYSTEM_BUS.transaction_accept(TRANS_STATE::WILL_GET);
+    if (SYSTEM_BUS.transaction_get(tmp, sizeof(tmp)).is_error())
     {
-        Debug_printf("Short read of %u bytes. Exiting.", bytes_read);
+        Debug_printf("Short read. Exiting.");
+        SYSTEM_BUS.transaction_error();
         return;
     }
+
+    tmp[sizeof(tmp)-1] = '\0';
+    Debug_printf("tmp = %s\n",tmp);
 
     deviceSpec = std::string(tmp);
 
@@ -115,7 +115,7 @@ void drivewireNetwork::open(fileAccessMode_t access, netProtoTranslation_t trans
             delete protocolParser;
             protocolParser = nullptr;
         }
-        //SYSTEM_BUS.write(ns.error);
+        SYSTEM_BUS.transaction_error();
         return;
     }
 
@@ -134,6 +134,7 @@ void drivewireNetwork::open(fileAccessMode_t access, netProtoTranslation_t trans
             delete protocolParser;
             protocolParser = nullptr;
         }
+        SYSTEM_BUS.transaction_error();
         return;
     }
 
@@ -143,7 +144,6 @@ void drivewireNetwork::open(fileAccessMode_t access, netProtoTranslation_t trans
     json->setProtocol(protocol);
     channelMode = PROTOCOL;
 
-    SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
     SYSTEM_BUS.transaction_success();
 }
 
@@ -155,6 +155,8 @@ void drivewireNetwork::close()
 {
     Debug_printf("drivewireNetwork::close()\n");
 
+    SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
+
     if (protocolParser != nullptr)
     {
         delete protocolParser;
@@ -164,7 +166,6 @@ void drivewireNetwork::close()
     // If no protocol enabled, we just signal complete, and return.
     if (protocol == nullptr)
     {
-        //SYSTEM_BUS.write(ns.error);
         return;
     }
 
@@ -188,7 +189,6 @@ void drivewireNetwork::close()
     Debug_printv("After protocol delete %lu\n",esp_get_free_internal_heap_size());
 #endif
 
-    SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
     SYSTEM_BUS.transaction_success();
 }
 
@@ -203,9 +203,12 @@ void drivewireNetwork::read(uint16_t num_bytes)
 {
     readAck = GET_TIMESTAMP();
 
+    SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
+
     if (!num_bytes)
     {
         Debug_printf("drivewireNetwork::read() - Zero bytes requested. Bailing.\n");
+        SYSTEM_BUS.transaction_error();
         return;
     }
 
@@ -236,7 +239,6 @@ void drivewireNetwork::read(uint16_t num_bytes)
     // Do the channel read
     read_channel(num_bytes);
 
-    SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
     SYSTEM_BUS.transaction_send(*receiveBuffer);
 
     // Remove from receive buffer and shrink.
@@ -288,9 +290,12 @@ void drivewireNetwork::write(uint16_t num_bytes)
 {
     char *txbuf=nullptr;
 
+    SYSTEM_BUS.transaction_accept(TRANS_STATE::WILL_GET);
+
     if (!num_bytes)
     {
         Debug_printf("drivewireNetwork::write() - refusing to write 0 bytes.\n");
+        SYSTEM_BUS.transaction_error();
         return;
     }
 
@@ -299,13 +304,15 @@ void drivewireNetwork::write(uint16_t num_bytes)
     if (!txbuf)
     {
         Debug_printf("drivewireNetwork::write() - could not allocate %u bytes.\n", num_bytes);
+        SYSTEM_BUS.transaction_error();
         return;
     }
 
-    if (SYSTEM_BUS.read((uint8_t *)txbuf, num_bytes) < num_bytes)
+    if (SYSTEM_BUS.transaction_get(txbuf, num_bytes).is_error())
     {
         Debug_printf("drivewireNetwork::write() - short read\n");
         free(txbuf);
+        SYSTEM_BUS.transaction_error();
         return;
     }
 
@@ -319,6 +326,7 @@ void drivewireNetwork::write(uint16_t num_bytes)
             delete protocolParser;
             protocolParser = nullptr;
         }
+        SYSTEM_BUS.transaction_error();
         _errorCode = NDEV_STATUS::NOT_CONNECTED;
         return;
     }
@@ -331,6 +339,7 @@ void drivewireNetwork::write(uint16_t num_bytes)
 
     // Do the channel write
     write_channel(num_bytes);
+    SYSTEM_BUS.transaction_success();
 }
 
 /**
@@ -435,6 +444,8 @@ void drivewireNetwork::status_channel()
     Debug_printf("drivewireNetwork::status_channel(%u)\n", channelMode);
 #endif /* TOO_MUCH_DEBUG */
 
+    SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
+
     switch (channelMode)
     {
     case PROTOCOL:
@@ -462,7 +473,6 @@ void drivewireNetwork::status_channel()
                  avail, ns.connected, ns.error);
 #endif /* TOO_MUCH_DEBUG */
 
-    SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
     SYSTEM_BUS.transaction_send(&status, sizeof(status));
 }
 
@@ -485,12 +495,10 @@ void drivewireNetwork::set_prefix()
 {
     std::string prefixSpec_str;
     char tmp[256];
-    memset(tmp,0,sizeof(tmp));
-    size_t read_bytes = SYSTEM_BUS.read((uint8_t *)tmp, 256);
 
-    if (read_bytes != 256)
+    if (SYSTEM_BUS.transaction_get(tmp, sizeof(tmp)).is_error())
     {
-        Debug_printf("Short read by %u bytes. Exiting.", read_bytes);
+        Debug_printf("Short read. Exiting.");
         return;
     }
 
@@ -553,6 +561,7 @@ void drivewireNetwork::set_prefix()
     prefix = util_get_canonical_path(prefix);
     Debug_printf("Prefix now: %s\n", prefix.c_str());
 
+    SYSTEM_BUS.transaction_success();
 }
 
 /**
@@ -581,17 +590,17 @@ void drivewireNetwork::set_channel_mode(uint8_t mode)
 void drivewireNetwork::set_login()
 {
     char tmp[256];
-    memset(tmp,0,sizeof(tmp));
 
-    size_t bytes_read = SYSTEM_BUS.read((uint8_t *)tmp, 256);
+    SYSTEM_BUS.transaction_accept(TRANS_STATE::WILL_GET);
 
-    if (bytes_read != 256)
+    if (SYSTEM_BUS.transaction_get(tmp, sizeof(tmp)).is_error())
     {
-        Debug_printf("Short read of %u bytes. Exiting.\n", bytes_read);
+        Debug_printf("Short read. Exiting.\n");
         return;
     }
 
     login = std::string(tmp,256);
+    SYSTEM_BUS.transaction_success();
 
     Debug_printf("drivewireNetwork::set_login(%s)\n",login.c_str());
 }
@@ -602,17 +611,17 @@ void drivewireNetwork::set_login()
 void drivewireNetwork::set_password()
 {
     char tmp[256];
-    memset(tmp,0,sizeof(tmp));
 
-    size_t bytes_read = SYSTEM_BUS.read((uint8_t *)tmp, 256);
+    SYSTEM_BUS.transaction_accept(TRANS_STATE::WILL_GET);
 
-    if (bytes_read != 256)
+    if (SYSTEM_BUS.transaction_get(tmp, sizeof(tmp)).is_error())
     {
-        Debug_printf("Short read of %u bytes. Exiting.\n", bytes_read);
+        Debug_printf("Short read. Exiting.\n");
         return;
     }
 
     password = std::string(tmp,256);
+    SYSTEM_BUS.transaction_success();
 
     Debug_printf("drivewireNetwork::set_password(%s)\n", password.c_str());
 }
@@ -725,6 +734,7 @@ void drivewireNetwork::parse_json()
 {
     bool success = json->parse();
 
+    SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
     _errorCode = NDEV_STATUS::SUCCESS;
 #ifdef UNUSED
     // Atari doesn't check for errors and blindly returns that
@@ -733,20 +743,20 @@ void drivewireNetwork::parse_json()
     if (!success)
         _errorCode = NDEV_STATUS::COULD_NOT_PARSE_JSON;
 #endif /* UNUSED */
+    SYSTEM_BUS.transaction_success();
 }
 
 void drivewireNetwork::json_query()
 {
     std::string in_string;
     char tmpq[256];
-    memset(tmpq,0,sizeof(tmpq));
 
-    size_t bytes_read = SYSTEM_BUS.read((uint8_t *)tmpq,256);
+    SYSTEM_BUS.transaction_accept(TRANS_STATE::WILL_GET);
 
-    // why does it need to be 256 bytes?
-    if (bytes_read != 256)
+    if (SYSTEM_BUS.transaction_get(tmpq, sizeof(tmpq)).is_error())
     {
-        Debug_printf("Short read of %u bytes. Exiting\n", bytes_read);
+        Debug_printf("Short read. Exiting\n");
+        SYSTEM_BUS.transaction_error();
         return;
     }
 
@@ -782,39 +792,37 @@ void drivewireNetwork::json_query()
 #endif
 
     Debug_printf("Query set to >%s<\r\n", in_string.c_str());
+    SYSTEM_BUS.transaction_success();
 }
 
-void drivewireNetwork::process(fujiCommandID_t cmd)
+void drivewireNetwork::processCommand(FujiDWPacket &packet)
 {
-    uint8_t param1 = SYSTEM_BUS.read();
-    uint8_t param2 = SYSTEM_BUS.read();
+    Debug_printf("comnd: '%c' %u\n", packet.command(), packet.command());
 
-    Debug_printf("comnd: '%c' %u,%u,%u\n", cmd, cmd, param1, param2);
-
-    switch (cmd)
+    switch (packet.command())
     {
     case NETCMD_OPEN:
-        open(static_cast<fileAccessMode_t>(param1),
-             static_cast<netProtoTranslation_t>(param2));
+        open(static_cast<fileAccessMode_t>(packet.param8(0)),
+             static_cast<netProtoTranslation_t>(packet.param8(1)));
         break;
     case NETCMD_CLOSE:
         close();
         break;
     case NETCMD_READ:
-        read((param1 << 8) | param2);
+        read(packet.param(0));
         break;
     case NETCMD_WRITE:
-        write((param1 << 8) | param2);
+        write(packet.param(0));
         break;
     case NETCMD_STATUS:
-        status(param2);
+        status(packet.param(1));
         break;
 
     case NETCMD_PARSE:
         parse_json();
         break;
     case NETCMD_CHANNEL_MODE:
-        set_channel_mode(param1);
+        set_channel_mode(packet.param(0));
         break;
 
     case NETCMD_GETCWD:
@@ -840,21 +848,21 @@ void drivewireNetwork::process(fujiCommandID_t cmd)
     case NETCMD_UNLOCK:
     case NETCMD_MKDIR:
     case NETCMD_RMDIR:
-        process_fs(cmd, static_cast<fileAccessMode_t>(param1) == ACCESS_MODE::DIRECTORY);
+        process_fs(packet);
         break;
 
     case NETCMD_CONTROL:
     case NETCMD_CLOSE_CLIENT:
-        process_tcp(cmd);
+        process_tcp(packet);
         break;
 
     case NETCMD_SET_CHANNEL_MODE:
-        process_http(cmd, param2);
+        process_http(packet);
         break;
 
     case NETCMD_GET_REMOTE:
     case NETCMD_SET_DESTINATION:
-        process_udp(cmd);
+        process_udp(packet);
         break;
 
     default:
@@ -863,9 +871,10 @@ void drivewireNetwork::process(fujiCommandID_t cmd)
     }
 }
 
-void drivewireNetwork::process_fs(fujiCommandID_t cmd, bool is_dir)
+void drivewireNetwork::process_fs(FujiDWPacket &packet)
 {
-    parse_and_instantiate_protocol(is_dir);
+    parse_and_instantiate_protocol(static_cast<fileAccessMode_t>(packet.param8(0))
+                                   == ACCESS_MODE::DIRECTORY);
 
     // Make sure this is really a FS protocol instance
     NetworkProtocolFS *fs = dynamic_cast<NetworkProtocolFS *>(protocol);
@@ -877,7 +886,7 @@ void drivewireNetwork::process_fs(fujiCommandID_t cmd, bool is_dir)
 
     fujiError_t err;
     auto url = urlParser.get();
-    switch (cmd)
+    switch (packet.command())
     {
     case NETCMD_RENAME:
         err = fs->rename(url);
@@ -908,7 +917,7 @@ void drivewireNetwork::process_fs(fujiCommandID_t cmd, bool is_dir)
     }
 }
 
-void drivewireNetwork::process_tcp(fujiCommandID_t cmd)
+void drivewireNetwork::process_tcp(FujiDWPacket &packet)
 {
     // Make sure this is really a TCP protocol instance
     NetworkProtocolTCP *tcp = dynamic_cast<NetworkProtocolTCP *>(protocol);
@@ -919,7 +928,7 @@ void drivewireNetwork::process_tcp(fujiCommandID_t cmd)
     }
 
     fujiError_t err;
-    switch (cmd)
+    switch (packet.command())
     {
     case NETCMD_CONTROL:
         err = tcp->accept_connection();
@@ -938,7 +947,7 @@ void drivewireNetwork::process_tcp(fujiCommandID_t cmd)
     }
 }
 
-void drivewireNetwork::process_http(fujiCommandID_t cmd, uint8_t chan_mode)
+void drivewireNetwork::process_http(FujiDWPacket &packet)
 {
     // Make sure this is really an HTTP protocol instance
     NetworkProtocolHTTP *http = dynamic_cast<NetworkProtocolHTTP *>(protocol);
@@ -948,11 +957,13 @@ void drivewireNetwork::process_http(fujiCommandID_t cmd, uint8_t chan_mode)
         return;
     }
 
+    SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
+
     fujiError_t err;
-    switch (cmd)
+    switch (packet.command())
     {
     case NETCMD_SET_CHANNEL_MODE:
-        err = http->set_channel_mode((netProtoHTTPChannelMode_t) chan_mode);
+        err = http->set_channel_mode((netProtoHTTPChannelMode_t) packet.param8(1));
         break;
     default:
         err = FUJI_ERROR::UNSPECIFIED;
@@ -962,10 +973,13 @@ void drivewireNetwork::process_http(fujiCommandID_t cmd, uint8_t chan_mode)
     if (err != FUJI_ERROR::NONE)
     {
         SYSTEM_BUS.transaction_error();
+        return;
     }
+
+    SYSTEM_BUS.transaction_success();
 }
 
-void drivewireNetwork::process_udp(fujiCommandID_t cmd)
+void drivewireNetwork::process_udp(FujiDWPacket &packet)
 {
     // Make sure this is really a UDP protocol instance
     NetworkProtocolUDP *udp = dynamic_cast<NetworkProtocolUDP *>(protocol);
@@ -976,30 +990,35 @@ void drivewireNetwork::process_udp(fujiCommandID_t cmd)
     }
 
     fujiError_t err;
-    switch (cmd)
+    switch (packet.command())
     {
 #ifndef ESP_PLATFORM
     case NETCMD_GET_REMOTE:
         receiveBuffer->resize(SPECIAL_BUFFER_SIZE);
         err = udp->get_remote(receiveBuffer->data(), receiveBuffer->size());
+        SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
         SYSTEM_BUS.transaction_send(*receiveBuffer);
         break;
 #endif /* ESP_PLATFORM */
     case NETCMD_SET_DESTINATION:
         {
             uint8_t spData[SPECIAL_BUFFER_SIZE];
-            size_t bytes_read = SYSTEM_BUS.read(spData, sizeof(spData));
-            err = udp->set_destination(spData, bytes_read);
+            SYSTEM_BUS.transaction_accept(TRANS_STATE::WILL_GET);
+            SYSTEM_BUS.transaction_get(spData, sizeof(spData));
+            err = udp->set_destination(spData, sizeof(spData));
             if (err != FUJI_ERROR::NONE)
             {
                 SYSTEM_BUS.transaction_error();
+                return;
             }
         }
         break;
     default:
         SYSTEM_BUS.transaction_error();
-        break;
+        return;
     }
+
+    SYSTEM_BUS.transaction_success();
 }
 
 #endif /* BUILD_COCO */

--- a/lib/device/drivewire/network.h
+++ b/lib/device/drivewire/network.h
@@ -43,11 +43,11 @@ public:
     /**
      * @brief process network device command
      */
-    void process(fujiCommandID_t cmd);
-    void process_fs(fujiCommandID_t cmd, bool is_dir);
-    void process_tcp(fujiCommandID_t cmd);
-    void process_http(fujiCommandID_t cmd, uint8_t chan_mode);
-    void process_udp(fujiCommandID_t cmd);
+    void processCommand(FujiDWPacket &packet) override;
+    void process_fs(FujiDWPacket &packet);
+    void process_tcp(FujiDWPacket &packet);
+    void process_http(FujiDWPacket &packet);
+    void process_udp(FujiDWPacket &packet);
 
     /**
      * Check to see if PROCEED needs to be asserted.

--- a/lib/device/drivewire/printer.h
+++ b/lib/device/drivewire/printer.h
@@ -10,7 +10,7 @@
 
 #define PRINTER_UNSUPPORTED "Unsupported"
 
-class drivewirePrinter : public virtualDevice
+class drivewirePrinter : public drivewireDevice
 {
 protected:
     // DRIVEWIRE THINGS

--- a/lib/network-protocol/UDP.cpp
+++ b/lib/network-protocol/UDP.cpp
@@ -186,12 +186,12 @@ fujiError_t NetworkProtocolUDP::status(NetworkStatus *status)
     return FUJI_ERROR::NONE;
 }
 
-fujiError_t NetworkProtocolUDP::set_destination(uint8_t *sp_buf, unsigned short len)
+fujiError_t NetworkProtocolUDP::set_destination(const uint8_t *sp_buf, unsigned short len)
 {
 #ifdef ESP_PLATFORM // TODO review & merge
     std::string path((const char *)sp_buf, len);
 #else
-    util_devicespec_fix_9b(sp_buf, len); // TODO check sp_buf, first byte seems corrupted
+    util_devicespec_fix_9b((uint8_t *) sp_buf, len); // TODO check sp_buf, first byte seems corrupted
     Debug_printf("set_destination %s\n", sp_buf);
     std::string path((const char *)sp_buf);
 #endif

--- a/lib/network-protocol/UDP.h
+++ b/lib/network-protocol/UDP.h
@@ -69,7 +69,7 @@ public:
      * @param sp_buf pointer to received special buffer.
      * @param len of special received buffer
      */
-    fujiError_t set_destination(uint8_t *sp_buf, unsigned short len);
+    fujiError_t set_destination(const uint8_t *sp_buf, unsigned short len);
 
     size_t available() override { return udp.available(); }
 


### PR DESCRIPTION
Introduce `FujiDWPacket`, a lazy-deserializing packet implementation that presents the same logical interface as `FujiBusPacket` while accommodating DriveWire's context-dependent packet format.

Packet fields are materialized on demand and cached, allowing parameters to be accessed in arbitrary order while preserving protocol ordering on the wire. Multi-byte parameters are transparently converted from DriveWire's big-endian encoding to native byte order.

This change also removes the remaining public transport bypass interfaces (`read()`, `write()`, `available()`, and `flush()`), eliminating the last direct dependencies between device implementations and the bus hardware.

Devices no longer perform bus I/O or implement DriveWire protocol mechanics. The bus layer is now solely responsible for transport, framing, and protocol handling, while devices operate exclusively on decoded packet abstractions.