### PR TITLE
[iwm] Make all devices use only transaction methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ data/webui/device_specific/BUILD_ATARI/fnconfig.ini
 fujinet_releases/*
 
 *~
+\#*
 *.orig
 *.rej
 *.lst

--- a/lib/bus/iwm/iwm.cpp
+++ b/lib/bus/iwm/iwm.cpp
@@ -132,11 +132,14 @@ void systemBus::transaction_success()
   assert(_transaction_state == TRANS_STATE::NO_GET
          || _transaction_state == TRANS_STATE::DID_GET);
   _transaction_state = TRANS_STATE::INVALID;
+  iwm_send_packet(_activeDev->id(), iwm_packet_type_t::status, SP_ERR::NOERROR, NULL, 0);
 }
 
-void systemBus::transaction_error()
+void systemBus::transaction_error(spError_t err)
 {
   _transaction_state = TRANS_STATE::INVALID;
+  assert(err != SP_ERR::NOERROR);
+  iwm_send_packet(_activeDev->id(), iwm_packet_type_t::status, err, nullptr, 0);
 }
 
 success_is_true systemBus::transaction_get(void *data, size_t len)
@@ -149,12 +152,32 @@ success_is_true systemBus::transaction_get(void *data, size_t len)
   RETURN_SUCCESS_AS_TRUE();
 }
 
-void systemBus::transaction_send(const void *data, size_t len, bool err)
+void systemBus::transaction_send(const void *data, size_t len, bool is_error)
 {
   assert(_transaction_state == TRANS_STATE::NO_GET);
-  memcpy(virtualDevice::data_buffer, data, len);
-  virtualDevice::data_len = len;
-  _transaction_state = TRANS_STATE::INVALID;
+  if (is_error) {
+    transaction_error();
+    return;
+  }
+
+  // SmartPort doesn't allow sending payload with STATUS commands, so
+  // CONTROL is used by Fuji devices to process payload and queue up
+  // reply data. If this was a CONTROL command, queue up the data and
+  // send it when a STATUS command is received.
+  switch (command.sp_command) {
+  case SP_CMD_CONTROL:
+  case SP_ECMD_CONTROL:
+    _transaction_response.insert(_transaction_response.end(),
+                                 static_cast<const uint8_t *>(data),
+                                 static_cast<const uint8_t *>(data) + len);
+    transaction_success();
+    break;
+
+  default:
+    _transaction_state = TRANS_STATE::INVALID;
+    iwm_send_packet(_activeDev->id(), iwm_packet_type_t::status, SP_ERR::NOERROR, data, len);
+    break;
+  }
 }
 
 void systemBus::iwm_ack_deassert()
@@ -274,14 +297,9 @@ void systemBus::setup(void)
 // to 4 partions, i.e. devices, so we need to specify when we are doing the last
 // init reply.
 //*****************************************************************************
-void virtualDevice::send_init_reply_packet(uint8_t source, spError_t err)
+void systemBus::send_init_reply_packet(uint8_t source, spError_t err)
 {
-  SYSTEM_BUS.iwm_send_packet(source, iwm_packet_type_t::status, err, nullptr, 0);
-}
-
-void virtualDevice::send_reply_packet(spError_t err)
-{
-  SYSTEM_BUS.iwm_send_packet(id(), iwm_packet_type_t::status, err, nullptr, 0);
+  iwm_send_packet(source, iwm_packet_type_t::status, err, nullptr, 0);
 }
 
 void systemBus::send_status_reply_packet()
@@ -300,11 +318,11 @@ void systemBus::send_status_dib_reply_packet()
     std::fill(dib_packet.name + dib_packet.name_len,
               dib_packet.name + sizeof(dib_packet.name), ' ');
 
-  SYSTEM_BUS.iwm_send_packet(_activeDev->id(), iwm_packet_type_t::status, SP_ERR::NOERROR,
-                             &dib_packet, sizeof(dib_packet));
+  iwm_send_packet(_activeDev->id(), iwm_packet_type_t::status, SP_ERR::NOERROR,
+                  &dib_packet, sizeof(dib_packet));
 }
 
-void virtualDevice::iwm_return_badcmd(iwm_decoded_cmd_t cmd)
+void virtualDevice::iwm_return_badcmd(const iwm_decoded_cmd_t &cmd)
 {
   //Handle possible data packet to avoid crash extended and non-extended
   switch(cmd.sp_command)
@@ -319,74 +337,45 @@ void virtualDevice::iwm_return_badcmd(iwm_decoded_cmd_t cmd)
       print_packet(data_buffer, data_len);
       break;
     default: //just send the response and return like before
-      send_reply_packet(SP_ERR::BADCMD);
+      SYSTEM_BUS.transaction_error(SP_ERR::BADCMD);
       Debug_printf("\r\nUnit %02x Bad Command %02x", id(), cmd.sp_command);
       return;
   }
 
   if(cmd.sp_command == SP_CMD_CONTROL) //Decode command control code
   {
-    send_reply_packet(SP_ERR::BADCTL); //we may be required to accept some control commands
-                                      // but for now just report bad control if it's a control
-                                      // command
+    //we may be required to accept some control commands but for now
+    // just report bad control if it's a control command
+    SYSTEM_BUS.transaction_error(SP_ERR::BADCTL);
     Debug_printf("\r\nbad command was a control command with control code %02x",cmd.control_status.fuji.command);
   }
   else
   {
-    send_reply_packet(SP_ERR::BADCMD); //response for Any other command with a data packet
+    SYSTEM_BUS.transaction_error(SP_ERR::BADCMD); //response for Any other command with a data packet
   }
 }
 
-void virtualDevice::iwm_return_device_offline(iwm_decoded_cmd_t cmd)
-{
-  //Handle possible data packet to avoid crash extended and non-extended
-  switch(cmd.sp_command)
-  {
-    case SP_ECMD_WRITEBLOCK:
-    case SP_ECMD_CONTROL:
-    case SP_ECMD_WRITE:
-    case SP_CMD_WRITEBLOCK:
-    case SP_CMD_CONTROL:
-    case SP_CMD_WRITE:
-      Debug_printf("\r\nUnit %02x Offline, Command with data packet %02x\r\n", id(), cmd.sp_command);
-      print_packet((uint8_t *)data_buffer, data_len);
-      break;
-    default: //just send the response and return like before
-      send_reply_packet(SP_ERR::OFFLINE);
-      Debug_printf("\r\nUnit %02x Offline, Command %02x", id(), cmd.sp_command);
-      return;
-  }
-
-  if(cmd.sp_command == SP_CMD_CONTROL) //Decode command control code
-  {
-    send_reply_packet(SP_ERR::OFFLINE);
-    Debug_printf("\r\nOffline command was a control command with control code %02x",cmd.control_status.fuji.command);
-  }
-  else
-  {
-    send_reply_packet(SP_ERR::OFFLINE); //response for Any other command with a data packet
-  }
-}
-
-void virtualDevice::iwm_return_ioerror()
-{
-  // Debug_printf("\r\nUnit %02x Bad Command %02x", id(), cmd.sp_command);
-  send_reply_packet(SP_ERR::IOERROR);
-}
-
-void virtualDevice::iwm_return_noerror()
-{
-  send_reply_packet(SP_ERR::NOERROR);
-}
-
-void systemBus::iwm_process(iwm_decoded_cmd_t cmd)
+void systemBus::iwm_process(const iwm_decoded_cmd_t &cmd)
 {
   fnLedManager.set(LED_BUS, true);
+
+  // SmartPort doesn't allow sending payload with STATUS commands, so
+  // CONTROL is used by Fuji devices to process payload and queue up
+  // reply data. If this was a STATUS command, send any data that is
+  // sitting in the queue.
+  if ((cmd.sp_command == SP_CMD_STATUS || cmd.sp_command == SP_ECMD_STATUS)
+      && _transaction_response.size()) {
+    iwm_send_packet(_activeDev->id(), iwm_packet_type_t::status, SP_ERR::NOERROR,
+                    _transaction_response.data(), _transaction_response.size());
+    _transaction_response.clear();
+    _transaction_response.shrink_to_fit();
+    goto done;
+  }
 
   switch (cmd.sp_command)
   {
   case SP_CMD_STATUS:
-    Debug_printf("\r\nhandling status command");
+    Debug_printf("\r\nhandling status command code=0x%02x", cmd.control_status.code);
     switch (cmd.control_status.code) {
     case SP_STAT_DEVICE:
         send_status_reply_packet();
@@ -435,50 +424,51 @@ void systemBus::iwm_process(iwm_decoded_cmd_t cmd)
     break;
   }
 
+ done:
   fnLedManager.set(LED_BUS, false);
 }
 
-void virtualDevice::iwm_status(iwm_decoded_cmd_t cmd)
+void virtualDevice::iwm_status(const iwm_decoded_cmd_t &cmd)
 {
   iwm_return_badcmd(cmd);
 }
 
-void virtualDevice::iwm_readblock(iwm_decoded_cmd_t cmd)
+void virtualDevice::iwm_readblock(const iwm_decoded_cmd_t &cmd)
 {
   iwm_return_badcmd(cmd);
 }
 
-void virtualDevice::iwm_writeblock(iwm_decoded_cmd_t cmd)
+void virtualDevice::iwm_writeblock(const iwm_decoded_cmd_t &cmd)
 {
   iwm_return_badcmd(cmd);
 }
 
-void virtualDevice::iwm_format(iwm_decoded_cmd_t cmd)
+void virtualDevice::iwm_format(const iwm_decoded_cmd_t &cmd)
 {
   iwm_return_badcmd(cmd);
 }
 
-void virtualDevice::iwm_ctrl(iwm_decoded_cmd_t cmd)
+void virtualDevice::iwm_ctrl(const iwm_decoded_cmd_t &cmd)
 {
   iwm_return_badcmd(cmd);
 }
 
-void virtualDevice::iwm_open(iwm_decoded_cmd_t cmd)
+void virtualDevice::iwm_open(const iwm_decoded_cmd_t &cmd)
 {
   iwm_return_badcmd(cmd);
 }
 
-void virtualDevice::iwm_close(iwm_decoded_cmd_t cmd)
+void virtualDevice::iwm_close(const iwm_decoded_cmd_t &cmd)
 {
   iwm_return_badcmd(cmd);
 }
 
-void virtualDevice::iwm_read(iwm_decoded_cmd_t cmd)
+void virtualDevice::iwm_read(const iwm_decoded_cmd_t &cmd)
 {
   iwm_return_badcmd(cmd);
 }
 
-void virtualDevice::iwm_write(iwm_decoded_cmd_t cmd)
+void virtualDevice::iwm_write(const iwm_decoded_cmd_t &cmd)
 {
   iwm_return_badcmd(cmd);
 }
@@ -873,17 +863,18 @@ void systemBus::handle_init()
     pDevice->switched = false; //reset switched condition on init
     if (pDevice->id() == 0)
     {
-      pDevice->_devnum = command_packet.dest; // assign address
+      _activeDev = pDevice;
+      _activeDev->_devnum = command_packet.dest; // assign address
       if (++it == _daisyChain.end())
         err = SP_ERR::ENDOFCHAIN; // end of the line, so status=non zero - to do: check GPIO for another device in the physical daisy chain
       Debug_printf("\r\nSending INIT Response Packet...");
-      pDevice->send_init_reply_packet(command_packet.dest, err);
+      send_init_reply_packet(command_packet.dest, err);
 
-      // smartport.iwm_send_packet_spi((uint8_t *)pDevice->packet_buffer); // timeout error return is not handled here (yet?)
+      // smartport.iwm_send_packet_spi((uint8_t *)_activeDev->packet_buffer); // timeout error return is not handled here (yet?)
 
       // print_packet ((uint8_t*) packet_buffer,get_packet_length());
 
-      Debug_printf("\r\nDrive: %02x\r\n", pDevice->id());
+      Debug_printf("\r\nDrive: %02x\r\n", _activeDev->id());
       fnLedManager.set(LED_BUS, false);
       return;
     }

--- a/lib/bus/iwm/iwm.h
+++ b/lib/bus/iwm/iwm.h
@@ -244,26 +244,20 @@ protected:
   uint8_t _devnum; // assigned by Apple II during INIT
   bool _initialized;
 
-  void send_init_reply_packet(uint8_t source, spError_t err);
-  void send_reply_packet(spError_t err);
-
   virtual void shutdown() = 0;
 
   // FIXME - these are all bus commands and belong in systemBus
-  virtual void iwm_status(iwm_decoded_cmd_t cmd);
-  virtual void iwm_readblock(iwm_decoded_cmd_t cmd);
-  virtual void iwm_writeblock(iwm_decoded_cmd_t cmd);
-  virtual void iwm_format(iwm_decoded_cmd_t cmd);
-  virtual void iwm_ctrl(iwm_decoded_cmd_t cmd);
-  virtual void iwm_open(iwm_decoded_cmd_t cmd);
-  virtual void iwm_close(iwm_decoded_cmd_t cmd);
-  virtual void iwm_read(iwm_decoded_cmd_t cmd);
-  virtual void iwm_write(iwm_decoded_cmd_t cmd);
+  virtual void iwm_status(const iwm_decoded_cmd_t &cmd);
+  virtual void iwm_readblock(const iwm_decoded_cmd_t &cmd);
+  virtual void iwm_writeblock(const iwm_decoded_cmd_t &cmd);
+  virtual void iwm_format(const iwm_decoded_cmd_t &cmd);
+  virtual void iwm_ctrl(const iwm_decoded_cmd_t &cmd);
+  virtual void iwm_open(const iwm_decoded_cmd_t &cmd);
+  virtual void iwm_close(const iwm_decoded_cmd_t &cmd);
+  virtual void iwm_read(const iwm_decoded_cmd_t &cmd);
+  virtual void iwm_write(const iwm_decoded_cmd_t &cmd);
 
-  void iwm_return_badcmd(iwm_decoded_cmd_t cmd);
-  void iwm_return_device_offline(iwm_decoded_cmd_t cmd);
-  void iwm_return_ioerror();
-  void iwm_return_noerror();
+  void iwm_return_badcmd(const iwm_decoded_cmd_t &cmd);
 
   // iwm packet handling
   static uint8_t data_buffer[MAX_DATA_LEN]; // un-encoded binary data (512 bytes for a block)
@@ -290,6 +284,7 @@ class systemBus : public SystemBusBase
 {
 private:
   virtualDevice *_activeDev = nullptr;
+  ByteBuffer _transaction_response;
 
   iwmPrinter *_printerdev = nullptr;
 
@@ -320,8 +315,10 @@ private:
   bool iwm_req_assert_timeout(int t) { return smartport.req_wait_for_rising_timeout(t); };
 
   iwm_decoded_cmd_t command;
-  void iwm_process(iwm_decoded_cmd_t cmd);
+  void iwm_process(const iwm_decoded_cmd_t &cmd);
+  error_is_true iwm_send_packet(uint8_t source, iwm_packet_type_t packet_type, spError_t err, const void* data, uint16_t num);
 
+  void send_init_reply_packet(uint8_t source, spError_t err);
   void send_status_reply_packet();
   void send_status_dib_reply_packet();
 
@@ -335,7 +332,6 @@ public:
 
   cmdPacket_t command_packet;
   bool iwm_decode_data_packet(uint8_t *a, int &n);
-  error_is_true iwm_send_packet(uint8_t source, iwm_packet_type_t packet_type, spError_t err, const void* data, uint16_t num);
 
   // these things stay for the most part
   void setup();
@@ -349,7 +345,8 @@ public:
 
   void transaction_accept(transState_t expectMoreData) override;
   void transaction_success() override;
-  void transaction_error() override;
+  void transaction_error(spError_t err);
+  void transaction_error() override { transaction_error(SP_ERR::IOERROR); }
   success_is_true transaction_get(void *data, size_t len) override;
   using SystemBusBase::transaction_send;
   void transaction_send(const void *data, size_t len, bool is_error=false) override;

--- a/lib/device/iwm/clock.cpp
+++ b/lib/device/iwm/clock.cpp
@@ -52,31 +52,27 @@ void iwmClock::set_alternate_tz()
     SYSTEM_BUS.transaction_success();
 }
 
-void iwmClock::iwm_ctrl(iwm_decoded_cmd_t cmd)
+void iwmClock::iwm_ctrl(const iwm_decoded_cmd_t &cmd)
 {
 #ifdef DEBUG
     Debug_printf("[CLOCK] Device %02x Control Code %02x('%c')\r\n", id(), cmd.control_status.fuji.command, isprint(cmd.control_status.fuji.command) ? (char) cmd.control_status.fuji.command : '.');
 #endif
 
-    spError_t err_result = SP_ERR::NOERROR;
-
     switch (cmd.control_status.fuji.command)
     {
-        case APETIMECMD_SETTZ_ALT2:
-            set_tz();
-            break;
-        case APETIMECMD_SETTZ_ALT:
-            set_alternate_tz();
-            break;
-        default:
-            err_result = SP_ERR::BADCTL;
-            break;
+    case APETIMECMD_SETTZ_ALT2:
+        set_tz();
+        break;
+    case APETIMECMD_SETTZ_ALT:
+        set_alternate_tz();
+        break;
+    default:
+        SYSTEM_BUS.transaction_error(SP_ERR::BADCTL);
+        break;
     }
-
-    send_reply_packet(err_result);
 }
 
-void iwmClock::iwm_status(iwm_decoded_cmd_t cmd)
+void iwmClock::iwm_status(const iwm_decoded_cmd_t &cmd)
 {
     bool use_alternate_tz = false;
 
@@ -154,24 +150,21 @@ void iwmClock::iwm_status(iwm_decoded_cmd_t cmd)
         break;
     }
     default:
-        send_reply_packet(SP_ERR::BADCTL);
+        SYSTEM_BUS.transaction_error(SP_ERR::BADCTL);
         return;
     }
-
-    // If we got here, we have data to send
-    SYSTEM_BUS.iwm_send_packet(id(), iwm_packet_type_t::data, SP_ERR::NOERROR, data_buffer, data_len);
 }
 
-void iwmClock::iwm_open(iwm_decoded_cmd_t cmd)
+void iwmClock::iwm_open(const iwm_decoded_cmd_t &cmd)
 {
     Debug_printf("\r\nClock: Open\n");
-    send_reply_packet(SP_ERR::NOERROR);
+    SYSTEM_BUS.transaction_error(SP_ERR::NOERROR);
 }
 
-void iwmClock::iwm_close(iwm_decoded_cmd_t cmd)
+void iwmClock::iwm_close(const iwm_decoded_cmd_t &cmd)
 {
     Debug_printf("\r\nClock: Close\n");
-    send_reply_packet(SP_ERR::NOERROR);
+    SYSTEM_BUS.transaction_error(SP_ERR::NOERROR);
 }
 
 void iwmClock::shutdown()

--- a/lib/device/iwm/clock.h
+++ b/lib/device/iwm/clock.h
@@ -13,10 +13,10 @@ private:
 public:
     iwmClock();
 
-    void iwm_ctrl(iwm_decoded_cmd_t cmd) override;
-    void iwm_status(iwm_decoded_cmd_t cmd) override;
-    void iwm_open(iwm_decoded_cmd_t cmd) override;
-    void iwm_close(iwm_decoded_cmd_t cmd) override;
+    void iwm_ctrl(const iwm_decoded_cmd_t &cmd) override;
+    void iwm_status(const iwm_decoded_cmd_t &cmd) override;
+    void iwm_open(const iwm_decoded_cmd_t &cmd) override;
+    void iwm_close(const iwm_decoded_cmd_t &cmd) override;
 
     void shutdown() override;
     iwm_device_info_block_t create_dib_reply_packet() override;

--- a/lib/device/iwm/cpm.cpp
+++ b/lib/device/iwm/cpm.cpp
@@ -82,7 +82,7 @@ void iwmCPM::sio_status()
     return;
 }
 
-void iwmCPM::iwm_open(iwm_decoded_cmd_t cmd)
+void iwmCPM::iwm_open(const iwm_decoded_cmd_t &cmd)
 {
     spError_t err_result = SP_ERR::NOERROR;
 
@@ -103,16 +103,16 @@ void iwmCPM::iwm_open(iwm_decoded_cmd_t cmd)
     }
 #endif
 
-    send_reply_packet(err_result);
+    SYSTEM_BUS.transaction_error(err_result);
 }
 
-void iwmCPM::iwm_close(iwm_decoded_cmd_t cmd)
+void iwmCPM::iwm_close(const iwm_decoded_cmd_t &cmd)
 {
     Debug_printf("\r\nCP/M: Close\n");
-    send_reply_packet(SP_ERR::NOERROR);
+    SYSTEM_BUS.transaction_error(SP_ERR::NOERROR);
 }
 
-void iwmCPM::iwm_status(iwm_decoded_cmd_t cmd)
+void iwmCPM::iwm_status(const iwm_decoded_cmd_t &cmd)
 {
     Debug_printf("\r\n[CPM] Device %02x Status Code %02x\r\n", id(), cmd.control_status.fuji.command);
 
@@ -143,14 +143,14 @@ void iwmCPM::iwm_status(iwm_decoded_cmd_t cmd)
         }
         break;
     default:
-        send_reply_packet(SP_ERR::BADCMD);
+        SYSTEM_BUS.transaction_error(SP_ERR::BADCMD);
         return;
     }
 
     Debug_printf("\r\nStatus code complete, sending response");
 }
 
-void iwmCPM::iwm_read(iwm_decoded_cmd_t cmd)
+void iwmCPM::iwm_read(const iwm_decoded_cmd_t &cmd)
 {
 #ifdef ESP_PLATFORM // OS
     unsigned short mw = uxQueueMessagesWaiting(rxq);
@@ -176,10 +176,11 @@ void iwmCPM::iwm_read(iwm_decoded_cmd_t cmd)
     }
 
     Debug_printf("\r\nsending CPM read data packet ...");
-    SYSTEM_BUS.iwm_send_packet(id(), iwm_packet_type_t::data, SP_ERR::NOERROR, buffer.data(), buffer.size());
+    SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
+    SYSTEM_BUS.transaction_send(buffer);
 }
 
-void iwmCPM::iwm_write(iwm_decoded_cmd_t cmd)
+void iwmCPM::iwm_write(const iwm_decoded_cmd_t &cmd)
 {
     Debug_printf("\nWRITE %u bytes\n", cmd.char_rw.length);
 
@@ -191,10 +192,10 @@ void iwmCPM::iwm_write(iwm_decoded_cmd_t cmd)
 #endif
     }
 
-    send_reply_packet(SP_ERR::NOERROR);
+    SYSTEM_BUS.transaction_error(SP_ERR::NOERROR);
 }
 
-void iwmCPM::iwm_ctrl(iwm_decoded_cmd_t cmd)
+void iwmCPM::iwm_ctrl(const iwm_decoded_cmd_t &cmd)
 {
     spError_t err_result = SP_ERR::NOERROR;
 
@@ -228,13 +229,13 @@ void iwmCPM::iwm_ctrl(iwm_decoded_cmd_t cmd)
             }
             break;
         default:
-            send_reply_packet(SP_ERR::BADCMD);
+            SYSTEM_BUS.transaction_error(SP_ERR::BADCMD);
             return;
         }
     else
         err_result = SP_ERR::IOERROR;
 
-    send_reply_packet(err_result);
+    SYSTEM_BUS.transaction_error(err_result);
 }
 
 void iwmCPM::shutdown()

--- a/lib/device/iwm/cpm.h
+++ b/lib/device/iwm/cpm.h
@@ -24,12 +24,12 @@ private:
 public:
     iwmCPM();
 
-    void iwm_ctrl(iwm_decoded_cmd_t cmd) override;
-    void iwm_open(iwm_decoded_cmd_t cmd) override;
-    void iwm_close(iwm_decoded_cmd_t cmd) override;
-    void iwm_read(iwm_decoded_cmd_t cmd) override;
-    void iwm_write(iwm_decoded_cmd_t cmd) override;
-    void iwm_status(iwm_decoded_cmd_t cmd) override;
+    void iwm_ctrl(const iwm_decoded_cmd_t &cmd) override;
+    void iwm_open(const iwm_decoded_cmd_t &cmd) override;
+    void iwm_close(const iwm_decoded_cmd_t &cmd) override;
+    void iwm_read(const iwm_decoded_cmd_t &cmd) override;
+    void iwm_write(const iwm_decoded_cmd_t &cmd) override;
+    void iwm_status(const iwm_decoded_cmd_t &cmd) override;
 
     void shutdown() override;
     iwm_device_info_block_t create_dib_reply_packet() override;

--- a/lib/device/iwm/disk.cpp
+++ b/lib/device/iwm/disk.cpp
@@ -114,9 +114,8 @@ iwm_device_info_block_t iwmDisk::create_dib_reply_packet()
   return dib;
 }
 
-void iwmDisk::iwm_ctrl(iwm_decoded_cmd_t cmd)
+void iwmDisk::iwm_ctrl(const iwm_decoded_cmd_t &cmd)
 {
-  err_result = SP_ERR::NOERROR;
   Debug_printf("\nDisk Device %02x Control Code %02x", id(), cmd.control_status.fuji.command);
   Debug_printf("\nDecoding Control Data Packet:");
   print_packet(data_buffer, data_len);
@@ -130,13 +129,12 @@ void iwmDisk::iwm_ctrl(iwm_decoded_cmd_t cmd)
     platformFuji.handle_ctl_eject(_devnum);
     break;
   default:
-    err_result = SP_ERR::BADCTL;
+    SYSTEM_BUS.transaction_error(SP_ERR::BADCTL);
     break;
   }
-  send_reply_packet(err_result);
 }
 
-void iwmDisk::iwm_readblock(iwm_decoded_cmd_t cmd)
+void iwmDisk::iwm_readblock(const iwm_decoded_cmd_t &cmd)
 {
   uint16_t sdstato;
 
@@ -146,17 +144,17 @@ void iwmDisk::iwm_readblock(iwm_decoded_cmd_t cmd)
   if (!(_disk != nullptr))
   {
     Debug_printf(" - ERROR - No image mounted");
-    send_reply_packet(SP_ERR::OFFLINE);
+    SYSTEM_BUS.transaction_error(SP_ERR::OFFLINE);
     return;
   }
   if((!device_active)) {
     Debug_printf("iwm_readblock while device offline!\r\n");
-    send_reply_packet(SP_ERR::OFFLINE);
+    SYSTEM_BUS.transaction_error(SP_ERR::OFFLINE);
     return;
   }
   if((switched) && (cmd.block_rw.num > 2)){
     Debug_printf("iwm_readblock() returning disk switched error\r\n");
-    send_reply_packet(SP_ERR::OFFLINE);
+    SYSTEM_BUS.transaction_error(SP_ERR::OFFLINE);
     switched = false;
     return;
   }
@@ -168,20 +166,18 @@ void iwmDisk::iwm_readblock(iwm_decoded_cmd_t cmd)
   if (_disk->read(cmd.block_rw.num, &sdstato, buffer.data()))
   {
     Debug_printf("\r\nFile Seek or Read err: %d bytes", sdstato);
-    send_reply_packet(SP_ERR::IOERROR);
+    SYSTEM_BUS.transaction_error(SP_ERR::IOERROR);
     return; // todo - true or false?
   }
 
   // send_data_packet();
   Debug_printf("\r\nsending block packet ...");
-  if (SYSTEM_BUS.iwm_send_packet(id(), iwm_packet_type_t::data, SP_ERR::NOERROR, buffer.data(), BLOCK_DATA_LEN))
-    ((MediaTypePO*)_disk)->reset_seek_opto();  // force seek next time if send error
+  SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
+  SYSTEM_BUS.transaction_send(buffer);
 }
 
-void iwmDisk::iwm_writeblock(iwm_decoded_cmd_t cmd)
+void iwmDisk::iwm_writeblock(const iwm_decoded_cmd_t &cmd)
 {
-  spError_t err = SP_ERR::NOERROR;
-
   Debug_printf("\r\nDrive %02x ", id());
   Debug_printf("Write block %06lx", cmd.block_rw.num);
   // partition number indicates which 32mb block we access
@@ -189,24 +185,24 @@ void iwmDisk::iwm_writeblock(iwm_decoded_cmd_t cmd)
 
   if((!device_active)) {
     Debug_printf("iwm_writeblock while device offline!\r\n");
-    send_reply_packet(SP_ERR::OFFLINE);
+    SYSTEM_BUS.transaction_error(SP_ERR::OFFLINE);
     return;
   }
   if(switched && readonly) {
     Debug_printf("iwm_writeblock while readonly and disk switched\r\n");
-    send_reply_packet(SP_ERR::NOWRITE);
+    SYSTEM_BUS.transaction_error(SP_ERR::NOWRITE);
     switched = false;
     return;
   }
   if(switched) {
     Debug_printf("iwm_writeblock while disk switched = true\r\nn");
-    send_reply_packet(SP_ERR::OFFLINE);
+    SYSTEM_BUS.transaction_error(SP_ERR::OFFLINE);
     switched = false;
     return;
   }
   if(readonly) {
     Debug_printf("\r\niwm_writeblock tried to write while readonly = true!");
-    send_reply_packet(SP_ERR::NOWRITE);
+    SYSTEM_BUS.transaction_error(SP_ERR::NOWRITE);
     return;
   }
 
@@ -220,20 +216,19 @@ void iwmDisk::iwm_writeblock(iwm_decoded_cmd_t cmd)
   {
     Debug_printf("\r\nFile Write err: %d bytes", sdstato);
     if (sdstato == 0)
-      err = SP_ERR::NOWRITE; // write protected todo: we should probably have a read-only flag that gets set and tested up top
+      SYSTEM_BUS.transaction_error(SP_ERR::NOWRITE); // write protected todo: we should probably have a read-only flag that gets set and tested up top
     else
-      err = SP_ERR::IOERROR; // 6;
-    //return;
+      SYSTEM_BUS.transaction_error(SP_ERR::IOERROR);
+    return;
   }
 
   SYSTEM_BUS.transaction_success();
-  //now return status code to host
-  send_reply_packet(err);
 }
 
-void iwmDisk::iwm_format(iwm_decoded_cmd_t cmd)
+void iwmDisk::iwm_format(const iwm_decoded_cmd_t &cmd)
 {
-    iwm_return_noerror();
+  SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
+  SYSTEM_BUS.transaction_success();
 }
 
 void iwmDisk::shutdown()

--- a/lib/device/iwm/disk.h
+++ b/lib/device/iwm/disk.h
@@ -9,7 +9,6 @@
 class iwmDisk : public virtualDevice
 {
 private:
-    spError_t err_result = SP_ERR::NOERROR;
     void prodos_encode_datetime(unsigned short *date_out, unsigned short *time_out);
     int prodos_write_block(fnFile *f, const unsigned char *buf);
     error_is_true prodos_write_boot_block(fnFile *f);
@@ -24,10 +23,10 @@ protected:
 
     MediaType *_disk = nullptr;
 
-    void iwm_ctrl(iwm_decoded_cmd_t cmd) override;
-    void iwm_readblock(iwm_decoded_cmd_t cmd) override;
-    void iwm_writeblock(iwm_decoded_cmd_t cmd) override;
-    void iwm_format(iwm_decoded_cmd_t cmd) override;
+    void iwm_ctrl(const iwm_decoded_cmd_t &cmd) override;
+    void iwm_readblock(const iwm_decoded_cmd_t &cmd) override;
+    void iwm_writeblock(const iwm_decoded_cmd_t &cmd) override;
+    void iwm_format(const iwm_decoded_cmd_t &cmd) override;
 
     void shutdown() override; //todo change back
 

--- a/lib/device/iwm/iwmFuji.cpp
+++ b/lib/device/iwm/iwmFuji.cpp
@@ -68,24 +68,26 @@ iwmFuji::iwmFuji() : fujiDevice(MAX_A2DISK_DEVICES, IMAGE_EXTENSION, LOBBY_URL)
         { FUJICMD_WRITE_HOST_SLOTS, [this]()           { this->fujicmd_write_host_slots(); }},         // 0xF3
 
         { FUJICMD_RESET,  [this]()                     {
-             this->send_reply_packet(err_result);
              this->fujicmd_reset();
          }},   // 0xFF
         { SP_CTRL_RESET, [this]()                     {
-             this->send_reply_packet(err_result);
              this->fujicmd_reset();
          }},   // 0x00
 #ifdef DEV_RELAY_SLIP
-        { SP_CTRL_CLEAR_DISKII_SEEN, [this]()              { err_result = SP_ERR::NODRIVE; }},
+        { SP_CTRL_CLEAR_DISKII_SEEN, [this]()              { SYSTEM_BUS.transaction_error(SP_ERR::NODRIVE); }},
 #else
-        { SP_CTRL_CLEAR_DISKII_SEEN, [this]()              { diskii_xface.d2_enable_seen = 0; err_result = SP_ERR::NOERROR; }},
+        { SP_CTRL_CLEAR_DISKII_SEEN, [this]()              { diskii_xface.d2_enable_seen = 0; SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET); SYSTEM_BUS.transaction_success(); }},
 #endif
 
-        { FUJICMD_MOUNT_ALL, [&]()                     {
-             err_result = fujicmd_mount_all_success() ? SP_ERR::NOERROR : SP_ERR::IOERROR;
-         }},          // 0xD7
-        { FUJICMD_MOUNT_IMAGE, [&]()                   { err_result = fujicmd_mount_disk_image_success(data_buffer[0], (disk_access_flags_t) data_buffer[1]) ? SP_ERR::NOERROR : SP_ERR::NODRIVE; }},  // 0xF8
-        { FUJICMD_OPEN_DIRECTORY, [&]()                { err_result = fujicore_open_directory_success(data_buffer[0], std::string((char *) &data_buffer[1], data_len - 1)) ? SP_ERR::NOERROR : SP_ERR::IOERROR; }}     // 0xF7
+        { FUJICMD_MOUNT_ALL, [&]()                     { fujicmd_mount_all_success(); }},          // 0xD7
+        { FUJICMD_MOUNT_IMAGE, [&]()                   { fujicmd_mount_disk_image_success(data_buffer[0], (disk_access_flags_t) data_buffer[1]); }},  // 0xF8
+        { FUJICMD_OPEN_DIRECTORY, [&]()                {
+            SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
+            if (fujicore_open_directory_success(data_buffer[0], std::string((char *) &data_buffer[1], data_len - 1)).is_error())
+                SYSTEM_BUS.transaction_error(SP_ERR::IOERROR);
+            else
+                SYSTEM_BUS.transaction_success();
+        }}     // 0xF7
     };
 
     status_handlers = {
@@ -317,11 +319,11 @@ void iwmFuji::send_stat_get_enable()
     transaction_put(1);
 }
 
-void iwmFuji::iwm_open(iwm_decoded_cmd_t cmd) {}
-void iwmFuji::iwm_close(iwm_decoded_cmd_t cmd) {}
-void iwmFuji::iwm_read(iwm_decoded_cmd_t cmd) {}
+void iwmFuji::iwm_open(const iwm_decoded_cmd_t &cmd) {}
+void iwmFuji::iwm_close(const iwm_decoded_cmd_t &cmd) {}
+void iwmFuji::iwm_read(const iwm_decoded_cmd_t &cmd) {}
 
-void iwmFuji::iwm_status(iwm_decoded_cmd_t cmd)
+void iwmFuji::iwm_status(const iwm_decoded_cmd_t &cmd)
 {
     active_fuji_command = cmd.control_status.fuji.command;
 
@@ -332,18 +334,13 @@ void iwmFuji::iwm_status(iwm_decoded_cmd_t cmd)
         it->second();
     } else {
         Debug_printf("ERROR: Unhandled status code: %02X\n", active_fuji_command);
-        data_len = 0;
+        transaction_error();
     }
-
-    Debug_printf("\nStatus code complete, sending response");
-    SYSTEM_BUS.iwm_send_packet(id(), iwm_packet_type_t::data, SP_ERR::NOERROR, data_buffer, data_len);
 }
 
-void iwmFuji::iwm_ctrl(iwm_decoded_cmd_t cmd)
+void iwmFuji::iwm_ctrl(const iwm_decoded_cmd_t &cmd)
 {
     Debug_printf("\ntheFuji Device %02x Control Code %02x", id(), cmd.control_status.fuji.command);
-
-    err_result = SP_ERR::NOERROR;
 
     Debug_printf("\nDecoding Control Data Packet for code: 0x%02x\r\n", cmd.control_status.fuji.command);
 
@@ -352,10 +349,8 @@ void iwmFuji::iwm_ctrl(iwm_decoded_cmd_t cmd)
         it->second();
     } else {
         Debug_printf("ERROR: Unhandled control code: %02X\n", cmd.control_status.fuji.command);
-        err_result = SP_ERR::BADCTL;
+        SYSTEM_BUS.transaction_error(SP_ERR::BADCTL);
     }
-
-    send_reply_packet(err_result);
 }
 
 void iwmFuji::handle_ctl_eject(uint8_t spid)

--- a/lib/device/iwm/iwmFuji.h
+++ b/lib/device/iwm/iwmFuji.h
@@ -85,17 +85,16 @@ protected:
     void iwm_ctrl_qrcode_output();                // 0xBF
     void iwm_stat_qrcode_output();                // 0xBF
 
-    void iwm_ctrl(iwm_decoded_cmd_t cmd) override;
-    void iwm_open(iwm_decoded_cmd_t cmd) override;
-    void iwm_close(iwm_decoded_cmd_t cmd) override;
-    void iwm_read(iwm_decoded_cmd_t cmd) override;
-    void iwm_status(iwm_decoded_cmd_t cmd) override;
+    void iwm_ctrl(const iwm_decoded_cmd_t &cmd) override;
+    void iwm_open(const iwm_decoded_cmd_t &cmd) override;
+    void iwm_close(const iwm_decoded_cmd_t &cmd) override;
+    void iwm_read(const iwm_decoded_cmd_t &cmd) override;
+    void iwm_status(const iwm_decoded_cmd_t &cmd) override;
 
     iwm_device_info_block_t create_dib_reply_packet() override;
     iwm_device_status_block_t create_status_reply_packet() override;
 
 public:
-    spError_t err_result = SP_ERR::NOERROR;
     fujiCommandID_t active_fuji_command;
 
     iwmFuji();
@@ -113,8 +112,8 @@ public:
 
     // Being used by iwm/disk.cpp
     void handle_ctl_eject(uint8_t spid);
-    void FujiStatus(iwm_decoded_cmd_t cmd) { iwm_status(cmd); }
-    void FujiControl(iwm_decoded_cmd_t cmd) { iwm_ctrl(cmd); }
+    void FujiStatus(const iwm_decoded_cmd_t &cmd) { iwm_status(cmd); }
+    void FujiControl(const iwm_decoded_cmd_t &cmd) { iwm_ctrl(cmd); }
 
     // ============ Wrapped Fuji commands ============
     void fujicmd_close_directory() override;

--- a/lib/device/iwm/modem.cpp
+++ b/lib/device/iwm/modem.cpp
@@ -1370,13 +1370,13 @@ iwm_device_info_block_t iwmModem::create_dib_reply_packet()
   return dib;
 }
 
-void iwmModem::iwm_open(iwm_decoded_cmd_t cmd)
+void iwmModem::iwm_open(const iwm_decoded_cmd_t &cmd)
 {
     Debug_printf("\nModem: Open\n");
-    send_reply_packet(SP_ERR::NOERROR);
+    SYSTEM_BUS.transaction_error(SP_ERR::NOERROR);
 }
 
-void iwmModem::iwm_close(iwm_decoded_cmd_t cmd)
+void iwmModem::iwm_close(const iwm_decoded_cmd_t &cmd)
 {
     Debug_printf("\nModem: Close\n");
     
@@ -1386,10 +1386,10 @@ void iwmModem::iwm_close(iwm_decoded_cmd_t cmd)
         tcpClient.stop();
     }
     
-    send_reply_packet(SP_ERR::NOERROR);
+    SYSTEM_BUS.transaction_error(SP_ERR::NOERROR);
 }
 
-void iwmModem::iwm_read(iwm_decoded_cmd_t cmd)
+void iwmModem::iwm_read(const iwm_decoded_cmd_t &cmd)
 {
 #ifdef ESP_PLATFORM // OS
     unsigned short mw = uxQueueMessagesWaiting(mrxq);
@@ -1415,10 +1415,11 @@ void iwmModem::iwm_read(iwm_decoded_cmd_t cmd)
     }
 
     Debug_printf("\r\nsending Modem read data packet ...");
-    SYSTEM_BUS.iwm_send_packet(id(), iwm_packet_type_t::data, SP_ERR::NOERROR, buffer.data(), buffer.size());
+    SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
+    SYSTEM_BUS.transaction_send(buffer);
 }
 
-void iwmModem::iwm_write(iwm_decoded_cmd_t cmd)
+void iwmModem::iwm_write(const iwm_decoded_cmd_t &cmd)
 {
     Debug_printf("\nWRITE %u bytes\n", cmd.char_rw.length);
 
@@ -1433,10 +1434,10 @@ void iwmModem::iwm_write(iwm_decoded_cmd_t cmd)
 #endif
     }
 
-    send_reply_packet(SP_ERR::NOERROR);
+    SYSTEM_BUS.transaction_error(SP_ERR::NOERROR);
 }
 
-void iwmModem::iwm_ctrl(iwm_decoded_cmd_t cmd)
+void iwmModem::iwm_ctrl(const iwm_decoded_cmd_t &cmd)
 {
     spError_t err_result = SP_ERR::NOERROR;
 
@@ -1444,7 +1445,7 @@ void iwmModem::iwm_ctrl(iwm_decoded_cmd_t cmd)
     print_packet(data_buffer,data_len);
 
     Debug_printf("\nSending Control Reply");
-    send_reply_packet(err_result);
+    SYSTEM_BUS.transaction_error(err_result);
 }
 
 void iwmModem::iwm_modem_status()
@@ -1460,7 +1461,7 @@ void iwmModem::iwm_modem_status()
     Debug_printf("--- %u bytes waiting\n", mw);
 }
 
-void iwmModem::iwm_status(iwm_decoded_cmd_t cmd)
+void iwmModem::iwm_status(const iwm_decoded_cmd_t &cmd)
 {
     Debug_printf("\r\n[MODEM] Device %02x Status Code %02x\r\n", id(), cmd.control_status.fuji.command);
     // Debug_printf("\r\nStatus List is at %02x %02x\n", cmd.g7byte1 & 0x7f, cmd.g7byte2 & 0x7f);
@@ -1471,12 +1472,9 @@ void iwmModem::iwm_status(iwm_decoded_cmd_t cmd)
         iwm_modem_status();
         break;
     default:
-        send_reply_packet(SP_ERR::BADCMD);
+        SYSTEM_BUS.transaction_error(SP_ERR::BADCMD);
         return;
     }
-
-    Debug_printf("\r\nStatus code complete, sending response");
-    SYSTEM_BUS.iwm_send_packet(id(), iwm_packet_type_t::data, SP_ERR::NOERROR, data_buffer, data_len);
 }
 
 #endif /* BUILD_APPLE */

