### PR TITLE
Fix fujiversal prototype startup hang

### DIFF
--- a/lib/bus/drivewire/drivewire.cpp
+++ b/lib/bus/drivewire/drivewire.cpp
@@ -16,6 +16,7 @@
 
 #include "fnSystem.h"
 #include "fnConfig.h"
+#include "fnWiFi.h"
 #include "fnDNS.h"
 #include "led.h"
 #include "utils.h"
@@ -44,6 +45,15 @@ std::queue<char> outgoingChannel[MAX_CHANNEL_QUEUES];
 std::queue<char> incomingChannel[MAX_CHANNEL_QUEUES];
 
 #define DEBOUNCE_THRESHOLD_US 50000ULL
+
+#if FUJINET_OVER_USB
+// Cold-boot mitigation: the WiFi association storm can preempt the USB tasks
+// that bridge DriveWire to the RP2040, stalling the CoCo's config load. Run the
+// USB channel just above the WiFi task (prio 23) until the station associates,
+// then return it to normal so interactive use is unaffected.
+#define DW_USB_BOOT_PRIORITY 24
+#define DW_USB_RUN_PRIORITY  20
+#endif
 
 #ifdef ESP_PLATFORM
 static void IRAM_ATTR drivewire_isr_handler(void *arg)
@@ -734,6 +744,16 @@ void systemBus::_drivewire_process_queue()
  */
 void systemBus::service()
 {
+#if FUJINET_OVER_USB
+    // Cold-boot association is over once the station has an IP; drop USB
+    // servicing back to normal priority (one-shot).
+    if (_usb_boot_priority && fnWiFi.connected())
+    {
+        _serial.setServicePriority(DW_USB_RUN_PRIORITY);
+        _usb_boot_priority = false;
+    }
+#endif
+
 #ifdef ESP_PLATFORM
     // Handle cassette play if MOTOR pin active.
     if (_cassetteDev)
@@ -899,7 +919,9 @@ void systemBus::setup()
     else
     {
 #if FUJINET_OVER_USB
+        _serial.setServicePriority(DW_USB_BOOT_PRIORITY);
         _serial.begin();
+        _usb_boot_priority = true;
 #else /* ! FUJINET_OVER_USB */
         _serial.begin(ChannelConfig()
                       .baud(_drivewireBaud)

--- a/lib/bus/drivewire/drivewire.h
+++ b/lib/bus/drivewire/drivewire.h
@@ -137,6 +137,12 @@ private:
     std::deque<uint8_t> _dbc_pushback;
 #endif
 
+#if FUJINET_OVER_USB
+    // USB servicing runs boosted through the cold-boot WiFi association storm,
+    // then drops to normal once the station associates (see setup()/service()).
+    bool _usb_boot_priority = false;
+#endif
+
     const FujiDWPacket *_activeFrame;
     drivewireDevice *_activeDev = nullptr;
     drivewireModem *_modemDev = nullptr;

--- a/lib/hardware/ACMChannel.cpp
+++ b/lib/hardware/ACMChannel.cpp
@@ -140,9 +140,19 @@ void ACMChannel::begin()
     host_config.intr_flags = ESP_INTR_FLAG_LEVEL1;
     ESP_ERROR_CHECK(usb_host_install(&host_config));
 
+#ifdef PINMAP_FUJIVERSAL_DRIVEWIRE
+    // Keep USB servicing off core 0. On core 0 the WiFi stack preempts these
+    // tasks during cold boot and stalls the DriveWire byte stream mid-sector,
+    // hanging the CoCo's CONFIG load. Core 1 (only the serve loop lives there)
+    // stays clear of the WiFi bring-up storm.
+    BaseType_t task_created = xTaskCreatePinnedToCore(usb_lib_task, "usb_lib", 4096,
+                                          xTaskGetCurrentTaskHandle(),
+                                          USB_HOST_PRIORITY, NULL, 1);
+#else
     BaseType_t task_created = xTaskCreate(usb_lib_task, "usb_lib", 4096,
                                           xTaskGetCurrentTaskHandle(),
                                           USB_HOST_PRIORITY, NULL);
+#endif
     assert(task_created == pdTRUE);
 
     ndc_instance = this;
@@ -152,7 +162,11 @@ void ACMChannel::begin()
     cdc_acm_host_driver_config_t driver_config = {};
     driver_config.driver_task_stack_size = 4096;
     driver_config.driver_task_priority = USB_HOST_PRIORITY;
+#ifdef PINMAP_FUJIVERSAL_DRIVEWIRE
+    driver_config.xCoreID = 1;
+#else
     driver_config.xCoreID = 0;
+#endif
     driver_config.new_dev_cb = newDevForwarder;
     ESP_ERROR_CHECK(cdc_acm_host_install(&driver_config));
 

--- a/lib/hardware/ACMChannel.cpp
+++ b/lib/hardware/ACMChannel.cpp
@@ -6,8 +6,6 @@
 
 #include "../../include/debug.h"
 
-#define USB_HOST_PRIORITY   (20)
-
 #define TX_TIMEOUT_MS       (1000)
 
 #include <inttypes.h> // debug
@@ -140,19 +138,9 @@ void ACMChannel::begin()
     host_config.intr_flags = ESP_INTR_FLAG_LEVEL1;
     ESP_ERROR_CHECK(usb_host_install(&host_config));
 
-#ifdef PINMAP_FUJIVERSAL_DRIVEWIRE
-    // Keep USB servicing off core 0. On core 0 the WiFi stack preempts these
-    // tasks during cold boot and stalls the DriveWire byte stream mid-sector,
-    // hanging the CoCo's CONFIG load. Core 1 (only the serve loop lives there)
-    // stays clear of the WiFi bring-up storm.
-    BaseType_t task_created = xTaskCreatePinnedToCore(usb_lib_task, "usb_lib", 4096,
-                                          xTaskGetCurrentTaskHandle(),
-                                          USB_HOST_PRIORITY, NULL, 1);
-#else
     BaseType_t task_created = xTaskCreate(usb_lib_task, "usb_lib", 4096,
                                           xTaskGetCurrentTaskHandle(),
-                                          USB_HOST_PRIORITY, NULL);
-#endif
+                                          _service_priority, NULL);
     assert(task_created == pdTRUE);
 
     ndc_instance = this;
@@ -161,12 +149,8 @@ void ACMChannel::begin()
     // devices that were already connected at boot
     cdc_acm_host_driver_config_t driver_config = {};
     driver_config.driver_task_stack_size = 4096;
-    driver_config.driver_task_priority = USB_HOST_PRIORITY;
-#ifdef PINMAP_FUJIVERSAL_DRIVEWIRE
-    driver_config.xCoreID = 1;
-#else
+    driver_config.driver_task_priority = _service_priority;
     driver_config.xCoreID = 0;
-#endif
     driver_config.new_dev_cb = newDevForwarder;
     ESP_ERROR_CHECK(cdc_acm_host_install(&driver_config));
 
@@ -274,6 +258,19 @@ bool ACMChannel::getDCD()
 bool ACMChannel::getRI()
 {
     return _serial_state.bRingSignal;
+}
+
+void ACMChannel::setServicePriority(UBaseType_t priority)
+{
+    _service_priority = priority;
+
+    // Apply immediately if the worker tasks are already running. "usb_lib" is
+    // created here; "USB-CDC" is the cdc_acm host driver task.
+    TaskHandle_t h;
+    if ((h = xTaskGetHandle("usb_lib")) != NULL)
+        vTaskPrioritySet(h, priority);
+    if ((h = xTaskGetHandle("USB-CDC")) != NULL)
+        vTaskPrioritySet(h, priority);
 }
 
 #endif /* CONFIG_USB_CDC_ACM_HOST_ENABLED */

--- a/lib/hardware/ACMChannel.h
+++ b/lib/hardware/ACMChannel.h
@@ -22,6 +22,10 @@ private:
     cdc_acm_uart_state_t _serial_state;
     bool _dsr, _cts;
 
+    // FreeRTOS priority for the USB worker tasks; the owner may override it
+    // (e.g. to win CPU against WiFi during startup) via setServicePriority().
+    UBaseType_t _service_priority = 20;
+
 protected:
     void updateFIFO() override;
     size_t dataOut(const void *buffer, size_t length) override;
@@ -29,6 +33,10 @@ protected:
 public:
     void begin();
     void end() override;
+
+    // Set the FreeRTOS priority of the USB worker tasks. Takes effect at the
+    // next begin(), and is applied immediately if they are already running.
+    void setServicePriority(UBaseType_t priority);
 
     void flushOutput() override;
 


### PR DESCRIPTION
This PR originally DID pin the USB host tasks to core 1 on the Fujiversal DriveWire build

Symptom: On the CoCo Fujiversal prototype (RP2350 bridge + ESP32-S3 over USB), a cold boot intermittently hangs while loading the config program. The FujiNet serves the small CFGLOAD.BIN loader fine and the splash appears, but the following load of the larger CONFIG.BIN (≈77 sectors) stalls partway and the machine hangs at the splash. Resetting and re-running the boot works, and pre-powering the board over USB before switching the CoCo on avoids it entirely.

It no longer does that.  What it does instead is temporarily boost the priority of those tasks over the wifi task until such time as the wifi task obtains an IP address. Once that happens, the tasks' priorities are returned to normal.

This tests well with both startup and regular operation.