### PR TITLE
[fujiHost][http] add random access with keep-alive to fujiHost HTTP/S.

### DIFF
--- a/fujinet_pc.cmake
+++ b/fujinet_pc.cmake
@@ -207,6 +207,7 @@ set(SOURCES src/main.cpp
     lib/FileSystem/fnFileSMB.h lib/FileSystem/fnFileSMB.cpp
     lib/FileSystem/fnFileNFS.h lib/FileSystem/fnFileNFS.cpp
     lib/FileSystem/fnFileMem.h lib/FileSystem/fnFileMem.cpp
+    lib/FileSystem/fnFileHTTP.h lib/FileSystem/fnFileHTTP.cpp
     lib/FileSystem/fnio.h lib/FileSystem/fnio.cpp
     lib/tcpip/fnDNS.h lib/tcpip/fnDNS.cpp
     lib/tcpip/fnUDP.h lib/tcpip/fnUDP.cpp

--- a/lib/FileSystem/fnFileHTTP.cpp
+++ b/lib/FileSystem/fnFileHTTP.cpp
@@ -12,9 +12,8 @@
 #include "../../include/debug.h"
 #include "string_utils.h"
 
-// Size of the read-ahead window fetched per HTTP Range request. Large enough to
-// amortize the per-request TLS handshake over runs of sequential block reads,
-// small enough that only this much is ever resident in memory.
+// Bytes fetched per Range request: big enough to amortize the TLS handshake over
+// sequential reads, small enough to keep memory bounded.
 #define HTTP_STREAM_WINDOW 65536
 
 static uint8_t *stream_buf_alloc(size_t len)
@@ -129,9 +128,8 @@ int FileHandlerHTTP::fetch_range(long pos, long want, long *out_total)
     if (rc != 200 && rc != 206)
         return rc;
 
-    // On 200 the server ignored the Range and the body starts at offset 0, so we
-    // must discard the leading bytes. create() confirmed range support, so this
-    // is only a safety net (and only viable for small resources).
+    // 200 means the server ignored the Range (body starts at 0); discard the
+    // leading bytes. A safety net only - create() already confirmed range support.
     long skip = (rc == 200) ? pos : 0;
     uint8_t scratch[512];
     while (skip > 0)
@@ -294,9 +292,8 @@ int FileHandlerHTTP::seek(long int off, int whence)
         return -1;
     }
 
-    // Purely logical: the next read() fetches the window if needed. This keeps
-    // filesize()'s seek(END)/seek(0) probe free of network traffic, and a small
-    // backward seek that stays inside the current window costs no request.
+    // Purely logical - the next read() fetches the window if needed. Keeps
+    // filesize()'s seek(END)/seek(0) probe (and in-window seeks) network-free.
     _position = new_pos;
     _eof = false;
     return 0;

