### PR TITLE
Enable Netstream TCP for Lynx, Fix Lynx Appkeys

### DIFF
--- a/lib/bus/comlynx/comlynx.cpp
+++ b/lib/bus/comlynx/comlynx.cpp
@@ -376,6 +376,11 @@ void systemBus::disableDevice(fujiDeviceID_t device_id)
 
 void systemBus::setStreamHost(const char *hostname, int port)
 {
+    setStreamHostWithOptions(hostname, port, 0, false, true);
+}
+
+void systemBus::setStreamHostWithOptions(const char *hostname, int port, int mode, bool register_enabled, bool redeye_enabled)
+{
     // Turn off if hostname is STOP
     if (hostname != nullptr && !strcmp(hostname, "STOP"))
     {
@@ -410,6 +415,12 @@ void systemBus::setStreamHost(const char *hostname, int port)
         _streamDev->netstream_port = 5004;
         Debug_printf("netstream port not provided or invalid (%d), setting to 5004\n", port);
     }
+
+    _streamDev->netstreamMode = (mode == 0)
+        ? lynxNetStream::NetStreamMode::UDP
+        : lynxNetStream::NetStreamMode::TCP;
+    _streamDev->netstreamRegisterEnabled = register_enabled;
+    _streamDev->redeye_mode = redeye_enabled;
 
     // Restart NetStream mode if needed
     if (_streamDev->netstreamActive) {

--- a/lib/bus/comlynx/comlynx.h
+++ b/lib/bus/comlynx/comlynx.h
@@ -156,7 +156,8 @@ public:
     void changeDeviceId(virtualDevice *pDevice, int device_id);
     bool deviceEnabled(fujiDeviceID_t device_id);
     QueueHandle_t qComlynxMessages = nullptr;
-    void setStreamHost(const char *newhost, int port);    
+    void setStreamHost(const char *newhost, int port);
+    void setStreamHostWithOptions(const char *newhost, int port, int mode, bool register_enabled, bool redeye_enabled);
 
     void setRedeyeMode(bool enable);
     void setRedeyeGameRemap(uint32_t remap);

--- a/lib/device/comlynx/lynxFuji.cpp
+++ b/lib/device/comlynx/lynxFuji.cpp
@@ -450,8 +450,14 @@ void lynxFuji::comlynx_process()
     case FUJICMD_MOUNT_ALL:
         fujicmd_mount_all_success();
         break;
+    case FUJICMD_OPEN_APPKEY:
+        fujicmd_open_app_key();
+        break;
+    case FUJICMD_CLOSE_APPKEY:
+        fujicmd_close_app_key();
+        break;
     case FUJICMD_WRITE_APPKEY:
-        fujicmd_write_app_key(0, 0);
+        fujicmd_write_app_key((len > 1) ? (len - 1) : 0, (len > 1) ? (len - 1) : 0);
         break;
     case FUJICMD_READ_APPKEY:
         fujicmd_read_app_key();

--- a/lib/device/comlynx/lynxFuji.cpp
+++ b/lib/device/comlynx/lynxFuji.cpp
@@ -268,6 +268,55 @@ void lynxFuji::fujicmd_get_time()
     Debug_printf("comlynx_get_time - Sending %02d/%02d/%02d %02d:%02d:%02d\n",now->tm_mon, now->tm_mday, now->tm_year, now->tm_hour, now->tm_min, now->tm_sec);
 }
 
+void lynxFuji::fujicmd_enable_netstream(int port, size_t host_payload_len)
+{
+    char host[64] = {};
+
+    transaction_begin(TRANS_STATE::WILL_GET);
+    if (!transaction_get(&host, sizeof(host)))
+    {
+        transaction_error();
+        return;
+    }
+
+    const char *nul = static_cast<const char *>(memchr(host, '\0', sizeof(host)));
+    size_t host_len = nul ? static_cast<size_t>(nul - host) : sizeof(host);
+    bool has_flags = false;
+    uint8_t flags = 0;
+
+    if (nul != nullptr)
+    {
+        size_t nul_index = static_cast<size_t>(nul - host);
+        has_flags = (host_payload_len > nul_index + 1) &&
+                    (host_payload_len < sizeof(host) || host[nul_index + 1] != 0);
+        if (has_flags && nul_index + 1 < sizeof(host))
+            flags = static_cast<uint8_t>(host[nul_index + 1]);
+    }
+
+    int stream_mode = (flags & 0x01) ? 1 : 0;
+    bool register_enabled = (flags & 0x02) != 0;
+    bool redeye_enabled = has_flags ? ((flags & 0x04) != 0) : true;
+
+    char host_out[64];
+    size_t copy_len = host_len;
+    if (copy_len > sizeof(host_out) - 1)
+        copy_len = sizeof(host_out) - 1;
+    memcpy(host_out, host, copy_len);
+    host_out[copy_len] = '\0';
+
+    Debug_printf("Fuji cmd ENABLE NETSTREAM: HOST:%s PORT: %d\n", host_out, port);
+
+    Config.store_netstream_host(host_out);
+    Config.store_netstream_port(port);
+    Config.store_netstream_mode(stream_mode);
+    Config.store_netstream_register(register_enabled);
+    Config.save();
+
+    transaction_complete();
+
+    SYSTEM_BUS.setStreamHostWithOptions(host_out, port, stream_mode, register_enabled, redeye_enabled);
+}
+
 void lynxFuji::comlynx_process()
 {
     uint8_t c;
@@ -427,7 +476,7 @@ void lynxFuji::comlynx_process()
     case FUJICMD_ENABLE_UDPSTREAM:
         uint16_t port;
         transaction_get(&port, sizeof(port));
-        fujicmd_enable_netstream(port);
+        fujicmd_enable_netstream(port, (len > 3) ? (len - 3) : 0);
         break;
     default:
         Debug_printf("lynxFuji::process - unknown command: %02X\n", c);

--- a/lib/device/comlynx/lynxFuji.h
+++ b/lib/device/comlynx/lynxFuji.h
@@ -28,6 +28,7 @@ protected:
     void comlynx_new_disk();               // 0xE7
     void fujicmd_random_number();          // 0xD3
     void fujicmd_get_time();               // 0xD2
+    void fujicmd_enable_netstream(int port, size_t host_payload_len);
 
     void comlynx_process() override;
 

--- a/lib/device/comlynx/netstream.cpp
+++ b/lib/device/comlynx/netstream.cpp
@@ -8,12 +8,70 @@
 #include "fnSystem.h"
 #include "utils.h"
 
+#include <cstring>
+
+#ifdef ESP_PLATFORM
+#include <errno.h>
+#include <sys/socket.h>
+#endif
+
 //#define DEBUG_NETSTREAM
+
+bool lynxNetStream::ensure_netstream_ready()
+{
+    if (netstreamMode == NetStreamMode::UDP)
+        return true;
+    if (netStreamTcp.connected())
+        return true;
+    if (netstream_host_ip == IPADDR_NONE || netstream_port <= 0)
+        return false;
+    if (!netStreamTcp.connect(netstream_host_ip, (uint16_t)netstream_port))
+    {
+#ifdef DEBUG_NETSTREAM
+        Debug_println("NETSTREAM: TCP connect failed");
+#endif
+        return false;
+    }
+    netStreamTcp.setNoDelay(true);
+    if (netstreamRegisterEnabled)
+    {
+        const char *str = "REGISTER";
+        netStreamTcp.write((const uint8_t *)str, strlen(str));
+    }
+    buf_stream_index = 0;
+    buf_net_index = 0;
+    return true;
+}
+
+void lynxNetStream::send_net_packet(const uint8_t *buf, size_t len)
+{
+    if (netstreamMode == NetStreamMode::UDP)
+    {
+        netStreamUdp.beginPacket(netstream_host_ip, netstream_port);
+        netStreamUdp.write(buf, len);
+        netStreamUdp.endPacket();
+    }
+    else if (ensure_netstream_ready())
+    {
+        netStreamTcp.write(buf, len);
+    }
+}
 
 void lynxNetStream::comlynx_enable_netstream()
 {
-    // Open the connection
-    netStream.begin(netstream_port);
+    if (netstreamMode == NetStreamMode::UDP)
+    {
+        netStreamUdp.begin(netstream_port);
+        if (netstreamRegisterEnabled)
+        {
+            const char *str = "REGISTER";
+            send_net_packet((const uint8_t *)str, strlen(str));
+        }
+    }
+    else
+    {
+        ensure_netstream_ready();
+    }
 
     netstreamActive = true;
 #ifdef DEBUG
@@ -24,7 +82,10 @@ void lynxNetStream::comlynx_enable_netstream()
 
 void lynxNetStream::comlynx_disable_netstream()
 {
-    netStream.stop();
+    netStreamTcp.stop();
+    netStreamUdp.stop();
+    buf_stream_index = 0;
+    buf_net_index = 0;
     netstreamActive = false;
 #ifdef DEBUG
     Debug_println("NETSTREAM mode DISABLED");
@@ -32,33 +93,69 @@ void lynxNetStream::comlynx_disable_netstream()
 #endif
 }
 
+void lynxNetStream::process_net_packet(const uint8_t *buf, size_t len)
+{
+    SYSTEM_BUS.wait_for_idle();
+    SYSTEM_BUS.write(buf, len);
+#ifdef DEBUG_NETSTREAM
+    Debug_print(netstreamMode == NetStreamMode::UDP ? "UDP-IN: " : "TCP-IN: ");
+    util_dump_bytes(buf, len);
+#endif
+    SYSTEM_BUS.read(buf_stream, len); // Trash what we just sent over serial
+}
+
+void lynxNetStream::drain_tcp_to_lynx()
+{
+    if (!ensure_netstream_ready())
+        return;
+
+    while (true)
+    {
+#ifdef ESP_PLATFORM
+        int bytes_read = recv(netStreamTcp.fd(), (char *)buf_net, NETSTREAM_BUFFER_SIZE, MSG_DONTWAIT);
+        if (bytes_read <= 0)
+        {
+            if (bytes_read == 0)
+                netStreamTcp.stop();
+            else if (errno != EWOULDBLOCK && errno != EAGAIN)
+                netStreamTcp.stop();
+            break;
+        }
+#else
+        size_t available = netStreamTcp.available();
+        if (available == 0)
+            break;
+        size_t to_read = (available > NETSTREAM_BUFFER_SIZE) ? NETSTREAM_BUFFER_SIZE : available;
+        int bytes_read = netStreamTcp.read(buf_net, to_read);
+        if (bytes_read <= 0)
+            break;
+#endif
+        process_net_packet(buf_net, bytes_read);
+    }
+}
 
 void lynxNetStream::comlynx_handle_netstream()
 {
-    uint8_t n;
-
-    // if there’s data available, read a packet
-    int packetSize = netStream.parsePacket();
-    if (packetSize > 0) {
-        netStream.read(buf_net, NETSTREAM_BUFFER_SIZE);
-
-        #ifdef DEBUG_NETSTREAM
-            Debug_print("UDP-IN: ");
-            util_dump_bytes(buf_net, packetSize);
-        #endif
-
-        _comlynx_bus->wait_for_idle();
-        SYSTEM_BUS.write(buf_net, packetSize);
-        SYSTEM_BUS.read(buf_net, packetSize); // Trash what we just sent over serial
+    if (netstreamMode == NetStreamMode::UDP)
+    {
+        int packetSize = netStreamUdp.parsePacket();
+        if (packetSize > 0)
+        {
+            netStreamUdp.read(buf_net, NETSTREAM_BUFFER_SIZE);
+            process_net_packet(buf_net, packetSize);
+        }
+    }
+    else
+    {
+        drain_tcp_to_lynx();
     }
 
-    //SYSTEM_BUS.flush();
-    
     // Read the data until there's a pause in the incoming stream
     buf_stream_index = 0;
-    if (SYSTEM_BUS.available() > 0) {
-        while (true) {
-            n = 0;  
+    if (SYSTEM_BUS.available() > 0)
+    {
+        while (true)
+        {
             if (SYSTEM_BUS.available() > 0)
             {
                 // Collect bytes read in our buffer
@@ -66,7 +163,6 @@ void lynxNetStream::comlynx_handle_netstream()
 
                 if (buf_stream_index < NETSTREAM_BUFFER_SIZE - 1)
                     buf_stream_index++;
-
             }
             else
             {
@@ -80,18 +176,14 @@ void lynxNetStream::comlynx_handle_netstream()
         if (buf_stream_index == 0)
             return;
 
-        // Send what we've collected over WiFi
-        netStream.beginPacket(netstream_host_ip, netstream_port); // remote IP and port
-        netStream.write(buf_stream, buf_stream_index);
-        netStream.endPacket();
+        send_net_packet(buf_stream, buf_stream_index);
 
-        #ifdef DEBUG_NETSTREAM
-            Debug_print("UDP-OUT: ");
-            util_dump_bytes(buf_stream, buf_stream_index);
-        #endif    
+#ifdef DEBUG_NETSTREAM
+        Debug_print(netstreamMode == NetStreamMode::UDP ? "UDP-OUT: " : "TCP-OUT: ");
+        util_dump_bytes(buf_stream, buf_stream_index);
+#endif
     }
 }
-
 
 void lynxNetStream::comlynx_process()
 {

--- a/lib/device/comlynx/netstream.h
+++ b/lib/device/comlynx/netstream.h
@@ -2,9 +2,12 @@
 #define NETSTREAM_H
 
 #include "bus.h"
+
+#include "fnTcpClient.h"
 #include "fnUDP.h"
 #include "redeye.h"
 
+#include <cstddef>
 
 #define LEDC_TIMER_RESOLUTION  LEDC_TIMER_1_BIT
 
@@ -16,18 +19,33 @@
 class lynxNetStream : public virtualDevice
 {
 private:
-    fnUDP netStream;
+    fnTcpClient netStreamTcp;
+    fnUDP netStreamUdp;
     systemBus *_comlynx_bus = nullptr;
 
     uint8_t buf_net[NETSTREAM_BUFFER_SIZE];
     uint8_t buf_stream[NETSTREAM_BUFFER_SIZE];
 
-    uint16_t buf_stream_index=0;
+    size_t buf_stream_index = 0;
+    size_t buf_net_index = 0;
 
+    bool ensure_netstream_ready();
+    void send_net_packet(const uint8_t *buf, size_t len);
+    void process_net_packet(const uint8_t *buf, size_t len);
+    void process_redeye_net_packet(uint8_t *buf, size_t len);
+    void drain_tcp_to_lynx();
     void comlynx_process() override;
 
 public:
+    enum class NetStreamMode : uint8_t
+    {
+        UDP = 0,
+        TCP = 1
+    };
+
     bool netstreamActive = false; // If we are in netstream mode or not
+    bool netstreamRegisterEnabled = false; // Send REGISTER on connect
+    NetStreamMode netstreamMode = NetStreamMode::UDP;
     in_addr_t netstream_host_ip = IPADDR_NONE;
     int netstream_port;
 

--- a/lib/device/comlynx/redeye.cpp
+++ b/lib/device/comlynx/redeye.cpp
@@ -8,6 +8,13 @@
 #include "fnSystem.h"
 #include "utils.h"
 
+#include <cstring>
+
+#ifdef ESP_PLATFORM
+#include <errno.h>
+#include <sys/socket.h>
+#endif
+
 //#define DEBUG_NETSTREAM
 
 GAME_LIST_T game_list[] = {
@@ -59,33 +66,89 @@ GAME_LIST_T game_list[] = {
 };
 
 
+void lynxNetStream::process_redeye_net_packet(uint8_t *buf, size_t len)
+{
+	if ((len <= 2) || (len >= 10))
+		return;
+
+#ifdef DEBUG_NETSTREAM
+	Debug_print("Netstream Redeye FROM NET: ");
+	util_dump_bytes(buf, len);
+#endif
+
+	if (redeye_validate_packet(buf, len))
+	{
+		if (game.state.logon)
+			redeye_process_logon_packet_from_net(buf);
+		else
+			redeye_process_game_packet_from_net(buf);
+	}
+}
+
+
 void lynxNetStream::comlynx_handle_redeye_netstream() {
 
 	redeye_check_logon_state();
 
 	// Get data from network
-	int packetSize = netStream.parsePacket();
-	if ((packetSize > 2) && (packetSize < 10)) {	// good packetsize is at least 3, and in practice less than 10
-		netStream.read(buf_net, NETSTREAM_BUFFER_SIZE);
-
-		#ifdef DEBUG_NETSTREAM 
-		Debug_print("Netstream Redeye FROM NET: ");
- 		util_dump_bytes(buf_net, packetSize);
- 		#endif // validate this is a good redeye packet
-
- 		if (redeye_validate_packet(buf_net, packetSize)) {
-			if (game.state.logon)
-				redeye_process_logon_packet_from_net(buf_net);
- 			else {
- 				redeye_process_game_packet_from_net(buf_net);
-				
-				// Send to Lynx UART
-    			//_comlynx_bus->wait_for_idle();
-    			//SYSTEM_BUS.write(buf_net, packetSize);
-    			//SYSTEM_BUS.read(buf_net, packetSize); 		// Trash what we just sent over serial
+	int packetSize = 0;
+	if (netstreamMode == NetStreamMode::UDP)
+	{
+		packetSize = netStreamUdp.parsePacket();
+		if (packetSize > 0)
+		{
+			netStreamUdp.read(buf_net, NETSTREAM_BUFFER_SIZE);
+			process_redeye_net_packet(buf_net, packetSize);
+		}
+	}
+	else if (ensure_netstream_ready())
+	{
+		while (buf_net_index < NETSTREAM_BUFFER_SIZE)
+		{
+			size_t free_space = NETSTREAM_BUFFER_SIZE - buf_net_index;
+#ifdef ESP_PLATFORM
+			int bytes_read = recv(netStreamTcp.fd(), (char *)&buf_net[buf_net_index], free_space, MSG_DONTWAIT);
+			if (bytes_read <= 0)
+			{
+				if (bytes_read == 0)
+					netStreamTcp.stop();
+				else if (errno != EWOULDBLOCK && errno != EAGAIN)
+					netStreamTcp.stop();
+				break;
 			}
- 		}
- 	}
+#else
+			size_t available = netStreamTcp.available();
+			if (available == 0)
+				break;
+			size_t to_read = (available > free_space) ? free_space : available;
+			int bytes_read = netStreamTcp.read(&buf_net[buf_net_index], to_read);
+			if (bytes_read <= 0)
+				break;
+#endif
+			buf_net_index += bytes_read;
+			while (buf_net_index > 0)
+			{
+				uint8_t size = buf_net[0];
+				if (size < 1 || size > 6)
+				{
+					memmove(buf_net, &buf_net[1], buf_net_index - 1);
+					buf_net_index--;
+					continue;
+				}
+
+				size_t packet_len = (size_t)size + 2;
+				if (buf_net_index < packet_len)
+					break;
+
+				process_redeye_net_packet(buf_net, packet_len);
+				memmove(buf_net, &buf_net[packet_len], buf_net_index - packet_len);
+				buf_net_index -= packet_len;
+			}
+		}
+
+		if (buf_net_index >= NETSTREAM_BUFFER_SIZE)
+			buf_net_index = 0;
+	}
 
 	// Collect data from serial bus
 	// serial collect loop, waiting until the serial has been idle for IDLE_TIME (2-3 char time at 62500 baud)
@@ -513,9 +576,7 @@ void lynxNetStream::redeye_process_logon_packet_from_lynx(uint8_t *buf)
 	}
 
     // Send to network
-	netStream.beginPacket(netstream_host_ip, netstream_port); // remote IP and port
-	netStream.write(buf, size+2);
-	netStream.endPacket();
+	send_net_packet(buf, size+2);
 }
 
 
@@ -594,9 +655,7 @@ void lynxNetStream::redeye_process_game_packet_from_lynx(uint8_t *buf)
 	}
 
     // Send to network
-	netStream.beginPacket(netstream_host_ip, netstream_port); // remote IP and port
-	netStream.write(buf, size);
-	netStream.endPacket();
+	send_net_packet(buf, size);
 }
 
 

--- a/lib/http/httpServiceConfigurator.cpp
+++ b/lib/http/httpServiceConfigurator.cpp
@@ -139,7 +139,12 @@ void netstream_activate()
         Config.get_network_netstream_register());
 #endif /* ATARI */
 #ifdef BUILD_LYNX
-    SYSTEM_BUS.setStreamHost(Config.get_network_netstream_host().c_str(), Config.get_network_netstream_port());
+    SYSTEM_BUS.setStreamHostWithOptions(
+        Config.get_network_netstream_host().c_str(),
+        Config.get_network_netstream_port(),
+        (Config.get_network_netstream_mode() == 0) ? 0 : 1,
+        Config.get_network_netstream_register(),
+        true);
 #endif /* LYNX */
 }
 


### PR DESCRIPTION
Lynx Netstream Fuji Command now accepts the extra flags byte like Atari Netstream to configure it. Allows selecting transport, whether to send REGISTER at start and redeye enable/disable.

Fix appkeys for lynx