### PR TITLE
Long dir var width

### DIFF
--- a/lib/device/adamnet/network.cpp
+++ b/lib/device/adamnet/network.cpp
@@ -165,6 +165,9 @@ void adamNetwork::open(unsigned short s)
     // Set the human-readable line ending for this platform (Adam: CR).
     protocol->setLineEnding("\x0d");
 
+    // Narrow DIR_FORMAT::LONG entries to fit Adam's 32-column mode.
+    protocol->setDirLongWidth(30);
+
     // Attempt protocol open
     if (protocol->open(urlParser.get(), (fileAccessMode_t) _aux1, (netProtoTranslation_t) _aux2) != FUJI_ERROR::NONE)
     {

--- a/lib/device/drivewire/network.cpp
+++ b/lib/device/drivewire/network.cpp
@@ -122,6 +122,9 @@ void drivewireNetwork::open(fileAccessMode_t access, netProtoTranslation_t trans
     // Set line ending to CR
     protocol->setLineEnding("\x0D");
 
+    // CoCo DIR_FORMAT::LONG entries are 31 columns wide.
+    protocol->setDirLongWidth(31);
+
     // Attempt protocol open
     if (protocol->open(urlParser.get(), access, trans_mode) != FUJI_ERROR::NONE)
     {

--- a/lib/network-protocol/FS.cpp
+++ b/lib/network-protocol/FS.cpp
@@ -22,15 +22,6 @@
 
 #define ENTRY_BUFFER_SIZE 256
 
-// System-specific width for DIR_FORMAT::LONG entries. 0 = util_long_entry
-// platform default. ADAM's default text mode is 32 columns, so keep entries
-// narrow enough to avoid wrapping.
-#ifdef BUILD_ADAM
-#define NETWORK_DIR_LONG_WIDTH 30
-#else
-#define NETWORK_DIR_LONG_WIDTH 0
-#endif
-
 NetworkProtocolFS::NetworkProtocolFS(std::string *rx_buf, std::string *tx_buf, std::string *sp_buf)
     : NetworkProtocol(rx_buf, tx_buf, sp_buf)
 {
@@ -136,7 +127,7 @@ fujiError_t NetworkProtocolFS::open_dir(dirFormat_t fmt)
             break;
         default:
             if (fmt >= DIR_FORMAT::LONG)
-                dirBuffer += util_long_entry((char *)entryBuffer.data(), fileSize, is_directory, NETWORK_DIR_LONG_WIDTH) + lineEnding;
+                dirBuffer += util_long_entry((char *)entryBuffer.data(), fileSize, is_directory, dirLongWidth) + lineEnding;
             else
                 dirBuffer += util_entry(util_crunch((char *)entryBuffer.data()), fileSize, is_directory, is_locked) + lineEnding;
             break;

--- a/lib/network-protocol/FS.cpp
+++ b/lib/network-protocol/FS.cpp
@@ -22,6 +22,15 @@
 
 #define ENTRY_BUFFER_SIZE 256
 
+// System-specific width for DIR_FORMAT::LONG entries. 0 = util_long_entry
+// platform default. ADAM's default text mode is 32 columns, so keep entries
+// narrow enough to avoid wrapping.
+#ifdef BUILD_ADAM
+#define NETWORK_DIR_LONG_WIDTH 30
+#else
+#define NETWORK_DIR_LONG_WIDTH 0
+#endif
+
 NetworkProtocolFS::NetworkProtocolFS(std::string *rx_buf, std::string *tx_buf, std::string *sp_buf)
     : NetworkProtocol(rx_buf, tx_buf, sp_buf)
 {
@@ -127,7 +136,7 @@ fujiError_t NetworkProtocolFS::open_dir(dirFormat_t fmt)
             break;
         default:
             if (fmt >= DIR_FORMAT::LONG)
-                dirBuffer += util_long_entry((char *)entryBuffer.data(), fileSize, is_directory) + lineEnding;
+                dirBuffer += util_long_entry((char *)entryBuffer.data(), fileSize, is_directory, NETWORK_DIR_LONG_WIDTH) + lineEnding;
             else
                 dirBuffer += util_entry(util_crunch((char *)entryBuffer.data()), fileSize, is_directory, is_locked) + lineEnding;
             break;

--- a/lib/network-protocol/Protocol.h
+++ b/lib/network-protocol/Protocol.h
@@ -128,6 +128,18 @@ public:
     void setFSSectorSize(int sectorSize) { FSSectorSize = sectorSize; }
 
     /**
+     * Width of a DIR_FORMAT::LONG directory entry, in characters. Systems set
+     * this to match their screen width (e.g. ADAM uses 30 to fit 32-column mode).
+     */
+    int dirLongWidth = 37;
+
+    /**
+     * @brief Set the DIR_FORMAT::LONG entry width for FS derived protocols.
+     * @param width entry width in characters.
+     */
+    void setDirLongWidth(int width) { dirLongWidth = width; }
+
+    /**
      * @brief Open connection to the protocol using URL
      * @param urlParser The URL object passed in to open.
      * @return FUJI_ERROR::NONE on success, FUJI_ERROR::UNSPECIFIED on error

--- a/lib/utils/utils.cpp
+++ b/lib/utils/utils.cpp
@@ -323,17 +323,23 @@ std::string util_entry(std::string crunched, size_t fileSize, bool is_dir, bool 
 }
 #endif /* !defined BUILD_RS232 */
 
-std::string util_long_entry(std::string filename, size_t fileSize, bool is_dir)
+std::string util_long_entry(std::string filename, size_t fileSize, bool is_dir, int width)
 {
 #ifdef BUILD_COCO
-#define LONG_ENTRY_TRIM_LEN 25
+#define LONG_ENTRY_RESERVE 6
 #define LONG_ENTRY_EOL "\x0D"
-    std::string returned_entry = "                               ";
+    if (width <= 0)
+        width = 31;
 #else
-#define LONG_ENTRY_TRIM_LEN 30
+#define LONG_ENTRY_RESERVE 7
 #define LONG_ENTRY_EOL "\x9B"
-    std::string returned_entry = "                                     ";
+    if (width <= 0)
+        width = 37;
 #endif /* BUILD_COCO */
+    // Filenames longer than this wrap to a second line; the remainder is the
+    // size field reserved at the end of the entry.
+    const int trim_len = width - LONG_ENTRY_RESERVE;
+    std::string returned_entry(width, ' ');
     std::string stylized_filesize;
 
     char tmp[12];
@@ -341,9 +347,9 @@ std::string util_long_entry(std::string filename, size_t fileSize, bool is_dir)
     if (is_dir == true)
         filename += "/";
 
-    // Double size of returned entry if > 30 chars.
+    // Double size of returned entry if filename too long for the width.
     // Add EOL so SpartaDOS doesn't truncate record. grrr.
-    if (filename.length() > LONG_ENTRY_TRIM_LEN)
+    if ((int)filename.length() > trim_len)
         returned_entry += LONG_ENTRY_EOL + returned_entry;
 
     returned_entry.replace(0, filename.length(), filename);

--- a/lib/utils/utils.cpp
+++ b/lib/utils/utils.cpp
@@ -328,14 +328,14 @@ std::string util_long_entry(std::string filename, size_t fileSize, bool is_dir, 
 #ifdef BUILD_COCO
 #define LONG_ENTRY_RESERVE 6
 #define LONG_ENTRY_EOL "\x0D"
-    if (width <= 0)
-        width = 31;
 #else
 #define LONG_ENTRY_RESERVE 7
 #define LONG_ENTRY_EOL "\x9B"
+#endif /* BUILD_COCO */
+    // Width comes from the caller (NetworkProtocol::dirLongWidth); guard against
+    // an unset value.
     if (width <= 0)
         width = 37;
-#endif /* BUILD_COCO */
     // Filenames longer than this wrap to a second line; the remainder is the
     // size field reserved at the end of the entry.
     const int trim_len = width - LONG_ENTRY_RESERVE;

--- a/lib/utils/utils.h
+++ b/lib/utils/utils.h
@@ -57,7 +57,7 @@ long util_parseInt(FILE *f);
 unsigned char util_checksum(const char *chunk, int length);
 std::string util_crunch(std::string filename);
 std::string util_entry(std::string crunched, size_t fileSize, bool is_dir, bool is_locked);
-std::string util_long_entry(std::string filename, size_t fileSize, bool is_dir);
+std::string util_long_entry(std::string filename, size_t fileSize, bool is_dir, int width = 0);
 std::string util_long_entry_apple2_80col(std::string filename, size_t fileSize, bool is_dir);
 std::string util_long_entry_with_gdrive_id(std::string filename, size_t fileSize, bool is_dir, const std::string &file_id);
 int util_ellipsize(const char* src, char *dst, int dstsize);


### PR DESCRIPTION
The long-dir OPEN_DIR translation=128 was driven by fixed compile time values. This undoes all of that, and provides sane values for the 32 column systems.