### PR TITLE
coco/drivewire: Ensure that failed reads get a retry

### DIFF
--- a/lib/bus/drivewire/drivewire.cpp
+++ b/lib/bus/drivewire/drivewire.cpp
@@ -630,9 +630,11 @@ void systemBus::_drivewire_process_cmd()
             op_reset();
             break;
         case OP::READEX:
+        case OP::REREADEX:
             op_readex();
             break;
         case OP::WRITE:
+        case OP::REWRITE:
             op_write();
             break;
         case OP::TIME:


### PR DESCRIPTION
This fixes the "coco boot goes to splash screen, then hangs" problem.