### PR TITLE
[network-protocol][fs] Raw filename directory type.

### DIFF
--- a/lib/network-protocol/FS.cpp
+++ b/lib/network-protocol/FS.cpp
@@ -115,6 +115,12 @@ fujiError_t NetworkProtocolFS::open_dir(dirFormat_t fmt)
         case DIR_FORMAT::GDRIVE:
             dirBuffer += util_long_entry_with_gdrive_id((char *)entryBuffer.data(), fileSize, is_directory, entry_id) + lineEnding;
             break;
+        case DIR_FORMAT::RAW:
+            // Exact filename only (no size, no crunch) so clients can
+            // enumerate/copy the real names, incl. long/spaced ones.
+            dirBuffer += (const char *)entryBuffer.data();
+            dirBuffer += lineEnding;
+            break;
         default:
             if (fmt >= DIR_FORMAT::LONG)
                 dirBuffer += util_long_entry((char *)entryBuffer.data(), fileSize, is_directory) + lineEnding;
@@ -130,8 +136,10 @@ fujiError_t NetworkProtocolFS::open_dir(dirFormat_t fmt)
     }
 
 #ifdef BUILD_ATARI
-    // Finally, drop a FREE SECTORS trailer.
-    dirBuffer += "999+FREE SECTORS\x9b";
+    // Finally, drop a FREE SECTORS trailer -- but not for RAW, which is
+    // machine-parsed filename-only output (a trailer would look like a file).
+    if (fmt != DIR_FORMAT::RAW)
+        dirBuffer += "999+FREE SECTORS\x9b";
 #endif /* BUILD_ATARI */
 
     if (error == NDEV_STATUS::END_OF_FILE)

--- a/lib/network-protocol/FS.h
+++ b/lib/network-protocol/FS.h
@@ -11,6 +11,7 @@ typedef enum class DIR_FORMAT {
     LONG   = 0x80,
     A2COL80 = 0x81,
     GDRIVE = 0x82,
+    RAW    = 0x83,   // filename only + line ending (no size, no crunch)
 } dirFormat_t;
 
 class NetworkProtocolFS : public NetworkProtocol


### PR DESCRIPTION
Add 0x83 for raw enumerated directory type for things like wildcard copying. NOS uses this.
-Thom