--- a/lib/FileSystem/fnFileHTTP.cpp
+++ b/lib/FileSystem/fnFileHTTP.cpp
@@ -1,0 +1,327 @@
+
+#include "fnFileHTTP.h"
+
+#ifndef FNIO_IS_STDIO
+
+#include <cerrno>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <vector>
+
+#include "../../include/debug.h"
+#include "string_utils.h"
+
+// Size of the read-ahead window fetched per HTTP Range request. Large enough to
+// amortize the per-request TLS handshake over runs of sequential block reads,
+// small enough that only this much is ever resident in memory.
+#define HTTP_STREAM_WINDOW 65536
+
+static uint8_t *stream_buf_alloc(size_t len)
+{
+#ifdef ESP_PLATFORM
+    return (uint8_t *)heap_caps_malloc(len, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+#else
+    return (uint8_t *)malloc(len);
+#endif
+}
+
+FileHandlerHTTP::FileHandlerHTTP(const std::string &url, long size)
+    : _url(url), _size(size), _position(0), _client(nullptr),
+      _buf(nullptr), _buf_start(-1), _buf_len(0), _eof(false)
+{
+    _buf = stream_buf_alloc(HTTP_STREAM_WINDOW);
+}
+
+FileHandlerHTTP::~FileHandlerHTTP()
+{
+    if (_client != nullptr)
+        delete _client;
+    if (_buf != nullptr)
+        free(_buf);
+}
+
+// Probe the URL for byte-range support and determine its size.
+FileHandlerHTTP *FileHandlerHTTP::create(const std::string &url)
+{
+    long size = -1;
+    bool ranges = false;
+
+    // --- HEAD probe: look for Accept-Ranges + Content-Length ---
+    HTTP_CLIENT_CLASS *client = new HTTP_CLIENT_CLASS();
+    if (client == nullptr)
+        return nullptr;
+
+    if (client->begin(url))
+    {
+        std::vector<std::string> wanted = {"Accept-Ranges", "Content-Length"};
+        client->create_empty_stored_headers(wanted);
+        int rc = client->HEAD();
+        if (rc >= 200 && rc < 400)
+        {
+            std::string ar = client->get_header("Accept-Ranges");
+            std::string cl = client->get_header("Content-Length");
+            mstr::toLower(ar);
+            if (ar.find("bytes") != std::string::npos)
+                ranges = true;
+            if (!cl.empty())
+                size = atol(cl.c_str());
+        }
+    }
+    delete client;
+    client = nullptr;
+
+    // --- Fallback probe: a bytes=0-0 GET; a 206 + Content-Range confirms ranges ---
+    if (!ranges || size < 0)
+    {
+        client = new HTTP_CLIENT_CLASS();
+        if (client == nullptr)
+            return nullptr;
+
+        if (client->begin(url))
+        {
+            std::vector<std::string> wanted = {"Content-Range", "Content-Length"};
+            client->create_empty_stored_headers(wanted);
+            client->set_header("Range", "bytes=0-0");
+            int rc = client->GET();
+            if (rc == 206)
+            {
+                ranges = true;
+                // Content-Range: "bytes 0-0/12345"  (total after '/')
+                std::string cr = client->get_header("Content-Range");
+                size_t slash = cr.find('/');
+                if (slash != std::string::npos)
+                {
+                    std::string total = cr.substr(slash + 1);
+                    if (!total.empty() && total[0] != '*')
+                        size = atol(total.c_str());
+                }
+            }
+        }
+        delete client;
+        client = nullptr;
+    }
+
+    // Streaming needs both range support and a known size (SEEK_END / filesize()).
+    if (!ranges || size < 0)
+    {
+        Debug_printf("FileHandlerHTTP::create - no usable range support for \"%s\" (ranges=%d, size=%ld)\r\n",
+                     url.c_str(), ranges, size);
+        return nullptr;
+    }
+
+    Debug_printf("FileHandlerHTTP::create - streaming \"%s\", size=%ld\r\n", url.c_str(), size);
+    return new FileHandlerHTTP(url, size);
+}
+
+// Issue one bounded ranged GET on the (reused) client, reading the body into _buf.
+int FileHandlerHTTP::fetch_range(long pos, long want, long *out_total)
+{
+    *out_total = 0;
+
+    // Bounded range: fetch exactly [pos, pos+want-1]. Open-ended ranges would
+    // make the PC client download the rest of the file during GET().
+    char range[48];
+    snprintf(range, sizeof(range), "bytes=%ld-%ld", pos, pos + want - 1);
+    _client->set_header("Range", range);
+
+    int rc = _client->GET();
+    if (rc != 200 && rc != 206)
+        return rc;
+
+    // On 200 the server ignored the Range and the body starts at offset 0, so we
+    // must discard the leading bytes. create() confirmed range support, so this
+    // is only a safety net (and only viable for small resources).
+    long skip = (rc == 200) ? pos : 0;
+    uint8_t scratch[512];
+    while (skip > 0)
+    {
+        int chunk = skip < (long)sizeof(scratch) ? (int)skip : (int)sizeof(scratch);
+        int got = _client->read(scratch, chunk);
+        if (got <= 0)
+            return -1;
+        skip -= got;
+    }
+
+    // Read the window body into _buf.
+    long total = 0;
+    while (total < want)
+    {
+        int got = _client->read(_buf + total, (int)(want - total));
+        if (got <= 0)
+            break;
+        total += got;
+    }
+
+    *out_total = total;
+    return rc;
+}
+
+// Fetch a bounded window of the resource into _buf, starting at absolute pos.
+// The client (and its connection) is reused across windows via keep-alive; a
+// dropped keep-alive connection is retried once on a fresh client.
+bool FileHandlerHTTP::fill_window(long pos)
+{
+    _buf_start = -1;
+    _buf_len = 0;
+
+    if (_buf == nullptr || pos < 0 || (_size >= 0 && pos >= _size))
+        return false;
+
+    long want = HTTP_STREAM_WINDOW;
+    if (_size >= 0 && pos + want > _size)
+        want = _size - pos;
+    if (want <= 0)
+        return false;
+
+    for (int attempt = 0; attempt < 2; attempt++)
+    {
+        bool fresh = false;
+        if (_client == nullptr)
+        {
+            _client = new HTTP_CLIENT_CLASS();
+            if (_client == nullptr)
+                return false;
+            _client->set_keep_alive(true);
+            if (!_client->begin(_url))
+            {
+                delete _client;
+                _client = nullptr;
+                return false;
+            }
+            fresh = true;
+        }
+
+        long total = 0;
+        int rc = fetch_range(pos, want, &total);
+
+        if ((rc == 200 || rc == 206) && total > 0)
+        {
+            _buf_start = pos;
+            _buf_len = total;
+#ifdef ESP_PLATFORM
+            // The ESP client is used one request per instance; don't reuse it.
+            delete _client;
+            _client = nullptr;
+#endif
+            return true;
+        }
+
+        // Failed. Drop the client so the next attempt reconnects fresh.
+        delete _client;
+        _client = nullptr;
+
+        if (rc == 416)
+        {
+            _eof = true; // requested past end
+            return false;
+        }
+        if (fresh)
+            return false; // a fresh connection genuinely failed; don't loop forever
+        // Otherwise the reused keep-alive connection was stale: retry fresh.
+    }
+
+    return false;
+}
+
+size_t FileHandlerHTTP::read(void *ptr, size_t size, size_t count)
+{
+    if (size == 0 || count == 0 || ptr == nullptr)
+        return 0;
+
+    size_t want = size * count;
+    size_t got = 0;
+    uint8_t *out = (uint8_t *)ptr;
+
+    while (got < want)
+    {
+        // (Re)fill the window when the cursor falls outside the buffered range.
+        if (_buf_start < 0 || _position < _buf_start || _position >= _buf_start + _buf_len)
+        {
+            if (!fill_window(_position))
+            {
+                if (_size >= 0 && _position >= _size)
+                    _eof = true;
+                break;
+            }
+        }
+
+        long off = _position - _buf_start;
+        long avail = _buf_len - off;
+        size_t n = (want - got) < (size_t)avail ? (want - got) : (size_t)avail;
+        memcpy(out + got, _buf + off, n);
+        got += n;
+        _position += n;
+    }
+
+    return got / size; // number of complete elements read (fread semantics)
+}
+
+size_t FileHandlerHTTP::write(const void *ptr, size_t size, size_t count)
+{
+    // HTTP host is read-only.
+    return 0;
+}
+
+int FileHandlerHTTP::seek(long int off, int whence)
+{
+    long new_pos;
+    switch (whence)
+    {
+    case SEEK_SET:
+        new_pos = off;
+        break;
+    case SEEK_CUR:
+        new_pos = _position + off;
+        break;
+    case SEEK_END:
+        if (_size < 0)
+        {
+            errno = EINVAL;
+            return -1;
+        }
+        new_pos = _size + off;
+        break;
+    default:
+        Debug_printf("FileHandlerHTTP::seek - invalid whence: %d\r\n", whence);
+        errno = EINVAL;
+        return -1;
+    }
+
+    if (new_pos < 0)
+    {
+        errno = EINVAL;
+        return -1;
+    }
+
+    // Purely logical: the next read() fetches the window if needed. This keeps
+    // filesize()'s seek(END)/seek(0) probe free of network traffic, and a small
+    // backward seek that stays inside the current window costs no request.
+    _position = new_pos;
+    _eof = false;
+    return 0;
+}
+
+long int FileHandlerHTTP::tell()
+{
+    return _position;
+}
+
+int FileHandlerHTTP::flush()
+{
+    return 0;
+}
+
+int FileHandlerHTTP::eof()
+{
+    return _eof ? 1 : 0;
+}
+
+int FileHandlerHTTP::close(bool destroy)
+{
+    if (destroy)
+        delete this;
+    return 0;
+}
+
+#endif // !FNIO_IS_STDIO

--- a/lib/FileSystem/fnFileHTTP.h
+++ b/lib/FileSystem/fnFileHTTP.h
@@ -1,0 +1,85 @@
+#ifndef FN_FILEHTTP_H
+#define FN_FILEHTTP_H
+
+#include "fnio.h"
+
+#ifndef FNIO_IS_STDIO
+
+#include <stdint.h>
+#include <string>
+
+#include "fnFile.h"
+
+#ifdef ESP_PLATFORM
+#include "fnHttpClient.h"
+#ifndef HTTP_CLIENT_CLASS
+#define HTTP_CLIENT_CLASS fnHttpClient
+#endif
+#else
+#include "mgHttpClient.h"
+#ifndef HTTP_CLIENT_CLASS
+#define HTTP_CLIENT_CLASS mgHttpClient
+#endif
+#endif
+
+/*
+ * FileHandlerHTTP - read-only FileHandler that streams a remote resource over
+ * HTTP instead of caching the whole thing locally.
+ *
+ * Random access (POINT/NOTE, disk sector reads) is served with bounded HTTP
+ * Range requests. seek() only moves a logical cursor; read() fetches a window
+ * of bytes starting at that cursor (bytes=lo-hi) into a small read-ahead
+ * buffer, so a run of sequential reads is satisfied from one request. Only a
+ * fixed-size window is ever held in memory, never the whole file.
+ *
+ * Bounded (not open-ended) ranges are required because the PC HTTP client
+ * downloads the entire response body during GET(); an open-ended bytes=N-
+ * would pull the rest of the file in one shot.
+ *
+ * Only usable when the server advertises byte-range support AND a content
+ * length; create() returns nullptr otherwise so the caller can fall back to
+ * downloading the file to a cache.
+ */
+class FileHandlerHTTP : public FileHandler
+{
+protected:
+    std::string _url;   // fully-qualified, url-encoded resource URL
+    long _size;         // total resource size (always known when constructed)
+    long _position;     // logical read cursor
+
+    HTTP_CLIENT_CLASS *_client; // persistent keep-alive client reused across windows
+
+    uint8_t *_buf;      // read-ahead window buffer
+    long _buf_start;    // absolute offset of _buf[0], or -1 when empty
+    long _buf_len;      // valid bytes in _buf
+    bool _eof;
+
+private:
+    // Fetch a window of data starting at absolute offset pos into _buf via a
+    // bounded HTTP Range request. Returns false on EOF/error.
+    bool fill_window(long pos);
+    // Issue one bounded ranged GET on _client into _buf. Returns the HTTP status
+    // and sets *out_total to the number of body bytes read.
+    int fetch_range(long pos, long want, long *out_total);
+
+public:
+    FileHandlerHTTP(const std::string &url, long size);
+    virtual ~FileHandlerHTTP() override;
+
+    // Probe url for byte-range support. Returns a new handler on success, or
+    // nullptr when the server can't serve ranges / size is unknown (caller
+    // should fall back to caching the whole file).
+    static FileHandlerHTTP *create(const std::string &url);
+
+    virtual int close(bool destroy = true) override;
+    virtual int seek(long int off, int whence) override;
+    virtual long int tell() override;
+    virtual size_t read(void *ptr, size_t size, size_t count) override;
+    virtual size_t write(const void *ptr, size_t size, size_t count) override;
+    virtual int flush() override;
+    virtual int eof() override;
+};
+
+#endif // !FNIO_IS_STDIO
+
+#endif // FN_FILEHTTP_H

--- a/lib/FileSystem/fnFileHTTP.h
+++ b/lib/FileSystem/fnFileHTTP.h
@@ -23,22 +23,16 @@
 #endif
 
 /*
- * FileHandlerHTTP - read-only FileHandler that streams a remote resource over
- * HTTP instead of caching the whole thing locally.
+ * FileHandlerHTTP - read-only FileHandler that streams a remote resource with
+ * HTTP Range requests instead of caching the whole file.
  *
- * Random access (POINT/NOTE, disk sector reads) is served with bounded HTTP
- * Range requests. seek() only moves a logical cursor; read() fetches a window
- * of bytes starting at that cursor (bytes=lo-hi) into a small read-ahead
- * buffer, so a run of sequential reads is satisfied from one request. Only a
- * fixed-size window is ever held in memory, never the whole file.
+ * seek() just moves a logical cursor; read() fetches a bounded window
+ * (bytes=lo-hi) at the cursor into a read-ahead buffer, so sequential reads
+ * share one request and only the window is ever held in memory. Ranges must be
+ * bounded, not open-ended: the PC client downloads the whole body during GET().
  *
- * Bounded (not open-ended) ranges are required because the PC HTTP client
- * downloads the entire response body during GET(); an open-ended bytes=N-
- * would pull the rest of the file in one shot.
- *
- * Only usable when the server advertises byte-range support AND a content
- * length; create() returns nullptr otherwise so the caller can fall back to
- * downloading the file to a cache.
+ * create() returns nullptr unless the server advertises range support and a
+ * content length, so the caller can fall back to caching.
  */
 class FileHandlerHTTP : public FileHandler
 {

--- a/lib/FileSystem/fnFsHTTP.cpp
+++ b/lib/FileSystem/fnFsHTTP.cpp
@@ -12,6 +12,7 @@
 
 #include "fnSystem.h"
 #include "fnFileCache.h"
+#include "fnFileHTTP.h"
 #include "string_utils.h"
 
 // http timeout in ms
@@ -102,11 +103,31 @@ FILE  *FileSystemHTTP::file_open(const char *path, const char *mode)
     return nullptr;
 }
 
+// url + '/' + url-encoded path
+std::string FileSystemHTTP::make_file_url(const char *path)
+{
+    std::string url_str = _url->url;
+    std::string path_str = mstr::urlEncode(path);
+    if (url_str.back() != '/') url_str.push_back('/');
+    if (path_str.front() == '/') path_str.erase(0, 1);
+    url_str += path_str;
+    return url_str;
+}
+
 #ifndef FNIO_IS_STDIO
 FileHandler *FileSystemHTTP::filehandler_open(const char *path, const char *mode)
 {
-    FileHandler *fh = cache_file(path, mode);
-    return fh;
+    // For read-only opens, try to stream directly from HTTP using Range requests
+    // (no full-file cache). Falls back to caching if the server can't serve ranges.
+    if (mode != nullptr && mode[0] == 'r' && strchr(mode, '+') == nullptr)
+    {
+        FileHandler *fh = FileHandlerHTTP::create(make_file_url(path));
+        if (fh != nullptr)
+            return fh;
+        Debug_println("FileSystemHTTP::filehandler_open - no range support, caching whole file");
+    }
+
+    return cache_file(path, mode);
 }
 
 // Read file from HTTP path and write it to cache file
@@ -135,11 +156,7 @@ FileHandler *FileSystemHTTP::cache_file(const char *path, const char *mode)
         return nullptr;
     }
     // url + '/' + path