--- a/lib/device/iwm/modem.h
+++ b/lib/device/iwm/modem.h
@@ -191,12 +191,12 @@ private:
 
     void shutdown() override;
 
-    void iwm_ctrl(iwm_decoded_cmd_t cmd) override;
-    void iwm_open(iwm_decoded_cmd_t cmd) override;
-    void iwm_close(iwm_decoded_cmd_t cmd) override;
-    void iwm_read(iwm_decoded_cmd_t cmd) override;
-    void iwm_write(iwm_decoded_cmd_t cmd) override;
-    void iwm_status(iwm_decoded_cmd_t cmd) override;
+    void iwm_ctrl(const iwm_decoded_cmd_t &cmd) override;
+    void iwm_open(const iwm_decoded_cmd_t &cmd) override;
+    void iwm_close(const iwm_decoded_cmd_t &cmd) override;
+    void iwm_read(const iwm_decoded_cmd_t &cmd) override;
+    void iwm_write(const iwm_decoded_cmd_t &cmd) override;
+    void iwm_status(const iwm_decoded_cmd_t &cmd) override;
 
     void iwm_modem_status();
 

--- a/lib/device/iwm/network.cpp
+++ b/lib/device/iwm/network.cpp
@@ -99,7 +99,6 @@ void iwmNetwork::open()
         current_network_data.urlParser.reset();
     }
 
