### PR TITLE
[iwm] Introduce FujiIWMPacket

### DIFF
--- a/fujinet_pc.cmake
+++ b/fujinet_pc.cmake
@@ -338,6 +338,7 @@ if(FUJINET_TARGET STREQUAL "APPLE")
     lib/bus/iwm/iwm_slip.h lib/utils/std_extensions.hpp lib/bus/iwm/iwm_slip.cpp
     lib/bus/iwm/connector.h
     lib/bus/iwm/iwm.h lib/bus/iwm/iwm.cpp
+    lib/bus/iwm/FujiIWMPacket.h lib/bus/iwm/FujiIWMPacket.cpp
 
     lib/devrelay/util.h lib/devrelay/util.cpp
     lib/devrelay/types/Request.h lib/devrelay/types/Request.cpp

--- a/lib/bus/iwm/FujiIWMPacket.cpp
+++ b/lib/bus/iwm/FujiIWMPacket.cpp
@@ -1,0 +1,83 @@
+#ifdef BUILD_APPLE
+
+#include "FujiIWMPacket.h"
+#include "iwm.h"
+
+void FujiIWMPacket::decode(uint8_t *raw)
+{
+  smartport.decode_data_packet(raw, reinterpret_cast<uint8_t *>(&frame));
+  _params.clear();
+  _data = std::nullopt;
+
+  switch (frame.sp_command) {
+  case SP_CMD_CONTROL:
+  case SP_CMD_WRITE:
+  case SP_CMD_WRITEBLOCK:
+  case SP_ECMD_CONTROL:
+  case SP_ECMD_WRITE:
+  case SP_ECMD_WRITEBLOCK:
+  _decoded.resize(MAX_DATA_LEN);
+  _decoded.resize(smartport.decode_data_packet(_decoded.data()));
+    break;
+  default:
+    break;
+  }
+}
+
+uint32_t FujiIWMPacket::getParam(size_t index, size_t psize) const
+{
+  size_t count;
+
+  assert(psize == 1 || psize == 2 || psize == 4);
+  assert(_params.size() == 0 || _paramSize == psize);
+  if (index >= _params.size()) {
+    assert(!_data.has_value());
+    _paramSize = psize;
+    count = index - _params.size() + 1;
+    assert(count * psize <= _decoded.size());
+    fillParams(count, psize);
+  }
+  return _params[index];
+}
+
+void FujiIWMPacket::fillParams(size_t count, size_t psize) const
+{
+  uint32_t val;
+  size_t idx;
+
+  for (idx = 0; idx < count; idx++)
+  {
+    switch (psize) {
+    case 1:
+      val = _decoded[0];
+      _decoded.erase(_decoded.begin(), _decoded.begin() + 1);
+      break;
+    case 2:
+      {
+        uint16_t ev;
+        __builtin_memcpy(&ev, &_decoded[0], sizeof(ev));
+        val = le16toh(ev);
+        _decoded.erase(_decoded.begin(), _decoded.begin() + sizeof(ev));
+      }
+      break;
+    case 4:
+      {
+        uint32_t ev;
+        __builtin_memcpy(&ev, &_decoded[0], sizeof(ev));
+        val = le32toh(ev);
+        _decoded.erase(_decoded.begin(), _decoded.begin() + sizeof(ev));
+      }
+      break;
+    }
+    _params.push_back(val);
+  }
+}
+
+const std::optional<std::span<const std::uint8_t>>& FujiIWMPacket::data() const
+{
+  if (!_data.has_value())
+    _data = _decoded;
+  return _data;
+}
+
+#endif /* BUILD_APPLE */

--- a/lib/bus/iwm/FujiIWMPacket.h
+++ b/lib/bus/iwm/FujiIWMPacket.h
@@ -1,0 +1,118 @@
+#ifndef FUJIIWMPACKET_H
+#define FUJIIWMPACKET_H
+
+#include "spCommandID.h"
+#include "spCode.h"
+#include "fujiCommandID.h"
+#include "global_types.h"
+
+#include <optional>
+#include <cassert>
+#include <span>
+#include <string>
+
+struct SmartPortFrame
+{
+  spCommandID_t sp_command;
+  uint8_t param_count;
+  uint8_t sp_dev_id;
+  uint8_t unknown;
+
+  union {
+    struct {
+      union {
+        spCode_t code;
+        struct {
+          fujiCommandID_t command;
+          uint8_t network_unit;
+        } fuji;
+      };
+    } control_status;
+    struct {
+      u24le_t num;
+    } block_rw;
+    struct {
+      u16le_t length;
+      union {
+        u24le_t address;
+        struct {
+          uint8_t network_unit;
+        } fuji;
+      };
+    } char_rw;
+    // format, init, open, close do not have any parameters
+  };
+} __attribute__((packed));
+static_assert(sizeof(SmartPortFrame) == 9, "SmartPortFrame must be 9 bytes");
+
+class FujiIWMPacket
+{
+private:
+  mutable std::vector<uint32_t> _params;
+  mutable unsigned _paramSize;
+  mutable ByteBuffer _decoded;
+  mutable std::optional<std::span<const uint8_t>> _data;
+
+  struct PacketParamProxy
+  {
+    size_t index;
+    const FujiIWMPacket *packet;
+
+    // These tell the compiler: "Run this code if the destination matches my type"
+    operator bool() const {
+      return static_cast<uint8_t>(*this) != 0;
+    }
+
+    // These tell the compiler exactly how to handle direct equality checks
+    // against any integer type without triggering conversion rule debates.
+
+    bool operator==(uint8_t val) const {
+      return static_cast<uint8_t>(*this) == val;
+    }
+
+    bool operator==(uint16_t val) const {
+      return static_cast<uint16_t>(*this) == val;
+    }
+
+    inline operator uint8_t() const {
+      return packet->getParam(index, sizeof(uint8_t));
+    }
+
+    inline operator uint16_t() const {
+      return packet->getParam(index, sizeof(uint16_t));
+    }
+
+    inline operator uint32_t() const {
+      return packet->getParam(index, sizeof(uint32_t));
+    }
+  };
+
+  friend PacketParamProxy;
+
+  uint32_t getParam(size_t index, size_t psize) const;
+  void fillParams(size_t count, size_t psize) const;
+
+public:
+  SmartPortFrame frame;
+
+  void decode(uint8_t *raw);
+
+  uint8_t device() const { return frame.sp_dev_id; }
+  fujiCommandID_t command() const { return frame.control_status.fuji.command; }
+
+  PacketParamProxy param(size_t index) const { return PacketParamProxy{ index, this }; }
+
+  const std::optional<std::span<const std::uint8_t>>& data() const;
+  const std::optional<const std::string> dataAsString() const {
+    auto d = data();
+    return std::string(reinterpret_cast<const char *>(d->data()), d->size());
+  }
+
+  // Explicit alternatives to the implicit PacketParamProxy conversions.
+  // These may be preferred where the destination type is not obvious.
+  uint8_t  param8(size_t index)  const { return (uint8_t) param(index); }
+  uint16_t param16(size_t index) const { return (uint16_t) param(index); }
+  uint32_t param32(size_t index) const { return (uint32_t) param(index); }
+};
+
+#endif /* FUJIIWMPACKET_H */

--- a/lib/bus/iwm/iwm.cpp
+++ b/lib/bus/iwm/iwm.cpp
@@ -118,9 +118,6 @@ void print_packet_wave(uint8_t *data, int bytes)
 
 //------------------------------------------------------------------------------
 