-    std::string url_str = _url->url;
-    std::string path_str = mstr::urlEncode(path);
-    if (url_str.back() != '/') url_str.push_back('/');
-    if (path_str.front() == '/') path_str.erase(0, 1);
-    url_str += path_str;
+    std::string url_str = make_file_url(path);
     if (!_http->begin(url_str))
     {
         Debug_println("FileSystemHTTP::cache_file - failed to start HTTP client");

--- a/lib/FileSystem/fnFsHTTP.h
+++ b/lib/FileSystem/fnFsHTTP.h
@@ -13,6 +13,8 @@
 #define HTTP_CLIENT_CLASS mgHttpClient
 #endif
 
+#include <string>
+
 #include "peoples_url_parser.h"
 #include "fnFS.h"
 #include "fnDirCache.h"
@@ -34,6 +36,9 @@ private:
     // directory cache
     char _last_dir[MAX_PATHLEN];
     DirCache _dircache;
+
+    // Build the fully-qualified, url-encoded URL for a file path under this host.
+    std::string make_file_url(const char *path);
 
 public:
     FileSystemHTTP();

--- a/lib/http/fnHttpClient.cpp
+++ b/lib/http/fnHttpClient.cpp
@@ -52,6 +52,22 @@ bool fnHttpClient::begin(const std::string &url)
     Debug_printf("fnHttpClient::begin \"%s\"\r\n", url.c_str());
 #endif
 
+    // Allow begin() to be called again on the same client (keep-alive reuse after
+    // a seek): esp_http_client_init() below would overwrite and leak _handle, and
+    // close() doesn't free it. No-op on the first call (_handle is null).
+    if (_handle != nullptr)
+    {
+        close();
+        esp_http_client_cleanup(_handle);
+        _handle = nullptr;
+    }
+    _buffer_pos = 0;
+    _buffer_len = 0;
+    _buffer_total_read = 0;
+    _transaction_begin = false;
+    _transaction_done = false;
+    _redirect_count = 0;
+
     esp_http_client_config_t cfg;
     memset(&cfg, 0, sizeof(cfg));
     cfg.url = url.c_str();

--- a/lib/http/fnHttpClient.h
+++ b/lib/http/fnHttpClient.h
@@ -80,7 +80,8 @@ public:
     int content_length();
     bool is_transaction_done();
 
-    // Enable/disable connection reuse (keep-alive). Must be set before begin().
+    // Request connection reuse (keep-alive). Accepted for interface parity;
+    // esp_http_client manages keep-alive itself.
     void set_keep_alive(bool enable) { _keep_alive = enable; }
 
     int read(uint8_t *dest_buffer, int dest_bufflen);

--- a/lib/http/fnHttpClient.h
+++ b/lib/http/fnHttpClient.h
@@ -29,6 +29,7 @@ private:
     bool _ignore_response_body = false;
     bool _transaction_begin = false;
     bool _transaction_done = false;
+    bool _keep_alive = false;
     int _redirect_count = 0;
     int _max_redirects = 0;
     bool connected = false;
@@ -78,6 +79,9 @@ public:
     int available();
     int content_length();
     bool is_transaction_done();
+
+    // Enable/disable connection reuse (keep-alive). Must be set before begin().
+    void set_keep_alive(bool enable) { _keep_alive = enable; }
 
     int read(uint8_t *dest_buffer, int dest_bufflen);
 

--- a/lib/http/mgHttpClient.cpp
+++ b/lib/http/mgHttpClient.cpp
@@ -416,9 +416,9 @@ void mgHttpClient::handle_connect(struct mg_connection *c)
         _conn = c;
 }
 