-    err = SP_ERR::NOERROR;
     current_network_data.open_error = NDEV_STATUS::SUCCESS;
 
     Debug_printf("\nopen()\n");
@@ -143,7 +142,6 @@ void iwmNetwork::open()
 void iwmNetwork::close()
 {
     Debug_printf("iwmNetwork::close()\n");
-    err = SP_ERR::NOERROR;
     if (network_data_map.find(current_network_unit) == network_data_map.end()) {
         Debug_printf("No network_data for unit: %d, exiting close\r\n", current_network_unit);
         return;
@@ -288,7 +286,7 @@ void iwmNetwork::channel_mode()
     SYSTEM_BUS.transaction_success();
 }
 
-void iwmNetwork::json_query(iwm_decoded_cmd_t cmd)
+void iwmNetwork::json_query(const iwm_decoded_cmd_t &cmd)
 {
     auto& current_network_data = network_data_map[current_network_unit];
     std::string buffer(data_len, 0);
@@ -304,22 +302,20 @@ void iwmNetwork::json_parse()
 {
     auto& current_network_data = network_data_map[current_network_unit];
     current_network_data.json->parse();
-#ifdef UNUSED
     SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
     SYSTEM_BUS.transaction_success();
-#endif /* UNUSED */
 }
 
-void iwmNetwork::iwm_open(iwm_decoded_cmd_t cmd)
+void iwmNetwork::iwm_open(const iwm_decoded_cmd_t &cmd)
 {
     // nothing in fujinet-lib calls this, it does a control with open command. This is used only by the Apple/// as it has no fn-lib support yet
-    send_reply_packet(SP_ERR::NOERROR);
+    SYSTEM_BUS.transaction_error(SP_ERR::NOERROR);
 }
 
-void iwmNetwork::iwm_close(iwm_decoded_cmd_t cmd)
+void iwmNetwork::iwm_close(const iwm_decoded_cmd_t &cmd)
 {
     // nothing in fujinet-lib calls this, it does a control with close command. This is used only by the Apple/// as it has no fn-lib support yet
-    send_reply_packet(SP_ERR::NOERROR);
+    SYSTEM_BUS.transaction_error(SP_ERR::NOERROR);
     close();
 }
 
@@ -335,7 +331,6 @@ void iwmNetwork::status()
     case CHANNEL_MODE::PROTOCOL:
         if (!current_network_data.protocol) {
             Debug_printf("ERROR: Calling status on a null protocol.\r\n");
-            err = SP_ERR::BADCMD;
             s.connected = 0;
             // A failed OPEN destroyed the protocol; report the remembered
             // open error (e.g. FILE_NOT_FOUND) rather than a generic code.
@@ -343,13 +338,12 @@ void iwmNetwork::status()
                         ? current_network_data.open_error
                         : NDEV_STATUS::INVALID_COMMAND;
         } else {
-            err = current_network_data.protocol->status(&s) == FUJI_ERROR::NONE
-                ? SP_ERR::NOERROR : SP_ERR::BADCMD;
+            current_network_data.protocol->status(&s);
             avail = current_network_data.protocol->available();
         }
         break;
     case CHANNEL_MODE::JSON:
-        err = (current_network_data.json->status(&s) == false) ? SP_ERR::NOERROR : SP_ERR::IOERROR;
+        current_network_data.json->status(&s);
         avail = current_network_data.json->available();
         break;
     }
@@ -364,7 +358,7 @@ void iwmNetwork::status()
     SYSTEM_BUS.transaction_send(&status, sizeof(status));
 }
 
