### PR TITLE
Created mixins for adding features to fujiDevice

### DIFF
--- a/fujinet_pc.cmake
+++ b/fujinet_pc.cmake
@@ -280,6 +280,9 @@ set(SOURCES src/main.cpp
     lib/device/modem.h
     lib/device/cassette.h
     lib/device/fujiDevice.h lib/device/fujiDevice.cpp
+    lib/device/FujiDeviceMixin.h
+    lib/device/Base64Mixin.h lib/device/Base64Mixin.cpp
+    lib/device/HashMixin.h lib/device/HashMixin.cpp
     lib/device/network.h
     lib/device/netstream.h
     lib/device/siocpm.h

--- a/lib/bus/adamnet/adamnet.cpp
+++ b/lib/bus/adamnet/adamnet.cpp
@@ -538,7 +538,7 @@ void systemBus::addDevice(virtualDevice *pDevice, uint8_t device_id)
         _printerDev = (adamPrinter *)pDevice;
         break;
     case 0x0f:
-        _fujiDev = (adamFuji *)pDevice;
+        _fujiDev = dynamic_cast<adamFuji*>(pDevice);
         break;
     }
 }

--- a/lib/bus/iwm/FujiIWMPacket.h
+++ b/lib/bus/iwm/FujiIWMPacket.h
@@ -95,6 +95,8 @@ private:
 public:
   SmartPortFrame frame;
 
+  FujiIWMPacket() = default;
+
   void decode(uint8_t *raw);
 
   uint8_t device() const { return frame.sp_dev_id; }
@@ -113,6 +115,11 @@ public:
   uint8_t  param8(size_t index)  const { return (uint8_t) param(index); }
   uint16_t param16(size_t index) const { return (uint16_t) param(index); }
   uint32_t param32(size_t index) const { return (uint32_t) param(index); }
+
+  // Delete copy semantics to prevent pass-by-value bugs
+  FujiIWMPacket(const FujiIWMPacket&) = delete;
+  FujiIWMPacket& operator=(const FujiIWMPacket&) = delete;
+
 };
 
 #endif /* FUJIIWMPACKET_H */

--- a/lib/bus/iwm/iwm.h
+++ b/lib/bus/iwm/iwm.h
@@ -24,6 +24,7 @@
 #include "fnFS.h"
 
 using iwm_decoded_cmd_t = FujiIWMPacket;
+#define FUJI_COMMAND_PACKET iwm_decoded_cmd_t
 
 // Windows defines this and it conflicts with the SmartPort erro
 // code. We don't need it, just undef it.