-// Write the HTTP request line, headers and (for write methods) body onto an
-// already-connected connection. Split out from handle_connect so a keep-alive
-// session can send a follow-up request on the reused connection.
+// Write the request line, headers and (for write methods) body onto a connected
+// socket. Split from handle_connect so keep-alive can send a follow-up request
+// on the reused connection.
 void mgHttpClient::send_request(struct mg_connection *c)
 {
     const char *url = _url.c_str();
@@ -555,8 +555,8 @@ void mgHttpClient::process_response_headers(struct mg_connection *c, struct mg_h
         }
     }
 
-    // Record the declared body length so a keep-alive transaction knows when the
-    // response is complete without waiting for the server to close the socket.
+    // Record the declared length so keep-alive knows when the body is complete
+    // without waiting for a socket close.
     _declared_len = -1;
     struct mg_str *clh = mg_http_get_header(&hm, "Content-Length");
     if (clh != nullptr)
@@ -653,8 +653,7 @@ void mgHttpClient::process_body_data(struct mg_connection *c, char *data, int le
 #ifdef VERBOSE_HTTP
                 Debug_printf("mgHttpClient: Final chunk received, body=%d bytes\n", _content_length);
 #endif
-                // Keep-alive: the socket stays open, so mark the transaction done
-                // here rather than waiting for a close that won't come.
+                // Keep-alive: socket stays open, so finish here, not on close.
                 if (_keep_alive)
                     _transaction_done = true;
             }