-void iwmNetwork::iwm_status(iwm_decoded_cmd_t cmd)
+void iwmNetwork::iwm_status(const iwm_decoded_cmd_t &cmd)
 {
     // TODO: remove this in the future when we decide to drop support of the deprecated fujinet-lib (with unit-id support)
     // We have moved to a separate control command that sets the active channel for all subsequent commands
@@ -390,22 +384,20 @@ void iwmNetwork::iwm_status(iwm_decoded_cmd_t cmd)
         status();
         break;
     default:
-        send_reply_packet(SP_ERR::BADCMD);
+        SYSTEM_BUS.transaction_error(SP_ERR::BADCMD);
         return;
     }
-
-    Debug_printf("\r\nStatus code complete, sending response");
-    SYSTEM_BUS.iwm_send_packet(id(), iwm_packet_type_t::data, SP_ERR::NOERROR, data_buffer, data_len);
 }
 
 void iwmNetwork::net_read()
 {
 }
 
-error_is_true iwmNetwork::read_channel_json(unsigned short num_bytes, iwm_decoded_cmd_t cmd)
+error_is_true iwmNetwork::read_channel_json(const iwm_decoded_cmd_t &cmd)
 {
     auto& current_network_data = network_data_map[current_network_unit];
-    Debug_printf("read_channel_json - num_bytes: %02x, json_bytes_remaining: %02x\n", num_bytes, current_network_data.json->available());
+    Debug_printf("read_channel_json - num_bytes: %02x, json_bytes_remaining: %02x\n",
+                 cmd.char_rw.length, current_network_data.json->available());
     if (current_network_data.json->available() == 0) // if no bytes, we just return with no data
     {
         SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
@@ -413,15 +405,16 @@ error_is_true iwmNetwork::read_channel_json(unsigned short num_bytes, iwm_decode
         RETURN_ERROR_AS_TRUE();
     }
 
-    num_bytes = std::min<uint16_t>(num_bytes, current_network_data.json->readValueLen());
-    ByteBuffer buffer(num_bytes, 0);
+    auto rlen = std::min<uint16_t>(cmd.char_rw.length,
+                                   current_network_data.json->readValueLen());
+    ByteBuffer buffer(rlen, 0);
     current_network_data.json->readValue(buffer.data(), buffer.size());
     SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
     SYSTEM_BUS.transaction_send(buffer);
     RETURN_SUCCESS_AS_FALSE();
 }
 
-error_is_true iwmNetwork::read_channel(unsigned short num_bytes, iwm_decoded_cmd_t cmd)
+error_is_true iwmNetwork::read_channel(const iwm_decoded_cmd_t &cmd)
 {
     NetworkStatus ns;
     size_t avail;
@@ -432,7 +425,7 @@ error_is_true iwmNetwork::read_channel(unsigned short num_bytes, iwm_decoded_cmd
 
     avail = current_network_data.protocol->available();
     auto rlen = std::min<size_t>({
-            num_bytes, 512, current_network_data.protocol->available()});
+            cmd.char_rw.length, 512, current_network_data.protocol->available()});
 
     if (current_network_data.protocol->read(rlen) != FUJI_ERROR::NONE) // protocol adapter returned error
         RETURN_ERROR_AS_TRUE();
@@ -456,10 +449,8 @@ error_is_true iwmNetwork::write_channel(unsigned short num_bytes)
     RETURN_SUCCESS_AS_FALSE();
 }
 