--- a/lib/bus/rs232/rs232.cpp
+++ b/lib/bus/rs232/rs232.cpp
@@ -237,7 +237,7 @@ void systemBus::addDevice(virtualDevice *pDevice, fujiDeviceID_t device_id)
 {
     if (device_id == FUJI_DEVICEID_FUJINET)
     {
-        _fujiDev = (rs232Fuji *)pDevice;
+        _fujiDev = dynamic_cast<rs232Fuji *>(pDevice);
     }
     else if (device_id == FUJI_DEVICEID_SERIAL)
     {

--- a/lib/bus/sio/sio.cpp
+++ b/lib/bus/sio/sio.cpp
@@ -548,7 +548,7 @@ void systemBus::addDevice(virtualDevice *pDevice, fujiDeviceID_t device_id)
 {
     if (device_id == FUJI_DEVICEID_FUJINET)
     {
-        _fujiDev = (sioFuji *)pDevice;
+        _fujiDev = dynamic_cast<sioFuji*>(pDevice);
     }
     else if (device_id == FUJI_DEVICEID_SERIAL)
     {

--- a/lib/device/Base64Mixin.cpp
+++ b/lib/device/Base64Mixin.cpp
@@ -1,0 +1,218 @@
+#include "Base64Mixin.h"
+#include "base64.h"
+#include "debug.h"
+
+#ifdef FUJI_BASE64_MIXIN_ENABLED
+
+void Base64Mixin::encode_input(uint16_t len)
+{
+    SYSTEM_BUS.transaction_accept(TRANS_STATE::WILL_GET);
+
+    Debug_printf("Base64Mixin: enode_input\n");
+
+    if (!len)
+    {
+        Debug_printf("Invalid length. Aborting");
+        SYSTEM_BUS.transaction_error();
+        return;
+    }
+
+    std::string p(len, 0);
+    SYSTEM_BUS.transaction_get(p.data(), len);
+    base64.base64_buffer += p;
+    SYSTEM_BUS.transaction_success();
+}
+
+void Base64Mixin::encode_compute()
+{
+    size_t out_len;
+
+    /* ACK before CPU work (matches sio_hash_compute); NetSIO/tight SIO timing
+     * otherwise leaves the host waiting past dtimlo (Atari status 138 timeout). */
+    SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
+
+    Debug_printf("Base64Mixin: ENCODE COMPUTE\n");
+
+    std::unique_ptr<char[]> p = Base64::encode(base64.base64_buffer.c_str(), base64.base64_buffer.size(), &out_len);
+    if (!p)
+    {
+        Debug_printf("base64_encode compute failed\n");
+        SYSTEM_BUS.transaction_error();
+        return;
+    }
+
+    base64.base64_buffer.clear();
+    base64.base64_buffer = std::string(p.get(), out_len);
+
+    Debug_printf("Resulting BASE64 encoded data is: %u bytes\n", out_len);
+    SYSTEM_BUS.transaction_success();
+}
+
+void Base64Mixin::encode_length()
+{
+    SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
+    Debug_printf("Base64Mixin: ENCODE LENGTH\n");
+
+    size_t len = base64.base64_buffer.length();
+    Debug_printf("base64 buffer length: %u bytes\n", len);
+
+#ifdef BUILD_COCO
+    uint32_t response = htobe32(len);
+#else
+    uint32_t response = htole32(len);
+#endif
+    SYSTEM_BUS.transaction_send(&response, sizeof(response), false);
+}
+
+void Base64Mixin::encode_output(uint16_t len)
+{
+    SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
+    Debug_printf("Base64Mixin: ENCODE OUTPUT\n");
+
+    if (!len)
+    {
+        Debug_printf("Refusing to send a zero byte buffer. Aborting\n");
+        SYSTEM_BUS.transaction_error();
+        return;
+    }
+    else if (len > base64.base64_buffer.length())
+    {
+        Debug_printf("Requested %u bytes, but buffer is only %u bytes, aborting.\n", len, base64.base64_buffer.length());
+        SYSTEM_BUS.transaction_error();
+        return;
+    }
+    else
+    {
+        Debug_printf("Requested %u bytes\n", len);
+    }
+
+    std::string result = base64.base64_buffer.substr(0, len);
+    SYSTEM_BUS.transaction_send(result);
+    base64.base64_buffer.erase(0, len);
+    base64.base64_buffer.shrink_to_fit();
+}
+
+void Base64Mixin::decode_input(uint16_t len)
+{
+    SYSTEM_BUS.transaction_accept(TRANS_STATE::WILL_GET);
+
+    Debug_printf("Base64Mixin: DECODE INPUT\n");
+
+    if (!len)
+    {
+        Debug_printf("Invalid length. Aborting");
+        SYSTEM_BUS.transaction_error();
+        return;
+    }
+
+    std::vector<unsigned char> p(len);
+    SYSTEM_BUS.transaction_get(p.data(), len);
+    base64.base64_buffer += std::string((const char *)p.data(), len);
+    SYSTEM_BUS.transaction_success();
+}
+
+void Base64Mixin::decode_compute()
+{
+    size_t out_len;
+
+    SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
+
+    Debug_printf("Base64Mixin: DECODE COMPUTE\n");
+
+    std::unique_ptr<unsigned char[]> p = Base64::decode(base64.base64_buffer.c_str(), base64.base64_buffer.size(), &out_len);
+    if (!p)
+    {
+        Debug_printf("base64_encode compute failed\n");
+        SYSTEM_BUS.transaction_error();
+        return;
+    }
+
+    base64.base64_buffer.clear();
+    base64.base64_buffer = std::string((const char *)p.get(), out_len);
+
+    Debug_printf("Resulting BASE64 encoded data is: %u bytes\n", out_len);
+    SYSTEM_BUS.transaction_success();
+}
+
+void Base64Mixin::decode_length()
+{
+    SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
+    Debug_printf("Base64Mixin: DECODE LENGTH\n");
+
+    size_t len = base64.base64_buffer.length();
+    Debug_printf("base64 buffer length: %u bytes\n", len);
+
+#ifdef BUILD_COCO
+    uint32_t response = htobe32(len);
+#else
+    uint32_t response = htole32(len);
+#endif
+    SYSTEM_BUS.transaction_send(&response, sizeof(response), false);
+}
+
+void Base64Mixin::decode_output(uint16_t len)
+{
+    SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
+    Debug_printf("Base64Mixin: DECODE OUTPUT\n");
+
+    if (!len)
+    {
+        Debug_printf("Refusing to send a zero byte buffer. Aborting\n");
+        SYSTEM_BUS.transaction_error();
+        return;
+    }
+    else if (len > base64.base64_buffer.length())
+    {
+        Debug_printf("Requested %u bytes, but buffer is only %u bytes, aborting.\n", len, base64.base64_buffer.length());
+        SYSTEM_BUS.transaction_error();
+        return;
+    }
+    else
+    {
+        Debug_printf("Requested %u bytes\n", len);
+    }
+
+    std::vector<unsigned char> p(len);
+    memcpy(p.data(), base64.base64_buffer.data(), len);
+    base64.base64_buffer.erase(0, len);
+    base64.base64_buffer.shrink_to_fit();
+    SYSTEM_BUS.transaction_send(p.data(), len, false);
+}
+
+bool Base64Mixin::processCommand(const FUJI_COMMAND_PACKET &packet)
+{
+    switch (packet.command())
+    {
+    case FUJICMD_BASE64_ENCODE_INPUT:
+        encode_input(packet.param(0));
+        break;
+    case FUJICMD_BASE64_ENCODE_COMPUTE:
+        encode_compute();
+        break;
+    case FUJICMD_BASE64_ENCODE_LENGTH:
+        encode_length();
+        break;
+    case FUJICMD_BASE64_ENCODE_OUTPUT:
+        encode_output(packet.param(0));
+        break;
+    case FUJICMD_BASE64_DECODE_INPUT:
+        decode_input(packet.param(0));
+        break;
+    case FUJICMD_BASE64_DECODE_COMPUTE:
+        decode_compute();
+        break;
+    case FUJICMD_BASE64_DECODE_LENGTH:
+        decode_length();
+        break;
+    case FUJICMD_BASE64_DECODE_OUTPUT:
+        decode_output(packet.param(0));
+        break;
+
+    default:
+        return false;
+    }
+
+    return true;
+}
+
+#endif // FUJI_BASE64_MIXIN_ENABLED

--- a/lib/device/Base64Mixin.h
+++ b/lib/device/Base64Mixin.h
@@ -1,0 +1,27 @@
+#ifndef BASE64MIXIN_H
+#define BASE64MIXIN_H
+
+#include "FujiDeviceMixin.h"
+
+#ifdef FUJI_MIXINS_ENABLED
+#define FUJI_BASE64_MIXIN_ENABLED
+
+class Base64Mixin : public FujiDeviceMixin
+{
+protected:
+    void encode_input(uint16_t len);
+    void encode_compute();
+    void encode_length();
+    void encode_output(uint16_t len);
+    void decode_input(uint16_t len);
+    void decode_compute();
+    void decode_length();
+    void decode_output(uint16_t len);
+
+ public:
+    bool processCommand(const FUJI_COMMAND_PACKET &packet) override;
+};
+
+#endif // FUJI_MIXINS_ENABLED
+
+#endif /* BASE64MIXIN_H */

--- a/lib/device/FujiDeviceMixin.h
+++ b/lib/device/FujiDeviceMixin.h
@@ -1,0 +1,22 @@
+#ifndef FUJIDEVICEMIXIN_H
+#define FUJIDEVICEMIXIN_H
+
+#include "bus.h"
+
+#ifdef FUJI_COMMAND_PACKET
+#define FUJI_MIXINS_ENABLED
+#endif
+
+#ifdef FUJI_MIXINS_ENABLED
+
+#include "bus.h"
+
+class FujiDeviceMixin : public virtual virtualDevice
+{
+public:
+    virtual bool processCommand(const FUJI_COMMAND_PACKET &packet) { return false; }
+};
+
+#endif // FUJI_MIXINS_ENABLED
+
+#endif /* FUJIDEVICEMIXIN_H */

--- a/lib/device/HashMixin.cpp
+++ b/lib/device/HashMixin.cpp
@@ -1,0 +1,99 @@
+#include "HashMixin.h"
+#include "debug.h"
+#include "utils.h"
+
+#ifdef FUJI_HASH_MIXIN_ENABLED
+
+constexpr uint8_t MODE_HEX = 1;
+
+void HashMixin::hash_input(uint16_t len)
+{
+    SYSTEM_BUS.transaction_accept(TRANS_STATE::WILL_GET);
+
+    Debug_printf("HashMixin: INPUT\n");
+
+    if (!len)
+    {
+        Debug_printf("Invalid length. Aborting");
+        SYSTEM_BUS.transaction_error();
+        return;
+    }
+
+    std::vector<unsigned char> p(len);
+    SYSTEM_BUS.transaction_get(p.data(), len);
+    hasher.add_data(p);
+    SYSTEM_BUS.transaction_success();
+}
+
+void HashMixin::hash_compute(bool clear_data, Hash::Algorithm algo)
+{
+    SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
+    Debug_printf("HashMixin: COMPUTE\n");
+    _algorithm = algo;
+    hasher.compute(_algorithm, clear_data);
+    SYSTEM_BUS.transaction_success();
+}
+
+void HashMixin::hash_length(bool as_hex)
+{
+    SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
+    Debug_printf("HashMixin: LENGTH\n");
+    uint8_t r = hasher.hash_length(_algorithm, as_hex);
+    SYSTEM_BUS.transaction_send(&r, 1, false);
+}
+
+void HashMixin::hash_output(bool as_hex)
+{
+    SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
+    Debug_printf("HashMixin: OUTPUT\n");
+
+    std::vector<uint8_t> hashed_data;
+    if (as_hex)
+    {
+        std::string hex = hasher.output_hex();
+        hashed_data.insert(hashed_data.end(), hex.begin(), hex.end());
+    }
+    else
+        hashed_data = hasher.output_binary();
+    SYSTEM_BUS.transaction_send(hashed_data.data(), hashed_data.size(), false);
+}
+
+void HashMixin::hash_clear()
+{
+    SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
+    Debug_printf("HashMixin: CLEAR\n");
+    hasher.clear();
+    SYSTEM_BUS.transaction_success();
+}
+
+bool HashMixin::processCommand(const FUJI_COMMAND_PACKET &packet)
+{
+    switch (packet.command())
+    {
+    case FUJICMD_HASH_INPUT:
+        hash_input(packet.param(0));
+        break;
+    case FUJICMD_HASH_COMPUTE:
+        hash_compute(true, Hash::to_algorithm(packet.param(0)));
+        break;
+    case FUJICMD_HASH_COMPUTE_NO_CLEAR:
+        hash_compute(false, Hash::to_algorithm(packet.param(0)));
+        break;
+    case FUJICMD_HASH_LENGTH:
+        hash_length(packet.param(0) == MODE_HEX);
+        break;
+    case FUJICMD_HASH_OUTPUT:
+        hash_output(packet.param(0) == MODE_HEX);
+        break;
+    case FUJICMD_HASH_CLEAR:
+        hash_clear();
+        break;
+
+    default:
+        return false;
+    }
+
+    return true;
+}
+
+#endif // FUJI_HASH_MIXIN_ENABLED

--- a/lib/device/HashMixin.h
+++ b/lib/device/HashMixin.h
@@ -1,0 +1,27 @@
+#ifndef HASHMIXIN_H
+#define HASHMIXIN_H
+
+#include "FujiDeviceMixin.h"
+#include "hash.h"
+
+#ifdef FUJI_MIXINS_ENABLED
+#define FUJI_HASH_MIXIN_ENABLED
+
+class HashMixin : public FujiDeviceMixin
+{
+protected:
+    Hash::Algorithm _algorithm = Hash::Algorithm::UNKNOWN;
+
+    void hash_input(uint16_t len);
+    void hash_compute(bool clear_data, Hash::Algorithm algo);
+    void hash_length(bool as_hex);
+    void hash_output(bool as_hex);
+    void hash_clear();
+
+public:
+    bool processCommand(const FUJI_COMMAND_PACKET &packet) override;
+};
+
+#endif // FUJI_MIXINS_ENABLED
+
+#endif /* HASHMIXIN_H */

--- a/lib/device/fujiDevice.h
+++ b/lib/device/fujiDevice.h
@@ -2,11 +2,11 @@
 #define FUJIDEVICE_H
 
 #include "fnConfig.h"
+#include "Base64Mixin.h"
+#include "HashMixin.h"
 
 #include "../fuji/fujiHost.h"
 #include "../fuji/fujiDisk.h"
-
-#include "hash.h"
 
 #include <string>
 #include <optional>
@@ -121,7 +121,28 @@ enum DET_file_flags_t {
     DET_FF_TRUNC = 0x02,
 };
 
-class fujiDevice : public virtualDevice, public VDevMigrationWrapper
+#ifdef FUJI_MIXINS_ENABLED
+/* Mixin handling. This allows adding additional commands to a
+   fujiDevice without having to mess around with the command handling
+   in each subclass. Just add a mixin and add more commands.
+ */
+
+// This class inherits from all the mixins you list and tries each one in order
+template<typename... FujiDeviceMixins>
+class FujiDeviceChain : public FujiDeviceMixins...
+{
+ protected:
+    bool tryAllMixins(const FUJI_COMMAND_PACKET &packet) {
+        // Try each mixin's processCommand() until one returns true
+        return (FujiDeviceMixins::processCommand(packet) || ...);
+    }
+};
+#endif // FUJI_MIXINS_ENABLED
+
+class fujiDevice : public virtual virtualDevice, public VDevMigrationWrapper
+#ifdef FUJI_MIXINS_ENABLED
+                 , public FujiDeviceChain<Base64Mixin, HashMixin>
+#endif // FUJI_MIXINS_ENABLED
 {
 private:
     bool hostMounted[MAX_HOSTS];
@@ -147,7 +168,10 @@ protected:
     std::atomic<bool> _startup_mount_lock{false};
     unsigned char _active_rotate_slot = 0;
 
+#ifndef FUJI_HASH_MIXIN_ENABLED
+    // FIXME - remove when mixins enabled for all buses
     Hash::Algorithm algorithm = Hash::Algorithm::UNKNOWN;
+#endif // FUJI_HASH_MIXIN_ENABLED
 
     virtual size_t set_additional_direntry_details(fsdir_entry_t *f, uint8_t *dest,
                                                    uint8_t maxlen) = 0;
@@ -165,6 +189,11 @@ public:
                std::optional<std::string> lobbyURL);
     virtual void setup() = 0;
     void shutdown() override;
+
+#ifdef FUJI_MIXINS_ENABLED
+    // Return true if command was handled here
+    bool processCommand(const FUJI_COMMAND_PACKET &packet) { return tryAllMixins(packet); }
+#endif // FUJI_MIXINS_ENABLED
 
     fujiHost *get_host(int i) { return &_fnHosts[i]; }
     std::string get_host_prefix(int host_slot) { return _fnHosts[host_slot].get_prefix(); }

--- a/lib/device/iwm/iwmFuji.cpp
+++ b/lib/device/iwm/iwmFuji.cpp
@@ -29,17 +29,13 @@ iwmFuji::iwmFuji() : fujiDevice(MAX_A2DISK_DEVICES, IMAGE_EXTENSION, LOBBY_URL)
         { FUJICMD_CLOSE_DIRECTORY, [this](const iwm_decoded_cmd_t &cmd)            { this->fujicmd_close_directory(); }},          // 0xF5
         { FUJICMD_GET_HOST_PREFIX, [this](const iwm_decoded_cmd_t &cmd)            { this->fujicmd_get_host_prefix(cmd.param(0)); }},                  // 0xE0
         { FUJICMD_CONFIG_BOOT, [this](const iwm_decoded_cmd_t &cmd)                { this->fujicmd_set_boot_config(cmd.param(0)); }},          // 0xD9
-        { FUJICMD_COPY_FILE, [this](const iwm_decoded_cmd_t &cmd)                  { this->fujicmd_copy_file_success(cmd.param(0), cmd.param(1), cmd.dataAsString()->data()); }},                // 0xD8
+        { FUJICMD_COPY_FILE, [this](const iwm_decoded_cmd_t &cmd)                  {
+            uint8_t source = cmd.param(0), dest = cmd.param(1);
+            this->fujicmd_copy_file_success(source, dest, cmd.dataAsString()->data());
+        }},                // 0xD8
         { FUJICMD_DISABLE_DEVICE, [this](const iwm_decoded_cmd_t &cmd)             { this->iwm_ctrl_disable_device(cmd); }},           // 0xD4
         { FUJICMD_ENABLE_DEVICE, [this](const iwm_decoded_cmd_t &cmd)              { this->iwm_ctrl_enable_device(cmd); }},            // 0xD5
         { FUJICMD_GET_SCAN_RESULT, [this](const iwm_decoded_cmd_t &cmd)            { this->fujicmd_net_scan_result(cmd.param(0)); }},          // 0xFC
-
-        { FUJICMD_HASH_INPUT, [this](const iwm_decoded_cmd_t &cmd)                 { this->iwm_ctrl_hash_input(cmd); }},               // 0xC8
-        { FUJICMD_HASH_COMPUTE, [this](const iwm_decoded_cmd_t &cmd)               { this->iwm_ctrl_hash_compute(cmd, true); }},         // 0xC7
-        { FUJICMD_HASH_COMPUTE_NO_CLEAR, [this](const iwm_decoded_cmd_t &cmd)      { this->iwm_ctrl_hash_compute(cmd, false); }},        // 0xC7
-        { FUJICMD_HASH_LENGTH, [this](const iwm_decoded_cmd_t &cmd)                { this->iwm_stat_hash_length(cmd); }},              // 0xC6
-        { FUJICMD_HASH_OUTPUT, [this](const iwm_decoded_cmd_t &cmd)                { this->iwm_stat_hash_output(); }},              // 0xC5
-        { FUJICMD_HASH_CLEAR, [this](const iwm_decoded_cmd_t &cmd)                 { this->iwm_ctrl_hash_clear(); }},               // 0xC2
 
         { FUJICMD_QRCODE_INPUT, [this](const iwm_decoded_cmd_t &cmd)               { this->iwm_ctrl_qrcode_input(cmd); }},             // 0xBC
         { FUJICMD_QRCODE_ENCODE, [this](const iwm_decoded_cmd_t &cmd)              { this->iwm_ctrl_qrcode_encode(cmd); }},            // 0xBD
@@ -330,6 +326,10 @@ void iwmFuji::iwm_status(const iwm_decoded_cmd_t &cmd)
 {
     Debug_printf("\r\n[Fuji] Device %02x Status Code %02x\r\n", id(), cmd.command());
 
+    // Let the base class handle standard commands
+    if (fujiDevice::processCommand(cmd))
+        return;
+
     auto it = status_handlers.find(cmd.command());
     if (it != status_handlers.end()) {
         it->second(cmd);
@@ -343,7 +343,9 @@ void iwmFuji::iwm_ctrl(const iwm_decoded_cmd_t &cmd)
 {
     Debug_printf("\ntheFuji Device %02x Control Code %02x", id(), cmd.command());
 
-    Debug_printf("\nDecoding Control Data Packet for code: 0x%02x\r\n", cmd.command());
+    // Let the base class handle standard commands
+    if (fujiDevice::processCommand(cmd))
+        return;
 
     auto it = control_handlers.find(cmd.command());
     if (it != control_handlers.end()) {
@@ -371,51 +373,6 @@ void iwmFuji::handle_ctl_eject(uint8_t spid)
                 Config.save();
                 theFuji->populate_slots_from_config();
         }
-}
-
-void iwmFuji::iwm_ctrl_hash_input(const iwm_decoded_cmd_t &cmd)
-{
-    transaction_begin(TRANS_STATE::NO_GET);
-    hasher.add_data(cmd.dataAsString().value());
-    transaction_complete();
-}
-
-void iwmFuji::iwm_ctrl_hash_compute(const iwm_decoded_cmd_t &cmd, bool clear_data)
-{
-    Debug_printf("FUJI: HASH COMPUTE\n");
-    algorithm = Hash::to_algorithm(cmd.param(0));
-    hasher.compute(algorithm, clear_data);
-}
-
-void iwmFuji::iwm_stat_hash_length(const iwm_decoded_cmd_t &cmd)
-{
-    uint8_t is_hex = cmd.param8(0) == 1;
-    uint8_t r = hasher.hash_length(algorithm, is_hex);
-
-    transaction_begin(TRANS_STATE::NO_GET);
-    transaction_put(r);
-}
-
-void iwmFuji::iwm_ctrl_hash_output(const iwm_decoded_cmd_t &cmd)
-{
-    Debug_printf("FUJI: HASH OUTPUT CONTROL\n");
-    hash_is_hex_output = cmd.param8(0) == 1;
-}
-
-void iwmFuji::iwm_stat_hash_output()
-{
-    Debug_printf("FUJI: HASH OUTPUT STAT\n");
-
-    transaction_begin(TRANS_STATE::NO_GET);
-    if (hash_is_hex_output)
-        transaction_put(hasher.output_hex());
-    else
-        transaction_put(hasher.output_binary());
-}
-
-void iwmFuji::iwm_ctrl_hash_clear()
-{
-    hasher.clear();
 }
 
 void iwmFuji::iwm_ctrl_qrcode_input(const iwm_decoded_cmd_t &cmd)

--- a/lib/device/iwm/iwmFuji.h
+++ b/lib/device/iwm/iwmFuji.h
@@ -56,7 +56,6 @@ private:
     std::unordered_map<uint8_t, IWMControlHandlers> control_handlers;
     std::unordered_map<uint8_t, IWMStatusHandlers> status_handlers;
 
-    bool hash_is_hex_output = false;
     QRManager _qrManager = QRManager();
 
 protected:
@@ -71,12 +70,6 @@ protected:
     void iwm_ctrl_disable_device(const iwm_decoded_cmd_t &cmd);               // 0xD4
     void send_stat_get_enable();                  // 0xD1
 
-    void iwm_ctrl_hash_input(const iwm_decoded_cmd_t &cmd);                   // 0xC8
-    void iwm_ctrl_hash_compute(const iwm_decoded_cmd_t &cmd, bool clear_data);  // 0xC7, 0xC3
-    void iwm_stat_hash_length(const iwm_decoded_cmd_t &cmd);                  // 0xC6
-    void iwm_ctrl_hash_output(const iwm_decoded_cmd_t &cmd);                  // 0xC5 set hash_is_hex_output
-    void iwm_stat_hash_output();                  // 0xC5 write response
-    void iwm_ctrl_hash_clear();                   // 0xC2
     void iwm_stat_get_heap();                     // 0xC1
 
     void iwm_ctrl_qrcode_input(const iwm_decoded_cmd_t &cmd);                 // 0xBC

--- a/lib/device/sio/sioFuji.h
+++ b/lib/device/sio/sioFuji.h
@@ -4,6 +4,7 @@
 #include "fujiDevice.h"
 #include "cassette.h"
 #include "netstream.h"
+#include "hash.h"
 #include "../../qrcode/qrmanager.h"
 
 #include <cassert>


### PR DESCRIPTION
Added a new ability to add features to fujiDevice via mixins which automatically handle command processing and don't need to be added to every single fujiDevice subclass.

Base64 and hash have already been converted to mixins. QR and appkeys will be converted soon.

Individual buses need to have been upgraded to use bus packet classes that conform to FujiBusPacket.