@@ -690,8 +689,7 @@ void mgHttpClient::process_body_data(struct mg_connection *c, char *data, int le
         c->recv.len = 0;   // cleanup mongoose receive buffer
         _processed = true; // stop polling, data is available in _buffer_str
 
-        // Keep-alive: the connection is not closed by the server, so detect the
-        // end of the body from the declared Content-Length.
+        // Keep-alive: server won't close, so detect end-of-body via Content-Length.
         if (_keep_alive && _declared_len >= 0 && _body_received >= _declared_len)
             _transaction_done = true;
     }
@@ -859,9 +857,8 @@ void mgHttpClient::_perform_connect()
 
     if (_keep_alive && _conn != nullptr)
     {
-        // Reuse the existing keep-alive connection: send the request directly on
-        // it. If the peer has since dropped it, the poll will surface MG_EV_CLOSE
-        // and the caller retries on a fresh connection.
+        // Reuse the keep-alive connection. If the peer dropped it, the poll
+        // surfaces MG_EV_CLOSE and the caller retries on a fresh connection.
         send_request(_conn);
     }
     else

--- a/lib/http/mgHttpClient.cpp
+++ b/lib/http/mgHttpClient.cpp
@@ -252,6 +252,8 @@ bool mgHttpClient::begin(std::string url)
     if (_handle == nullptr)
         return false;
 
