### PR TITLE
[network-protocol][http] defer to base class for WebDAV dirs.

### DIFF
--- a/lib/FileSystem/fnFsFTP.cpp
+++ b/lib/FileSystem/fnFsFTP.cpp
@@ -434,18 +434,18 @@ success_is_true FileSystemFTP::dir_open(const char  *path, const char *pattern, 
         res = _ftp->read_directory(filename, filesz, is_dir);
         while(res == FUJI_ERROR::NONE)
         {
-            // skip hidden
-            if (filename[0] == '.')
-                continue;
+            // skip hidden (must still advance to next entry, else infinite loop)
+            if (filename[0] != '.')
+            {
+                // new dir entry
+                fs_de = &_dircache.new_entry();
 
-            // new dir entry
-            fs_de = &_dircache.new_entry();
-
-            // set entry members
-            strlcpy(fs_de->filename, filename.c_str(), sizeof(fs_de->filename));
-            fs_de->isDir = is_dir;
-            fs_de->size = (uint32_t)filesz;
-            fs_de->modified_time = 0; // TODO
+                // set entry members
+                strlcpy(fs_de->filename, filename.c_str(), sizeof(fs_de->filename));
+                fs_de->isDir = is_dir;
+                fs_de->size = (uint32_t)filesz;
+                fs_de->modified_time = 0; // TODO
+            }
 
             // get next
             res = _ftp->read_directory(filename, filesz, is_dir);

--- a/lib/ftp/fnFTP.cpp
+++ b/lib/ftp/fnFTP.cpp
@@ -973,7 +973,7 @@ fujiError_t fnFTP::read_directory(string &name, long &filesize, bool &is_dir)
     getline(dirBuffer, line);
 
     if (line.empty())
-        return FUJI_ERROR::NONE; // no more entries
+        return FUJI_ERROR::UNSPECIFIED; // empty line / EOF: stop, no more entries
 
     //Debug_printf("fnFTP::read_directory - %s\r\n",line.c_str());
     line = line.substr(0, line.size() - 1);

--- a/lib/network-protocol/HTTP.cpp
+++ b/lib/network-protocol/HTTP.cpp
@@ -924,6 +924,9 @@ fujiError_t NetworkProtocolHTTP::rmdir(PeoplesUrlParser *url)
 
 size_t NetworkProtocolHTTP::available()
 {
+    if (streamType == streamType_t::DIR)
+        return NetworkProtocolFS::available();
+
     size_t avail = 0;
 
     if (client == nullptr)


### PR DESCRIPTION
The HTTP channel did not hold the size of the built directory entries parsed by the WebDAV object.

Fix was to defer to the base class, which does.