-uint8_t virtualDevice::data_buffer[MAX_DATA_LEN] = {0};
-int virtualDevice::data_len = 0;
-
 void systemBus::transaction_accept(transState_t expectMoreData)
 {
   assert(_transaction_state == TRANS_STATE::INVALID);
@@ -146,9 +143,9 @@ success_is_true systemBus::transaction_get(void *data, size_t len)
 {
   assert(_transaction_state == TRANS_STATE::WILL_GET);
   _transaction_state = TRANS_STATE::DID_GET;
-  if (len > virtualDevice::data_len)
-    len = virtualDevice::data_len;
-  memcpy((uint8_t *) data, virtualDevice::data_buffer, len);
+  auto spanData = command.data().value();
+  len = std::min(len, spanData.size());
+  std::copy(spanData.begin(), spanData.end(), static_cast<uint8_t *>(data));
   RETURN_SUCCESS_AS_TRUE();
 }
 
@@ -164,7 +161,7 @@ void systemBus::transaction_send(const void *data, size_t len, bool is_error)
   // CONTROL is used by Fuji devices to process payload and queue up
   // reply data. If this was a CONTROL command, queue up the data and
   // send it when a STATUS command is received.
-  switch (command.sp_command) {
+  switch (command.frame.sp_command) {
   case SP_CMD_CONTROL:
   case SP_ECMD_CONTROL:
     _transaction_response.insert(_transaction_response.end(),
@@ -325,7 +322,7 @@ void systemBus::send_status_dib_reply_packet()
 void virtualDevice::iwm_return_badcmd(const iwm_decoded_cmd_t &cmd)
 {
   //Handle possible data packet to avoid crash extended and non-extended
-  switch(cmd.sp_command)
+  switch (cmd.frame.sp_command)
   {
     case SP_ECMD_WRITEBLOCK:
     case SP_ECMD_CONTROL:
@@ -333,21 +330,20 @@ void virtualDevice::iwm_return_badcmd(const iwm_decoded_cmd_t &cmd)
     case SP_CMD_WRITEBLOCK:
     case SP_CMD_CONTROL:
     case SP_CMD_WRITE:
-      Debug_printf("\r\nUnit %02x Bad Command with data packet %02x\r\n", id(), cmd.sp_command);
-      print_packet(data_buffer, data_len);
+      Debug_printf("\r\nUnit %02x Bad Command with data packet %02x\r\n", id(), cmd.frame.sp_command);
       break;
     default: //just send the response and return like before
       SYSTEM_BUS.transaction_error(SP_ERR::BADCMD);
-      Debug_printf("\r\nUnit %02x Bad Command %02x", id(), cmd.sp_command);
+      Debug_printf("\r\nUnit %02x Bad Command %02x", id(), cmd.frame.sp_command);
       return;
   }
 
-  if(cmd.sp_command == SP_CMD_CONTROL) //Decode command control code
+  if (cmd.frame.sp_command == SP_CMD_CONTROL) //Decode command control code
   {
     //we may be required to accept some control commands but for now
     // just report bad control if it's a control command
     SYSTEM_BUS.transaction_error(SP_ERR::BADCTL);
-    Debug_printf("\r\nbad command was a control command with control code %02x",cmd.control_status.fuji.command);
+    Debug_printf("\r\nbad command was a control command with control code %02x",cmd.command());
   }
   else
   {
@@ -363,7 +359,7 @@ void systemBus::iwm_process(const iwm_decoded_cmd_t &cmd)
   // CONTROL is used by Fuji devices to process payload and queue up
   // reply data. If this was a STATUS command, send any data that is
   // sitting in the queue.
-  if ((cmd.sp_command == SP_CMD_STATUS || cmd.sp_command == SP_ECMD_STATUS)
+  if ((cmd.frame.sp_command == SP_CMD_STATUS || cmd.frame.sp_command == SP_ECMD_STATUS)
       && _transaction_response.size()) {
     iwm_send_packet(_activeDev->id(), iwm_packet_type_t::status, SP_ERR::NOERROR,
                     _transaction_response.data(), _transaction_response.size());
@@ -372,17 +368,17 @@ void systemBus::iwm_process(const iwm_decoded_cmd_t &cmd)
     goto done;
   }
 
-  switch (cmd.sp_command)
+  switch (cmd.frame.sp_command)
   {
   case SP_CMD_STATUS:
-    Debug_printf("\r\nhandling status command code=0x%02x", cmd.control_status.code);
-    switch (cmd.control_status.code) {
+    Debug_printf("\r\nhandling status command code=0x%02x", cmd.frame.control_status.code);
+    switch (cmd.frame.control_status.code) {
     case SP_STAT_DEVICE:
-        send_status_reply_packet();
-        break;
+      send_status_reply_packet();
+      break;
     case SP_STAT_DIB:
-        send_status_dib_reply_packet();
-        break;
+      send_status_dib_reply_packet();
+      break;
     default:
       _activeDev->iwm_status(cmd);
       break;
@@ -626,21 +622,7 @@ bool IRAM_ATTR systemBus::serviceSmartPort()
 
           _activeDev = devicep;
           // handle command
-          smartport.decode_data_packet(command_packet.data, &command);
-          print_packet(&command, sizeof(command));
-          switch (command.sp_command)
-          {
-          case SP_CMD_CONTROL:
-          case SP_CMD_WRITE:
-          case SP_CMD_WRITEBLOCK:
-          case SP_ECMD_CONTROL:
-          case SP_ECMD_WRITE:
-          case SP_ECMD_WRITEBLOCK:
-            virtualDevice::data_len = smartport.decode_data_packet(virtualDevice::data_buffer);
-            break;
-          default:
-            break;
-          }
+          command.decode(command_packet.data);
           iwm_process(command);
           break; // we don't need to needlessly keep looping once we find it
         }

--- a/lib/bus/iwm/iwm.h
+++ b/lib/bus/iwm/iwm.h
@@ -3,7 +3,7 @@
 #define IWM_H
 
 #include "bus.h"
-#include "fujiCommandID.h"
+#include "FujiIWMPacket.h"
 #include "../../include/debug.h"
 
 // for ESP IWM-SLIP build, DEV_RELAY_SLIP should be defined in platformio.ini
@@ -23,28 +23,7 @@
 
 #include "fnFS.h"
 
-enum spCommandID_t : uint8_t {
-  SP_CMD_STATUS         = 0x00,
-  SP_CMD_READBLOCK      = 0x01,
-  SP_CMD_WRITEBLOCK     = 0x02,
-  SP_CMD_FORMAT         = 0x03,
-  SP_CMD_CONTROL        = 0x04,
-  SP_CMD_INIT           = 0x05,
-  SP_CMD_OPEN           = 0x06,
-  SP_CMD_CLOSE          = 0x07,
-  SP_CMD_READ           = 0x08,
-  SP_CMD_WRITE          = 0x09,
-  SP_ECMD_STATUS        = 0x40,
-  SP_ECMD_READBLOCK     = 0x41,
-  SP_ECMD_WRITEBLOCK    = 0x42,
-  SP_ECMD_FORMAT        = 0x43,
-  SP_ECMD_CONTROL       = 0x44,
-  SP_ECMD_INIT          = 0x45,
-  SP_ECMD_OPEN          = 0x46,
-  SP_ECMD_CLOSE         = 0x47,
-  SP_ECMD_READ          = 0x48,
-  SP_ECMD_WRITE         = 0x49,
-};
+using iwm_decoded_cmd_t = FujiIWMPacket;
 
 // Windows defines this and it conflicts with the SmartPort erro
 // code. We don't need it, just undef it.
@@ -125,66 +104,6 @@ class fujiDevice;
 #define BLOCK_DATA_LEN      512
 #define MAX_DATA_LEN        767
 
-enum spCode_t : uint8_t {
-  SP_STAT_DEVICE            = 0x00,
-  SP_STAT_CONTROL_BLOCK     = 0x01,
-  SP_STAT_NEWLINE           = 0x02,
-  SP_STAT_DIB               = 0x03,
-  SP_STAT_UNIDISK           = 0x05,
-
-  SP_CTRL_RESET             = 0x00,
-  SP_CTRL_SET_DCB           = 0x01,
-  SP_CTRL_SET_NEWLINE       = 0x02,
-  SP_CTRL_DEV_INTERRUPT     = 0x03,
-  SP_CTRL_EJECT             = 0x04, // Apple 3.5, UniDisk 3.5
-  SP_CTRL_EXECUTE           = 0x05, // UniDisk 3.5
-  SP_CTRL_SET_ADDRESS       = 0x06, // UniDisk 3.5
-  SP_CTRL_DOWNLOAD          = 0x07, // UniDiisk 3.5
-  SP_CTRL_SET_HOOK          = 0x05, // Apple 3.5
-  SP_CTRL_RESET_HOOK        = 0x06, // Apple 3.5
-  SP_CTRL_SET_MARK          = 0x07, // Apple 3.5
-  SP_CTRL_RESET_MARK        = 0x08, // Apple 3.5
-  SP_CTRL_SET_SIDES         = 0x09, // Apple 3.5
-  SP_CTRL_SET_INTERLEAVE    = 0x0A, // Apple 3.5
-
-  SP_CTRL_CLEAR_DISKII_SEEN = 0x08, // iwmFuji
-  SP_STAT_GET_DISKII_SEEN   = 0x08, // iwmFuji
-};
-
-struct iwm_decoded_cmd_t
-{
-  spCommandID_t sp_command;
-  uint8_t param_count;
-  uint8_t sp_dev_id;
-  uint8_t unknown;
-
-  union {
-    struct {
-      union {
-        spCode_t code;
-        struct {
-          fujiCommandID_t command;
-          uint8_t network_unit;
-        } fuji;
-      };
-    } control_status;
-    struct {
-      u24le_t num;
-    } block_rw;
-    struct {
-      u16le_t length;
-      union {
-        u24le_t address;
-        struct {
-          uint8_t network_unit;
-        } fuji;
-      };
-    } char_rw;
-    // format, init, open, close do not have any parameters
-  };
-} __attribute__((packed));
-static_assert(sizeof(iwm_decoded_cmd_t) == 9, "iwm_decoded_cmd_t must be 9 bytes");
-
 enum class iwm_smartport_type_t
 {
   Block_Device,
@@ -234,8 +153,8 @@ void print_packet(void *data);
 
 class virtualDevice
 {
-    friend systemBus; // put here for prototype, not sure if will need to keep it
-    friend fujiDevice;
+  friend systemBus; // put here for prototype, not sure if will need to keep it
+  friend fujiDevice;
 
 protected:
   // set these things in constructor or initializer?
@@ -258,10 +177,6 @@ protected:
   virtual void iwm_write(const iwm_decoded_cmd_t &cmd);
 
   void iwm_return_badcmd(const iwm_decoded_cmd_t &cmd);
-
-  // iwm packet handling
-  static uint8_t data_buffer[MAX_DATA_LEN]; // un-encoded binary data (512 bytes for a block)
-  static int data_len; // how many bytes in the data buffer
 
   virtual iwm_device_info_block_t create_dib_reply_packet() = 0;
   virtual iwm_device_status_block_t create_status_reply_packet() = 0;

--- a/lib/bus/iwm/spCode.h
+++ b/lib/bus/iwm/spCode.h
@@ -1,0 +1,30 @@
+#ifndef SPCODE_H
+#define SPCODE_H
+
+enum spCode_t : uint8_t {
+  SP_STAT_DEVICE            = 0x00,
+  SP_STAT_CONTROL_BLOCK     = 0x01,
+  SP_STAT_NEWLINE           = 0x02,
+  SP_STAT_DIB               = 0x03,
+  SP_STAT_UNIDISK           = 0x05,
+
+  SP_CTRL_RESET             = 0x00,
+  SP_CTRL_SET_DCB           = 0x01,
+  SP_CTRL_SET_NEWLINE       = 0x02,
+  SP_CTRL_DEV_INTERRUPT     = 0x03,
+  SP_CTRL_EJECT             = 0x04, // Apple 3.5, UniDisk 3.5
+  SP_CTRL_EXECUTE           = 0x05, // UniDisk 3.5
+  SP_CTRL_SET_ADDRESS       = 0x06, // UniDisk 3.5
+  SP_CTRL_DOWNLOAD          = 0x07, // UniDiisk 3.5
+  SP_CTRL_SET_HOOK          = 0x05, // Apple 3.5
+  SP_CTRL_RESET_HOOK        = 0x06, // Apple 3.5
+  SP_CTRL_SET_MARK          = 0x07, // Apple 3.5
+  SP_CTRL_RESET_MARK        = 0x08, // Apple 3.5
+  SP_CTRL_SET_SIDES         = 0x09, // Apple 3.5
+  SP_CTRL_SET_INTERLEAVE    = 0x0A, // Apple 3.5
+
+  SP_CTRL_CLEAR_DISKII_SEEN = 0x08, // iwmFuji
+  SP_STAT_GET_DISKII_SEEN   = 0x08, // iwmFuji
+};
+
+#endif /* SPCODE_H */

--- a/lib/bus/iwm/spCommandID.h
+++ b/lib/bus/iwm/spCommandID.h
@@ -1,0 +1,29 @@
+#ifndef SPCOMMANDID_H
+#define SPCOMMANDID_H
+
+#include <cstdint>
+
+enum spCommandID_t : uint8_t {
+  SP_CMD_STATUS         = 0x00,
+  SP_CMD_READBLOCK      = 0x01,
+  SP_CMD_WRITEBLOCK     = 0x02,
+  SP_CMD_FORMAT         = 0x03,
+  SP_CMD_CONTROL        = 0x04,
+  SP_CMD_INIT           = 0x05,
+  SP_CMD_OPEN           = 0x06,
+  SP_CMD_CLOSE          = 0x07,
+  SP_CMD_READ           = 0x08,
+  SP_CMD_WRITE          = 0x09,
+  SP_ECMD_STATUS        = 0x40,
+  SP_ECMD_READBLOCK     = 0x41,
+  SP_ECMD_WRITEBLOCK    = 0x42,
+  SP_ECMD_FORMAT        = 0x43,
+  SP_ECMD_CONTROL       = 0x44,
+  SP_ECMD_INIT          = 0x45,
+  SP_ECMD_OPEN          = 0x46,
+  SP_ECMD_CLOSE         = 0x47,
+  SP_ECMD_READ          = 0x48,
+  SP_ECMD_WRITE         = 0x49,
+};
+
+#endif /* SPCOMMANDID_H */

--- a/lib/device/fujiDevice.cpp
+++ b/lib/device/fujiDevice.cpp
@@ -360,6 +360,12 @@ success_is_true fujiDevice::fujicore_mount_host_success(unsigned hostSlot)
 success_is_true fujiDevice::fujicmd_mount_host_success(unsigned hostSlot)
 {
     transaction_begin(TRANS_STATE::NO_GET);
+    if (hostSlot >= MAX_HOSTS)
+    {
+        transaction_error();
+        RETURN_ERROR_AS_FALSE();
+    }
+
     if (!fujicore_mount_host_success(hostSlot))
     {
         Debug_println("fujicore_mount_host_success returned false");

--- a/lib/device/iwm/clock.cpp
+++ b/lib/device/iwm/clock.cpp
@@ -31,23 +31,19 @@ iwm_device_info_block_t iwmClock::create_dib_reply_packet()
   return dib;
 }
 
-void iwmClock::set_tz()
+void iwmClock::set_tz(const iwm_decoded_cmd_t &cmd)
 {
-    std::string buffer(data_len, 0);
-    SYSTEM_BUS.transaction_accept(TRANS_STATE::WILL_GET);
-    SYSTEM_BUS.transaction_get(buffer.data(), buffer.size());
-    Config.store_general_timezone(buffer.c_str());
+    SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
+    Config.store_general_timezone(cmd.dataAsString()->c_str());
     Config.save();
     Debug_printf("sys_tz set to: >%s<\n", Config.get_general_timezone().c_str());
     SYSTEM_BUS.transaction_success();
 }
 
-void iwmClock::set_alternate_tz()
+void iwmClock::set_alternate_tz(const iwm_decoded_cmd_t &cmd)
 {
-    std::string buffer(data_len, 0);
-    SYSTEM_BUS.transaction_accept(TRANS_STATE::WILL_GET);
-    SYSTEM_BUS.transaction_get(buffer.data(), buffer.size());
-    alternate_tz = buffer;
+    SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
+    alternate_tz = cmd.dataAsString().value();
     Debug_printf("alt_tz set to: >%s<\n", alternate_tz.c_str());
     SYSTEM_BUS.transaction_success();
 }
@@ -55,16 +51,16 @@ void iwmClock::set_alternate_tz()
 void iwmClock::iwm_ctrl(const iwm_decoded_cmd_t &cmd)
 {
 #ifdef DEBUG
-    Debug_printf("[CLOCK] Device %02x Control Code %02x('%c')\r\n", id(), cmd.control_status.fuji.command, isprint(cmd.control_status.fuji.command) ? (char) cmd.control_status.fuji.command : '.');
+    Debug_printf("[CLOCK] Device %02x Control Code %02x('%c')\r\n", id(), cmd.command(), isprint(cmd.command()) ? (char) cmd.command() : '.');
 #endif
 
-    switch (cmd.control_status.fuji.command)
+    switch (cmd.command())
     {
     case APETIMECMD_SETTZ_ALT2:
-        set_tz();
+        set_tz(cmd);
         break;
     case APETIMECMD_SETTZ_ALT:
-        set_alternate_tz();
+        set_alternate_tz(cmd);
         break;
     default:
         SYSTEM_BUS.transaction_error(SP_ERR::BADCTL);
@@ -77,14 +73,14 @@ void iwmClock::iwm_status(const iwm_decoded_cmd_t &cmd)
     bool use_alternate_tz = false;
 
 #ifdef DEBUG
-    Debug_printf("[CLOCK] Device %02x Status Code %02x('%c')\r\n", id(), cmd.control_status.fuji.command, isprint(cmd.control_status.fuji.command) ? (char)cmd.control_status.fuji.command : '.');
+    Debug_printf("[CLOCK] Device %02x Status Code %02x('%c')\r\n", id(), cmd.command(), isprint(cmd.command()) ? (char)cmd.command() : '.');
 #endif
-    switch (cmd.control_status.fuji.command)
+    switch (cmd.command())
     {
     // Uppercase = use FN tz, otherwise use alt tz
     case APETIMECMD_SETTZ_ALT2:
     case APETIMECMD_SETTZ_ALT: {
-        use_alternate_tz = cmd.control_status.fuji.command == APETIMECMD_SETTZ_ALT;
+        use_alternate_tz = cmd.command() == APETIMECMD_SETTZ_ALT;
         // Date and time, easy to be used by general programs
         auto simpleTime = Clock::get_current_time_simple(Clock::tz_to_use(use_alternate_tz, alternate_tz, Config.get_general_timezone()));
         SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
@@ -99,7 +95,7 @@ void iwmClock::iwm_status(const iwm_decoded_cmd_t &cmd)
     }
     case APETIMECMD_GET_PRODOS:
     case APETIMECMD_GET_PRODOS_ALT: {
-        use_alternate_tz = cmd.control_status.fuji.command == APETIMECMD_GET_PRODOS_ALT;
+        use_alternate_tz = cmd.command() == APETIMECMD_GET_PRODOS_ALT;
         // Date and time, to be used by a ProDOS driver
         auto prodosTime = Clock::get_current_time_prodos(Clock::tz_to_use(use_alternate_tz, alternate_tz, Config.get_general_timezone()));
         SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
@@ -108,7 +104,7 @@ void iwmClock::iwm_status(const iwm_decoded_cmd_t &cmd)
     }
     case APETIMECMD_GET_SOS:
     case APETIMECMD_GET_SOS_ALT: {
-        use_alternate_tz = cmd.control_status.fuji.command == APETIMECMD_GET_SOS_ALT;
+        use_alternate_tz = cmd.command() == APETIMECMD_GET_SOS_ALT;
         // Date and time, ASCII string in Apple /// SOS format: YYYYMMDD0HHMMSS000
         std::string sosTime = Clock::get_current_time_sos(Clock::tz_to_use(use_alternate_tz, alternate_tz, Config.get_general_timezone()));
         SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
@@ -117,7 +113,7 @@ void iwmClock::iwm_status(const iwm_decoded_cmd_t &cmd)
     }
     case APETIMECMD_GET_ISO_LOCAL:
     case APETIMECMD_GET_ISO_LOCAL_ALT: {
-        use_alternate_tz = cmd.control_status.fuji.command == APETIMECMD_GET_ISO_LOCAL_ALT;
+        use_alternate_tz = cmd.command() == APETIMECMD_GET_ISO_LOCAL_ALT;
         // Date and time, ASCII string in ISO format
         std::string utcTime = Clock::get_current_time_iso(Clock::tz_to_use(use_alternate_tz, alternate_tz, Config.get_general_timezone()));
         SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
@@ -126,7 +122,7 @@ void iwmClock::iwm_status(const iwm_decoded_cmd_t &cmd)
     }
     case APETIMECMD_GET_ISO_UTC:
     case APETIMECMD_GET_ISO_UTC_ALT: {
-        use_alternate_tz = cmd.control_status.fuji.command == APETIMECMD_GET_ISO_UTC_ALT;
+        use_alternate_tz = cmd.command() == APETIMECMD_GET_ISO_UTC_ALT;
         // utc (zulu)
         std::string isoTime = Clock::get_current_time_iso("UTC+0");
         SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
@@ -135,7 +131,7 @@ void iwmClock::iwm_status(const iwm_decoded_cmd_t &cmd)
     }
     case APETIMECMD_GET_ATARI:
     case APETIMECMD_GET_ATARI_ALT: {
-        use_alternate_tz = cmd.control_status.fuji.command == APETIMECMD_GET_ATARI_ALT;
+        use_alternate_tz = cmd.command() == APETIMECMD_GET_ATARI_ALT;
         // Apetime (Atari, but why not eh?) with TZ
         auto apeTime = Clock::get_current_time_apetime(Clock::tz_to_use(use_alternate_tz, alternate_tz, Config.get_general_timezone()));
         SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);

--- a/lib/device/iwm/clock.h
+++ b/lib/device/iwm/clock.h
@@ -7,8 +7,8 @@
 class iwmClock : public virtualDevice
 {
 private:
-    void set_tz();
-    void set_alternate_tz();
+    void set_tz(const iwm_decoded_cmd_t &cmd);
+    void set_alternate_tz(const iwm_decoded_cmd_t &cmd);
     std::string alternate_tz = "";
 public:
     iwmClock();

--- a/lib/device/iwm/cpm.cpp
+++ b/lib/device/iwm/cpm.cpp
@@ -114,9 +114,9 @@ void iwmCPM::iwm_close(const iwm_decoded_cmd_t &cmd)
 
 void iwmCPM::iwm_status(const iwm_decoded_cmd_t &cmd)
 {
-    Debug_printf("\r\n[CPM] Device %02x Status Code %02x\r\n", id(), cmd.control_status.fuji.command);
+    Debug_printf("\r\n[CPM] Device %02x Status Code %02x\r\n", id(), cmd.command());
 
-    switch (cmd.control_status.fuji.command)
+    switch (cmd.command())
     {
     case CPMCMD_STATUS:
         {
@@ -158,12 +158,12 @@ void iwmCPM::iwm_read(const iwm_decoded_cmd_t &cmd)
     unsigned short mw;
 #endif
 
-    Debug_printf("\r\nDevice %02x READ %04x bytes from address %06lx\n", id(), cmd.char_rw.length, cmd.char_rw.address);
+    Debug_printf("\r\nDevice %02x READ %04x bytes from address %06lx\n", id(), cmd.frame.char_rw.length, cmd.frame.char_rw.address);
 
     std::vector<uint8_t> buffer;
     if (mw) // check if we really have some bytes waiting
     {
-        size_t numbytes = std::min<uint16_t>(mw, cmd.char_rw.length);
+        size_t numbytes = std::min<uint16_t>(mw, cmd.frame.char_rw.length);
 
         for (size_t i = 0; i < numbytes; i++)
         {
@@ -182,13 +182,14 @@ void iwmCPM::iwm_read(const iwm_decoded_cmd_t &cmd)
 
 void iwmCPM::iwm_write(const iwm_decoded_cmd_t &cmd)
 {
-    Debug_printf("\nWRITE %u bytes\n", cmd.char_rw.length);
+    Debug_printf("\nWRITE %u bytes\n", cmd.frame.char_rw.length);
 
     {
+        auto buffer = cmd.data().value();
         // DO write
 #ifdef ESP_PLATFORM // OS
-        for (int i = 0; i < cmd.char_rw.length; i++)
-            xQueueSend(txq, &data_buffer[i], portMAX_DELAY);
+        for (int i = 0; i < cmd.frame.char_rw.length; i++)
+            xQueueSend(txq, &buffer[i], portMAX_DELAY);
 #endif
     }
 
@@ -199,14 +200,10 @@ void iwmCPM::iwm_ctrl(const iwm_decoded_cmd_t &cmd)
 {
     spError_t err_result = SP_ERR::NOERROR;
 
-    // uint8_t source = cmd.dest;                                                 // we are the destination and will become the source // data_buffer[6];
-    Debug_printf("\r\nCPM Device %02x Control Code %02x", id(), cmd.control_status.fuji.command);
-    // Debug_printf("\r\nControl List is at %02x %02x", cmd.g7byte1 & 0x7f, cmd.g7byte2 & 0x7f);
-    // Debug_printf("\r\nThere are %02x Odd Bytes and %02x 7-byte Groups", packet_buffer[11] & 0x7f, data_buffer[12] & 0x7f);
-    print_packet(data_buffer);
+    Debug_printf("\r\nCPM Device %02x Control Code %02x", id(), cmd.command());
 
-    if (data_len > 0)
-        switch (cmd.control_status.fuji.command)
+    if (cmd.data()->size() > 0)
+      switch (cmd.command())
         {
         case CPMCMD_BOOT:
 #ifdef ESP_PLATFORM // OS

--- a/lib/device/iwm/disk.cpp
+++ b/lib/device/iwm/disk.cpp
@@ -116,11 +116,10 @@ iwm_device_info_block_t iwmDisk::create_dib_reply_packet()
 
 void iwmDisk::iwm_ctrl(const iwm_decoded_cmd_t &cmd)
 {
-  Debug_printf("\nDisk Device %02x Control Code %02x", id(), cmd.control_status.fuji.command);
+  Debug_printf("\nDisk Device %02x Control Code %02x", id(), cmd.command());
   Debug_printf("\nDecoding Control Data Packet:");
-  print_packet(data_buffer, data_len);
 
-  switch (cmd.control_status.code)
+  switch (cmd.frame.control_status.code)
   {
   case SP_CTRL_EJECT:
     Debug_printf("Handling Eject command\r\n");
@@ -140,7 +139,7 @@ void iwmDisk::iwm_readblock(const iwm_decoded_cmd_t &cmd)
 
   Debug_printf("\r\nDrive %02x ", id());
 
-  Debug_printf(" Read block %06lx\r\n", cmd.block_rw.num);
+  Debug_printf(" Read block %06lx\r\n", cmd.frame.block_rw.num);
   if (!(_disk != nullptr))
   {
     Debug_printf(" - ERROR - No image mounted");
@@ -152,7 +151,7 @@ void iwmDisk::iwm_readblock(const iwm_decoded_cmd_t &cmd)
     SYSTEM_BUS.transaction_error(SP_ERR::OFFLINE);
     return;
   }
-  if((switched) && (cmd.block_rw.num > 2)){
+  if((switched) && (cmd.frame.block_rw.num > 2)){
     Debug_printf("iwm_readblock() returning disk switched error\r\n");
     SYSTEM_BUS.transaction_error(SP_ERR::OFFLINE);
     switched = false;
@@ -163,7 +162,7 @@ void iwmDisk::iwm_readblock(const iwm_decoded_cmd_t &cmd)
 
   sdstato = BLOCK_DATA_LEN;
   ByteBuffer buffer(sdstato);
-  if (_disk->read(cmd.block_rw.num, &sdstato, buffer.data()))
+  if (_disk->read(cmd.frame.block_rw.num, &sdstato, buffer.data()))
   {
     Debug_printf("\r\nFile Seek or Read err: %d bytes", sdstato);
     SYSTEM_BUS.transaction_error(SP_ERR::IOERROR);
@@ -179,7 +178,7 @@ void iwmDisk::iwm_readblock(const iwm_decoded_cmd_t &cmd)
 void iwmDisk::iwm_writeblock(const iwm_decoded_cmd_t &cmd)
 {
   Debug_printf("\r\nDrive %02x ", id());
-  Debug_printf("Write block %06lx", cmd.block_rw.num);
+  Debug_printf("Write block %06lx", cmd.frame.block_rw.num);
   // partition number indicates which 32mb block we access
   // We have to return the error after ingesting the block to write or ProDOS doesn't correctly see the status.
 
@@ -210,7 +209,7 @@ void iwmDisk::iwm_writeblock(const iwm_decoded_cmd_t &cmd)
   ByteBuffer buffer(sdstato, 0);
   SYSTEM_BUS.transaction_accept(TRANS_STATE::WILL_GET);
   SYSTEM_BUS.transaction_get(buffer.data(), buffer.size());
-  _disk->write(cmd.block_rw.num, &sdstato, buffer.data());
+  _disk->write(cmd.frame.block_rw.num, &sdstato, buffer.data());
 
   if (sdstato != BLOCK_DATA_LEN)
   {

--- a/lib/device/iwm/iwmFuji.cpp
+++ b/lib/device/iwm/iwmFuji.cpp
@@ -22,68 +22,69 @@ iwmFuji::iwmFuji() : fujiDevice(MAX_A2DISK_DEVICES, IMAGE_EXTENSION, LOBBY_URL)
                 _fnHosts[i].slotid = i;
 
     control_handlers = {
-        { 0xAA, [this]()                               { this->iwm_dummy_command(); }},
-        { SP_CTRL_SET_DCB, [this]()                   { this->iwm_dummy_command(); }},                 // 0x01
-        { SP_CTRL_SET_NEWLINE, [this]()               { this->iwm_dummy_command(); }},                 // 0x02
+        { 0xAA, [this](const iwm_decoded_cmd_t &cmd)                               { this->iwm_dummy_command(cmd); }},
+        { SP_CTRL_SET_DCB, [this](const iwm_decoded_cmd_t &cmd)                   { this->iwm_dummy_command(cmd); }},                 // 0x01
+        { SP_CTRL_SET_NEWLINE, [this](const iwm_decoded_cmd_t &cmd)               { this->iwm_dummy_command(cmd); }},                 // 0x02
 
-        { FUJICMD_CLOSE_DIRECTORY, [this]()            { this->fujicmd_close_directory(); }},          // 0xF5
-        { FUJICMD_GET_HOST_PREFIX, [this]()            { this->fujicmd_get_host_prefix(data_buffer[0]); }},                  // 0xE0
-        { FUJICMD_CONFIG_BOOT, [this]()                { this->fujicmd_set_boot_config(data_buffer[0]); }},          // 0xD9
-        { FUJICMD_COPY_FILE, [this]()                  { this->fujicmd_copy_file_success(data_buffer[0], data_buffer[1], (char *)&data_buffer[2]); }},                // 0xD8
-        { FUJICMD_DISABLE_DEVICE, [this]()             { this->iwm_ctrl_disable_device(); }},           // 0xD4
-        { FUJICMD_ENABLE_DEVICE, [this]()              { this->iwm_ctrl_enable_device(); }},            // 0xD5
-        { FUJICMD_GET_SCAN_RESULT, [this]()            { this->fujicmd_net_scan_result(data_buffer[0]); }},          // 0xFC
+        { FUJICMD_CLOSE_DIRECTORY, [this](const iwm_decoded_cmd_t &cmd)            { this->fujicmd_close_directory(); }},          // 0xF5
+        { FUJICMD_GET_HOST_PREFIX, [this](const iwm_decoded_cmd_t &cmd)            { this->fujicmd_get_host_prefix(cmd.param(0)); }},                  // 0xE0
+        { FUJICMD_CONFIG_BOOT, [this](const iwm_decoded_cmd_t &cmd)                { this->fujicmd_set_boot_config(cmd.param(0)); }},          // 0xD9
+        { FUJICMD_COPY_FILE, [this](const iwm_decoded_cmd_t &cmd)                  { this->fujicmd_copy_file_success(cmd.param(0), cmd.param(1), cmd.dataAsString()->data()); }},                // 0xD8
+        { FUJICMD_DISABLE_DEVICE, [this](const iwm_decoded_cmd_t &cmd)             { this->iwm_ctrl_disable_device(cmd); }},           // 0xD4
+        { FUJICMD_ENABLE_DEVICE, [this](const iwm_decoded_cmd_t &cmd)              { this->iwm_ctrl_enable_device(cmd); }},            // 0xD5
+        { FUJICMD_GET_SCAN_RESULT, [this](const iwm_decoded_cmd_t &cmd)            { this->fujicmd_net_scan_result(cmd.param(0)); }},          // 0xFC
 
-        { FUJICMD_HASH_INPUT, [this]()                 { this->iwm_ctrl_hash_input(); }},               // 0xC8
-        { FUJICMD_HASH_COMPUTE, [this]()               { this->iwm_ctrl_hash_compute(true); }},         // 0xC7
-        { FUJICMD_HASH_COMPUTE_NO_CLEAR, [this]()      { this->iwm_ctrl_hash_compute(false); }},        // 0xC7
-        { FUJICMD_HASH_LENGTH, [this]()                { this->iwm_stat_hash_length(); }},              // 0xC6
-        { FUJICMD_HASH_OUTPUT, [this]()                { this->iwm_stat_hash_output(); }},              // 0xC5
-        { FUJICMD_HASH_CLEAR, [this]()                 { this->iwm_ctrl_hash_clear(); }},               // 0xC2
+        { FUJICMD_HASH_INPUT, [this](const iwm_decoded_cmd_t &cmd)                 { this->iwm_ctrl_hash_input(cmd); }},               // 0xC8
+        { FUJICMD_HASH_COMPUTE, [this](const iwm_decoded_cmd_t &cmd)               { this->iwm_ctrl_hash_compute(cmd, true); }},         // 0xC7
+        { FUJICMD_HASH_COMPUTE_NO_CLEAR, [this](const iwm_decoded_cmd_t &cmd)      { this->iwm_ctrl_hash_compute(cmd, false); }},        // 0xC7
+        { FUJICMD_HASH_LENGTH, [this](const iwm_decoded_cmd_t &cmd)                { this->iwm_stat_hash_length(cmd); }},              // 0xC6
+        { FUJICMD_HASH_OUTPUT, [this](const iwm_decoded_cmd_t &cmd)                { this->iwm_stat_hash_output(); }},              // 0xC5
+        { FUJICMD_HASH_CLEAR, [this](const iwm_decoded_cmd_t &cmd)                 { this->iwm_ctrl_hash_clear(); }},               // 0xC2
 
-        { FUJICMD_QRCODE_INPUT, [this]()               { this->iwm_ctrl_qrcode_input(); }},             // 0xBC
-        { FUJICMD_QRCODE_ENCODE, [this]()              { this->iwm_ctrl_qrcode_encode(); }},            // 0xBD
-        { FUJICMD_QRCODE_OUTPUT, [this]()              { this->iwm_ctrl_qrcode_output(); }},            // 0xBF
+        { FUJICMD_QRCODE_INPUT, [this](const iwm_decoded_cmd_t &cmd)               { this->iwm_ctrl_qrcode_input(cmd); }},             // 0xBC
+        { FUJICMD_QRCODE_ENCODE, [this](const iwm_decoded_cmd_t &cmd)              { this->iwm_ctrl_qrcode_encode(cmd); }},            // 0xBD
+        { FUJICMD_QRCODE_OUTPUT, [this](const iwm_decoded_cmd_t &cmd)              { this->iwm_ctrl_qrcode_output(cmd); }},            // 0xBF
 
-        { FUJICMD_MOUNT_HOST, [this]()                 { this->fujicmd_mount_host_success(data_buffer[0]); }},               // 0xF9
-        { FUJICMD_NEW_DISK, [this]()                   { this->iwm_ctrl_new_disk(); }},                 // 0xE7
-        { FUJICMD_OPEN_APPKEY, [this]()                { this->fujicmd_open_app_key(); }},             // 0xDC
-        { FUJICMD_READ_DIR_ENTRY, [this]()             { this->fujicmd_read_directory_entry(data_buffer[0], data_buffer[1]); }},     // 0xF6
-        { FUJICMD_SET_BOOT_MODE, [this]()              { this->fujicmd_set_boot_mode(data_buffer[0], MEDIATYPE_PO, get_disk_dev(0)); }},            // 0xD6
-        { FUJICMD_SET_DEVICE_FULLPATH, [this]()        { this->fujicmd_set_device_filename_success(data_buffer[0], data_buffer[1], (disk_access_flags_t) data_buffer[2]); }},      // 0xE2
-        { FUJICMD_SET_DIRECTORY_POSITION, [this]()     { this->fujicmd_set_directory_position(le16toh(*((uint16_t *) &data_buffer))); }},   // 0xE4
-        { FUJICMD_SET_HOST_PREFIX, [this]()            { this->fujicmd_set_host_prefix(data_buffer[0], (const char *) &data_buffer[1]); }},          // 0xE1
-        { FUJICMD_SET_SSID, [this]()                   {
-            // FIXME - make sure data_len > MAX_SSID_LEN + 1
-            std::string buffer(data_len, 0);
-            transaction_begin(TRANS_STATE::WILL_GET);
-            transaction_get(buffer.data(), buffer.size());
-            this->fujicmd_net_set_ssid_success(buffer.c_str(),
-                                               buffer.c_str() + MAX_SSID_LEN + 1, true);
+        { FUJICMD_MOUNT_HOST, [this](const iwm_decoded_cmd_t &cmd)                 { this->fujicmd_mount_host_success(cmd.param8(0)); }},               // 0xF9
+        { FUJICMD_NEW_DISK, [this](const iwm_decoded_cmd_t &cmd)                   { this->iwm_ctrl_new_disk(cmd); }},                 // 0xE7
+        { FUJICMD_OPEN_APPKEY, [this](const iwm_decoded_cmd_t &cmd)                { this->fujicmd_open_app_key(); }},             // 0xDC
+        { FUJICMD_READ_DIR_ENTRY, [this](const iwm_decoded_cmd_t &cmd)             { this->fujicmd_read_directory_entry(cmd.param8(0), cmd.param(1)); }},     // 0xF6
+        { FUJICMD_SET_BOOT_MODE, [this](const iwm_decoded_cmd_t &cmd)              { this->fujicmd_set_boot_mode(cmd.param(0), MEDIATYPE_PO, get_disk_dev(0)); }},            // 0xD6
+        { FUJICMD_SET_DEVICE_FULLPATH, [this](const iwm_decoded_cmd_t &cmd)        { this->fujicmd_set_device_filename_success(cmd.param(0), cmd.param(1), (disk_access_flags_t) cmd.param8(2)); }},      // 0xE2
+        { FUJICMD_SET_DIRECTORY_POSITION, [this](const iwm_decoded_cmd_t &cmd)     { this->fujicmd_set_directory_position(cmd.param(0)); }},   // 0xE4
+        { FUJICMD_SET_HOST_PREFIX, [this](const iwm_decoded_cmd_t &cmd)            {
+            uint8_t slot = cmd.param(0);
+            this->fujicmd_set_host_prefix(slot, cmd.dataAsString()->data());
+        }},          // 0xE1
+        { FUJICMD_SET_SSID, [this](const iwm_decoded_cmd_t &cmd)                   {
+            this->fujicmd_net_set_ssid_success(cmd.dataAsString()->c_str(),
+                                               cmd.dataAsString()->c_str() + MAX_SSID_LEN + 1,
+                                               true);
         }},             // 0xFB
-        { FUJICMD_UNMOUNT_HOST, [this]()               { this->fujicmd_unmount_host_success(data_buffer[0]); }},             // 0xE6
-        { FUJICMD_UNMOUNT_IMAGE, [this]()              { this->fujicmd_unmount_disk_image_success(data_buffer[0]); }},        // 0xE9
-        { FUJICMD_WRITE_APPKEY, [this]()               { this->fujicmd_write_app_key(data_len); }},            // 0xDE
-        { FUJICMD_WRITE_DEVICE_SLOTS, [this]()         { this->fujicmd_write_device_slots(); }},       // 0xF1
-        { FUJICMD_WRITE_HOST_SLOTS, [this]()           { this->fujicmd_write_host_slots(); }},         // 0xF3
+        { FUJICMD_UNMOUNT_HOST, [this](const iwm_decoded_cmd_t &cmd)               { this->fujicmd_unmount_host_success(cmd.param(0)); }},             // 0xE6
+        { FUJICMD_UNMOUNT_IMAGE, [this](const iwm_decoded_cmd_t &cmd)              { this->fujicmd_unmount_disk_image_success(cmd.param(0)); }},        // 0xE9
+        { FUJICMD_WRITE_APPKEY, [this](const iwm_decoded_cmd_t &cmd)               { this->fujicmd_write_app_key(cmd.data()->size()); }},            // 0xDE
+        { FUJICMD_WRITE_DEVICE_SLOTS, [this](const iwm_decoded_cmd_t &cmd)         { this->fujicmd_write_device_slots(); }},       // 0xF1
+        { FUJICMD_WRITE_HOST_SLOTS, [this](const iwm_decoded_cmd_t &cmd)           { this->fujicmd_write_host_slots(); }},         // 0xF3
 
-        { FUJICMD_RESET,  [this]()                     {
+        { FUJICMD_RESET,  [this](const iwm_decoded_cmd_t &cmd)                     {
              this->fujicmd_reset();
          }},   // 0xFF
-        { SP_CTRL_RESET, [this]()                     {
+        { SP_CTRL_RESET, [this](const iwm_decoded_cmd_t &cmd)                     {
              this->fujicmd_reset();
          }},   // 0x00
 #ifdef DEV_RELAY_SLIP
-        { SP_CTRL_CLEAR_DISKII_SEEN, [this]()              { SYSTEM_BUS.transaction_error(SP_ERR::NODRIVE); }},
+        { SP_CTRL_CLEAR_DISKII_SEEN, [this](const iwm_decoded_cmd_t &cmd)              { SYSTEM_BUS.transaction_error(SP_ERR::NODRIVE); }},
 #else
-        { SP_CTRL_CLEAR_DISKII_SEEN, [this]()              { diskii_xface.d2_enable_seen = 0; SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET); SYSTEM_BUS.transaction_success(); }},
+        { SP_CTRL_CLEAR_DISKII_SEEN, [this](const iwm_decoded_cmd_t &cmd)              { diskii_xface.d2_enable_seen = 0; SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET); SYSTEM_BUS.transaction_success(); }},
 #endif
 
-        { FUJICMD_MOUNT_ALL, [&]()                     { fujicmd_mount_all_success(); }},          // 0xD7
-        { FUJICMD_MOUNT_IMAGE, [&]()                   { fujicmd_mount_disk_image_success(data_buffer[0], (disk_access_flags_t) data_buffer[1]); }},  // 0xF8
-        { FUJICMD_OPEN_DIRECTORY, [&]()                {
+        { FUJICMD_MOUNT_ALL, [this](const iwm_decoded_cmd_t &cmd)                     { fujicmd_mount_all_success(); }},          // 0xD7
+        { FUJICMD_MOUNT_IMAGE, [this](const iwm_decoded_cmd_t &cmd)                   { fujicmd_mount_disk_image_success(cmd.param(0), (disk_access_flags_t) cmd.param8(1)); }},  // 0xF8
+        { FUJICMD_OPEN_DIRECTORY, [this](const iwm_decoded_cmd_t &cmd)                {
             SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
-            if (fujicore_open_directory_success(data_buffer[0], std::string((char *) &data_buffer[1], data_len - 1)).is_error())
+            uint8_t slot = cmd.param(0);
+            if (fujicore_open_directory_success(slot, cmd.dataAsString().value()).is_error())
                 SYSTEM_BUS.transaction_error(SP_ERR::IOERROR);
             else
                 SYSTEM_BUS.transaction_success();
@@ -91,54 +92,55 @@ iwmFuji::iwmFuji() : fujiDevice(MAX_A2DISK_DEVICES, IMAGE_EXTENSION, LOBBY_URL)
     };
 
     status_handlers = {
-        { 0xAA, [this]()                               { this->iwm_hello_world(); }},
+        { 0xAA, [this](const iwm_decoded_cmd_t &cmd)                               { this->iwm_hello_world(); }},
 
 #ifndef DEV_RELAY_SLIP
-        { SP_STAT_GET_DISKII_SEEN, [this]()                  { data_len = 1; data_buffer[0] = diskii_xface.d2_enable_seen; }},
+        { SP_STAT_GET_DISKII_SEEN, [this](const iwm_decoded_cmd_t &cmd)                  {
+            transaction_begin(TRANS_STATE::NO_GET);
+            transaction_put(diskii_xface.d2_enable_seen);
+        }},
 #endif
 
-        { FUJICMD_DEVICE_ENABLE_STATUS, [this]()       { this->send_stat_get_enable(); }},                      // 0xD1
-        { FUJICMD_GET_ADAPTERCONFIG_EXTENDED, [this]() { this->fujicmd_get_adapter_config_extended(); }},      // 0xC4
-        { FUJICMD_GET_ADAPTERCONFIG, [this]()          { this->fujicmd_get_adapter_config(); }},               // 0xE8
-        { FUJICMD_GET_DEVICE_FULLPATH, [this]()        { this->fujicmd_get_device_filename(data_buffer[0]); }},   // 0xDA
-        { FUJICMD_GET_DEVICE1_FULLPATH, [this]()       { this->fujicmd_get_device_filename(active_fuji_command - 160); }},   // 0xA0
-        { FUJICMD_GET_DEVICE2_FULLPATH, [this]()       { this->fujicmd_get_device_filename(active_fuji_command - 160); }},   // 0xA1
-        { FUJICMD_GET_DEVICE3_FULLPATH, [this]()       { this->fujicmd_get_device_filename(active_fuji_command - 160); }},   // 0xA2
-        { FUJICMD_GET_DEVICE4_FULLPATH, [this]()       { this->fujicmd_get_device_filename(active_fuji_command - 160); }},   // 0xA3
-        { FUJICMD_GET_DEVICE5_FULLPATH, [this]()       { this->fujicmd_get_device_filename(active_fuji_command - 160); }},   // 0xA4
-        { FUJICMD_GET_DEVICE6_FULLPATH, [this]()       { this->fujicmd_get_device_filename(active_fuji_command - 160); }},   // 0xA5
-        { FUJICMD_GET_DEVICE7_FULLPATH, [this]()       { this->fujicmd_get_device_filename(active_fuji_command - 160); }},   // 0xA6
-        { FUJICMD_GET_DEVICE8_FULLPATH, [this]()       { this->fujicmd_get_device_filename(active_fuji_command - 160); }},   // 0xA7
-        { FUJICMD_GET_DEVICE9_FULLPATH, [this]()       { this->fujicmd_get_device_filename(active_fuji_command - 160); }},   // 0xA8
-        { FUJICMD_GET_DEVICE10_FULLPATH, [this]()      { this->fujicmd_get_device_filename(active_fuji_command - 160); }},   // 0xA9
-        { FUJICMD_GET_DIRECTORY_POSITION, [this]()     { this->fujicmd_get_directory_position(); }},           // 0xE5
-        { FUJICMD_GET_HOST_PREFIX, [this]()            { }},                  // 0xE0
-        { FUJICMD_GET_SCAN_RESULT, [this]()            { }},                  // 0xFC
-        { FUJICMD_GET_SSID, [this]()                   { this->fujicmd_net_get_ssid(); }},                     // 0xFE
-        { FUJICMD_GET_WIFI_ENABLED, [this]()           { this->iwm_stat_get_wifi_enabled(); }},                 // 0xEA
-        { FUJICMD_GET_WIFISTATUS, [this]()             { this->fujicmd_net_get_wifi_status(); }},              // 0xFA
-        { FUJICMD_READ_APPKEY, [this]()                { this->fujicmd_read_app_key(); }},                     // 0xDD
-        { FUJICMD_READ_DEVICE_SLOTS, [this]()          { this->fujicmd_read_device_slots(); }},                // 0xF2
-        { FUJICMD_READ_DIR_ENTRY, [this]()             { }},             // 0xF6
-        { FUJICMD_READ_HOST_SLOTS, [this]()            { this->fujicmd_read_host_slots(); }},                  // 0xF4
-        { FUJICMD_SCAN_NETWORKS, [this]()              { this->fujicmd_net_scan_networks(); }},                // 0xFD
-        { FUJICMD_QRCODE_LENGTH, [this]()              { this->iwm_stat_qrcode_length(); }},                    // 0xBE
-        { FUJICMD_QRCODE_OUTPUT, [this]()              { this->iwm_stat_qrcode_output(); }},                    // 0xBE
-        { FUJICMD_STATUS, [this]()                     { this->fujicmd_status(); }},                      // 0x53
-        { FUJICMD_GET_HEAP, [this]()                   { this->iwm_stat_get_heap(); }},                         // 0xC1
-        { FUJICMD_GENERATE_GUID, [this]()              { this->fujicmd_generate_guid(); }},                     // 0xBB
+        { FUJICMD_DEVICE_ENABLE_STATUS, [this](const iwm_decoded_cmd_t &cmd)       { this->send_stat_get_enable(); }},                      // 0xD1
+        { FUJICMD_GET_ADAPTERCONFIG_EXTENDED, [this](const iwm_decoded_cmd_t &cmd) { this->fujicmd_get_adapter_config_extended(); }},      // 0xC4
+        { FUJICMD_GET_ADAPTERCONFIG, [this](const iwm_decoded_cmd_t &cmd)          { this->fujicmd_get_adapter_config(); }},               // 0xE8
+        { FUJICMD_GET_DEVICE_FULLPATH, [this](const iwm_decoded_cmd_t &cmd)        { this->fujicmd_get_device_filename(cmd.param(0)); }},   // 0xDA
+        { FUJICMD_GET_DEVICE1_FULLPATH, [this](const iwm_decoded_cmd_t &cmd)       { this->fujicmd_get_device_filename(cmd.command() - 160); }},   // 0xA0
+        { FUJICMD_GET_DEVICE2_FULLPATH, [this](const iwm_decoded_cmd_t &cmd)       { this->fujicmd_get_device_filename(cmd.command() - 160); }},   // 0xA1
+        { FUJICMD_GET_DEVICE3_FULLPATH, [this](const iwm_decoded_cmd_t &cmd)       { this->fujicmd_get_device_filename(cmd.command() - 160); }},   // 0xA2
+        { FUJICMD_GET_DEVICE4_FULLPATH, [this](const iwm_decoded_cmd_t &cmd)       { this->fujicmd_get_device_filename(cmd.command() - 160); }},   // 0xA3
+        { FUJICMD_GET_DEVICE5_FULLPATH, [this](const iwm_decoded_cmd_t &cmd)       { this->fujicmd_get_device_filename(cmd.command() - 160); }},   // 0xA4
+        { FUJICMD_GET_DEVICE6_FULLPATH, [this](const iwm_decoded_cmd_t &cmd)       { this->fujicmd_get_device_filename(cmd.command() - 160); }},   // 0xA5
+        { FUJICMD_GET_DEVICE7_FULLPATH, [this](const iwm_decoded_cmd_t &cmd)       { this->fujicmd_get_device_filename(cmd.command() - 160); }},   // 0xA6
+        { FUJICMD_GET_DEVICE8_FULLPATH, [this](const iwm_decoded_cmd_t &cmd)       { this->fujicmd_get_device_filename(cmd.command() - 160); }},   // 0xA7
+        { FUJICMD_GET_DEVICE9_FULLPATH, [this](const iwm_decoded_cmd_t &cmd)       { this->fujicmd_get_device_filename(cmd.command() - 160); }},   // 0xA8
+        { FUJICMD_GET_DEVICE10_FULLPATH, [this](const iwm_decoded_cmd_t &cmd)      { this->fujicmd_get_device_filename(cmd.command() - 160); }},   // 0xA9
+        { FUJICMD_GET_DIRECTORY_POSITION, [this](const iwm_decoded_cmd_t &cmd)     { this->fujicmd_get_directory_position(); }},           // 0xE5
+        { FUJICMD_GET_HOST_PREFIX, [this](const iwm_decoded_cmd_t &cmd)            { }},                  // 0xE0
+        { FUJICMD_GET_SCAN_RESULT, [this](const iwm_decoded_cmd_t &cmd)            { }},                  // 0xFC
+        { FUJICMD_GET_SSID, [this](const iwm_decoded_cmd_t &cmd)                   { this->fujicmd_net_get_ssid(); }},                     // 0xFE
+        { FUJICMD_GET_WIFI_ENABLED, [this](const iwm_decoded_cmd_t &cmd)           { this->iwm_stat_get_wifi_enabled(); }},                 // 0xEA
+        { FUJICMD_GET_WIFISTATUS, [this](const iwm_decoded_cmd_t &cmd)             { this->fujicmd_net_get_wifi_status(); }},              // 0xFA
+        { FUJICMD_READ_APPKEY, [this](const iwm_decoded_cmd_t &cmd)                { this->fujicmd_read_app_key(); }},                     // 0xDD
+        { FUJICMD_READ_DEVICE_SLOTS, [this](const iwm_decoded_cmd_t &cmd)          { this->fujicmd_read_device_slots(); }},                // 0xF2
+        { FUJICMD_READ_DIR_ENTRY, [this](const iwm_decoded_cmd_t &cmd)             { }},             // 0xF6
+        { FUJICMD_READ_HOST_SLOTS, [this](const iwm_decoded_cmd_t &cmd)            { this->fujicmd_read_host_slots(); }},                  // 0xF4
+        { FUJICMD_SCAN_NETWORKS, [this](const iwm_decoded_cmd_t &cmd)              { this->fujicmd_net_scan_networks(); }},                // 0xFD
+        { FUJICMD_QRCODE_LENGTH, [this](const iwm_decoded_cmd_t &cmd)              { this->iwm_stat_qrcode_length(); }},                    // 0xBE
+        { FUJICMD_QRCODE_OUTPUT, [this](const iwm_decoded_cmd_t &cmd)              { this->iwm_stat_qrcode_output(); }},                    // 0xBE
+        { FUJICMD_STATUS, [this](const iwm_decoded_cmd_t &cmd)                     { this->fujicmd_status(); }},                      // 0x53
+        { FUJICMD_GET_HEAP, [this](const iwm_decoded_cmd_t &cmd)                   { this->iwm_stat_get_heap(); }},                         // 0xC1
+        { FUJICMD_GENERATE_GUID, [this](const iwm_decoded_cmd_t &cmd)              { this->fujicmd_generate_guid(); }},                     // 0xBB
     };
 
 }
 
-void iwmFuji::iwm_dummy_command() // SP CTRL command
+void iwmFuji::iwm_dummy_command(const iwm_decoded_cmd_t &cmd) // SP CTRL command
 {
         Debug_printf("\r\nData Received: ");
-        transaction_begin(TRANS_STATE::WILL_GET);
-        std::string buffer(data_len, 0);
-        transaction_get(buffer.data(), buffer.size());
-        for (uint8_t byte : buffer)
+        for (uint8_t byte : cmd.data().value())
             Debug_printf(" %02x", byte);
+        transaction_complete();
 }
 
 void iwmFuji::iwm_hello_world()
@@ -185,16 +187,17 @@ void iwmFuji::iwm_stat_get_heap()
 }
 
 //  Make new disk and shove into device slot
-void iwmFuji::iwm_ctrl_new_disk()
+void iwmFuji::iwm_ctrl_new_disk(const iwm_decoded_cmd_t &cmd)
 {
-    uint8_t hs = data_buffer[0];
-    uint8_t ds = data_buffer[1];
-    uint8_t t = data_buffer[2];
+    uint8_t hs = cmd.param(0);
+    uint8_t ds = cmd.param(1);
+    uint8_t t = cmd.param(2);
     u32le_t numBlocks;
     const uint8_t *ptr;
 
-    memcpy(&numBlocks, &data_buffer[3], sizeof(numBlocks));
-    ptr = &data_buffer[3] + sizeof(numBlocks);
+    ptr = cmd.data()->data();
+    memcpy(&numBlocks, ptr, sizeof(numBlocks));
+    ptr += sizeof(numBlocks);
 
     fujiDisk &disk = _fnDisks[ds];
     fujiHost &host = _fnHosts[hs];
@@ -230,17 +233,17 @@ void iwmFuji::iwm_stat_get_wifi_enabled()
         transaction_put(e);
 }
 
-void iwmFuji::iwm_ctrl_enable_device()
+void iwmFuji::iwm_ctrl_enable_device(const iwm_decoded_cmd_t &cmd)
 {
-        unsigned char d = data_buffer[0];
+        unsigned char d = cmd.param(0);
 
         Debug_printf("\nFuji cmd: ENABLE DEVICE");
         SYSTEM_BUS.enableDevice(d);
 }
 
-void iwmFuji::iwm_ctrl_disable_device()
+void iwmFuji::iwm_ctrl_disable_device(const iwm_decoded_cmd_t &cmd)
 {
-        unsigned char d = data_buffer[0];
+        unsigned char d = cmd.param(0);
 
         Debug_printf("\nFuji cmd: DISABLE DEVICE");
         SYSTEM_BUS.disableDevice(d);
@@ -325,30 +328,28 @@ void iwmFuji::iwm_read(const iwm_decoded_cmd_t &cmd) {}
 
 void iwmFuji::iwm_status(const iwm_decoded_cmd_t &cmd)
 {
-    active_fuji_command = cmd.control_status.fuji.command;
+    Debug_printf("\r\n[Fuji] Device %02x Status Code %02x\r\n", id(), cmd.command());
 
-    Debug_printf("\r\n[Fuji] Device %02x Status Code %02x\r\n", id(), active_fuji_command);
-
-    auto it = status_handlers.find(active_fuji_command);
+    auto it = status_handlers.find(cmd.command());
     if (it != status_handlers.end()) {
-        it->second();
+        it->second(cmd);
     } else {
-        Debug_printf("ERROR: Unhandled status code: %02X\n", active_fuji_command);
+        Debug_printf("ERROR: Unhandled status code: %02X\n", cmd.command());
         transaction_error();
     }
 }
 
 void iwmFuji::iwm_ctrl(const iwm_decoded_cmd_t &cmd)
 {
-    Debug_printf("\ntheFuji Device %02x Control Code %02x", id(), cmd.control_status.fuji.command);
+    Debug_printf("\ntheFuji Device %02x Control Code %02x", id(), cmd.command());
 
-    Debug_printf("\nDecoding Control Data Packet for code: 0x%02x\r\n", cmd.control_status.fuji.command);
+    Debug_printf("\nDecoding Control Data Packet for code: 0x%02x\r\n", cmd.command());
 
-    auto it = control_handlers.find(cmd.control_status.fuji.command);
+    auto it = control_handlers.find(cmd.command());
     if (it != control_handlers.end()) {
-        it->second();
+        it->second(cmd);
     } else {
-        Debug_printf("ERROR: Unhandled control code: %02X\n", cmd.control_status.fuji.command);
+        Debug_printf("ERROR: Unhandled control code: %02X\n", cmd.command());
         SYSTEM_BUS.transaction_error(SP_ERR::BADCTL);
     }
 }
@@ -372,35 +373,33 @@ void iwmFuji::handle_ctl_eject(uint8_t spid)
         }
 }
 
-void iwmFuji::iwm_ctrl_hash_input()
+void iwmFuji::iwm_ctrl_hash_input(const iwm_decoded_cmd_t &cmd)
 {
-    ByteBuffer data(data_len, 0);
-    transaction_begin(TRANS_STATE::WILL_GET);
-    transaction_get(data.data(), data.size());
-    hasher.add_data(data);
+    transaction_begin(TRANS_STATE::NO_GET);
+    hasher.add_data(cmd.dataAsString().value());
     transaction_complete();
 }
 
-void iwmFuji::iwm_ctrl_hash_compute(bool clear_data)
+void iwmFuji::iwm_ctrl_hash_compute(const iwm_decoded_cmd_t &cmd, bool clear_data)
 {
     Debug_printf("FUJI: HASH COMPUTE\n");
-    algorithm = Hash::to_algorithm(data_buffer[0]);
+    algorithm = Hash::to_algorithm(cmd.param(0));
     hasher.compute(algorithm, clear_data);
 }
 
-void iwmFuji::iwm_stat_hash_length()
+void iwmFuji::iwm_stat_hash_length(const iwm_decoded_cmd_t &cmd)
 {
-    uint8_t is_hex = data_buffer[0] == 1;
+    uint8_t is_hex = cmd.param8(0) == 1;
     uint8_t r = hasher.hash_length(algorithm, is_hex);
 
     transaction_begin(TRANS_STATE::NO_GET);
     transaction_put(r);
 }
 
-void iwmFuji::iwm_ctrl_hash_output()
+void iwmFuji::iwm_ctrl_hash_output(const iwm_decoded_cmd_t &cmd)
 {
     Debug_printf("FUJI: HASH OUTPUT CONTROL\n");
-    hash_is_hex_output = data_buffer[0] == 1;
+    hash_is_hex_output = cmd.param8(0) == 1;
 }
 
 void iwmFuji::iwm_stat_hash_output()
@@ -419,21 +418,19 @@ void iwmFuji::iwm_ctrl_hash_clear()
     hasher.clear();
 }
 
-void iwmFuji::iwm_ctrl_qrcode_input()
+void iwmFuji::iwm_ctrl_qrcode_input(const iwm_decoded_cmd_t &cmd)
 {
-    Debug_printf("FUJI: QRCODE INPUT (len: %d)\n", data_len);
-    std::string data(data_len, 0);
-    transaction_begin(TRANS_STATE::WILL_GET);
-    transaction_get(data.data(), data.size());
-    _qrManager.data += data;
+    Debug_printf("FUJI: QRCODE INPUT (len: %d)\n", cmd.data()->size());
+    transaction_begin(TRANS_STATE::NO_GET);
+    _qrManager.data += cmd.dataAsString().value();
     transaction_complete();
 }
 
-void iwmFuji::iwm_ctrl_qrcode_encode()
+void iwmFuji::iwm_ctrl_qrcode_encode(const iwm_decoded_cmd_t &cmd)
 {
-    uint8_t version = data_buffer[0] & 0b01111111;
-    uint8_t ecc_mode = data_buffer[1];
-    bool shorten = data_buffer[2];
+    uint8_t version = cmd.param8(0) & 0b01111111;
+    uint8_t ecc_mode = cmd.param(1);
+    bool shorten = cmd.param(2);
 
     Debug_printf("FUJI: QRCODE ENCODE\n");
     Debug_printf("QR Version: %d, ECC: %d, Shorten: %s\n", version, ecc_mode, shorten ? "Y" : "N");
@@ -469,11 +466,11 @@ void iwmFuji::iwm_stat_qrcode_length()
     transaction_put(&len, sizeof(len));
 }
 
-void iwmFuji::iwm_ctrl_qrcode_output()
+void iwmFuji::iwm_ctrl_qrcode_output(const iwm_decoded_cmd_t &cmd)
 {
     Debug_printf("FUJI: QRCODE OUTPUT CONTROL\n");
 
-    uint8_t output_mode = data_buffer[0];
+    uint8_t output_mode = cmd.param(0);
     Debug_printf("Output mode: %i\n", output_mode);
 
     size_t len = _qrManager.code.size();

--- a/lib/device/iwm/iwmFuji.h
+++ b/lib/device/iwm/iwmFuji.h
@@ -17,8 +17,8 @@
 #define MAX_DISK2_DEVICES 2 // for now until we add 3.5" disks
 #define MAX_A2DISK_DEVICES (MAX_SPDISK_DEVICES + MAX_DISK2_DEVICES)
 
-using IWMControlHandlers = std::function<void()>;
-using IWMStatusHandlers = std::function<void()>;
+using IWMControlHandlers = std::function<void(const iwm_decoded_cmd_t &cmd)>;
+using IWMStatusHandlers = std::function<void(const iwm_decoded_cmd_t &cmd)>;
 
 class iwmFuji : public fujiDevice
 {
@@ -63,26 +63,26 @@ protected:
     size_t set_additional_direntry_details(fsdir_entry_t *f, uint8_t *dest,
                                            uint8_t maxlen) override;
 
-    void iwm_dummy_command();                     // control 0xAA
+    void iwm_dummy_command(const iwm_decoded_cmd_t &cmd);                     // control 0xAA
     void iwm_hello_world();                       // status 0xAA
     void iwm_stat_get_wifi_enabled();             // 0xEA
-    void iwm_ctrl_new_disk();                     // 0xE7
-    void iwm_ctrl_enable_device();                // 0xD5
-    void iwm_ctrl_disable_device();               // 0xD4
+    void iwm_ctrl_new_disk(const iwm_decoded_cmd_t &cmd);                     // 0xE7
+    void iwm_ctrl_enable_device(const iwm_decoded_cmd_t &cmd);                // 0xD5
+    void iwm_ctrl_disable_device(const iwm_decoded_cmd_t &cmd);               // 0xD4
     void send_stat_get_enable();                  // 0xD1
 
-    void iwm_ctrl_hash_input();                   // 0xC8
-    void iwm_ctrl_hash_compute(bool clear_data);  // 0xC7, 0xC3
-    void iwm_stat_hash_length();                  // 0xC6
-    void iwm_ctrl_hash_output();                  // 0xC5 set hash_is_hex_output
+    void iwm_ctrl_hash_input(const iwm_decoded_cmd_t &cmd);                   // 0xC8
+    void iwm_ctrl_hash_compute(const iwm_decoded_cmd_t &cmd, bool clear_data);  // 0xC7, 0xC3
+    void iwm_stat_hash_length(const iwm_decoded_cmd_t &cmd);                  // 0xC6
+    void iwm_ctrl_hash_output(const iwm_decoded_cmd_t &cmd);                  // 0xC5 set hash_is_hex_output
     void iwm_stat_hash_output();                  // 0xC5 write response
     void iwm_ctrl_hash_clear();                   // 0xC2
     void iwm_stat_get_heap();                     // 0xC1
 
-    void iwm_ctrl_qrcode_input();                 // 0xBC
-    void iwm_ctrl_qrcode_encode();                // 0xBD
+    void iwm_ctrl_qrcode_input(const iwm_decoded_cmd_t &cmd);                 // 0xBC
+    void iwm_ctrl_qrcode_encode(const iwm_decoded_cmd_t &cmd);                // 0xBD
     void iwm_stat_qrcode_length();                // 0xBE
-    void iwm_ctrl_qrcode_output();                // 0xBF
+    void iwm_ctrl_qrcode_output(const iwm_decoded_cmd_t &cmd);                // 0xBF
     void iwm_stat_qrcode_output();                // 0xBF
 
     void iwm_ctrl(const iwm_decoded_cmd_t &cmd) override;
@@ -95,8 +95,6 @@ protected:
     iwm_device_status_block_t create_status_reply_packet() override;
 
 public:
-    fujiCommandID_t active_fuji_command;
-
     iwmFuji();
     void setup() override;
 

--- a/lib/device/iwm/modem.cpp
+++ b/lib/device/iwm/modem.cpp
@@ -1397,12 +1397,13 @@ void iwmModem::iwm_read(const iwm_decoded_cmd_t &cmd)
     unsigned short mw;
 #endif
 
-    Debug_printf("\r\nDevice %02x READ %04x bytes from address %06lx\n", id(), cmd.char_rw.length, cmd.char_rw.address);
+    Debug_printf("\r\nDevice %02x READ %04x bytes from address %06lx\n", id(), cmd.frame.char_rw.length, cmd.frame.char_rw.address);
 
+    SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
     std::vector<uint8_t> buffer;
     if (mw) // check if we really have some bytes waiting
     {
-        size_t numbytes = std::min<uint16_t>(mw, cmd.char_rw.length);
+        size_t numbytes = std::min<uint16_t>(mw, cmd.frame.char_rw.length);
 
         for (size_t i = 0; i < numbytes; i++)
         {
@@ -1421,16 +1422,17 @@ void iwmModem::iwm_read(const iwm_decoded_cmd_t &cmd)
 
 void iwmModem::iwm_write(const iwm_decoded_cmd_t &cmd)
 {
-    Debug_printf("\nWRITE %u bytes\n", cmd.char_rw.length);
+    Debug_printf("\nWRITE %u bytes\n", cmd.frame.char_rw.length);
 
     // get write data packet, keep trying until no timeout
     //  to do - this blows up - check handshaking
 
     {
+        auto buffer = cmd.data().value();
         // DO write
 #ifdef ESP_PLATFORM // OS
-        for (int i = 0; i < cmd.char_rw.length; i++)
-            xQueueSend(mtxq, &data_buffer[i], portMAX_DELAY);
+        for (int i = 0; i < cmd.frame.char_rw.length; i++)
+            xQueueSend(mtxq, &buffer[i], portMAX_DELAY);
 #endif
     }
 
@@ -1439,13 +1441,10 @@ void iwmModem::iwm_write(const iwm_decoded_cmd_t &cmd)
 
 void iwmModem::iwm_ctrl(const iwm_decoded_cmd_t &cmd)
 {
-    spError_t err_result = SP_ERR::NOERROR;
-
-    Debug_printf("\r\nModem Device %02x Control Code %02x", id(), cmd.control_status.fuji.command);
-    print_packet(data_buffer,data_len);
-
+    Debug_printf("\r\nModem Device %02x Control Code %02x", id(), cmd.command());
     Debug_printf("\nSending Control Reply");
-    SYSTEM_BUS.transaction_error(err_result);
+    SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
+    SYSTEM_BUS.transaction_success();
 }
 
 void iwmModem::iwm_modem_status()
@@ -1455,7 +1454,6 @@ void iwmModem::iwm_modem_status()
     mw = uxQueueMessagesWaiting(mrxq);
 #endif
 
-
     SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
     SYSTEM_BUS.transaction_send(&mw, sizeof(mw));
     Debug_printf("--- %u bytes waiting\n", mw);
@@ -1463,10 +1461,9 @@ void iwmModem::iwm_modem_status()
 
 void iwmModem::iwm_status(const iwm_decoded_cmd_t &cmd)
 {
-    Debug_printf("\r\n[MODEM] Device %02x Status Code %02x\r\n", id(), cmd.control_status.fuji.command);
-    // Debug_printf("\r\nStatus List is at %02x %02x\n", cmd.g7byte1 & 0x7f, cmd.g7byte2 & 0x7f);
+    Debug_printf("\r\n[MODEM] Device %02x Status Code %02x\r\n", id(), cmd.command());
 
-    switch (cmd.control_status.fuji.command)
+    switch (cmd.command())
     {
     case MODEMCMD_STATUS:
         iwm_modem_status();

--- a/lib/device/iwm/network.cpp
+++ b/lib/device/iwm/network.cpp
@@ -71,19 +71,16 @@ iwm_device_info_block_t iwmNetwork::create_dib_reply_packet()
  * Called in response to 'O' command. Instantiate a protocol, pass URL to it, call its open
  * method. Also set up RX interrupt.
  */
-void iwmNetwork::open()
+void iwmNetwork::open(const iwm_decoded_cmd_t &cmd)
 {
     // This will create the entry if one doesn't exist yet.
     auto& current_network_data = network_data_map[current_network_unit];
-    uint8_t _aux1 = data_buffer[0];
-    uint8_t _aux2 = data_buffer[1];
+    uint8_t _aux1 = cmd.param(0);
+    uint8_t _aux2 = cmd.param(1);
 
-    auto start = data_buffer + 2;
-    auto end = start + std::min<std::size_t>(256, data_len - 2);
-    auto null_pos = std::find(start, end, 0);
-
-    // ensure the string does not go past a null, but can be up to 256 bytes long if one not found
-    string d(start, null_pos);
+    bool is_dir = static_cast<fileAccessMode_t>(_aux1) == ACCESS_MODE::DIRECTORY;
+    string d = cmd.dataAsString().value();
+    d.resize(strlen(d.c_str())); // Truncate to null terminator
 
     Debug_printf("\naux1: %u aux2: %u path %s", _aux1, _aux2, d.c_str());
 
@@ -104,7 +101,8 @@ void iwmNetwork::open()
     Debug_printf("\nopen()\n");
 
     // Parse and instantiate protocol
-    parse_and_instantiate_protocol(d);
+    parse_and_instantiate_protocol(d, is_dir);
+
 
     if (!current_network_data.protocol)
     {
@@ -113,7 +111,10 @@ void iwmNetwork::open()
     }
 
     // Attempt protocol open
-    if (current_network_data.protocol->open(current_network_data.urlParser.get(), (fileAccessMode_t) data_buffer[0], (netProtoTranslation_t) data_buffer[1]) != FUJI_ERROR::NONE)
+    if (current_network_data.protocol->open(current_network_data.urlParser.get(),
+                                            (fileAccessMode_t) cmd.param8(0),
+                                            (netProtoTranslation_t) cmd.param8(1))
+        != FUJI_ERROR::NONE)
     {
         // Remember the failure before the protocol (and its error) is destroyed,
         // so a subsequent STATUS can report the real code (e.g. FILE_NOT_FOUND).
@@ -184,13 +185,12 @@ void iwmNetwork::get_prefix()
 /**
  * Set Prefix
  */
-void iwmNetwork::set_prefix()
+void iwmNetwork::set_prefix(const iwm_decoded_cmd_t &cmd)
 {
     auto& current_network_data = network_data_map[current_network_unit];
 
-    string prefixSpec_str(data_len, 0);
-    SYSTEM_BUS.transaction_accept(TRANS_STATE::WILL_GET);
-    SYSTEM_BUS.transaction_get(prefixSpec_str.data(), prefixSpec_str.size());
+    string prefixSpec_str = cmd.dataAsString().value();
+    SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
     prefixSpec_str = prefixSpec_str.substr(prefixSpec_str.find_first_of(":") + 1);
     Debug_printf("iwmNetwork::iwmnet_set_prefix(%s)\n", prefixSpec_str.c_str());
 
@@ -238,14 +238,12 @@ void iwmNetwork::set_prefix()
 /**
  * Set login
  */
-void iwmNetwork::set_login()
+void iwmNetwork::set_login(const iwm_decoded_cmd_t &cmd)
 {
     auto& current_network_data = network_data_map[current_network_unit];
 
-    string buffer(data_len, 0);
-    SYSTEM_BUS.transaction_accept(TRANS_STATE::WILL_GET);
-    SYSTEM_BUS.transaction_get(buffer.data(), buffer.size());
-    current_network_data.login = buffer;
+    SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
+    current_network_data.login = cmd.dataAsString().value();
     Debug_printf("Login is %s\n", current_network_data.login.c_str());
     SYSTEM_BUS.transaction_success();
 }
@@ -253,34 +251,34 @@ void iwmNetwork::set_login()
 /**
  * Set password
  */
-void iwmNetwork::set_password()
+void iwmNetwork::set_password(const iwm_decoded_cmd_t &cmd)
 {
     auto& current_network_data = network_data_map[current_network_unit];
 
-    string buffer(data_len, 0);
-    SYSTEM_BUS.transaction_accept(TRANS_STATE::WILL_GET);
-    SYSTEM_BUS.transaction_get(buffer.data(), buffer.size());
-    current_network_data.password = buffer;
+    SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
+    current_network_data.password = cmd.dataAsString().value();
     Debug_printf("Password is %s\n", current_network_data.password.c_str()); // GREAT LOGGING
     SYSTEM_BUS.transaction_success();
 }
 
-void iwmNetwork::channel_mode()
+void iwmNetwork::channel_mode(const iwm_decoded_cmd_t &cmd)
 {
     auto& current_network_data = network_data_map[current_network_unit];
-    switch (data_buffer[0])
+    channelMode_t mode = static_cast<channelMode_t>(cmd.param8(0));
+    switch (mode)
     {
-    case 0:
+    case CHANNEL_MODE::PROTOCOL:
         Debug_printf("channelMode = PROTOCOL\n");
-        current_network_data.channelMode = CHANNEL_MODE::PROTOCOL;
+        current_network_data.channelMode = mode;
         break;
-    case 1:
+    case CHANNEL_MODE::JSON:
         Debug_printf("channelMode = JSON\n");
-        current_network_data.channelMode = CHANNEL_MODE::JSON;
+        current_network_data.channelMode = mode;
         break;
     default:
-        Debug_printf("INVALID MODE = %02x\r\n", data_buffer[0]);
-        break;
+        Debug_printf("INVALID MODE = %02x\r\n", mode);
+        SYSTEM_BUS.transaction_error();
+        return;
     }
     SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
     SYSTEM_BUS.transaction_success();
@@ -289,9 +287,8 @@ void iwmNetwork::channel_mode()
 void iwmNetwork::json_query(const iwm_decoded_cmd_t &cmd)
 {
     auto& current_network_data = network_data_map[current_network_unit];
-    std::string buffer(data_len, 0);
-    SYSTEM_BUS.transaction_accept(TRANS_STATE::WILL_GET);
-    SYSTEM_BUS.transaction_get(buffer.data(), buffer.size());
+    SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
+    std::string buffer = cmd.dataAsString().value();
     buffer.resize(strlen(buffer.c_str())); // Truncate to null terminator
     Debug_printf("\r\nQuery set to: %s, data_len: %d\r\n", buffer.c_str(), buffer.size());
     current_network_data.json->setReadQuery(buffer, 0);
@@ -364,15 +361,15 @@ void iwmNetwork::iwm_status(const iwm_decoded_cmd_t &cmd)
     // We have moved to a separate control command that sets the active channel for all subsequent commands
     // fujinet-lib (with unit-id support) sends the count of bytes for a status as 4 to cater for the network unit.
     // Older code sends 3 as the count, so we can detect if the network unit byte is there or not.
-    if (cmd.param_count == 4) {
-        current_network_unit = cmd.control_status.fuji.network_unit;
+    if (cmd.frame.param_count == 4) {
+        current_network_unit = cmd.frame.control_status.fuji.network_unit;
     }
 
 #ifdef DEBUG
-    Debug_printf("\r\n[NETWORK] Device %02x Status Code %02x('%c') net_unit %02x\r\n", id(), cmd.control_status.fuji.command, isprint(cmd.control_status.fuji.command) ? (char) cmd.control_status.fuji.command : '.', current_network_unit);
+    Debug_printf("\r\n[NETWORK] Device %02x Status Code %02x('%c') net_unit %02x\r\n", id(), cmd.command(), isprint(cmd.command()) ? (char) cmd.command() : '.', current_network_unit);
 #endif
 
-    switch (cmd.control_status.fuji.command)
+    switch (cmd.command())
     {
     case NETCMD_GETCWD:
         get_prefix();
@@ -397,7 +394,7 @@ error_is_true iwmNetwork::read_channel_json(const iwm_decoded_cmd_t &cmd)
 {
     auto& current_network_data = network_data_map[current_network_unit];
     Debug_printf("read_channel_json - num_bytes: %02x, json_bytes_remaining: %02x\n",
-                 cmd.char_rw.length, current_network_data.json->available());
+                 cmd.frame.char_rw.length, current_network_data.json->available());
     if (current_network_data.json->available() == 0) // if no bytes, we just return with no data
     {
         SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
@@ -405,7 +402,7 @@ error_is_true iwmNetwork::read_channel_json(const iwm_decoded_cmd_t &cmd)
         RETURN_ERROR_AS_TRUE();
     }
 
-    auto rlen = std::min<uint16_t>(cmd.char_rw.length,
+    auto rlen = std::min<uint16_t>(cmd.frame.char_rw.length,
                                    current_network_data.json->readValueLen());
     ByteBuffer buffer(rlen, 0);
     current_network_data.json->readValue(buffer.data(), buffer.size());
@@ -425,7 +422,7 @@ error_is_true iwmNetwork::read_channel(const iwm_decoded_cmd_t &cmd)
 
     avail = current_network_data.protocol->available();
     auto rlen = std::min<size_t>({
-            cmd.char_rw.length, 512, current_network_data.protocol->available()});
+            cmd.frame.char_rw.length, 512, current_network_data.protocol->available()});
 
     if (current_network_data.protocol->read(rlen) != FUJI_ERROR::NONE) // protocol adapter returned error
         RETURN_ERROR_AS_TRUE();
@@ -455,12 +452,12 @@ void iwmNetwork::iwm_read(const iwm_decoded_cmd_t &cmd)
     // We have moved to a separate control command that sets the active channel for all subsequent commands
     // fujinet-lib (with unit-id support) sends the count of bytes for a read as 5 to cater for the network unit.
     // Older code sends 4 as the count, so we can detect if the network unit byte is there or not.
-    if (cmd.param_count == 5) {
+    if (cmd.frame.param_count == 5) {
         // in a network device, there is no "address" value, this is hijacked by fujinet-lib to pass the network unit in first byte
-        current_network_unit = cmd.char_rw.fuji.network_unit;
+        current_network_unit = cmd.frame.char_rw.fuji.network_unit;
     }
 
-    Debug_printf("\r\nDevice %02x Read %04x bytes, net_unit %02x\n", id(), cmd.char_rw.length, current_network_unit);
+    Debug_printf("\r\nDevice %02x Read %04x bytes, net_unit %02x\n", id(), cmd.frame.char_rw.length, current_network_unit);
 
     auto& current_network_data = network_data_map[current_network_unit];
 
@@ -475,15 +472,14 @@ void iwmNetwork::iwm_read(const iwm_decoded_cmd_t &cmd)
     }
 }
 
-void iwmNetwork::net_write()
+void iwmNetwork::net_write(const iwm_decoded_cmd_t &cmd)
 {
     auto& current_network_data = network_data_map[current_network_unit];
     // TODO: Handle errors.
-    std::string buffer(data_len, 0);
-    SYSTEM_BUS.transaction_accept(TRANS_STATE::WILL_GET);
-    SYSTEM_BUS.transaction_get(buffer.data(), buffer.size());
-    current_network_data.transmitBuffer += buffer;
-    write_channel(buffer.size());
+    SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
+    std::string data = cmd.dataAsString().value();
+    current_network_data.transmitBuffer += data;
+    write_channel(data.size());
 }
 
 void iwmNetwork::iwm_write(const iwm_decoded_cmd_t &cmd)
@@ -492,16 +488,16 @@ void iwmNetwork::iwm_write(const iwm_decoded_cmd_t &cmd)
     // We have moved to a separate control command that sets the active channel for all subsequent commands
     // fujinet-lib (with unit-id support) sends the count of bytes for a write as 5 to cater for the network unit.
     // Older code sends 4 as the count, so we can detect if the network unit byte is there or not.
-    if (cmd.param_count == 5) {
+    if (cmd.frame.param_count == 5) {
         // in a network device, there is no "address" value, this is hijacked by fujinet-lib to pass the network unit in first byte
-        current_network_unit = cmd.char_rw.fuji.network_unit;
+        current_network_unit = cmd.frame.char_rw.fuji.network_unit;
     }
 
-    Debug_printf("\r\nDevice %02x Write %04x bytes, net_unit %02x\n", id(), cmd.char_rw.length, current_network_unit);
+    Debug_printf("\r\nDevice %02x Write %04x bytes, net_unit %02x\n", id(), cmd.frame.char_rw.length, current_network_unit);
 
     auto& current_network_data = network_data_map[current_network_unit];
 
-    string buffer(cmd.char_rw.length, 0);
+    string buffer(cmd.frame.char_rw.length, 0);
     SYSTEM_BUS.transaction_accept(TRANS_STATE::WILL_GET);
     SYSTEM_BUS.transaction_get(buffer.data(), buffer.size());
     current_network_data.transmitBuffer += buffer;
@@ -522,55 +518,53 @@ void iwmNetwork::iwm_ctrl(const iwm_decoded_cmd_t &cmd)
     // We have moved to a separate control command that sets the active channel for all subsequent commands
     // fujinet-lib (with unit-id support) sends the count of bytes for a control as 4 to cater for the network unit.
     // Older code sends 3 as the count, so we can detect if the network unit byte is there or not.
-    if (cmd.param_count == 4) {
-        current_network_unit = cmd.control_status.fuji.network_unit;
+    if (cmd.frame.param_count == 4) {
+        current_network_unit = cmd.frame.control_status.fuji.network_unit;
     }
 
     auto& current_network_data = network_data_map[current_network_unit];
 
-    print_packet(data_buffer);
-
 #ifdef DEBUG
-    if (cmd.control_status.fuji.command == NETCMD_SET_CHANNEL)
-        Debug_printf("\r\nNet Device %02x Control Code %02x('%c') net_unit %02x", id(), cmd.control_status.fuji.command, isprint(cmd.control_status.fuji.command) ? (char)cmd.control_status.fuji.command : '.', data_buffer[0]);
+    if (cmd.command() == NETCMD_SET_CHANNEL)
+        Debug_printf("\r\nNet Device %02x Control Code %02x('%c') net_unit %02x", id(), cmd.command(), isprint(cmd.command()) ? (char)cmd.command() : '.', cmd.param(0));
     else
-        Debug_printf("\r\nNet Device %02x Control Code %02x('%c') net_unit %02x", id(), cmd.control_status.fuji.command, isprint(cmd.control_status.fuji.command) ? (char)cmd.control_status.fuji.command : '.', current_network_unit);
+        Debug_printf("\r\nNet Device %02x Control Code %02x('%c') net_unit %02x", id(), cmd.command(), isprint(cmd.command()) ? (char)cmd.command() : '.', current_network_unit);
 #endif
 
-    // Debug_printv("cmd (looking for network_unit in byte 6, i.e. hex[5]):\r\n%s\r\n", mstr::toHex(cmd.decoded, 9).c_str());
+    // Debug_printv("cmd (looking for network_unit in byte 6, i.e. hex[5]):\r\n%s\r\n", mstr::toHex(cmd.frame.decoded, 9).c_str());
 
-    if (cmd.control_status.fuji.command != NETCMD_OPEN && current_network_data.json == nullptr) {
+    if (cmd.command() != NETCMD_OPEN && current_network_data.json == nullptr) {
         Debug_printv("control should not be called on a non-open channel - FN was probably reset");
     }
 
-    switch (cmd.control_status.fuji.command)
+    switch (cmd.command())
     {
     case NETCMD_SET_CHANNEL:
-        current_network_unit = data_buffer[0];
+        current_network_unit = cmd.param(0);
         break;
     case NETCMD_CHDIR:
-        set_prefix();
+        set_prefix(cmd);
         break;
     case NETCMD_GETCWD:
         get_prefix();
         break;
     case NETCMD_OPEN:
-        open();
+        open(cmd);
         break;
     case NETCMD_CLOSE:
         close();
         break;
     case NETCMD_WRITE:
-        net_write();
+        net_write(cmd);
         break;
     case NETCMD_CHANNEL_MODE:
-        channel_mode();
+        channel_mode(cmd);
         break;
     case NETCMD_USERNAME: // login
-        set_login();
+        set_login(cmd);
         break;
     case NETCMD_PASSWORD: // password
-        set_password();
+        set_password(cmd);
         break;
 
     case NETCMD_PARSE:
@@ -586,21 +580,21 @@ void iwmNetwork::iwm_ctrl(const iwm_decoded_cmd_t &cmd)
     case NETCMD_UNLOCK:
     case NETCMD_MKDIR:
     case NETCMD_RMDIR:
-        process_fs(cmd.control_status.fuji.command);
+        process_fs(cmd);
         break;
 
     case NETCMD_CONTROL:
     case NETCMD_CLOSE_CLIENT:
-        process_tcp(cmd.control_status.fuji.command);
+        process_tcp(cmd);
         break;
 
     case NETCMD_SET_CHANNEL_MODE:
-        process_http(cmd.control_status.fuji.command);
+        process_http(cmd);
         break;
 
     case NETCMD_GET_REMOTE:
     case NETCMD_SET_DESTINATION:
-        process_udp(cmd.control_status.fuji.command);
+        process_udp(cmd);
         break;
 
     default:
@@ -632,10 +626,10 @@ bool iwmNetwork::instantiate_protocol()
  * Preprocess deviceSpec given aux1 open mode. This is used to work around various assumptions that different
  * disk utility packages do when opening a device, such as adding wildcards for directory opens.
  */
-void iwmNetwork::create_devicespec(string d)
+void iwmNetwork::create_devicespec(string d, bool is_dir)
 {
     auto& current_network_data = network_data_map[current_network_unit];
-    current_network_data.deviceSpec = util_devicespec_fix_for_parsing(d, current_network_data.prefix, data_buffer[0] == 6, false);
+    current_network_data.deviceSpec = util_devicespec_fix_for_parsing(d, current_network_data.prefix, is_dir, false);
 }
 
 /*
@@ -649,10 +643,10 @@ void iwmNetwork::create_url_parser()
     current_network_data.urlParser = std::move(PeoplesUrlParser::parseURL(url));
 }
 
-error_is_true iwmNetwork::parse_and_instantiate_protocol(string d)
+error_is_true iwmNetwork::parse_and_instantiate_protocol(string d, bool is_dir)
 {
     auto& current_network_data = network_data_map[current_network_unit];
-    create_devicespec(d);
+    create_devicespec(d, is_dir);
     create_url_parser();
 
     // Invalid URL returns error 165 in status.
@@ -684,14 +678,15 @@ void iwmNetwork::iwmnet_set_timer_rate()
 {
 }
 
-void iwmNetwork::process_fs(fujiCommandID_t fuji_command)
+void iwmNetwork::process_fs(const iwm_decoded_cmd_t &cmd)
 {
     auto& current_network_data = network_data_map[current_network_unit];
-    string d(256, 0);
 
-    SYSTEM_BUS.transaction_accept(TRANS_STATE::WILL_GET);
-    SYSTEM_BUS.transaction_get(d.data(), d.size());
-    parse_and_instantiate_protocol(d);
+    SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
+    bool is_dir = static_cast<fileAccessMode_t>(cmd.param8(0)) == ACCESS_MODE::DIRECTORY;
+    std::string d = cmd.dataAsString().value();
+    d.resize(strlen(d.c_str())); // Truncate to null terminator
+    parse_and_instantiate_protocol(d, is_dir);
 
     if (!current_network_data.protocol)
     {
@@ -709,7 +704,7 @@ void iwmNetwork::process_fs(fujiCommandID_t fuji_command)
 
     fujiError_t cmd_err;
     auto url = current_network_data.urlParser.get();
-    switch (fuji_command)
+    switch (cmd.command())
     {
     case NETCMD_RENAME:
         cmd_err = fs->rename(url);
@@ -743,7 +738,7 @@ void iwmNetwork::process_fs(fujiCommandID_t fuji_command)
     SYSTEM_BUS.transaction_success();
 }
 
-void iwmNetwork::process_tcp(fujiCommandID_t fuji_command)
+void iwmNetwork::process_tcp(const iwm_decoded_cmd_t &cmd)
 {
     auto& current_network_data = network_data_map[current_network_unit];
     // Make sure this is really a TCP protocol instance
@@ -755,7 +750,7 @@ void iwmNetwork::process_tcp(fujiCommandID_t fuji_command)
     }
 
     fujiError_t cmd_err;
-    switch (fuji_command)
+    switch (cmd.command())
     {
     case NETCMD_CONTROL:
         cmd_err = tcp->accept_connection();
@@ -777,7 +772,7 @@ void iwmNetwork::process_tcp(fujiCommandID_t fuji_command)
     SYSTEM_BUS.transaction_success();
 }
 
-void iwmNetwork::process_http(fujiCommandID_t fuji_command)
+void iwmNetwork::process_http(const iwm_decoded_cmd_t &cmd)
 {
     auto& current_network_data = network_data_map[current_network_unit];
     // Make sure this is really an HTTP protocol instance
@@ -791,10 +786,10 @@ void iwmNetwork::process_http(fujiCommandID_t fuji_command)
     SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
 
     fujiError_t cmd_err;
-    switch (fuji_command)
+    switch (cmd.command())
     {
     case NETCMD_SET_CHANNEL_MODE:
-        cmd_err = http->set_channel_mode((netProtoHTTPChannelMode_t) data_buffer[1]);
+        cmd_err = http->set_channel_mode((netProtoHTTPChannelMode_t) cmd.param8(1));
         break;
     default:
         cmd_err = FUJI_ERROR::UNSPECIFIED;
@@ -810,7 +805,7 @@ void iwmNetwork::process_http(fujiCommandID_t fuji_command)
     SYSTEM_BUS.transaction_success();
 }
 
-void iwmNetwork::process_udp(fujiCommandID_t fuji_command)
+void iwmNetwork::process_udp(const iwm_decoded_cmd_t &cmd)
 {
     auto& current_network_data = network_data_map[current_network_unit];
     // Make sure this is really a UDP protocol instance
@@ -822,7 +817,7 @@ void iwmNetwork::process_udp(fujiCommandID_t fuji_command)
     }
 
     fujiError_t cmd_err;
-    switch (fuji_command)
+    switch (cmd.command())
     {
 #ifndef ESP_PLATFORM
     case NETCMD_GET_REMOTE:
@@ -836,10 +831,9 @@ void iwmNetwork::process_udp(fujiCommandID_t fuji_command)
 #endif /* ESP_PLATFORM */
     case NETCMD_SET_DESTINATION:
         {
-            ByteBuffer buffer(data_len, 0);
-            SYSTEM_BUS.transaction_accept(TRANS_STATE::WILL_GET);
-            SYSTEM_BUS.transaction_get(buffer.data(), buffer.size());
-            cmd_err = udp->set_destination(buffer.data(), buffer.size());
+            SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
+            auto data = cmd.data().value();
+            cmd_err = udp->set_destination(data.data(), data.size());
             if (cmd_err != FUJI_ERROR::NONE)
                 SYSTEM_BUS.transaction_error(SP_ERR::IOERROR);
             else

--- a/lib/device/iwm/network.h
+++ b/lib/device/iwm/network.h
@@ -63,7 +63,7 @@ public:
      * Called for iwm Command 'O' to open a connection to a network protocol, allocate all buffers,
      * and start the receive PROCEED interrupt.
      */
-    virtual void open();
+    virtual void open(const iwm_decoded_cmd_t &cmd);
 
     /**
      * Called for iwm Command 'C' to close a connection to a network protocol, de-allocate all buffers,
@@ -74,7 +74,7 @@ public:
     /**
      * Write to Network Socket 'W'
      */
-    void net_write();
+    void net_write(const iwm_decoded_cmd_t &cmd);
 
     /**
      * Read from Network Socket 'R'
@@ -96,10 +96,10 @@ public:
      */
     virtual void status();
 
-    void process_fs(fujiCommandID_t fuji_command);
-    void process_tcp(fujiCommandID_t fuji_command);
-    void process_http(fujiCommandID_t fuji_command);
-    void process_udp(fujiCommandID_t fuji_command);
+    void process_fs(const iwm_decoded_cmd_t &cmd);
+    void process_tcp(const iwm_decoded_cmd_t &cmd);
+    void process_http(const iwm_decoded_cmd_t &cmd);
+    void process_udp(const iwm_decoded_cmd_t &cmd);
 
     void iwm_ctrl(const iwm_decoded_cmd_t &cmd) override;
     void iwm_open(const iwm_decoded_cmd_t &cmd) override;
@@ -114,7 +114,7 @@ public:
     /**
      * @brief Called to set prefix
      */
-    virtual void set_prefix();
+    virtual void set_prefix(const iwm_decoded_cmd_t &cmd);
 
     /**
      * @brief Called to get prefix
@@ -124,17 +124,17 @@ public:
     /**
      * @brief called to set login
      */
-    virtual void set_login();
+    virtual void set_login(const iwm_decoded_cmd_t &cmd);
 
     /**
      * @brief called to set password
      */
-    virtual void set_password();
+    virtual void set_password(const iwm_decoded_cmd_t &cmd);
 
     /**
      * @brief set channel mode
      */
-    void channel_mode();
+    void channel_mode(const iwm_decoded_cmd_t &cmd);
 
     /**
      * @brief parse incoming data
@@ -187,7 +187,7 @@ private:
     /**
      * Create the deviceSpec and fix it for parsing
      */
-    void create_devicespec(std::string d);
+    void create_devicespec(std::string d, bool is_dir);
 
     /**
      * Create a urlParser from deviceSpec
@@ -267,7 +267,7 @@ private:
      * @brief parse URL and instantiate protocol
      * @param db pointer to devicespecbuf 256 chars
      */
-    error_is_true parse_and_instantiate_protocol(std::string d);
+    error_is_true parse_and_instantiate_protocol(std::string d, bool is_dir);
 };
 
 #endif /* NETWORK_H */

--- a/lib/device/iwm/printer.cpp
+++ b/lib/device/iwm/printer.cpp
@@ -59,14 +59,13 @@ void iwmPrinter::iwm_close(const iwm_decoded_cmd_t &cmd)
 
 void iwmPrinter::iwm_write(const iwm_decoded_cmd_t &cmd)
 {
-    Debug_printf("\nPrinter: Write %u bytes\n", cmd.char_rw.length);
+    Debug_printf("\nPrinter: Write %u bytes\n", cmd.frame.char_rw.length);
 
-    size_t offset = 0;
-    ByteBuffer buffer(data_len, 0);
-
+    ByteBuffer buffer(cmd.frame.char_rw.length, 0);
     SYSTEM_BUS.transaction_accept(TRANS_STATE::WILL_GET);
     SYSTEM_BUS.transaction_get(buffer.data(), buffer.size());
 
+    size_t offset = 0;
     while (offset < buffer.size())
     {
         size_t chunk_size = std::min<size_t>(80, buffer.size() - offset);


### PR DESCRIPTION
Introduce `FujiIWMPacket`, a packet implementation that presents the same logical interface as `FujiBusPacket` while accommodating the SmartPort context-dependent packet format.

Parameters are pulled from the SmartPort payload, allowing them to be accessed easily without needing to keep track of where the non-parameter bytes start. Multi-byte parameters are transparently converted from the Apple II little-endian encoding to native byte order.