-void iwmNetwork::iwm_read(iwm_decoded_cmd_t cmd)
+void iwmNetwork::iwm_read(const iwm_decoded_cmd_t &cmd)
 {
-    bool error = false;
-
     // TODO: remove this in the future when we decide to drop support of the deprecated fujinet-lib (with unit-id support)
     // We have moved to a separate control command that sets the active channel for all subsequent commands
     // fujinet-lib (with unit-id support) sends the count of bytes for a read as 5 to cater for the network unit.
@@ -476,21 +467,11 @@ void iwmNetwork::iwm_read(iwm_decoded_cmd_t cmd)
     switch (current_network_data.channelMode)
     {
     case CHANNEL_MODE::PROTOCOL:
-        error = read_channel(cmd.char_rw.length, cmd);
+        read_channel(cmd);
         break;
     case CHANNEL_MODE::JSON:
-        error = read_channel_json(cmd.char_rw.length, cmd);
+        read_channel_json(cmd);
         break;
-    }
-
-    if (error)
-    {
-        iwm_return_ioerror();
-    }
-    else
-    {
-        Debug_printf("\r\nsending Network read data packet (%04x bytes)...", data_len);
-        SYSTEM_BUS.iwm_send_packet(id(), iwm_packet_type_t::data, SP_ERR::NOERROR, data_buffer, data_len);
     }
 }
 