+    _conn = nullptr; // fresh manager, any previous connection is invalid
+
     _url = url;
     // For mongoose, lowercase the first 5 characters of the URL, assuming it starts with http:// or https://
     for (size_t i = 0; i < 5 && i < _url.size(); ++i)
@@ -336,6 +338,9 @@ void mgHttpClient::close()
     _redirect_count = 0;
     _status_code = -1;
     _content_length = 0;
+    _conn = nullptr;
+    _declared_len = -1;
+    _body_received = 0;
     _is_chunked = false;
     _chunked_complete = false;
     _location.clear();
@@ -404,8 +409,23 @@ void mgHttpClient::handle_connect(struct mg_connection *c)
         _password = std::string(p.buf, p.len);
     }
 
-    // Send request
-    const char* method_str = method_to_string(_method);
+    send_request(c);
+
+    // Remember the connection so a keep-alive session can reuse it next request.
+    if (_keep_alive)
+        _conn = c;
+}
+
+// Write the HTTP request line, headers and (for write methods) body onto an
+// already-connected connection. Split out from handle_connect so a keep-alive
+// session can send a follow-up request on the reused connection.
+void mgHttpClient::send_request(struct mg_connection *c)
+{
+    const char *url = _url.c_str();
+    struct mg_str host = mg_url_host(url);
+    const char *method_str = method_to_string(_method);
+    const char *conn_hdr = _keep_alive ? "keep-alive" : "close";
+
     switch(_method)
     {
         case HTTP_GET:
@@ -421,8 +441,8 @@ void mgHttpClient::handle_connect(struct mg_connection *c)
             // start the request
             mg_printf(c, "%s %s HTTP/1.1\r\n"
                             "Host: %.*s\r\n"
-                            "Connection: close\r\n",
-                            method_str, mg_url_uri(url), (int)host.len, host.buf);
+                            "Connection: %s\r\n",
+                            method_str, mg_url_uri(url), (int)host.len, host.buf, conn_hdr);
 
             // send auth header
             if (!_username.empty())
@@ -535,6 +555,19 @@ void mgHttpClient::process_response_headers(struct mg_connection *c, struct mg_h
         }
     }
 