@@ -505,7 +486,7 @@ void iwmNetwork::net_write()
     write_channel(buffer.size());
 }
 
-void iwmNetwork::iwm_write(iwm_decoded_cmd_t cmd)
+void iwmNetwork::iwm_write(const iwm_decoded_cmd_t &cmd)
 {
     // TODO: remove this in the future when we decide to drop support of the deprecated fujinet-lib (with unit-id support)
     // We have moved to a separate control command that sets the active channel for all subsequent commands
@@ -527,16 +508,13 @@ void iwmNetwork::iwm_write(iwm_decoded_cmd_t cmd)
     if (write_channel(buffer.size()))
     {
         SYSTEM_BUS.transaction_error();
-        send_reply_packet(SP_ERR::IOERROR);
+        return;
     }
-    else
-    {
-        SYSTEM_BUS.transaction_success();
-        send_reply_packet(SP_ERR::NOERROR);
-    }
+
+    SYSTEM_BUS.transaction_success();
 }
 
-void iwmNetwork::iwm_ctrl(iwm_decoded_cmd_t cmd)
+void iwmNetwork::iwm_ctrl(const iwm_decoded_cmd_t &cmd)
 {
     spError_t err_result = SP_ERR::NOERROR;
 
@@ -626,14 +604,9 @@ void iwmNetwork::iwm_ctrl(iwm_decoded_cmd_t cmd)
         break;
 
     default:
-        err = SP_ERR::IOERROR;
+        SYSTEM_BUS.transaction_error(SP_ERR::IOERROR);
         break;
     }
-
-    if (err != SP_ERR::NOERROR)
-        err_result = SP_ERR::IOERROR;
-
-    send_reply_packet(err_result);
 }
 
 /**
@@ -686,7 +659,6 @@ error_is_true iwmNetwork::parse_and_instantiate_protocol(string d)
     if (!current_network_data.urlParser->isValidUrl())
     {
         Debug_printf("Invalid devicespec: %s\n", current_network_data.deviceSpec.c_str());
-        err = SP_ERR::BADCTLPARM;
         RETURN_ERROR_AS_TRUE();
     }
 
@@ -698,7 +670,6 @@ error_is_true iwmNetwork::parse_and_instantiate_protocol(string d)
     if (!instantiate_protocol())
     {
         Debug_printf("Could not open protocol. spec: >%s<, url: >%s<\n", current_network_data.deviceSpec.c_str(), current_network_data.urlParser->mRawUrl.c_str());
-        err = SP_ERR::BADCMD;
         RETURN_ERROR_AS_TRUE();
     }
 
@@ -732,7 +703,7 @@ void iwmNetwork::process_fs(fujiCommandID_t fuji_command)
     NetworkProtocolFS *fs = dynamic_cast<NetworkProtocolFS *>(current_network_data.protocol.get());
     if (!fs)
     {
-        err = SP_ERR::IOERROR;
+        SYSTEM_BUS.transaction_error(SP_ERR::IOERROR);
         return;
     }
 
@@ -765,7 +736,7 @@ void iwmNetwork::process_fs(fujiCommandID_t fuji_command)
 
     if (cmd_err != FUJI_ERROR::NONE)
     {
-        err = SP_ERR::IOERROR;
+        SYSTEM_BUS.transaction_error(SP_ERR::IOERROR);
         return;
     }
 
@@ -779,7 +750,7 @@ void iwmNetwork::process_tcp(fujiCommandID_t fuji_command)
     NetworkProtocolTCP *tcp = dynamic_cast<NetworkProtocolTCP *>(current_network_data.protocol.get());
     if (!tcp)
     {
-        err = SP_ERR::IOERROR;
+        SYSTEM_BUS.transaction_error(SP_ERR::IOERROR);
         return;
     }
 
@@ -798,7 +769,12 @@ void iwmNetwork::process_tcp(fujiCommandID_t fuji_command)
     }
 
     if (cmd_err != FUJI_ERROR::NONE)
-        err = SP_ERR::IOERROR;
+    {
+        SYSTEM_BUS.transaction_error(SP_ERR::IOERROR);
+        return;
+    }
+
+    SYSTEM_BUS.transaction_success();
 }
 
 void iwmNetwork::process_http(fujiCommandID_t fuji_command)
@@ -808,9 +784,11 @@ void iwmNetwork::process_http(fujiCommandID_t fuji_command)
     NetworkProtocolHTTP *http = dynamic_cast<NetworkProtocolHTTP *>(current_network_data.protocol.get());
     if (!http)
     {
-        err = SP_ERR::IOERROR;
+        SYSTEM_BUS.transaction_error(SP_ERR::IOERROR);
         return;
     }
+
+    SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
 
     fujiError_t cmd_err;
     switch (fuji_command)
@@ -824,7 +802,12 @@ void iwmNetwork::process_http(fujiCommandID_t fuji_command)
     }
 
     if (cmd_err != FUJI_ERROR::NONE)
-        err = SP_ERR::IOERROR;
+    {
+        SYSTEM_BUS.transaction_error(SP_ERR::IOERROR);
+        return;
+    }
+
+    SYSTEM_BUS.transaction_success();
 }
 
 void iwmNetwork::process_udp(fujiCommandID_t fuji_command)
@@ -834,7 +817,7 @@ void iwmNetwork::process_udp(fujiCommandID_t fuji_command)
     NetworkProtocolUDP *udp = dynamic_cast<NetworkProtocolUDP *>(current_network_data.protocol.get());
     if (!udp)
     {
-        err = SP_ERR::IOERROR;
+        SYSTEM_BUS.transaction_error(SP_ERR::IOERROR);
         return;
     }
 
@@ -847,8 +830,7 @@ void iwmNetwork::process_udp(fujiCommandID_t fuji_command)
             ByteBuffer buffer(SPECIAL_BUFFER_SIZE, 0);
             SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
             cmd_err = udp->get_remote(buffer.data(), buffer.size());
-            SYSTEM_BUS.iwm_send_packet(id(), iwm_packet_type_t::data, SP_ERR::NOERROR,
-                                       buffer.data(), buffer.size());
+            SYSTEM_BUS.transaction_send(buffer);
         }
         break;
 #endif /* ESP_PLATFORM */