+    // Record the declared body length so a keep-alive transaction knows when the
+    // response is complete without waiting for the server to close the socket.
+    _declared_len = -1;
+    struct mg_str *clh = mg_http_get_header(&hm, "Content-Length");
+    if (clh != nullptr)
+    {
+        std::string cls(clh->buf, clh->len);
+        _declared_len = atol(cls.c_str());
+    }
+    // A HEAD (or 204/304) carries no body: it is complete as soon as headers arrive.
+    if (_keep_alive && (_method == HTTP_HEAD || _status_code == 204 || _status_code == 304))
+        _transaction_done = true;
+
 #ifdef VERBOSE_HTTP
     Debug_printf("  Headers: %d bytes\n", hdrs_len);
     Debug_printf("  status_code: %d\n", _status_code);
@@ -620,6 +653,10 @@ void mgHttpClient::process_body_data(struct mg_connection *c, char *data, int le
 #ifdef VERBOSE_HTTP
                 Debug_printf("mgHttpClient: Final chunk received, body=%d bytes\n", _content_length);
 #endif
+                // Keep-alive: the socket stays open, so mark the transaction done
+                // here rather than waiting for a close that won't come.
+                if (_keep_alive)
+                    _transaction_done = true;
             }
             o += cl;
         }
@@ -649,8 +686,14 @@ void mgHttpClient::process_body_data(struct mg_connection *c, char *data, int le
     {
         // Append entire body data to buffer
         _buffer_str.append(data, len);
+        _body_received += len;
         c->recv.len = 0;   // cleanup mongoose receive buffer
         _processed = true; // stop polling, data is available in _buffer_str
+
+        // Keep-alive: the connection is not closed by the server, so detect the
+        // end of the body from the declared Content-Length.
+        if (_keep_alive && _declared_len >= 0 && _body_received >= _declared_len)
+            _transaction_done = true;
     }
 }
 
@@ -724,11 +767,13 @@ void mgHttpClient::_httpevent_handler(struct mg_connection *c, int ev, void *ev_
             Debug_println("mgHttpClient: Chunked response ended before final chunk");
             client->_status_code = 902; // Fake HTTP status code to indicate truncated chunked body. Maybe should be 204-"Connection was reset during read/write"
         }
+        client->_conn = nullptr; // connection gone; a keep-alive reuse must reconnect
         client->_transaction_done = true;
         break;
 
     case MG_EV_ERROR:
         Debug_printf("mgHttpClient: Error - %s\n", (const char*)ev_data);
+        client->_conn = nullptr;
         client->_transaction_done = true;
         client->_status_code = 901; // Fake HTTP status code to indicate connection error
         break;