@@ -859,13 +841,13 @@ void iwmNetwork::process_udp(fujiCommandID_t fuji_command)
             SYSTEM_BUS.transaction_get(buffer.data(), buffer.size());
             cmd_err = udp->set_destination(buffer.data(), buffer.size());
             if (cmd_err != FUJI_ERROR::NONE)
-                err = SP_ERR::IOERROR;
+                SYSTEM_BUS.transaction_error(SP_ERR::IOERROR);
             else
                 SYSTEM_BUS.transaction_success();
         }
         break;
     default:
-        err = SP_ERR::IOERROR;
+        SYSTEM_BUS.transaction_error(SP_ERR::BADCMD);
         break;
     }
 }

--- a/lib/device/iwm/network.h
+++ b/lib/device/iwm/network.h
@@ -101,12 +101,12 @@ public:
     void process_http(fujiCommandID_t fuji_command);
     void process_udp(fujiCommandID_t fuji_command);
 
-    void iwm_ctrl(iwm_decoded_cmd_t cmd) override;
-    void iwm_open(iwm_decoded_cmd_t cmd) override;
-    void iwm_close(iwm_decoded_cmd_t cmd) override;
-    void iwm_read(iwm_decoded_cmd_t cmd) override;
-    void iwm_write(iwm_decoded_cmd_t cmd) override;
-    void iwm_status(iwm_decoded_cmd_t cmd) override;
+    void iwm_ctrl(const iwm_decoded_cmd_t &cmd) override;
+    void iwm_open(const iwm_decoded_cmd_t &cmd) override;
+    void iwm_close(const iwm_decoded_cmd_t &cmd) override;
+    void iwm_read(const iwm_decoded_cmd_t &cmd) override;
+    void iwm_write(const iwm_decoded_cmd_t &cmd) override;
+    void iwm_status(const iwm_decoded_cmd_t &cmd) override;
     void shutdown() override;
     iwm_device_info_block_t create_dib_reply_packet() override;
     iwm_device_status_block_t create_status_reply_packet() override;
@@ -145,17 +145,12 @@ public:
      * @brief JSON Query
      * @param s size of query
      */
-    void json_query(iwm_decoded_cmd_t cmd);
+    void json_query(const iwm_decoded_cmd_t &cmd);
 
     std::unordered_map<uint8_t, NetworkData> network_data_map;
     uint8_t current_network_unit = 1;
 
 private:
-    /**
-     * SP_ERR number when there's an ... error!
-     */
-    spError_t err = SP_ERR::NOERROR;
-
     /**
      * ESP timer handle for the Interrupt rate limiting timer
      */
@@ -226,14 +221,14 @@ private:
      * @param num_bytes Number of bytes to read.
      * @return TRUE on error, FALSE on success. Passed directly to bus_to_computer().
      */
-    error_is_true read_channel(unsigned short num_bytes, iwm_decoded_cmd_t cmd);
+    error_is_true read_channel(const iwm_decoded_cmd_t &cmd);
 
     /**
      * Perform the correct read based on value of channelMode
      * @param num_bytes Number of bytes to read.
      * @return TRUE on error, FALSE on success. Passed directly to bus_to_computer().
      */
-    error_is_true read_channel_json(unsigned short num_bytes, iwm_decoded_cmd_t cmd);
+    error_is_true read_channel_json(const iwm_decoded_cmd_t &cmd);
 
     /**
      * Perform the correct write based on value of channelMode

--- a/lib/device/iwm/printer.cpp
+++ b/lib/device/iwm/printer.cpp
@@ -45,19 +45,19 @@ iwm_device_info_block_t iwmPrinter::create_dib_reply_packet()
   return dib;
 }
 
-void iwmPrinter::iwm_open(iwm_decoded_cmd_t cmd)
+void iwmPrinter::iwm_open(const iwm_decoded_cmd_t &cmd)
 {
     Debug_printf("\nPrinter: Open\n");
-    send_reply_packet(SP_ERR::NOERROR);
+    SYSTEM_BUS.transaction_error(SP_ERR::NOERROR);
 }
 
-void iwmPrinter::iwm_close(iwm_decoded_cmd_t cmd)
+void iwmPrinter::iwm_close(const iwm_decoded_cmd_t &cmd)
 {
     Debug_printf("\nPrinter: Close\n");
-    send_reply_packet(SP_ERR::NOERROR);
+    SYSTEM_BUS.transaction_error(SP_ERR::NOERROR);
 }
 
-void iwmPrinter::iwm_write(iwm_decoded_cmd_t cmd)
+void iwmPrinter::iwm_write(const iwm_decoded_cmd_t &cmd)
 {
     Debug_printf("\nPrinter: Write %u bytes\n", cmd.char_rw.length);
 
@@ -78,7 +78,7 @@ void iwmPrinter::iwm_write(iwm_decoded_cmd_t cmd)
     SYSTEM_BUS.transaction_success();
 
     _last_ms = fnSystem.millis();
-    send_reply_packet(SP_ERR::NOERROR);
+    SYSTEM_BUS.transaction_error(SP_ERR::NOERROR);
 }
 
 /**

--- a/lib/device/iwm/printer.h
+++ b/lib/device/iwm/printer.h
@@ -20,9 +20,9 @@ protected:
     iwm_device_status_block_t create_status_reply_packet() override;
 
     // IWM methods
-    void iwm_open(iwm_decoded_cmd_t cmd) override;
-    void iwm_close(iwm_decoded_cmd_t cmd) override;
-    void iwm_write(iwm_decoded_cmd_t cmd) override;
+    void iwm_open(const iwm_decoded_cmd_t &cmd) override;
+    void iwm_close(const iwm_decoded_cmd_t &cmd) override;
+    void iwm_write(const iwm_decoded_cmd_t &cmd) override;
     void shutdown() override {}
 
     printer_emu *_pptr = nullptr;


### PR DESCRIPTION
Changed all devices to use the SystemBusBase transaction methods instead of directly writing into various variables and hoping that something else down the line will convert the variables into a packet.