@@ -799,6 +844,8 @@ void mgHttpClient::_perform_connect()
     _content_length = 0;
     _is_chunked = false;
     _chunked_complete = false;
+    _declared_len = -1;
+    _body_received = 0;
 
     _transaction_begin = true; // waiting for response headers
     _transaction_done = false;
@@ -810,7 +857,17 @@ void mgHttpClient::_perform_connect()
         return;
     }
 
-    mg_connect(_handle.get(), _url.c_str(), _httpevent_handler, this);  // Create client connection
+    if (_keep_alive && _conn != nullptr)
+    {
+        // Reuse the existing keep-alive connection: send the request directly on
+        // it. If the peer has since dropped it, the poll will surface MG_EV_CLOSE
+        // and the caller retries on a fresh connection.
+        send_request(_conn);
+    }
+    else
+    {
+        mg_connect(_handle.get(), _url.c_str(), _httpevent_handler, this);  // Create client connection
+    }
 }
 
 void mgHttpClient::_perform_fetch()

--- a/lib/http/mgHttpClient.h
+++ b/lib/http/mgHttpClient.h
@@ -61,6 +61,15 @@ private:
     int _status_code = -1;
     int _content_length = 0;
 
+    // keep-alive (persistent connection) support. When enabled, requests are
+    // sent with "Connection: keep-alive", response completion is detected via
+    // Content-Length (instead of the server closing the socket), and the
+    // connection is reused across requests.
+    bool _keep_alive = false;
+    struct mg_connection *_conn = nullptr; // reused connection when keep-alive
+    long _declared_len = -1;               // Content-Length of current response, -1 if unknown
+    long _body_received = 0;               // body bytes received so far this transaction
+
     // chunked transfer encoding
     bool _is_chunked = false;
     bool _chunked_complete = false;
@@ -103,6 +112,7 @@ private:
 	// int _perform_stream(esp_http_client_method_t method, uint8_t *write_data, int write_size);
 
     void handle_connect(struct mg_connection *c);
+    void send_request(struct mg_connection *c);
     void handle_http_msg(struct mg_connection *c, struct mg_http_message *hm);
     void handle_read(struct mg_connection *c);
 	void process_response_headers(mg_connection *c, mg_http_message &hm, int hdrs_len);
@@ -138,6 +148,9 @@ public:
     bool is_transaction_done() { return _transaction_done; }
     int content_length() const { return _content_length; }
     int available();
+
+    // Enable/disable connection reuse (keep-alive) for subsequent requests.
+    void set_keep_alive(bool enable) { _keep_alive = enable; }
 
     int read(uint8_t *dest_buffer, int dest_bufflen);
 

--- a/lib/http/mgHttpClient.h
+++ b/lib/http/mgHttpClient.h
@@ -61,10 +61,8 @@ private:
     int _status_code = -1;
     int _content_length = 0;
 
-    // keep-alive (persistent connection) support. When enabled, requests are
-    // sent with "Connection: keep-alive", response completion is detected via
-    // Content-Length (instead of the server closing the socket), and the
-    // connection is reused across requests.
+    // keep-alive: when enabled, send "Connection: keep-alive", detect completion
+    // via Content-Length (not socket close), and reuse the connection.
     bool _keep_alive = false;
     struct mg_connection *_conn = nullptr; // reused connection when keep-alive
     long _declared_len = -1;               // Content-Length of current response, -1 if unknown

--- a/lib/network-protocol/HTTP.cpp
+++ b/lib/network-protocol/HTTP.cpp
@@ -824,9 +824,10 @@ off_t NetworkProtocolHTTP::seek(off_t offset, int whence)
     if (newPos < 0)
         return -1;
 
-    // Re-request the body starting at newPos via an HTTP Range header.
-    delete client;
-    client = new HTTP_CLIENT_CLASS();
+    // Re-request the body from newPos via a Range header. Reuse the client object
+    // instead of reallocating it: begin() rebuilds the connection cheaply, whereas
+    // a new client would reload the whole system cert store (on PC) every seek.
+    client->set_keep_alive(true);
     if (!client->begin(opened_url->url))
     {
         resultCode = 901; // Fake HTTP status code indicating connection error


### PR DESCRIPTION
* Adds a new fnFileHTTP class that can properly manage esp_http and mgHttp* to handle ranges, with keep-alive.
* Wire in fnFileHTTP to fujiHost
* Turn on keepalive for N: device so that notes-points don't have to rebuild connection.
