### PR TITLE
Introduce FujioSIOPacket

### DIFF
--- a/fujinet_pc.cmake
+++ b/fujinet_pc.cmake
@@ -310,6 +310,7 @@ if(FUJINET_TARGET STREQUAL "ATARI")
     list(APPEND SOURCES
 
     lib/bus/sio/sio.h lib/bus/sio/sio.cpp
+    lib/bus/sio/FujiSIOPacket.h lib/bus/sio/FujiSIOPacket.cpp
     lib/bus/sio/NetSIO.h lib/bus/sio/NetSIO.cpp
     lib/media/atari/diskType.h lib/media/atari/diskType.cpp
     lib/media/atari/diskTypeAtr.h lib/media/atari/diskTypeAtr.cpp

--- a/lib/bus/sio/FujiSIOPacket.cpp
+++ b/lib/bus/sio/FujiSIOPacket.cpp
@@ -1,0 +1,66 @@
+#ifdef BUILD_ATARI
+
+#include "FujiSIOPacket.h"
+#include "sio.h"
+#include "fnSystem.h"
+
+uint16_t FujiSIOPacket::getParam(size_t index, size_t psize) const
+{
+    size_t count;
+
+    assert(psize == 1 || psize == 2);
+    assert(_params.size() == 0 || _paramSize == psize);
+    if (index >= _params.size())
+    {
+        _paramSize = psize;
+        if (_paramSize == 1)
+        {
+            _params.push_back(frame.aux1);
+            _params.push_back(frame.aux2);
+        }
+        else
+            _params.push_back(frame.aux12);
+    }
+    return _params[index];
+}
+
+error_is_true FujiSIOPacket::setDataLength(const size_t len) const
+{
+    size_t rlen;
+
+
+    assert(!_data.has_value());
+
+#ifndef ESP_PLATFORM
+    if (SYSTEM_BUS.isBoIP())
+    {
+        SYSTEM_BUS.netsio_write_size(len); // set hint for NetSIO
+    }
+#endif /* ! ESP_PLATFORM */
+
+    _data.emplace(len, 0);
+    rlen = SYSTEM_BUS.read(_data->data(), _data->size());
+    if (rlen != len)
+        _data->resize(rlen);
+
+    // Wait for checksum
+    while (SYSTEM_BUS.available() <= 0)
+        fnSystem.yield();
+    uint8_t ck_rcv = SYSTEM_BUS.read();
+
+    uint8_t ck_tst = sio_checksum(_data->data(), _data->size());
+
+    fnSystem.delay_microseconds(DELAY_T4);
+
+    if (ck_rcv != ck_tst)
+    {
+        SYSTEM_BUS._sio_error();
+        RETURN_ERROR_AS_TRUE();
+    }
+
+    SYSTEM_BUS._sio_ack();
+
+    RETURN_SUCCESS_AS_FALSE();
+}
+
+#endif /* BUILD_ATARI */

--- a/lib/bus/sio/FujiSIOPacket.h
+++ b/lib/bus/sio/FujiSIOPacket.h
@@ -1,0 +1,88 @@
+#ifndef FUJISIOPACKET_H
+#define FUJISIOPACKET_H
+
+#include "cmdFrame.h"
+
+#include <optional>
+#include <cassert>
+#include <span>
+#include <string>
+
+class FujiSIOPacket
+{
+private:
+    mutable std::vector<uint16_t> _params;
+    mutable std::optional<ByteBuffer> _data;
+    mutable unsigned _paramSize;
+
+    struct PacketParamProxy
+    {
+        size_t index;
+        const FujiSIOPacket *packet;
+
+        // These tell the compiler: "Run this code if the destination matches my type"
+        operator bool() const {
+            return static_cast<uint8_t>(*this) != 0;
+        }
+
+        // These tell the compiler exactly how to handle direct equality checks
+        // against any integer type without triggering conversion rule debates.
+
+        bool operator==(uint8_t val) const {
+            return static_cast<uint8_t>(*this) == val;
+        }
+
+        bool operator==(uint16_t val) const {
+            return static_cast<uint16_t>(*this) == val;
+        }
+
+        inline operator uint8_t() const {
+            return packet->getParam(index, sizeof(uint8_t));
+        }
+
+        inline operator uint16_t() const {
+            return packet->getParam(index, sizeof(uint16_t));
+        }
+    };
+
+    friend PacketParamProxy;
+
+    uint16_t getParam(size_t index, size_t psize) const;
+
+public:
+    cmdFrame_t frame;
+
+    FujiSIOPacket() = default;
+
+    void decode(uint8_t *raw);
+
+    fujiDeviceID_t device() const { return frame.device; }
+    fujiCommandID_t command() const { return frame.comnd; }
+
+    PacketParamProxy param(size_t index) const { return PacketParamProxy{ index, this }; }
+
+    // Completes deserialization by reading the trailing data field once its
+    // length has been determined from command-specific context.
+    error_is_true setDataLength(const size_t len) const;
+
+    const std::optional<ByteBuffer>& data() const {
+        assert(_data.has_value());
+        return _data;
+    }
+    const std::optional<const std::string> dataAsString() const {
+        auto d = data();
+        return std::string(reinterpret_cast<const char *>(d->data()), d->size());
+    }
+
+    // Explicit alternatives to the implicit PacketParamProxy conversions.
+    // These may be preferred where the destination type is not obvious.
+    uint8_t  param8(size_t index)  const { return (uint8_t) param(index); }
+    uint16_t param16(size_t index) const { return (uint16_t) param(index); }
+
+    // Delete copy semantics to prevent pass-by-value bugs
+    FujiSIOPacket(const FujiSIOPacket&) = delete;
+    FujiSIOPacket& operator=(const FujiSIOPacket&) = delete;
+
+};
+
+#endif /* FUJISIOPACKET_H */

--- a/lib/bus/sio/sio.cpp
+++ b/lib/bus/sio/sio.cpp
@@ -130,7 +130,7 @@ void systemBus::transaction_send(const void *data, size_t len, bool is_error)
    SIO READ from ATARI by DEVICE
    data = buffer from atari to fujinet
    len = length
-   Returns TRUE on success, FALse on error
+   Returns TRUE on success, FALSE on error
 */
 success_is_true systemBus::transaction_get(void *data, size_t len)
 {
@@ -140,41 +140,10 @@ success_is_true systemBus::transaction_get(void *data, size_t len)
     assert(_transaction_state == TRANS_STATE::WILL_GET);
     _transaction_state = TRANS_STATE::DID_GET;
 
-#ifndef ESP_PLATFORM
-    if (SYSTEM_BUS.isBoIP())
-    {
-        SYSTEM_BUS.netsio_write_size(len); // set hint for NetSIO
-    }
-#endif /* ! ESP_PLATFORM */
-
-    __BEGIN_IGNORE_UNUSEDVARS
-    size_t l = SYSTEM_BUS.read(data, len);
-    __END_IGNORE_UNUSEDVARS
-
-    // Wait for checksum
-    while (SYSTEM_BUS.available() <= 0)
-        fnSystem.yield();
-    uint8_t ck_rcv = SYSTEM_BUS.read();
-
-    uint8_t ck_tst = sio_checksum((uint8_t *) data, len);
-
-#ifdef VERBOSE_SIO
-    Debug_printf("RECV <%u> BYTES, checksum: %hu\n\t", (unsigned int)l, ck_rcv);
-    for (int i = 0; i < len; i++)
-        Debug_printf("%02x ", buf[i]);
-    Debug_print("\n");
-#endif
-
-    fnSystem.delay_microseconds(DELAY_T4);
-
-    if (ck_rcv != ck_tst)
-    {
-        _sio_error();
-        Debug_printf("bus_to_peripheral() - Data Frame Chksum error, calc %02x, rcv %02x\n", ck_tst, ck_rcv);
+    if (_activeFrame->setDataLength(len).is_error())
         RETURN_ERROR_AS_FALSE();
-    }
-
-    _sio_ack();
+    std::copy(_activeFrame->data()->begin(), _activeFrame->data()->end(),
+              static_cast<uint8_t *>(data));
     RETURN_SUCCESS_AS_TRUE();
 }
 
@@ -236,11 +205,9 @@ void systemBus::_sio_process_cmd()
     }
 
     // Read CMD frame
-    cmdFrame_t tempFrame;
-    tempFrame.commanddata = 0;
-    tempFrame.checksum = 0;
+    FujiSIOPacket tmpFrame;
 
-    if (_port->read((uint8_t *)&tempFrame, sizeof(tempFrame)) != sizeof(tempFrame))
+    if (_port->read((uint8_t *)&tmpFrame.frame, sizeof(tmpFrame.frame)) != sizeof(tmpFrame.frame))
     {
         // Debug_println("Timeout waiting for data after CMD pin asserted");
         return;
@@ -250,7 +217,8 @@ void systemBus::_sio_process_cmd()
 
     Debug_print("\n");
     Debug_printf("CF: %02x %02x %02x %02x %02x\n",
-                 tempFrame.device, tempFrame.comnd, tempFrame.aux1, tempFrame.aux2, tempFrame.checksum);
+                 tmpFrame.device(), tmpFrame.command(),
+                 tmpFrame.frame.aux1, tmpFrame.frame.aux2, tmpFrame.frame.checksum);
 
     // Wait for CMD line to raise again
 #ifdef ESP_PLATFORM
@@ -277,14 +245,15 @@ void systemBus::_sio_process_cmd()
     }
 #endif
 
-    uint8_t ck = sio_checksum((uint8_t *)&tempFrame.commanddata, sizeof(tempFrame.commanddata)); // Calculate Checksum
-    if (ck == tempFrame.checksum)
+    uint8_t ck = sio_checksum((uint8_t *)&tmpFrame.frame.commanddata, sizeof(tmpFrame.frame.commanddata)); // Calculate Checksum
+    if (ck == tmpFrame.frame.checksum)
     {
+        _activeFrame = &tmpFrame;
 #ifndef ESP_PLATFORM
         // reset counter if checksum was correct
         _command_frame_counter = 0;
 #endif
-        if (tempFrame.device == FUJI_DEVICEID_DISK && _fujiDev != nullptr && _fujiDev->boot_config)
+        if (tmpFrame.device() == FUJI_DEVICEID_DISK && _fujiDev != nullptr && _fujiDev->boot_config)
         {
             _activeDev = &_fujiDev->bootdisk;
 
@@ -292,7 +261,7 @@ void systemBus::_sio_process_cmd()
             // SIO status calls (of the 26 Atari sends) so a real D1:
             // can take over. Once status_waint_count expires, respond
             // normally; if disabled, respond immediately.
-            if (_activeDev->status_wait_count > 0 && tempFrame.comnd == 'R' && _fujiDev->status_wait_enabled)
+            if (_activeDev->status_wait_count > 0 && tmpFrame.command() == DISKCMD_READ && _fujiDev->status_wait_enabled)
             {
                 Debug_printf("Disabling CONFIG boot.\n");
                 _fujiDev->boot_config = false;
@@ -302,13 +271,13 @@ void systemBus::_sio_process_cmd()
             {
                 Debug_println("FujiNet CONFIG boot");
                 // handle command
-                _activeDev->sio_process(tempFrame.commanddata, tempFrame.checksum);
+                _activeDev->sio_process(tmpFrame);
             }
         }
         else
         {
             // Command FUJI_DEVICEID_TYPE3POLL is a Type3 poll - send it to every device that cares
-            if (tempFrame.device == FUJI_DEVICEID_TYPE3POLL)
+            if (tmpFrame.device() == FUJI_DEVICEID_TYPE3POLL)
             {
                 Debug_println("SIO TYPE3 POLL");
                 for (auto devicep : _daisyChain)
@@ -318,7 +287,7 @@ void systemBus::_sio_process_cmd()
                         Debug_printf("Sending TYPE3 poll to dev %x\n", devicep->_devnum);
                         _activeDev = devicep;
                         // handle command
-                        _activeDev->sio_process(tempFrame.commanddata, tempFrame.checksum);
+                        _activeDev->sio_process(tmpFrame);
                     }
                 }
             }
@@ -328,11 +297,11 @@ void systemBus::_sio_process_cmd()
                 // or go back to WAIT
                 for (auto devicep : _daisyChain)
                 {
-                    if (tempFrame.device == devicep->_devnum)
+                    if (tmpFrame.device() == devicep->_devnum)
                     {
                         _activeDev = devicep;
                         // handle command
-                        _activeDev->sio_process(tempFrame.commanddata, tempFrame.checksum);
+                        _activeDev->sio_process(tmpFrame);
                     }
                 }
             }
@@ -724,6 +693,8 @@ int systemBus::getCurrentBaudrate()
 // changed here.
 void systemBus::setBaudrate(int baud)
 {
+    flushOutput();
+
     // Yah this looks stupid but C++ doesn't do true polymorphism
     if (isBoIP())
         _netsio.setBaudrate(baud);

--- a/lib/bus/sio/sio.h
+++ b/lib/bus/sio/sio.h
@@ -2,12 +2,14 @@
 #define SIO_H
 
 #include "bus.h"
-#include "cmdFrame.h"
+#include "FujiSIOPacket.h"
 #include "UARTChannel.h"
 #include "NetSIO.h"
 #include "global_types.h"
 #include <forward_list>
 #include <cassert>
+
+#define FUJI_COMMAND_PACKET FujiSIOPacket
 
 #define DELAY_T4 850
 #define DELAY_T5 250
@@ -86,126 +88,21 @@ class virtualDevice
     friend systemBus;
     friend fujiDevice;
 
-private:
-#ifdef OBSOLETE
-    transState_t _transaction_state = TRANS_STATE::INVALID;
-
-    /**
-     * @brief Send the desired buffer to the Atari.
-     * @param buff The byte buffer to send to the Atari
-     * @param len The length of the buffer to send to the Atari.
-     * @return TRUE if the Atari processed the data in error, FALSE if the Atari successfully processed
-     * the data.
-     */
-    void _bus_to_computer(uint8_t *buff, uint16_t len, bool err);
-
-    /**
-     * @brief Receive data from the Atari.
-     * @param buff The byte buffer provided for data from the Atari.
-     * @param len The length of the amount of data to receive from the Atari.
-     * @return An 8-bit wrap-around checksum calculated by the Atari, which should be checked with sio_checksum()
-     */
-    uint8_t _bus_to_peripheral(uint8_t *buff, uint16_t len);
-
-    /**
-     * @brief Send an acknowledgement byte to the Atari 'A'
-     * This should be used if the command received by the SIO device is valid, and is used to signal to the
-     * Atari that we are now processing the command.
-     */
-    void _sio_ack();
-
-    /**
-     * @brief Send an acknowledgement byte to the Atari 'A'
-     * - without NetSIO, send ACK as usually
-     * - with NetSIO, ACK is delayed untill we now how much data should be written by Atari to peripheral
-     *   ACK byte together with expected write size is send as part of SYNC_RESPONSE
-     */
-#ifdef ESP_PLATFORM
-    inline void _sio_late_ack() { _sio_ack(); };
-#else
-    void _sio_late_ack();
-#endif
-
-    /**
-     * @brief Send a non-acknowledgement (NAK) to the Atari 'N'
-     * This should be used if the command received by the SIO device is invalid, in the first place. It is not
-     * the same as sio_error().
-     */
-    void _sio_nak();
-
-    /**
-     * @brief Send a COMPLETE to the Atari 'C'
-     * This should be used after processing of the command to indicate that we've successfully finished. Failure to send
-     * either a COMPLETE or ERROR will result in a SIO TIMEOUT (138) to be reported in DSTATS.
-     */
-    void _sio_complete();
-
-    /**
-     * @brief Send an ERROR to the Atari 'E'
-     * This should be used during or after processing of the command to indicate that an error resulted
-     * from processing the command, and that the Atari should probably re-try the command. Failure to
-     * send an ERROR or COMPLTE will result in a SIO TIMEOUT (138) to be reported in DSTATS.
-     */
-    void _sio_error();
-#endif /* OBSOLETE */
-
 protected:
     fujiDeviceID_t _devnum;
-
-#ifdef OBSOLETE
-    void transaction_begin(transState_t expectMoreData) {
-        assert(_transaction_state == TRANS_STATE::INVALID);
-        _transaction_state = expectMoreData;
-        // For some reason NetSIO needs a hint that this is a WRITE transaction
-        if (expectMoreData == TRANS_STATE::WILL_GET)
-            _sio_late_ack();
-        else
-            _sio_ack();
-    }
-    void transaction_complete() {
-        assert(_transaction_state == TRANS_STATE::NO_GET || _transaction_state == TRANS_STATE::DID_GET);
-        _sio_complete();
-        _transaction_state = TRANS_STATE::INVALID;
-    }
-    void transaction_error() {
-        // Not yet ACKed -> the command itself was invalid: NAK.  Already
-        // ACKed -> failure during/after processing: ERROR ('E' -> 144).
-        if (_transaction_state == TRANS_STATE::INVALID)
-            _sio_nak();
-        else
-            _sio_error();
-        _transaction_state = TRANS_STATE::INVALID;
-    }
-    success_is_true transaction_get(void *data, size_t len) {
-        assert(_transaction_state == TRANS_STATE::WILL_GET);
-        _transaction_state = TRANS_STATE::DID_GET;
-
-        uint8_t ck = _bus_to_peripheral((uint8_t *) data, len);
-        if (sio_checksum((uint8_t *) data, len) != ck)
-            RETURN_ERROR_AS_FALSE();
-        RETURN_SUCCESS_AS_TRUE();
-    }
-    void transaction_put(const void *data, size_t len, bool err=false) {
-        assert(_transaction_state == TRANS_STATE::NO_GET);
-        _bus_to_computer((uint8_t *) data, len, err);
-        _transaction_state = TRANS_STATE::INVALID;
-    }
-#endif /* OBSOLETE */
-
-    cmdFrame_t cmdFrame;
     bool listen_to_type3_polls = false;
 
     /**
      * @brief All SIO commands by convention should return a status command, using bus_to_computer() to return
      * four bytes of status information to be put into DVSTAT ($02EA)
      */
-    virtual void sio_status() = 0;
+    virtual void sio_status(const FujiSIOPacket &packet) = 0;
 
     /**
      * @brief All SIO devices repeatedly call this routine to fan out to other methods for each command.
      * This is typcially implemented as a switch() statement.
      */
-    virtual void sio_process(uint32_t commanddata, uint8_t checksum) = 0;
+    virtual void sio_process(const FujiSIOPacket &packet) = 0;
 
     // Optional shutdown/reboot cleanup routine
     virtual void shutdown(){};
@@ -257,12 +154,15 @@ struct sio_message_t
 
 class systemBus : public SystemBusBase
 {
+    friend FujiSIOPacket;
+
 private:
     std::forward_list<virtualDevice *> _daisyChain;
 
     int _command_frame_counter = 0;
 
     virtualDevice *_activeDev = nullptr;
+    FujiSIOPacket *_activeFrame;
     modem *_modemDev = nullptr;
     sioFuji *_fujiDev = nullptr;
     sioNetwork *_netDev[8] = {nullptr};

--- a/lib/device/sio/cassette.h
+++ b/lib/device/sio/cassette.h
@@ -90,8 +90,8 @@ protected:
     bool motor_line() { return SYSTEM_BUS.motor_asserted(); }
 
     // have to populate virtual functions to complete class
-    void sio_status() override{}; // $53, 'S', Status
-    void sio_process(uint32_t commanddata, uint8_t checksum) override{};
+    void sio_status(const FujiSIOPacket &packet) override{}; // $53, 'S', Status
+    void sio_process(const FujiSIOPacket &packet) override{};
 
     void open_cassette_file(FileSystem *filesystem);
     void close_cassette_file();

--- a/lib/device/sio/clock.cpp
+++ b/lib/device/sio/clock.cpp
@@ -12,10 +12,10 @@
 #include "fnConfig.h"
 #include "utils.h"
 
-std::optional<std::string> sioClock::read_tz_from_host()
+std::optional<std::string> sioClock::read_tz_from_host(const FujiSIOPacket &packet)
 {
     Debug_println("sioClock read_tz_from_host");
-    int bufsz = cmdFrame.aux12;
+    int bufsz = packet.param16(0);
 
     if (bufsz <= 0) {
         Debug_printv("ERROR: No timezone sent");
@@ -33,31 +33,42 @@ std::optional<std::string> sioClock::read_tz_from_host()
     }
 }
 
-void sioClock::set_fn_tz()
+void sioClock::set_fn_tz(const FujiSIOPacket &packet)
 {
-    auto result = read_tz_from_host();
+    auto result = read_tz_from_host(packet);
     if (result) {
         Config.store_general_timezone(result->c_str());
     }
 }
 
-void sioClock::set_alternate_tz()
+void sioClock::set_alternate_tz(const FujiSIOPacket &packet)
 {
-    auto result = read_tz_from_host();
+    auto result = read_tz_from_host(packet);
     if (result) {
         alternate_tz = result.value();
     }
 }
 
-void sioClock::sio_process(uint32_t commanddata, uint8_t checksum)
+void sioClock::sio_process(const FujiSIOPacket &packet)
 {
-    cmdFrame.commanddata = commanddata;
-    cmdFrame.checksum = checksum;
+    // packet.param(0) = 0x01 means use alternate TZ if it exists, any other value would use system TZ
+    bool use_alternate_tz;
+    switch (packet.command())
+    {
+    case APETIMECMD_GETTZTIME:
+    case APETIMECMD_GETTIME:
+    case APETIMECMD_SETTZ_ALT2:
+    case APETIMECMD_GET_SIMPLE_HUNDREDTHS:
+    case APETIMECMD_GET_PRODOS:
+    case APETIMECMD_GET_SOS:
+    case APETIMECMD_GET_ISO_LOCAL:
+        use_alternate_tz = packet.param8(0) == 0x01;
+        break;
+    default:
+        use_alternate_tz = false;
+    }
 
-    // cmdFrame.aux1 = 0x01 means use alternate TZ if it exists, any other value would use system TZ
-    bool use_alternate_tz = cmdFrame.aux1 == 0x01;
-
-    switch (cmdFrame.comnd)
+    switch (packet.command())
     {
     ////////////////////////////////////////////////////////////////////////////////////
     // TIME FUNCTIONS
@@ -69,47 +80,47 @@ void sioClock::sio_process(uint32_t commanddata, uint8_t checksum)
         // Note: APETIME.COM uses 0x93 with aux1=A0, aux2=EE, so we will always get the FN timezone in response, but fujinet-lib can use the alternate timezone functionality
         SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
         // for backwards compatibility, if we're sent APETIMECMD_GETTZTIME we always use the ALT timezone if set
-        if (cmdFrame.comnd == APETIMECMD_GETTZTIME) use_alternate_tz = true;
+        if (packet.command() == APETIMECMD_GETTZTIME) use_alternate_tz = true;
 
         auto apeTime = Clock::get_current_time_apetime(Clock::tz_to_use(use_alternate_tz, alternate_tz, Config.get_general_timezone()));
         SYSTEM_BUS.transaction_send(apeTime.data(), apeTime.size(), false);
         break;
     }
-    case 'T': {
+    case APETIMECMD_SETTZ_ALT2: {
         // Date and time, easy to be used by general programs
         SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
         auto simpleTime = Clock::get_current_time_simple(Clock::tz_to_use(use_alternate_tz, alternate_tz, Config.get_general_timezone()));
         SYSTEM_BUS.transaction_send(simpleTime.data(), simpleTime.size(), false);
         break;
     }
-    case 'M': {
+    case APETIMECMD_GET_SIMPLE_HUNDREDTHS: {
         SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
         auto hundredthsTime = Clock::get_current_time_simple_hundredths(Clock::tz_to_use(use_alternate_tz, alternate_tz, Config.get_general_timezone()));
         SYSTEM_BUS.transaction_send(hundredthsTime.data(), hundredthsTime.size(), false);
         break;
     }
-    case 'P': {
+    case APETIMECMD_GET_PRODOS: {
         // Date and time, to be used by a ProDOS driver
         SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
         auto prodosTime = Clock::get_current_time_prodos(Clock::tz_to_use(use_alternate_tz, alternate_tz, Config.get_general_timezone()));
         SYSTEM_BUS.transaction_send(prodosTime.data(), prodosTime.size(), false);
         break;
     }
-    case 'S': {
+    case APETIMECMD_GET_SOS: {
         // Date and time, ASCII string in Apple /// SOS format: YYYYMMDD0HHMMSS000
         SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
         std::string sosTime = Clock::get_current_time_sos(Clock::tz_to_use(use_alternate_tz, alternate_tz, Config.get_general_timezone()));
         SYSTEM_BUS.transaction_send((uint8_t *) sosTime.c_str(), sosTime.size() + 1, false);
         break;
     }
-    case 'I': {
+    case APETIMECMD_GET_ISO_LOCAL: {
         // Date and time, ASCII string in ISO format - making this consistent with APPLE code
         SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
         std::string utcTime = Clock::get_current_time_iso(Clock::tz_to_use(use_alternate_tz, alternate_tz, Config.get_general_timezone()));
         SYSTEM_BUS.transaction_send((uint8_t *) utcTime.c_str(), utcTime.size() + 1, false);
         break;
     }
-    case 'Z': {
+    case APETIMECMD_GET_ISO_UTC: {
         // utc (zulu)
         SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
         std::string isoTime = Clock::get_current_time_iso("UTC+0");
@@ -124,13 +135,13 @@ void sioClock::sio_process(uint32_t commanddata, uint8_t checksum)
     // for backwards compatibility with APOD, we use the 0x99 for this command
     case APETIMECMD_SETTZ: {
         SYSTEM_BUS.transaction_accept(TRANS_STATE::WILL_GET);
-        set_alternate_tz();
+        set_alternate_tz(packet);
         break;
     }
     // can't use "T" as that's taken by getter
     case APETIMECMD_SETTZ_ALT: {
         SYSTEM_BUS.transaction_accept(TRANS_STATE::WILL_GET);
-        set_fn_tz();
+        set_fn_tz(packet);
         break;
     }
     case APETIMECMD_GET_GENERAL: {

--- a/lib/device/sio/clock.h
+++ b/lib/device/sio/clock.h
@@ -11,15 +11,15 @@ class sioClock : public virtualDevice
 {
 private:
     std::string alternate_tz = "";
-    std::optional<std::string> read_tz_from_host();
+    std::optional<std::string> read_tz_from_host(const FujiSIOPacket &packet);
 
     // set the Config timezone for the whole FujiNet (as in WebUI)
-    void set_fn_tz();
-    void set_alternate_tz();
+    void set_fn_tz(const FujiSIOPacket &packet);
+    void set_alternate_tz(const FujiSIOPacket &packet);
 
 public:
-    void sio_process(uint32_t commanddata, uint8_t checksum) override;
-    virtual void sio_status() override {};
+    void sio_process(const FujiSIOPacket &packet) override;
+    void sio_status(const FujiSIOPacket &packet) override {};
 };
 
 #endif // SIO_CLOCK_H

--- a/lib/device/sio/disk.cpp
+++ b/lib/device/sio/disk.cpp
@@ -16,8 +16,18 @@ sioDisk::sioDisk()
 }
 
 // Read disk data and send to computer
-void sioDisk::sio_read()
+void sioDisk::sio_read(const FujiSIOPacket &packet)
 {
+    if (packet.command() == DISKCMD_HSIO_READ && !_disk->_allow_hsio)
+        return;
+
+    uint16_t sectorNum = packet.param(0);
+    if (!sectorNum || sectorNum > _disk->_disk_num_sectors)
+    {
+        SYSTEM_BUS.transaction_error();
+        return;
+    }
+
     SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
 
     // Debug_print("disk READ\n");
@@ -33,33 +43,37 @@ void sioDisk::sio_read()
 
     uint16_t readcount;
 
-    bool err = _disk->read(UINT16_FROM_HILOBYTES(cmdFrame.aux2, cmdFrame.aux1), &readcount);
+    bool err = _disk->read(sectorNum, &readcount);
 
     // Send result to Atari
     SYSTEM_BUS.transaction_send(_disk->_disk_sectorbuff, readcount, err);
 }
 
 // Write disk data from computer
-void sioDisk::sio_write(bool verify)
+void sioDisk::sio_write(const FujiSIOPacket &packet)
 {
+    if ((packet.command() == DISKCMD_HSIO_PUT || packet.command() == DISKCMD_HSIO_WRITE)
+        && !_disk->_allow_hsio)
+        return;
+
+    uint16_t sectorNum = packet.param(0);
+    bool verify = true;
+    if (packet.command() == DISKCMD_PUT || packet.command() == DISKCMD_HSIO_PUT)
+        verify = false;
+
     SYSTEM_BUS.transaction_accept(TRANS_STATE::WILL_GET);
 
     // Debug_print("disk WRITE\n");
 
     if (_disk != nullptr)
     {
-        uint16_t sectorNum = UINT16_FROM_HILOBYTES(cmdFrame.aux2, cmdFrame.aux1);
         uint16_t sectorSize = _disk->sector_size(sectorNum);
 
-        memset(_disk->_disk_sectorbuff, 0, DISK_SECTORBUF_SIZE);
-
-        if (SYSTEM_BUS.transaction_get(_disk->_disk_sectorbuff, sectorSize))
+        if (SYSTEM_BUS.transaction_get(_disk->_disk_sectorbuff, sectorSize)
+            && _disk->write(sectorNum, verify).is_success())
         {
-            if (_disk->write(sectorNum, verify) == false)
-            {
-                SYSTEM_BUS.transaction_success();
-                return;
-            }
+            SYSTEM_BUS.transaction_success();
+            return;
         }
     }
 
@@ -67,7 +81,7 @@ void sioDisk::sio_write(bool verify)
 }
 
 // Status
-void sioDisk::sio_status()
+void sioDisk::sio_status(const FujiSIOPacket &packet)
 {
     SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
 
@@ -306,79 +320,28 @@ success_is_true sioDisk::write_blank(fnFile *f, uint16_t sectorSize, uint16_t nu
 }
 
 // Process command
-void sioDisk::sio_process(uint32_t commanddata, uint8_t checksum)
+void sioDisk::sio_process(const FujiSIOPacket &packet)
 {
-    cmdFrame.commanddata = commanddata;
-    cmdFrame.checksum = checksum;
-
     if (_disk == nullptr || _disk->_disktype == MEDIATYPE_UNKNOWN)
         return;
 
-    if ((device_active == false && cmdFrame.device != FUJI_DEVICEID_DISK) || // not active and not D1
+    if ((device_active == false && packet.device() != FUJI_DEVICEID_DISK) || // not active and not D1
         (device_active == false && theFuji->boot_config == false)) // not active and not config boot
         return;
 
     Debug_printf("disk sio_process(), baud: %d\n", SYSTEM_BUS.getBaudrate());
 
-    switch (cmdFrame.comnd)
+    switch (packet.command())
     {
     case DISKCMD_READ:
-        if (UINT16_FROM_HILOBYTES(cmdFrame.aux2, cmdFrame.aux1) > _disk->_disk_num_sectors)
-        {
-            SYSTEM_BUS.transaction_error();
-            return;
-        }
-        else if ((cmdFrame.aux1 == 0) && (cmdFrame.aux2 == 0))
-        {
-            SYSTEM_BUS.transaction_error();
-            return;
-        }
-        else
-        {
-            sio_read();
-        }
-        return;
     case DISKCMD_HSIO_READ:
-        if (_disk->_allow_hsio)
-        {
-            sio_read();
-            return;
-        }
+        sio_read(packet);
         break;
     case DISKCMD_PUT:
-        if (UINT16_FROM_HILOBYTES(cmdFrame.aux2, cmdFrame.aux1) > _disk->_disk_num_sectors)
-        {
-            SYSTEM_BUS.transaction_error();
-            return;
-        }
-        else if ((cmdFrame.aux1 == 0) && (cmdFrame.aux2 == 0))
-        {
-            SYSTEM_BUS.transaction_error();
-            return;
-        }
-        else
-        {
-            sio_write(false);
-        }
-        return;
     case DISKCMD_HSIO_PUT:
-        if (_disk->_allow_hsio)
-        {
-            if (UINT16_FROM_HILOBYTES(cmdFrame.aux2, cmdFrame.aux1) > _disk->_disk_num_sectors)
-            {
-                SYSTEM_BUS.transaction_error();
-                return;
-            }
-            else if ((cmdFrame.aux1 == 0) && (cmdFrame.aux2 == 0))
-            {
-                SYSTEM_BUS.transaction_error();
-                return;
-            }
-            else
-            {
-                sio_write(false);
-            }
-        }
+    case DISKCMD_WRITE:
+    case DISKCMD_HSIO_WRITE:
+        sio_write(packet);
         break;
     case DISKCMD_STATUS:
     case DISKCMD_HSIO_STATUS:
@@ -394,53 +357,17 @@ void sioDisk::sio_process(uint32_t commanddata, uint8_t checksum)
                 else
                 {
                     device_active = true;
-                    sio_status();
+                    sio_status(packet);
                 }
             }
         }
         else
         {
-            if (cmdFrame.comnd == DISKCMD_HSIO_STATUS && _disk->_allow_hsio == false)
+            if (packet.command() == DISKCMD_HSIO_STATUS && _disk->_allow_hsio == false)
                 break;
-            sio_status();
+            sio_status(packet);
         }
         return;
-    case DISKCMD_WRITE:
-        if (UINT16_FROM_HILOBYTES(cmdFrame.aux2, cmdFrame.aux1) > _disk->_disk_num_sectors)
-        {
-            SYSTEM_BUS.transaction_error();
-            return;
-        }
-        else if ((cmdFrame.aux1 == 0) && (cmdFrame.aux2 == 0))
-        {
-            SYSTEM_BUS.transaction_error();
-            return;
-        }
-        else
-        {
-            sio_write(true);
-        }
-        return;
-    case DISKCMD_HSIO_WRITE:
-        if (_disk->_allow_hsio)
-        {
-            if (UINT16_FROM_HILOBYTES(cmdFrame.aux2, cmdFrame.aux1) > _disk->_disk_num_sectors)
-            {
-                SYSTEM_BUS.transaction_error();
-                return;
-            }
-            else if ((cmdFrame.aux1 == 0) && (cmdFrame.aux2 == 0))
-            {
-                SYSTEM_BUS.transaction_error();
-                return;
-            }
-            else
-            {
-                sio_write(true);
-            }
-            return;
-        }
-        break;
     case DISKCMD_FORMAT:
     case DISKCMD_FORMAT_MEDIUM:
         sio_format();
@@ -468,10 +395,9 @@ void sioDisk::sio_process(uint32_t commanddata, uint8_t checksum)
         }
         break;
     default:
-        break;
+        SYSTEM_BUS.transaction_error();
+        return;
     }
-
-    SYSTEM_BUS.transaction_error();
 }
 
 #endif /* BUILD_ATARI */

--- a/lib/device/sio/disk.h
+++ b/lib/device/sio/disk.h
@@ -10,11 +10,11 @@ class sioDisk : public virtualDevice
 private:
     MediaType *_disk = nullptr;
 
-    void sio_read();
-    void sio_write(bool verify);
+    void sio_read(const FujiSIOPacket &packet);
+    void sio_write(const FujiSIOPacket &packet);
     void sio_format();
-    void sio_status() override;
-    void sio_process(uint32_t commanddata, uint8_t checksum) override;
+    void sio_status(const FujiSIOPacket &packet) override;
+    void sio_process(const FujiSIOPacket &packet) override;
 
     void derive_percom_block(uint16_t numSectors);
     void sio_read_percom_block();

--- a/lib/device/sio/modem.cpp
+++ b/lib/device/sio/modem.cpp
@@ -102,14 +102,14 @@ modem::~modem()
 }
 
 // 0x40 / '@' - TYPE 3 POLL
-void modem::sio_poll_3(uint8_t device, uint8_t aux1, uint8_t aux2)
+void modem::sio_poll_3(const FujiSIOPacket &packet)
 {
     bool respond = false;
 
-    // When AUX1 and AUX == 0x4E, it's a normal/general poll
+    // When packet.param8(0) and packet.param8(1) == 0x4E, it's a normal/general poll
     // Since XL/XE OS always does this during boot, we're going to ignore these, otherwise
     // we'd load our handler every time, and that's probably not desireable
-    if (aux1 == 0 && aux2 == 0)
+    if (packet.param8(0) == 0 && packet.param8(1) == 0)
     {
         Debug_printf("MODEM TYPE 3 POLL #%d\n", ++count_PollType3);
         if (count_PollType3 == 26)
@@ -120,23 +120,23 @@ void modem::sio_poll_3(uint8_t device, uint8_t aux1, uint8_t aux2)
         else
             return;
     }
-    // When AUX1 and AUX == 0x4F, it's a request to reset the whole polling process
-    if (aux1 == 0x4F && aux2 == 0x4F)
+    // When packet.param8(0) and packet.param8(1) == 0x4F, it's a request to reset the whole polling process
+    if (packet.param8(0) == 0x4F && packet.param8(1) == 0x4F)
     {
         Debug_print("MODEM TYPE 3 POLL <<RESET POLL>>\n");
         count_PollType3 = 0;
         firmware_sent = false;
         return;
     }
-    // When AUX1 and AUX == 0x4E, it's a request to reset poll counters
-    if (aux1 == 0x4E && aux2 == 0x4E)
+    // When packet.param8(0) and packet.param8(1) == 0x4E, it's a request to reset poll counters
+    if (packet.param8(0) == 0x4E && packet.param8(1) == 0x4E)
     {
         Debug_print("MODEM TYPE 3 POLL <<NULL POLL>>\n");
         count_PollType3 = 0;
         return;
     }
-    // When AUX1 = 0x52 'R' and AUX == 1 or DEVICE == x050, it's a directed poll to "R1:"
-    if ((aux1 == 0x52 && aux2 == 0x01) || device == FUJI_DEVICEID_SERIAL)
+    // When packet.param8(0) = 0x52 'R' and packet.param8(1) == 1 or DEVICE == x050, it's a directed poll to "R1:"
+    if ((packet.param8(0) == 0x52 && packet.param8(1) == 0x01) || packet.device() == FUJI_DEVICEID_SERIAL)
     {
         Debug_print("MODEM TYPE 4 \"R1:\" DIRECTED POLL\n");
         respond = true;
@@ -278,17 +278,17 @@ void modem::sio_send_firmware(uint8_t loadcommand)
 }
 
 // 0x57 / 'W' - WRITE
-void modem::sio_write()
+void modem::sio_write(const FujiSIOPacket &packet)
 {
     uint8_t ck;
 
     Debug_println("Modem cmd: WRITE");
 
-    /* AUX1: Bytes in payload, 0-64
-       AUX2: NA
+    /* packet.param(0): Bytes in payload, 0-64
+       packet.param(1): NA
        Payload always padded to 64 bytes
     */
-    if (cmdFrame.aux1 == 0)
+    if (packet.param8(0) == 0)
     {
         SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
         SYSTEM_BUS.transaction_success();
@@ -307,7 +307,7 @@ void modem::sio_write()
     if (cmdMode == true)
     {
         cmdOutput = false;
-        cmd.assign((char *)txBuf, cmdFrame.aux1);
+        cmd.assign((char *)txBuf, packet.param8(0));
 
         if (cmd == "ATA\r")
             answerHack = true;
@@ -320,14 +320,14 @@ void modem::sio_write()
     {
         fnLedManager.blink(LED_BT,1);
         if (tcpClient.connected())
-            tcpClient.write(txBuf, cmdFrame.aux1);
+            tcpClient.write(txBuf, packet.param8(0));
     }
 
     SYSTEM_BUS.transaction_success();
 }
 
 // 0x53 / 'S' - STATUS
-void modem::sio_status()
+void modem::sio_status(const FujiSIOPacket &packet)
 {
 
     Debug_println("Modem cmd: STATUS");
@@ -371,7 +371,7 @@ void modem::sio_status()
 }
 
 // 0x41 / 'A' - CONTROL
-void modem::sio_control()
+void modem::sio_control(const FujiSIOPacket &packet)
 {
     /* AUX1: Set control state
         7: Enable DTR (Data Terminal Ready) change (1=change, 0=ignore)
@@ -387,21 +387,21 @@ void modem::sio_control()
 
     Debug_println("Modem cmd: CONTROL");
 
-    if (cmdFrame.aux1 & 0x02)
+    if (packet.param8(0) & 0x02)
     {
-        XMT = (cmdFrame.aux1 & 0x01 ? true : false);
+        XMT = (packet.param8(0) & 0x01 ? true : false);
         Debug_printf("XMT=%d\n", XMT);
     }
 
-    if (cmdFrame.aux1 & 0x20)
+    if (packet.param8(0) & 0x20)
     {
-        RTS = (cmdFrame.aux1 & 0x10 ? true : false);
+        RTS = (packet.param8(0) & 0x10 ? true : false);
         Debug_printf("RTS=%d\n", RTS);
     }
 
-    if (cmdFrame.aux1 & 0x80)
+    if (packet.param8(0) & 0x80)
     {
-        DTR = (cmdFrame.aux1 & 0x40 ? true : false);
+        DTR = (packet.param8(0) & 0x40 ? true : false);
 
         Debug_printf("DTR=%d\n", DTR);
 
@@ -423,7 +423,7 @@ void modem::sio_control()
 }
 
 // 0x42 / 'B' - CONFIGURE
-void modem::sio_config()
+void modem::sio_config(const FujiSIOPacket &packet)
 {
 
     Debug_println("Modem cmd: CONFIGURE");
@@ -454,9 +454,9 @@ void modem::sio_config()
     // Complete and then set newbaud
     SYSTEM_BUS.transaction_success();
 
-    uint8_t newBaud = 0x0F & cmdFrame.aux1; // Get baud rate
-    //uint8_t wordSize = 0x30 & cmdFrame.aux1; // Get word size
-    //uint8_t stopBit = (1 << 7) & cmdFrame.aux1; // Get stop bits
+    uint8_t newBaud = 0x0F & packet.param8(0); // Get baud rate
+    //uint8_t wordSize = 0x30 & packet.param(0); // Get word size
+    //uint8_t stopBit = (1 << 7) & packet.param(0); // Get stop bits
 
     // Do not reset MODEM baud rate if locked.
     if (baudLock == true)
@@ -496,9 +496,9 @@ void modem::sio_config()
 }
 
 // 0x44 / 'D' - Dump
-void modem::sio_set_dump()
+void modem::sio_set_dump(const FujiSIOPacket &packet)
 {
-    modemSniffer->setEnable(cmdFrame.aux1);
+    modemSniffer->setEnable(packet.param(0));
     SYSTEM_BUS.transaction_success();
 }
 
@@ -564,7 +564,7 @@ void modem::sio_stream()
 /**
  * Set listen port
  */
-void modem::sio_listen()
+void modem::sio_listen(const FujiSIOPacket &packet)
 {
     if (listenPort != 0)
     {
@@ -574,7 +574,7 @@ void modem::sio_listen()
 
     fnLedManager.blink(LED_BT);
 
-    listenPort = cmdFrame.aux2 * 256 + cmdFrame.aux1;
+    listenPort = packet.param(0);
 
     if (listenPort < 1)
         SYSTEM_BUS.transaction_error();
@@ -608,11 +608,11 @@ void modem::sio_unlisten()
 /**
  * Lock MODEM baud rate to last configured value
  */
-void modem::sio_baudlock()
+void modem::sio_baudlock(const FujiSIOPacket &packet)
 {
     SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
-    baudLock = (cmdFrame.aux1 > 0 ? true : false);
-    modemBaud = cmdFrame.aux12;
+    modemBaud = packet.param16(0);
+    baudLock = (modemBaud & 0xFF) > 0;
 
     fnLedManager.blink(LED_BT);
 
@@ -624,10 +624,10 @@ void modem::sio_baudlock()
 /**
  * enable/disable auto-answer
  */
-void modem::sio_autoanswer()
+void modem::sio_autoanswer(const FujiSIOPacket &packet)
 {
     SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
-    autoAnswer = (cmdFrame.aux1 > 0 ? true : false);
+    autoAnswer = (packet.param8(0) > 0 ? true : false);
 
     fnLedManager.blink(LED_BT);
 
@@ -1868,11 +1868,8 @@ void modem::shutdown()
 /*
   Process command
 */
-void modem::sio_process(uint32_t commanddata, uint8_t checksum)
+void modem::sio_process(const FujiSIOPacket &packet)
 {
-    cmdFrame.commanddata = commanddata;
-    cmdFrame.checksum = checksum;
-
     if (!Config.get_modem_enabled())
     {
         Debug_println("modem::disabled, ignoring");
@@ -1881,22 +1878,22 @@ void modem::sio_process(uint32_t commanddata, uint8_t checksum)
     {
         Debug_println("modem::sio_process() called");
 
-        switch (cmdFrame.comnd)
+        switch (packet.command())
         {
         case MODEMCMD_LOAD_RELOCATOR:
             Debug_printf("MODEM $21 RELOCATOR #%d\n", ++count_ReqRelocator);
-            sio_send_firmware(cmdFrame.comnd);
+            sio_send_firmware(packet.command());
             break;
 
         case MODEMCMD_LOAD_HANDLER:
             Debug_printf("MODEM $26 HANDLER DL #%d\n", ++count_ReqHandler);
-            sio_send_firmware(cmdFrame.comnd);
+            sio_send_firmware(packet.command());
             break;
 
         case MODEMCMD_TYPE1_POLL:
             Debug_printf("MODEM TYPE 1 POLL #%d\n", ++count_PollType1);
             // The 850 is only supposed to respond to this if AUX1 = 1 or on the 26th poll attempt
-            if (cmdFrame.aux1 == 1 || count_PollType1 == 16)
+            if (packet.param8(0) == 1 || count_PollType1 == 16)
             {
                 sio_poll_1();
                 count_PollType1 = 0; // Reset the counter so we can respond again if asked
@@ -1904,39 +1901,39 @@ void modem::sio_process(uint32_t commanddata, uint8_t checksum)
             break;
 
         case MODEMCMD_TYPE3_POLL:
-            sio_poll_3(cmdFrame.device, cmdFrame.aux1, cmdFrame.aux2);
+            sio_poll_3(packet);
             break;
 
         case MODEMCMD_CONTROL:
             SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
-            sio_control();
+            sio_control(packet);
             break;
         case MODEMCMD_CONFIGURE:
             SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
-            sio_config();
+            sio_config(packet);
             break;
         case MODEMCMD_SET_DUMP:
             SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
-            sio_set_dump();
+            sio_set_dump(packet);
             break;
         case MODEMCMD_LISTEN:
-            sio_listen();
+            sio_listen(packet);
             break;
         case MODEMCMD_UNLISTEN:
             sio_unlisten();
             break;
         case MODEMCMD_BAUDRATELOCK:
-            sio_baudlock();
+            sio_baudlock(packet);
             break;
         case MODEMCMD_AUTOANSWER:
-            sio_autoanswer();
+            sio_autoanswer(packet);
             break;
         case MODEMCMD_STATUS:
             SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
-            sio_status();
+            sio_status(packet);
             break;
         case MODEMCMD_WRITE:
-            sio_write();
+            sio_write(packet);
             break;
         case MODEMCMD_STREAM:
             SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);

--- a/lib/device/sio/modem.h
+++ b/lib/device/sio/modem.h
@@ -193,20 +193,20 @@ private:
     bool answered=false;
     int ringCount;                  // Keep track of how many incoming RINGs
 
-    void sio_send_firmware(uint8_t loadcommand); // $21 and $26: Booter/Relocator download; Handler download
-    void sio_poll_1();                           // $3F, '?', Type 1 Poll
-    void sio_poll_3(uint8_t device, uint8_t aux1, uint8_t aux2); // $40, '@', Type 3 Poll
-    void sio_control();                          // $41, 'A', Control
-    void sio_config();                           // $42, 'B', Configure
-    void sio_set_dump();                         // $$4, 'D', Dump
-    void sio_listen();                           // $4C, 'L', Listen
-    void sio_unlisten();                         // $4D, 'M', Unlisten
-    void sio_baudlock();                         // $4E, 'N', Baud lock
-    void sio_autoanswer();                       // $4F, 'O', auto answer
-    void sio_status() override;                  // $53, 'S', Status
-    void sio_write();                            // $57, 'W', Write
-    void sio_stream();                           // $58, 'X', Concurrent/Stream
-    void sio_process(uint32_t commanddata, uint8_t checksum) override;
+    void sio_send_firmware(uint8_t loadcommand);           // $21 and $26: Booter/Relocator download; Handler download
+    void sio_poll_1();                                     // $3F, '?', Type 1 Poll
+    void sio_poll_3(const FujiSIOPacket &packet);          // $40, '@', Type 3 Poll
+    void sio_control(const FujiSIOPacket &packet);         // $41, 'A', Control
+    void sio_config(const FujiSIOPacket &packet);          // $42, 'B', Configure
+    void sio_set_dump(const FujiSIOPacket &packet);        // $$4, 'D', Dump
+    void sio_listen(const FujiSIOPacket &packet);                                     // $4C, 'L', Listen
+    void sio_unlisten();                                   // $4D, 'M', Unlisten
+    void sio_baudlock(const FujiSIOPacket &packet);                                   // $4E, 'N', Baud lock
+    void sio_autoanswer(const FujiSIOPacket &packet);                                 // $4F, 'O', auto answer
+    void sio_status(const FujiSIOPacket &packet) override; // $53, 'S', Status
+    void sio_write(const FujiSIOPacket &packet);           // $57, 'W', Write
+    void sio_stream();                                     // $58, 'X', Concurrent/Stream
+    void sio_process(const FujiSIOPacket &packet) override;
 
     void crx_toggle(bool toggle);                // CRX active/inactive?
 

--- a/lib/device/sio/netstream.cpp
+++ b/lib/device/sio/netstream.cpp
@@ -566,13 +566,13 @@ void sioNetStream::sio_handle_netstream()
     pace_to_atari(min_gap_us);
 }
 
-void sioNetStream::sio_status()
+void sioNetStream::sio_status(const FujiSIOPacket &packet)
 {
     // Nothing to do here
     return;
 }
 
-void sioNetStream::sio_process(uint32_t commanddata, uint8_t checksum)
+void sioNetStream::sio_process(const FujiSIOPacket &packet)
 {
     // Nothing to do here
     return;

--- a/lib/device/sio/netstream.h
+++ b/lib/device/sio/netstream.h
@@ -82,8 +82,8 @@ private:
     void enqueue_rx(const uint8_t *data, int len);    // byte path enqueue; TCP drains are capped before overflow
     void enqueue_frame(const uint8_t *data, int len); // framed path (lossy UDP): push whole frame, evict oldest whole frames over cap
     void drain_net_to_ring();                         // pull all available net datagrams into the buffer
-    void sio_status() override;
-    void sio_process(uint32_t commanddata, uint8_t checksum) override;
+    void sio_status(const FujiSIOPacket &packet) override;
+    void sio_process(const FujiSIOPacket &packet) override;
 
 public:
     enum class NetStreamMode : uint8_t

--- a/lib/device/sio/network.cpp
+++ b/lib/device/sio/network.cpp
@@ -96,7 +96,7 @@ sioNetwork::~sioNetwork()
  * Called in response to 'O' command. Instantiate a protocol, pass URL to it, call its open
  * method. Also set up RX interrupt.
  */
-void sioNetwork::sio_open()
+void sioNetwork::sio_open(const FujiSIOPacket &packet)
 {
     Debug_println("sioNetwork::sio_open()");
 
@@ -144,7 +144,8 @@ void sioNetwork::sio_open()
     status.reset();
 
     // Parse and instantiate protocol
-    parse_and_instantiate_protocol();
+    bool is_dir = static_cast<fileAccessMode_t>(packet.param8(0)) == ACCESS_MODE::DIRECTORY;
+    parse_and_instantiate_protocol(is_dir);
 
     if (protocol == nullptr)
     {
@@ -159,8 +160,8 @@ void sioNetwork::sio_open()
         return;
     }
 
-    fileAccessMode_t open_mode = (fileAccessMode_t) cmdFrame.aux1;
-    netProtoTranslation_t open_trans = (netProtoTranslation_t) cmdFrame.aux2;
+    fileAccessMode_t open_mode = (fileAccessMode_t) packet.param8(0);
+    netProtoTranslation_t open_trans = (netProtoTranslation_t) packet.param8(1);
 
     // Ignore aux2 value if NTRANS set 0xFF, for ACTION!
     if (trans_aux2 == 0xFF)
@@ -261,9 +262,9 @@ void sioNetwork::sio_close()
  *
  * @note It is the channel's responsibility to pad to required length.
  */
-void sioNetwork::sio_read()
+void sioNetwork::sio_read(const FujiSIOPacket &packet)
 {
-    uint16_t num_bytes = cmdFrame.aux12;
+    uint16_t num_bytes = packet.param(0);
     fujiError_t err = FUJI_ERROR::NONE;
 
 #ifdef VERBOSE_PROTOCOL
@@ -343,9 +344,9 @@ fujiError_t sioNetwork::sio_read_channel(unsigned short num_bytes)
  * Write # of bytes specified by aux1/aux2 from tx_buffer out to SIO. If protocol is unable to return requested
  * number of bytes, return ERROR.
  */
-void sioNetwork::sio_write()
+void sioNetwork::sio_write(const FujiSIOPacket &packet)
 {
-    uint16_t num_bytes = cmdFrame.aux12;
+    uint16_t num_bytes = packet.param(0);
     fujiError_t err = FUJI_ERROR::NONE;
 
 #ifdef VERBOSE_PROTOCOL
@@ -414,13 +415,13 @@ fujiError_t sioNetwork::sio_write_channel(unsigned short num_bytes)
  * or Protocol does not want to fill status buffer (e.g. due to unknown aux1/aux2 values), then try to deal
  * with them locally. Then serialize resulting NetworkStatus object to SIO.
  */
-void sioNetwork::sio_status()
+void sioNetwork::sio_status(const FujiSIOPacket &packet)
 {
     // Acknowledge
     SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
 
     if (protocol == nullptr)
-        sio_status_local();
+        sio_status_local(packet);
     else
         sio_status_channel();
 }
@@ -429,7 +430,7 @@ void sioNetwork::sio_status()
  * @brief perform local status commands, if protocol is not bound, based on cmdFrame
  * value.
  */
-void sioNetwork::sio_status_local()
+void sioNetwork::sio_status_local(const FujiSIOPacket &packet)
 {
     uint8_t ipAddress[4];
     uint8_t ipNetmask[4];
@@ -438,13 +439,13 @@ void sioNetwork::sio_status_local()
     NDeviceStatus default_status {};
 
 #ifdef VERBOSE_PROTOCOL
-    Debug_printf("sioNetwork::sio_status_local(%u)\n", cmdFrame.aux2);
+    Debug_printf("sioNetwork::sio_status_local(%u)\n", packet.param(1));
 #endif
 
     fnSystem.Net.get_ip4_info((uint8_t *)ipAddress, (uint8_t *)ipNetmask, (uint8_t *)ipGateway);
     fnSystem.Net.get_ip4_dns_info((uint8_t *)ipDNS);
 
-    switch (cmdFrame.aux2)
+    switch (packet.param8(1))
     {
     case 1: // IP Address
 #ifdef VERBOSE_PROTOCOL
@@ -641,11 +642,11 @@ void sioNetwork::sio_set_prefix()
 /**
  * @brief set channel mode
  */
-void sioNetwork::sio_set_channel_mode()
+void sioNetwork::sio_set_channel_mode(const FujiSIOPacket &packet)
 {
     SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
 
-    switch (cmdFrame.aux2)
+    switch (packet.param8(1))
     {
     case 0:
         channelMode = PROTOCOL;
@@ -698,10 +699,10 @@ void sioNetwork::sio_set_password()
  * The command code to query is passed in DAUX1 (aux1).
  * Returns a single byte: 0x00 (no payload), 0x40 (FujiNet→Atari), 0x80 (Atari→FujiNet), or 0xFF (invalid command).
  */
-void sioNetwork::sio_get_dstats_value()
+void sioNetwork::sio_get_dstats_value(const FujiSIOPacket &packet)
 {
     SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
-    uint8_t command = cmdFrame.aux1;
+    uint8_t command = packet.param(0);
     uint8_t dstats = get_dstats_for_command(command);
     SYSTEM_BUS.transaction_send(&dstats, 1, false);
 }
@@ -777,54 +778,51 @@ void sioNetwork::sio_tell()
  * @param comanddata incoming 4 bytes containing command and aux bytes
  * @param checksum 8 bit checksum
  */
-void sioNetwork::sio_process(uint32_t commanddata, uint8_t checksum)
+void sioNetwork::sio_process(const FujiSIOPacket &packet)
 {
-    cmdFrame.commanddata = commanddata;
-    cmdFrame.checksum = checksum;
-
     // leaving this one to print
     Debug_printf("sioNetwork::sio_process 0x%02hx '%c': 0x%02hx, 0x%02hx baud: %d\n",
-                 cmdFrame.comnd, cmdFrame.comnd, cmdFrame.aux1, cmdFrame.aux2,
+                 packet.command(), packet.command(), packet.param(0), packet.param(1),
                  SYSTEM_BUS.getBaudrate());
 
-    switch (cmdFrame.comnd)
+    switch (packet.command())
     {
     case NETCMD_HSIO_INDEX:
         sio_high_speed();
         break;
     case NETCMD_OPEN:
-        sio_open();
+        sio_open(packet);
         break;
     case NETCMD_CLOSE:
         sio_close();
         break;
     case NETCMD_READ:
-        sio_read();
+        sio_read(packet);
         break;
     case NETCMD_WRITE:
-        sio_write();
+        sio_write(packet);
         break;
     case NETCMD_STATUS:
-        sio_status();
+        sio_status(packet);
         break;
 
     case NETCMD_PARSE:
         sio_parse_json();
         break;
     case NETCMD_TRANSLATION:
-        sio_set_translation();
+        sio_set_translation(packet);
         break;
     case NETCMD_SET_EOL:
-        sio_set_eol();
+        sio_set_eol(packet);
         break;
     case NETCMD_SET_INT_RATE:
-        sio_set_timer_rate();
+        sio_set_timer_rate(packet);
         break;
     case NETCMD_SET_PARAMETERS: // JSON parameter wrangling
-        sio_set_json_parameters();
+        sio_set_json_parameters(packet);
         break;
     case NETCMD_CHANNEL_MODE:
-        sio_set_channel_mode();
+        sio_set_channel_mode(packet);
         break;
 
     case NETCMD_GETCWD:
@@ -835,7 +833,7 @@ void sioNetwork::sio_process(uint32_t commanddata, uint8_t checksum)
         sio_set_prefix();
         return;
     case NETCMD_QUERY:
-        sio_set_json_query();
+        sio_set_json_query(packet);
         return;
     case NETCMD_USERNAME:
         sio_set_login();
@@ -845,7 +843,7 @@ void sioNetwork::sio_process(uint32_t commanddata, uint8_t checksum)
         return;
 
     case NETCMD_GET_DSTATS_VALUE:
-        sio_get_dstats_value();
+        sio_get_dstats_value(packet);
         break;
 
     case NETCMD_SEEK: // POINT
@@ -861,21 +859,21 @@ void sioNetwork::sio_process(uint32_t commanddata, uint8_t checksum)
     case NETCMD_UNLOCK:
     case NETCMD_MKDIR:
     case NETCMD_RMDIR:
-        process_fs();
+        process_fs(packet);
         break;
 
     case NETCMD_CONTROL:
     case NETCMD_CLOSE_CLIENT:
-        process_tcp();
+        process_tcp(packet);
         break;
 
     case NETCMD_SET_CHANNEL_MODE:
-        process_http();
+        process_http(packet);
         break;
 
     case NETCMD_GET_REMOTE:
     case NETCMD_SET_DESTINATION:
-        process_udp();
+        process_udp(packet);
         break;
 
     default:
@@ -1008,7 +1006,7 @@ success_is_true sioNetwork::instantiate_protocol()
  * Preprocess deviceSpec given aux1 open mode. This is used to work around various assumptions that different
  * disk utility packages do when opening a device, such as adding wildcards for directory opens.
  */
-void sioNetwork::create_devicespec()
+void sioNetwork::create_devicespec(bool is_dir)
 {
     // Clean up devicespec buffer.
     memset(devicespecBuf, 0, sizeof(devicespecBuf));
@@ -1017,7 +1015,7 @@ void sioNetwork::create_devicespec()
     SYSTEM_BUS.transaction_get(devicespecBuf, sizeof(devicespecBuf)); // TODO test checksum
     util_devicespec_fix_9b(devicespecBuf, sizeof(devicespecBuf));
     deviceSpec = string((char *)devicespecBuf);
-    deviceSpec = util_devicespec_fix_for_parsing(deviceSpec, prefix, cmdFrame.aux1 == 6, true);
+    deviceSpec = util_devicespec_fix_for_parsing(deviceSpec, prefix, is_dir, true);
 }
 
 /*
@@ -1030,9 +1028,9 @@ void sioNetwork::create_url_parser()
     urlParser = PeoplesUrlParser::parseURL(url);
 }
 
-void sioNetwork::parse_and_instantiate_protocol()
+void sioNetwork::parse_and_instantiate_protocol(bool is_dir)
 {
-    create_devicespec();
+    create_devicespec(is_dir);
     create_url_parser();
 
     // Invalid URL returns error 165 in status.
@@ -1103,7 +1101,7 @@ void sioNetwork::timer_stop()
  *
  * DeviceSpec will be transformed to only contain the relevant part of the deviceSpec, sans comma.
  */
-void sioNetwork::processCommaFromDevicespec()
+void sioNetwork::processCommaFromDevicespec(fujiDeviceID_t device)
 {
     size_t comma_pos = deviceSpec.find(",");
     vector<string> tokens;
@@ -1121,7 +1119,7 @@ void sioNetwork::processCommaFromDevicespec()
 
         if (item[0] != 'N')
             continue;                                       // not us.
-        else if (item[1] == ':' && cmdFrame.device != 0x71) // N: but we aren't N1:
+        else if (item[1] == ':' && device != FUJI_DEVICEID_NETWORK) // N: but we aren't N1:
             continue;                                       // also not us.
         else
         {
@@ -1169,24 +1167,24 @@ void sioNetwork::sio_clear_interrupt()
 }
 #endif
 
-void sioNetwork::sio_set_translation()
+void sioNetwork::sio_set_translation(const FujiSIOPacket &packet)
 {
     SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
-    trans_aux2 = (netProtoTranslation_t) cmdFrame.aux2;
+    trans_aux2 = (netProtoTranslation_t) packet.param8(1);
     SYSTEM_BUS.transaction_success();
 }
 
-void sioNetwork::sio_set_eol()
+void sioNetwork::sio_set_eol(const FujiSIOPacket &packet)
 {
     SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
 
     // aux1/aux2 carry the EOL bytes; aux1==0 clears the override (restore default).
     native_eol_override.clear();
-    if (cmdFrame.aux1 != 0x00)
+    if (packet.param8(0) != 0x00)
     {
-        native_eol_override.push_back((char)cmdFrame.aux1);
-        if (cmdFrame.aux2 != 0x00)
-            native_eol_override.push_back((char)cmdFrame.aux2);
+        native_eol_override.push_back((char)packet.param8(0));
+        if (packet.param8(1) != 0x00)
+            native_eol_override.push_back((char)packet.param8(1));
     }
 
     // Apply to a live protocol immediately; restore default when cleared.
@@ -1203,7 +1201,7 @@ void sioNetwork::sio_parse_json()
     SYSTEM_BUS.transaction_success();
 }
 
-void sioNetwork::sio_set_json_query()
+void sioNetwork::sio_set_json_query(const FujiSIOPacket &packet)
 {
     uint8_t in[256];
 
@@ -1234,7 +1232,7 @@ void sioNetwork::sio_set_json_query()
         inp_string = in_string;
     }
 
-    json->setReadQuery(inp_string, cmdFrame.aux2);
+    json->setReadQuery(inp_string, packet.param(1));
     int query_bytes = json->available();
     json_bytes_remaining += query_bytes;
 
@@ -1250,7 +1248,7 @@ void sioNetwork::sio_set_json_query()
     SYSTEM_BUS.transaction_success();
 }
 
-void sioNetwork::sio_set_json_parameters()
+void sioNetwork::sio_set_json_parameters(const FujiSIOPacket &packet)
 {
     SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
 
@@ -1258,23 +1256,23 @@ void sioNetwork::sio_set_json_parameters()
     // 0     | 0/1/2   |  Set the json->_queryParam value, which is the translation value for string processing
     // 1     |   c     |  Set the json->lineEnding = c, convert from char to single byte string
 
-    switch (cmdFrame.aux1)
+    switch (packet.param8(0))
     {
     case 0:     // JSON QUERY PARAM
-        if (cmdFrame.aux2 > 2)
+        if (packet.param8(1) > 2)
         {
             SYSTEM_BUS.transaction_error();
             return;
         }
-        json->setQueryParam(cmdFrame.aux2);
+        json->setQueryParam(packet.param(1));
         SYSTEM_BUS.transaction_success();
         break;
     case 1:     // LINE ENDING
     {
         std::stringstream ss;
-        ss << cmdFrame.aux2;
+        ss << packet.param8(1);
         string new_le = ss.str();
-        Debug_printf("JSON line ending changed to 0x%02hx\r\n", cmdFrame.aux2);
+        Debug_printf("JSON line ending changed to 0x%02hx\r\n", packet.param(1));
         json->setLineEnding(new_le);
         SYSTEM_BUS.transaction_success();
         break;
@@ -1285,10 +1283,10 @@ void sioNetwork::sio_set_json_parameters()
     }
 }
 
-void sioNetwork::sio_set_timer_rate()
+void sioNetwork::sio_set_timer_rate(const FujiSIOPacket &packet)
 {
     SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
-    timerRate = (cmdFrame.aux2 * 256) + cmdFrame.aux1;
+    timerRate = packet.param8(0);
 
     // Stop extant timer
     timer_stop();
@@ -1300,11 +1298,12 @@ void sioNetwork::sio_set_timer_rate()
     SYSTEM_BUS.transaction_success();
 }
 
-void sioNetwork::process_fs()
+void sioNetwork::process_fs(const FujiSIOPacket &packet)
 {
     SYSTEM_BUS.transaction_accept(TRANS_STATE::WILL_GET); // command frame ACK must precede SYSTEM_BUS.transaction_get() in parse_and_instantiate_protocol()
 
-    parse_and_instantiate_protocol();
+    bool is_dir = static_cast<fileAccessMode_t>(packet.param8(0)) == ACCESS_MODE::DIRECTORY;
+    parse_and_instantiate_protocol(is_dir);
 
     if (protocol == nullptr)
     {
@@ -1324,7 +1323,7 @@ void sioNetwork::process_fs()
 
     fujiError_t err;
     auto url = urlParser.get();
-    switch (cmdFrame.comnd)
+    switch (packet.command())
     {
     case NETCMD_RENAME:
         err = fs->rename(url);
@@ -1369,7 +1368,7 @@ void sioNetwork::process_fs()
     SYSTEM_BUS.transaction_success();
 }
 
-void sioNetwork::process_tcp()
+void sioNetwork::process_tcp(const FujiSIOPacket &packet)
 {
     // Make sure this is really a TCP protocol instance
     NetworkProtocolTCP *tcp = dynamic_cast<NetworkProtocolTCP *>(protocol);
@@ -1380,7 +1379,7 @@ void sioNetwork::process_tcp()
     }
 
     fujiError_t err;
-    switch (cmdFrame.comnd)
+    switch (packet.command())
     {
     case NETCMD_CONTROL:
         SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
@@ -1404,7 +1403,7 @@ void sioNetwork::process_tcp()
     SYSTEM_BUS.transaction_success();
 }
 
-void sioNetwork::process_http()
+void sioNetwork::process_http(const FujiSIOPacket &packet)
 {
     // Make sure this is really an HTTP protocol instance
     NetworkProtocolHTTP *http = dynamic_cast<NetworkProtocolHTTP *>(protocol);
@@ -1415,11 +1414,11 @@ void sioNetwork::process_http()
     }
 
     fujiError_t err;
-    switch (cmdFrame.comnd)
+    switch (packet.command())
     {
     case NETCMD_SET_CHANNEL_MODE:
         SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
-        err = http->set_channel_mode((netProtoHTTPChannelMode_t) cmdFrame.aux2);
+        err = http->set_channel_mode((netProtoHTTPChannelMode_t) packet.param8(1));
         break;
     default:
         SYSTEM_BUS.transaction_error();
@@ -1435,7 +1434,7 @@ void sioNetwork::process_http()
     SYSTEM_BUS.transaction_success();
 }
 
-void sioNetwork::process_udp()
+void sioNetwork::process_udp(const FujiSIOPacket &packet)
 {
     // Make sure this is really a UDP protocol instance
     NetworkProtocolUDP *udp = dynamic_cast<NetworkProtocolUDP *>(protocol);
@@ -1446,7 +1445,7 @@ void sioNetwork::process_udp()
     }
 
     fujiError_t err;
-    switch (cmdFrame.comnd)
+    switch (packet.command())
     {
 #ifndef ESP_PLATFORM
     case NETCMD_GET_REMOTE:

--- a/lib/device/sio/network.h
+++ b/lib/device/sio/network.h
@@ -63,7 +63,7 @@ public:
      * Called for SIO Command 'O' to open a connection to a network protocol, allocate all buffers,
      * and start the receive PROCEED interrupt.
      */
-    virtual void sio_open();
+    virtual void sio_open(const FujiSIOPacket &packet);
 
     /**
      * Called for SIO Command 'C' to close a connection to a network protocol, de-allocate all buffers,
@@ -78,14 +78,14 @@ public:
      *
      * @note It is the channel's responsibility to pad to required length.
      */
-    virtual void sio_read();
+    virtual void sio_read(const FujiSIOPacket &packet);
 
     /**
      * SIO Write command
      * Write # of bytes specified by aux1/aux2 from tx_buffer out to SIO. If protocol is unable to return requested
      * number of bytes, return ERROR.
      */
-    virtual void sio_write();
+    virtual void sio_write(const FujiSIOPacket &packet);
 
     /**
      * SIO Special, called as a default for any other SIO command not processed by the other sio_ functions.
@@ -93,12 +93,12 @@ public:
      * process the special command. Otherwise, the command is handled locally. In either case, either sio_complete()
      * or sio_error() is called.
      */
-    virtual void sio_status();
+    virtual void sio_status(const FujiSIOPacket &packet);
 
     /**
      * @brief set channel mode, JSON or PROTOCOL
      */
-    virtual void sio_set_channel_mode();
+    virtual void sio_set_channel_mode(const FujiSIOPacket &packet);
 
     /**
      * @brief Called to set prefix
@@ -124,7 +124,7 @@ public:
      * @brief Get DSTATS value for a given network command
      * Allows programs to query the data direction for any command.
      */
-    virtual void sio_get_dstats_value();
+    virtual void sio_get_dstats_value(const FujiSIOPacket &packet);
 
     /**
      * @brief called to seek to a file position (POINT)
@@ -146,11 +146,11 @@ public:
      * @param comanddata incoming 4 bytes containing command and aux bytes
      * @param checksum 8 bit checksum
      */
-    virtual void sio_process(uint32_t commanddata, uint8_t checksum);
-    void process_fs();
-    void process_tcp();
-    void process_http();
-    void process_udp();
+    void sio_process(const FujiSIOPacket &packet) override;
+    void process_fs(const FujiSIOPacket &packet);
+    void process_tcp(const FujiSIOPacket &packet);
+    void process_http(const FujiSIOPacket &packet);
+    void process_udp(const FujiSIOPacket &packet);
 
 private:
     /**
@@ -293,7 +293,7 @@ private:
     /**
      * Create the deviceSpec and fix it for parsing
      */
-    void create_devicespec();
+    void create_devicespec(bool is_dir);
 
     /**
      * Create a urlParser from deviceSpec
@@ -327,7 +327,7 @@ private:
      *
      * DeviceSpec will be transformed to only contain the relevant part of the deviceSpec, sans comma.
      */
-    void processCommaFromDevicespec();
+    void processCommaFromDevicespec(fujiDeviceID_t device);
 
     /**
      * Perform the correct read based on value of channelMode
@@ -353,7 +353,7 @@ private:
      * @brief perform local status commands, if protocol is not bound, based on cmdFrame
      * value.
      */
-    void sio_status_local();
+    void sio_status_local(const FujiSIOPacket &packet);
 
     /**
      * @brief perform channel status commands, if there is a protocol bound.
@@ -380,12 +380,12 @@ private:
     /**
      * @brief set translation specified by aux1 to aux2_translation mode.
      */
-    void sio_set_translation();
+    void sio_set_translation(const FujiSIOPacket &packet);
 
     /**
      * @brief set the computer's native EOL from aux1/aux2 (aux1==0 restores default).
      */
-    void sio_set_eol();
+    void sio_set_eol(const FujiSIOPacket &packet);
 
     /**
      * @brief Parse incoming JSON. (must be in JSON channelMode)
@@ -395,23 +395,23 @@ private:
     /**
      * @brief Set JSON query string. (must be in JSON channelMode)
      */
-    void sio_set_json_query();
+    void sio_set_json_query(const FujiSIOPacket &packet);
 
     /**
      * @brief Set JSON parameters. (must be in JSON channelMode)
      * Used to affect values on the JSON object
      */
-    void sio_set_json_parameters();
+    void sio_set_json_parameters(const FujiSIOPacket &packet);
 
     /**
      * @brief Set timer rate for PROCEED timer in ms
      */
-    void sio_set_timer_rate();
+    void sio_set_timer_rate(const FujiSIOPacket &packet);
 
     /**
      * @brief parse URL and instantiate protocol
      */
-    void parse_and_instantiate_protocol();
+    void parse_and_instantiate_protocol(bool is_dir);
 };
 
 #endif /* NETWORK_H */

--- a/lib/device/sio/pclink.cpp
+++ b/lib/device/sio/pclink.cpp
@@ -2651,7 +2651,7 @@ void sioPCLink::unmount(int no)
 }
 
 // Status
-void sioPCLink::sio_status()
+void sioPCLink::sio_status(const FujiSIOPacket &packet)
 {
 // # ifdef SIOTRACE
 //      if (log_flag)
@@ -2661,12 +2661,9 @@ void sioPCLink::sio_status()
 }
 
 // Process SIO command
-void sioPCLink::sio_process(uint32_t commanddata, uint8_t checksum)
+void sioPCLink::sio_process(const FujiSIOPacket &packet)
 {
-    cmdFrame.commanddata = commanddata;
-    cmdFrame.checksum = checksum;
-
-    uchar cunit = cmdFrame.aux2 & 0x0f; /* PCLink ignores DUNIT */
+    uchar cunit = packet.param8(1) & 0x0f; /* PCLink ignores DUNIT */
     uchar cdev = FUJI_DEVICEID_PCLINK;
     uchar devno = cdev >> 4; // ??? magical 6
 
@@ -2681,21 +2678,21 @@ void sioPCLink::sio_process(uint32_t commanddata, uint8_t checksum)
     /* cunit == 0 is init during warm reset */
     if ((cunit == 0) || device[cunit].on)
     {
-        switch (cmdFrame.comnd)
+        switch (packet.command())
         {
         case 'P':
             Debug_println("PARBLK");
-            do_pclink(devno, cmdFrame.comnd, cmdFrame.aux1, cmdFrame.aux2);
+            do_pclink(devno, packet.command(), packet.param(0), packet.param(1));
             break;
         case 'R':
             Debug_println("EXEC");
-            do_pclink(devno, cmdFrame.comnd, cmdFrame.aux1, cmdFrame.aux2);
+            do_pclink(devno, packet.command(), packet.param(0), packet.param(1));
             break;
         case 'S':       /* status */
             Debug_println("STATUS");
             pclink_ack(devno, cunit, 'A');
             get_device_status(devno, cunit, status);
-            sio_status();
+            sio_status(packet);
             break;
         case '?':       /* send hi-speed index */
             Debug_println("HIGH SPEED INDEX");

--- a/lib/device/sio/pclink.h
+++ b/lib/device/sio/pclink.h
@@ -12,8 +12,8 @@ public:
     sioPCLink();
 
     // these methods must be implemented
-    void sio_process(uint32_t commanddata, uint8_t checksum) override;
-    virtual void sio_status() override;
+    void sio_process(const FujiSIOPacket &packet) override;
+    void sio_status(const FujiSIOPacket &packet) override;
 
     // public wrapper around protected virtualDevice::sio_ack(), virtualDevice::sio_nak()
     //  to make these protected methotds reachable from sio2bsd/pclink code

--- a/lib/device/sio/printer.cpp
+++ b/lib/device/sio/printer.cpp
@@ -118,7 +118,7 @@ void sioPrinter::print_from_cpm(uint8_t c)
 }
 
 // Status
-void sioPrinter::sio_status()
+void sioPrinter::sio_status(const FujiSIOPacket &packet)
 {
     /*
   STATUS frame per the 400/800 OS ROM Manual
@@ -275,23 +275,20 @@ sioPrinter::printer_type sioPrinter::match_modelname(std::string model_name)
 }
 
 // Process command
-void sioPrinter::sio_process(uint32_t commanddata, uint8_t checksum)
+void sioPrinter::sio_process(const FujiSIOPacket &packet)
 {
-    cmdFrame.commanddata = commanddata;
-    cmdFrame.checksum = checksum;
-
     if (!Config.get_printer_enabled())
     {
         Debug_println("sioPrinter::disabled, ignoring");
     }
     else
     {
-        switch (cmdFrame.comnd)
+        switch (packet.command())
         {
         case SIO_PRINTERCMD_PUT: // Needed by A822 for graphics mode printing
         case SIO_PRINTERCMD_WRITE:
-            _lastaux1 = cmdFrame.aux1;
-            _lastaux2 = cmdFrame.aux2;
+            _lastaux1 = packet.param(0);
+            _lastaux2 = packet.param(1);
             _last_ms = fnSystem.millis();
             SYSTEM_BUS.transaction_accept(TRANS_STATE::WILL_GET);
             sio_write(_lastaux1, _lastaux2);
@@ -299,7 +296,7 @@ void sioPrinter::sio_process(uint32_t commanddata, uint8_t checksum)
         case SIO_PRINTERCMD_STATUS:
             _last_ms = fnSystem.millis();
             SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
-            sio_status();
+            sio_status(packet);
             break;
         default:
             SYSTEM_BUS.transaction_error();

--- a/lib/device/sio/printer.h
+++ b/lib/device/sio/printer.h
@@ -16,8 +16,8 @@ protected:
     // SIO THINGS
     uint8_t _buffer[40];
     void sio_write(uint8_t aux1, uint8_t aux2);
-    void sio_status() override;
-    void sio_process(uint32_t commanddata, uint8_t checksum) override;
+    void sio_status(const FujiSIOPacket &packet) override;
+    void sio_process(const FujiSIOPacket &packet) override;
     void shutdown() override;
 
     printer_emu *_pptr = nullptr;

--- a/lib/device/sio/sioFuji.cpp
+++ b/lib/device/sio/sioFuji.cpp
@@ -143,7 +143,7 @@ sioFuji::sioFuji() : fujiDevice(MAX_DISK_DEVICES, IMAGE_EXTENSION, LOBBY_URL)
 }
 
 // Set SSID
-void sioFuji::sio_net_set_ssid()
+void sioFuji::sio_net_set_ssid(const FujiSIOPacket &packet)
 {
     SSIDConfig cfg;
     transaction_begin(TRANS_STATE::WILL_GET);
@@ -152,17 +152,17 @@ void sioFuji::sio_net_set_ssid()
         return;
     }
 
-    fujicore_net_set_ssid_success(cfg.ssid, cfg.password, cmdFrame.aux1);
+    fujicore_net_set_ssid_success(cfg.ssid, cfg.password, packet.param(0));
     transaction_complete();
 }
 
 // Set SIO baudrate
-void sioFuji::sio_set_baudrate()
+void sioFuji::sio_set_baudrate(const FujiSIOPacket &packet)
 {
 
     int br = 0;
 
-    switch(cmdFrame.aux1) {
+    switch(packet.param8(0)) {
 
         case 0:
             br = 19200;
@@ -200,7 +200,6 @@ void sioFuji::sio_set_baudrate()
     // send complete with current baudrate
     transaction_complete();
 
-    SYSTEM_BUS.flushOutput();
 #ifndef ESP_PLATFORM
     fnSystem.delay_microseconds(2000);
 #endif
@@ -208,7 +207,7 @@ void sioFuji::sio_set_baudrate()
 }
 
 // Do SIO copy
-void sioFuji::sio_copy_file()
+void sioFuji::sio_copy_file(const FujiSIOPacket &packet)
 {
     uint8_t csBuf[256];
     std::string copySpec;
@@ -254,22 +253,17 @@ void sioFuji::sio_copy_file()
         return;
     }
 
-    if (cmdFrame.aux1 < 1 || cmdFrame.aux1 > 8)
+    sourceSlot = packet.param(0);
+    destSlot = packet.param(1);
+
+    sourceSlot--, destSlot--;
+
+    if (!validate_host_slot(sourceSlot) || !validate_host_slot(destSlot))
     {
         transaction_error();
         free(dataBuf);
         return;
     }
-
-    if (cmdFrame.aux2 < 1 || cmdFrame.aux2 > 8)
-    {
-        transaction_error();
-        free(dataBuf);
-        return;
-    }
-
-    sourceSlot = cmdFrame.aux1 - 1;
-    destSlot = cmdFrame.aux2 - 1;
 
     // All good, after this point...
 
@@ -486,12 +480,12 @@ void sioFuji::sio_new_disk()
 
 // AUX1 is our index value (from 0 to SIO_HISPEED_LOWEST_INDEX, for FN-PC 0 .. 10, 16)
 // AUX2 requests a save of the change if set to 1
-void sioFuji::sio_set_hsio_index()
+void sioFuji::sio_set_hsio_index(const FujiSIOPacket &packet)
 {
     Debug_println("Fuji cmd: SET HSIO INDEX");
 
     // DAUX1 holds the desired index value
-    uint8_t index = cmdFrame.aux1;
+    uint8_t index = packet.param(0);
 
     // Make sure it's a valid value
 #ifdef ESP_PLATFORM
@@ -507,7 +501,7 @@ void sioFuji::sio_set_hsio_index()
     SYSTEM_BUS.setHighSpeedIndex(index);
 
     // Go ahead and save it if AUX2 = 1
-    if (cmdFrame.aux2 & 1)
+    if (packet.param8(1) & 1)
     {
         Config.store_general_hsioindex(index);
         Config.save();
@@ -598,7 +592,7 @@ void sioFuji::setup()
 }
 
 // Set NetStream HOST, PORT, and options, then start it.
-void sioFuji::sio_enable_netstream()
+void sioFuji::sio_enable_netstream(const FujiSIOPacket &packet)
 {
     char host[64];
 
@@ -642,7 +636,7 @@ void sioFuji::sio_enable_netstream()
     memcpy(host_out, host, copy_len);
     host_out[copy_len] = '\0';
 
-    int port = (cmdFrame.aux1 << 8) | cmdFrame.aux2;
+    uint16_t port = packet.param(0);
 
     Debug_printf("Fuji cmd ENABLE NETSTREAM: HOST:%s PORT: %d\n", host_out, port);
 #ifdef DEBUG_NETSTREAM
@@ -672,11 +666,11 @@ void sioFuji::sio_enable_netstream()
                                         has_audf3);
 }
 
-void sioFuji::sio_qrcode_input()
+void sioFuji::sio_qrcode_input(const FujiSIOPacket &packet)
 {
     transaction_begin(TRANS_STATE::WILL_GET);
 
-    uint16_t len = cmdFrame.aux12;
+    uint16_t len = packet.param(0);
 
     Debug_printf("FUJI: QRCODE INPUT (len: %d)\n", len);
 
@@ -693,9 +687,9 @@ void sioFuji::sio_qrcode_input()
     transaction_complete();
 }
 
-void sioFuji::sio_qrcode_encode()
+void sioFuji::sio_qrcode_encode(const FujiSIOPacket &packet)
 {
-    uint16_t aux = cmdFrame.aux12;
+    uint16_t aux = packet.param(0);
     uint8_t version = aux & 0b01111111;
     uint8_t ecc_mode = ((aux >> 8) & 0b00000011);
     bool shorten = (aux >> 12) & 0b00000001;
@@ -727,10 +721,10 @@ void sioFuji::sio_qrcode_encode()
     transaction_complete();
 }
 
-void sioFuji::sio_qrcode_length()
+void sioFuji::sio_qrcode_length(const FujiSIOPacket &packet)
 {
     Debug_printf("FUJI: QRCODE LENGTH\n");
-    uint16_t output_mode = cmdFrame.aux12;
+    uint16_t output_mode = packet.param(0);
     Debug_printf("Output mode: %i\n", output_mode);
 
     size_t len = _qrManager.size();
@@ -762,11 +756,11 @@ void sioFuji::sio_qrcode_length()
     transaction_put(response, sizeof(response), false);
 }
 
-void sioFuji::sio_qrcode_output()
+void sioFuji::sio_qrcode_output(const FujiSIOPacket &packet)
 {
     Debug_printf("FUJI: QRCODE OUTPUT\n");
 
-    size_t len = cmdFrame.aux12;
+    size_t len = packet.param16(0);
 
     if (!len)
     {
@@ -789,109 +783,6 @@ void sioFuji::sio_qrcode_output()
     _qrManager.code.shrink_to_fit();
 }
 
-void sioFuji::sio_base64_encode_input()
-{
-    transaction_begin(TRANS_STATE::WILL_GET);
-
-    uint16_t len = cmdFrame.aux12;
-
-    Debug_printf("FUJI: BASE64 ENCODE INPUT\n");
-
-    if (!len)
-    {
-        Debug_printf("Invalid length. Aborting");
-        transaction_error();
-        return;
-    }
-
-    std::vector<unsigned char> p(len);
-    transaction_get(p.data(), len);
-    base64.base64_buffer += std::string((const char *)p.data(), len);
-    transaction_complete();
-}
-
-void sioFuji::sio_base64_encode_compute()
-{
-    size_t out_len;
-
-    /* ACK before CPU work (matches sio_hash_compute); NetSIO/tight SIO timing
-     * otherwise leaves the host waiting past dtimlo (Atari status 138 timeout). */
-    transaction_begin(TRANS_STATE::NO_GET);
-
-    Debug_printf("FUJI: BASE64 ENCODE COMPUTE\n");
-
-    std::unique_ptr<char[]> p = Base64::encode(base64.base64_buffer.c_str(), base64.base64_buffer.size(), &out_len);
-    if (!p)
-    {
-        Debug_printf("base64_encode compute failed\n");
-        transaction_error();
-        return;
-    }
-
-    base64.base64_buffer.clear();
-    base64.base64_buffer = std::string(p.get(), out_len);
-
-    Debug_printf("Resulting BASE64 encoded data is: %u bytes\n", out_len);
-    transaction_complete();
-}
-
-void sioFuji::sio_base64_encode_length()
-{
-    transaction_begin(TRANS_STATE::NO_GET);
-    Debug_printf("FUJI: BASE64 ENCODE LENGTH\n");
-
-    size_t l = base64.base64_buffer.length();
-    uint8_t response[4] = {
-        (uint8_t)(l >>  0),
-        (uint8_t)(l >>  8),
-        (uint8_t)(l >>  16),
-        (uint8_t)(l >>  24)
-    };
-
-    if (!l)
-    {
-        Debug_printf("BASE64 buffer is 0 bytes, sending error.\n");
-        transaction_put(response, sizeof(response), true);
-        return;
-    }
-
-    Debug_printf("base64 buffer length: %u bytes\n", l);
-
-    transaction_put(response, sizeof(response), false);
-}
-
-void sioFuji::sio_base64_encode_output()
-{
-    transaction_begin(TRANS_STATE::NO_GET);
-    Debug_printf("FUJI: BASE64 ENCODE OUTPUT\n");
-
-    size_t len = cmdFrame.aux12;
-
-    if (!len)
-    {
-        Debug_printf("Refusing to send a zero byte buffer. Aborting\n");
-        transaction_error();
-        return;
-    }
-    else if (len > base64.base64_buffer.length())
-    {
-        Debug_printf("Requested %u bytes, but buffer is only %u bytes, aborting.\n", len, base64.base64_buffer.length());
-        transaction_error();
-        return;
-    }
-    else
-    {
-        Debug_printf("Requested %u bytes\n", len);
-    }
-
-    std::vector<unsigned char> p(len);
-    std::memcpy(p.data(), base64.base64_buffer.data(), len);
-    base64.base64_buffer.erase(0, len);
-    base64.base64_buffer.shrink_to_fit();
-
-    transaction_put(p.data(), len, false);
-}
-
 void sioFuji::sio_random_number()
 {
     transaction_begin(TRANS_STATE::NO_GET);
@@ -899,175 +790,15 @@ void sioFuji::sio_random_number()
     transaction_put(&r,sizeof(int),false);
 }
 
-void sioFuji::sio_base64_decode_input()
+void sioFuji::sio_process(const FujiSIOPacket &packet)
 {
-    transaction_begin(TRANS_STATE::WILL_GET);
-
-    uint16_t len = cmdFrame.aux12;
-
-    Debug_printf("FUJI: BASE64 DECODE INPUT\n");
-
-    if (!len)
-    {
-        Debug_printf("Invalid length. Aborting");
-        transaction_error();
-        return;
-    }
-
-    std::vector<unsigned char> p(len);
-    transaction_get(p.data(), len);
-    base64.base64_buffer += std::string((const char *)p.data(), len);
-    transaction_complete();
-}
-
-void sioFuji::sio_base64_decode_compute()
-{
-    size_t out_len;
-
-    transaction_begin(TRANS_STATE::NO_GET);
-
-    Debug_printf("FUJI: BASE64 DECODE COMPUTE\n");
-
-    std::unique_ptr<unsigned char[]> p = Base64::decode(base64.base64_buffer.c_str(), base64.base64_buffer.size(), &out_len);
-    if (!p)
-    {
-        Debug_printf("base64_encode compute failed\n");
-        transaction_error();
-        return;
-    }
-
-    base64.base64_buffer.clear();
-    base64.base64_buffer = std::string((const char *)p.get(), out_len);
-
-    Debug_printf("Resulting BASE64 encoded data is: %u bytes\n", out_len);
-    transaction_complete();
-}
-
-void sioFuji::sio_base64_decode_length()
-{
-    transaction_begin(TRANS_STATE::NO_GET);
-    Debug_printf("FUJI: BASE64 DECODE LENGTH\n");
-
-    size_t len = base64.base64_buffer.length();
-    uint8_t response[4] = {
-        (uint8_t)(len >>  0),
-        (uint8_t)(len >>  8),
-        (uint8_t)(len >>  16),
-        (uint8_t)(len >>  24)
-    };
-
-    if (!len)
-    {
-        Debug_printf("BASE64 buffer is 0 bytes, sending error.\n");
-        transaction_put(response, sizeof(response), true);
-        return;
-    }
-
-    Debug_printf("base64 buffer length: %u bytes\n", len);
-
-    transaction_put(response, sizeof(response), false);
-}
-
-void sioFuji::sio_base64_decode_output()
-{
-    transaction_begin(TRANS_STATE::NO_GET);
-    Debug_printf("FUJI: BASE64 DECODE OUTPUT\n");
-
-    size_t len = cmdFrame.aux12;
-
-    if (!len)
-    {
-        Debug_printf("Refusing to send a zero byte buffer. Aborting\n");
-        transaction_error();
-        return;
-    }
-    else if (len > base64.base64_buffer.length())
-    {
-        Debug_printf("Requested %u bytes, but buffer is only %u bytes, aborting.\n", len, base64.base64_buffer.length());
-        transaction_error();
-        return;
-    }
-    else
-    {
-        Debug_printf("Requested %u bytes\n", len);
-    }
-
-    std::vector<unsigned char> p(len);
-    memcpy(p.data(), base64.base64_buffer.data(), len);
-    base64.base64_buffer.erase(0, len);
-    base64.base64_buffer.shrink_to_fit();
-    transaction_put(p.data(), len, false);
-}
-
-void sioFuji::sio_hash_input()
-{
-    transaction_begin(TRANS_STATE::WILL_GET);
-
-    Debug_printf("FUJI: HASH INPUT\n");
-    uint16_t len = cmdFrame.aux12;
-    if (!len)
-    {
-        Debug_printf("Invalid length. Aborting");
-        transaction_error();
-        return;
-    }
-
-    std::vector<unsigned char> p(len);
-    transaction_get(p.data(), len);
-    hasher.add_data(p);
-    transaction_complete();
-}
-
-void sioFuji::sio_hash_compute(bool clear_data)
-{
-    transaction_begin(TRANS_STATE::NO_GET);
-    Debug_printf("FUJI: HASH COMPUTE\n");
-    algorithm = Hash::to_algorithm(cmdFrame.aux12);
-    hasher.compute(algorithm, clear_data);
-    transaction_complete();
-}
-
-void sioFuji::sio_hash_length()
-{
-    transaction_begin(TRANS_STATE::NO_GET);
-    Debug_printf("FUJI: HASH LENGTH\n");
-    uint16_t is_hex = cmdFrame.aux12 == 1;
-    uint8_t r = hasher.hash_length(algorithm, is_hex);
-    transaction_put(&r, 1, false);
-}
-
-void sioFuji::sio_hash_output()
-{
-    transaction_begin(TRANS_STATE::NO_GET);
-    Debug_printf("FUJI: HASH OUTPUT\n");
-    uint16_t is_hex = cmdFrame.aux12 == 1;
-
-    std::vector<uint8_t> hashed_data;
-    if (is_hex) {
-        std::string hex = hasher.output_hex();
-        hashed_data.insert(hashed_data.end(), hex.begin(), hex.end());
-    } else {
-        hashed_data = hasher.output_binary();
-    }
-    transaction_put(hashed_data.data(), hashed_data.size(), false);
-}
-
-void sioFuji::sio_hash_clear()
-{
-    transaction_begin(TRANS_STATE::NO_GET);
-    Debug_printf("FUJI: HASH CLEAR\n");
-    hasher.clear();
-    transaction_complete();
-}
-
-void sioFuji::sio_process(uint32_t commanddata, uint8_t checksum)
-{
-    cmdFrame.commanddata = commanddata;
-    cmdFrame.checksum = checksum;
-
     Debug_printf("sioFuji::fujicmd_process() called, baud: %d\n", SYSTEM_BUS.getBaudrate());
 
-    switch (cmdFrame.comnd)
+    // Let the base class handle standard commands
+    if (fujiDevice::processCommand(packet))
+        return;
+
+    switch (packet.command())
     {
     case FUJICMD_HSIO_INDEX:
         /* ACK is required here since it's not done elsewhere for this device/command. The bus should probably
@@ -1076,10 +807,10 @@ void sioFuji::sio_process(uint32_t commanddata, uint8_t checksum)
         sio_high_speed();
         break;
     case FUJICMD_SET_HSIO_INDEX:
-        sio_set_hsio_index();
+        sio_set_hsio_index(packet);
         break;
     case FUJICMD_STATUS:
-        sio_status();
+        sio_status(packet);
         break;
     case FUJICMD_RESET:
         fujicmd_reset();
@@ -1088,10 +819,10 @@ void sioFuji::sio_process(uint32_t commanddata, uint8_t checksum)
         fujicmd_net_scan_networks();
         break;
     case FUJICMD_GET_SCAN_RESULT:
-        fujicmd_net_scan_result(cmdFrame.aux1);
+        fujicmd_net_scan_result(packet.param(0));
         break;
     case FUJICMD_SET_SSID:
-        sio_net_set_ssid();
+        sio_net_set_ssid(packet);
         break;
     case FUJICMD_GET_SSID:
         fujicmd_net_get_ssid();
@@ -1100,16 +831,16 @@ void sioFuji::sio_process(uint32_t commanddata, uint8_t checksum)
         fujicmd_net_get_wifi_status();
         break;
     case FUJICMD_MOUNT_HOST:
-        fujicmd_mount_host_success(cmdFrame.aux1);
+        fujicmd_mount_host_success(packet.param8(0));
         break;
     case FUJICMD_MOUNT_IMAGE:
-        fujicmd_mount_disk_image_success(cmdFrame.aux1, (disk_access_flags_t) cmdFrame.aux2);
+        fujicmd_mount_disk_image_success(packet.param(0), (disk_access_flags_t) packet.param8(1));
         break;
     case FUJICMD_OPEN_DIRECTORY:
-        fujicmd_open_directory_success(cmdFrame.aux1);
+        fujicmd_open_directory_success(packet.param(0));
         break;
     case FUJICMD_READ_DIR_ENTRY:
-        fujicmd_read_directory_entry(cmdFrame.aux1, cmdFrame.aux2);
+        fujicmd_read_directory_entry(packet.param8(0), packet.param(1));
         break;
     case FUJICMD_CLOSE_DIRECTORY:
         fujicmd_close_directory();
@@ -1118,7 +849,7 @@ void sioFuji::sio_process(uint32_t commanddata, uint8_t checksum)
         fujicmd_get_directory_position();
         break;
     case FUJICMD_SET_DIRECTORY_POSITION:
-        fujicmd_set_directory_position(le16toh(cmdFrame.aux12));
+        fujicmd_set_directory_position(packet.param(0));
         break;
     case FUJICMD_READ_HOST_SLOTS:
         fujicmd_read_host_slots();
@@ -1136,16 +867,16 @@ void sioFuji::sio_process(uint32_t commanddata, uint8_t checksum)
         fujicmd_net_get_wifi_enabled();
         break;
     case FUJICMD_SET_BAUDRATE:
-        sio_set_baudrate();
+        sio_set_baudrate(packet);
         break;
     case FUJICMD_UNMOUNT_IMAGE:
-        fujicmd_unmount_disk_image_success(cmdFrame.aux1);
+        fujicmd_unmount_disk_image_success(packet.param(0));
         break;
     case FUJICMD_GET_ADAPTERCONFIG:
         // THIS IS STILL NEEDED FOR BACKWARDS COMPATIBILITY WITH
         // FUJINET-LIB THAT SENDS 0xE8 FOR ADAPTER_CONFIG_EXTENDED
         // WITH 0x01 IN THE AUX1 BYTE
-        if (cmdFrame.aux1 == 1)
+        if (packet.param8(0) == 1)
             fujicmd_get_adapter_config_extended();
         else
             fujicmd_get_adapter_config();
@@ -1157,23 +888,23 @@ void sioFuji::sio_process(uint32_t commanddata, uint8_t checksum)
         sio_new_disk();
         break;
     case FUJICMD_UNMOUNT_HOST:
-        fujicmd_unmount_host_success(cmdFrame.aux1);
+        fujicmd_unmount_host_success(packet.param(0));
         break;
     case FUJICMD_SET_DEVICE_FULLPATH:
-        fujicmd_set_device_filename_success(cmdFrame.aux1, cmdFrame.aux2 >> 4,
-                                            (disk_access_flags_t) (cmdFrame.aux2 & 0x0F));
+        fujicmd_set_device_filename_success(packet.param(0), packet.param8(1) >> 4,
+                                            (disk_access_flags_t) (packet.param8(1) & 0x0F));
         break;
     case FUJICMD_SET_HOST_PREFIX:
-        fujicmd_set_host_prefix(cmdFrame.aux1);
+        fujicmd_set_host_prefix(packet.param(0));
         break;
     case FUJICMD_GET_HOST_PREFIX:
-        fujicmd_get_host_prefix(cmdFrame.aux1);
+        fujicmd_get_host_prefix(packet.param(0));
         break;
     case FUJICMD_SET_SIO_EXTERNAL_CLOCK:
-        fujicmd_set_sio_external_clock(le16toh(cmdFrame.aux12));
+        fujicmd_set_sio_external_clock(packet.param(0));
         break;
     case FUJICMD_WRITE_APPKEY:
-        fujicmd_write_app_key(le16toh(cmdFrame.aux12),
+        fujicmd_write_app_key(packet.param(0),
                               get_value_or_default(mode_to_keysize, _current_appkey.mode, 64));
         break;
     case FUJICMD_READ_APPKEY:
@@ -1186,76 +917,34 @@ void sioFuji::sio_process(uint32_t commanddata, uint8_t checksum)
         fujicmd_close_app_key();
         break;
     case FUJICMD_GET_DEVICE_FULLPATH:
-        fujicmd_get_device_filename(cmdFrame.aux1);
+        fujicmd_get_device_filename(packet.param(0));
         break;
     case FUJICMD_CONFIG_BOOT:
-        fujicmd_set_boot_config(cmdFrame.aux1);
+        fujicmd_set_boot_config(packet.param(0));
         break;
     case FUJICMD_COPY_FILE:
-        sio_copy_file();
+        sio_copy_file(packet);
         break;
     case FUJICMD_MOUNT_ALL:
         fujicmd_mount_all_success();
         break;
     case FUJICMD_SET_BOOT_MODE:
-        fujicmd_set_boot_mode(cmdFrame.aux1, MEDIATYPE_UNKNOWN, &bootdisk);
+        fujicmd_set_boot_mode(packet.param(0), MEDIATYPE_UNKNOWN, &bootdisk);
         break;
     case FUJICMD_ENABLE_UDPSTREAM:
-        sio_enable_netstream();
+        sio_enable_netstream(packet);
         break;
     case FUJICMD_QRCODE_INPUT:
-        sio_qrcode_input();
+        sio_qrcode_input(packet);
         break;
     case FUJICMD_QRCODE_ENCODE:
-        sio_qrcode_encode();
+        sio_qrcode_encode(packet);
         break;
     case FUJICMD_QRCODE_LENGTH:
-        sio_qrcode_length();
+        sio_qrcode_length(packet);
         break;
     case FUJICMD_QRCODE_OUTPUT:
-        sio_qrcode_output();
-        break;
-    case FUJICMD_BASE64_ENCODE_INPUT:
-        sio_base64_encode_input();
-        break;
-    case FUJICMD_BASE64_ENCODE_COMPUTE:
-        sio_base64_encode_compute();
-        break;
-    case FUJICMD_BASE64_ENCODE_LENGTH:
-        sio_base64_encode_length();
-        break;
-    case FUJICMD_BASE64_ENCODE_OUTPUT:
-        sio_base64_encode_output();
-        break;
-    case FUJICMD_BASE64_DECODE_INPUT:
-        sio_base64_decode_input();
-        break;
-    case FUJICMD_BASE64_DECODE_COMPUTE:
-        sio_base64_decode_compute();
-        break;
-    case FUJICMD_BASE64_DECODE_LENGTH:
-        sio_base64_decode_length();
-        break;
-    case FUJICMD_BASE64_DECODE_OUTPUT:
-        sio_base64_decode_output();
-        break;
-    case FUJICMD_HASH_INPUT:
-        sio_hash_input();
-        break;
-    case FUJICMD_HASH_COMPUTE:
-        sio_hash_compute(true);
-        break;
-    case FUJICMD_HASH_COMPUTE_NO_CLEAR:
-        sio_hash_compute(false);
-        break;
-    case FUJICMD_HASH_LENGTH:
-        sio_hash_length();
-        break;
-    case FUJICMD_HASH_OUTPUT:
-        sio_hash_output();
-        break;
-    case FUJICMD_HASH_CLEAR:
-        sio_hash_clear();
+        sio_qrcode_output(packet);
         break;
     case FUJICMD_RANDOM_NUMBER:
         sio_random_number();

--- a/lib/device/sio/sioFuji.h
+++ b/lib/device/sio/sioFuji.h
@@ -20,40 +20,24 @@ protected:
     size_t set_additional_direntry_details(fsdir_entry_t *f, uint8_t *dest,
                                            uint8_t maxlen) override;
 
-    void sio_net_set_ssid();           // 0xFB
-    void sio_read_directory_block();   // 0xF6
-    void sio_set_baudrate();           // 0xEB
-    void sio_new_disk();               // 0xE7
-    void sio_set_hsio_index();         // 0xE3
-    void sio_copy_file();              // 0xD8
-    void sio_enable_netstream();       // 0xF0
+    void sio_net_set_ssid(const FujiSIOPacket &packet);                  // 0xFB
+    void sio_read_directory_block();                                  // 0xF6
+    void sio_set_baudrate(const FujiSIOPacket &packet);                  // 0xEB
+    void sio_new_disk();                                              // 0xE7
+    void sio_set_hsio_index(const FujiSIOPacket &packet);                // 0xE3
+    void sio_copy_file(const FujiSIOPacket &packet);                     // 0xD8
+    void sio_enable_netstream(const FujiSIOPacket &packet);              // 0xF0
+
+    void sio_random_number();                                         // 0xD3
 
     // FIXME - move to fujiDevice mixin
-    void sio_random_number();          // 0xD3
-    void sio_base64_encode_input();    // 0xD0
-    void sio_base64_encode_compute();  // 0xCF
-    void sio_base64_encode_length();   // 0xCE
-    void sio_base64_encode_output();   // 0xCD
-    void sio_base64_decode_input();    // 0xCC
-    void sio_base64_decode_compute();  // 0xCB
-    void sio_base64_decode_length();   // 0xCA
-    void sio_base64_decode_output();   // 0xC9
+    void sio_qrcode_input(const FujiSIOPacket &packet);                  // 0xBC
+    void sio_qrcode_encode(const FujiSIOPacket &packet);                 // 0xBD
+    void sio_qrcode_length(const FujiSIOPacket &packet);                 // OxBE
+    void sio_qrcode_output(const FujiSIOPacket &packet);                 // 0xBF
 
-    // FIXME - move to fujiDevice mixin
-    void sio_hash_input();             // 0xC8
-    void sio_hash_compute(bool clear_data); // 0xC7, 0xC3
-    void sio_hash_length();            // 0xC6
-    void sio_hash_output();            // 0xC5
-    void sio_hash_clear();             // 0xC2
-
-    // FIXME - move to fujiDevice mixin
-    void sio_qrcode_input();           // 0xBC
-    void sio_qrcode_encode();          // 0xBD
-    void sio_qrcode_length();          // OxBE
-    void sio_qrcode_output();          // 0xBF
-
-    void sio_status() override { fujicmd_status(); }
-    void sio_process(uint32_t commanddata, uint8_t checksum) override;
+    void sio_status(const FujiSIOPacket &packet) override { fujicmd_status(); }
+    void sio_process(const FujiSIOPacket &packet) override;
 
 public:
     sioFuji();

--- a/lib/device/sio/siocpm.cpp
+++ b/lib/device/sio/siocpm.cpp
@@ -23,7 +23,7 @@
 #endif
 
 
-void sioCPM::sio_status()
+void sioCPM::sio_status(const FujiSIOPacket &packet)
 {
     // Nothing to do here
     return;
@@ -68,12 +68,9 @@ void sioCPM::init_cpm(int baud)
     memset(pattern, 0, sizeof(pattern));
 }
 
-void sioCPM::sio_process(uint32_t commanddata, uint8_t checksum)
+void sioCPM::sio_process(const FujiSIOPacket &packet)
 {
-    cmdFrame.commanddata = commanddata;
-    cmdFrame.checksum = checksum;
-
-    switch (cmdFrame.comnd)
+    switch (packet.command())
     {
     case CPMCMD_INIT:
         SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);

--- a/lib/device/sio/siocpm.h
+++ b/lib/device/sio/siocpm.h
@@ -16,8 +16,8 @@ class sioCPM : public virtualDevice
 {
 private:
 
-    void sio_status() override;
-    void sio_process(uint32_t commanddata, uint8_t checksum) override;
+    void sio_status(const FujiSIOPacket &packet) override;
+    void sio_process(const FujiSIOPacket &packet) override;
 
 public:
     bool cpmActive = false;

--- a/lib/device/sio/voice.cpp
+++ b/lib/device/sio/voice.cpp
@@ -232,7 +232,7 @@ void sioVoice::sio_write()
 }
 
 // Status
-void sioVoice::sio_status()
+void sioVoice::sio_status(const FujiSIOPacket &packet)
 {
     // act like a printer for POC
     uint8_t status[4];
@@ -245,23 +245,20 @@ void sioVoice::sio_status()
     SYSTEM_BUS.transaction_send(status, sizeof(status), false);
 }
 
-void sioVoice::sio_process(uint32_t commanddata, uint8_t checksum)
+void sioVoice::sio_process(const FujiSIOPacket &packet)
 {
-    cmdFrame.commanddata = commanddata;
-    cmdFrame.checksum = checksum;
-
     // act like a printer for POC
-    switch (cmdFrame.comnd)
+    switch (packet.command())
     {
     case 'P': // 0x50
     case 'W': // 0x57
         SYSTEM_BUS.transaction_accept(TRANS_STATE::WILL_GET);
         sio_write();
-        lastAux1 = cmdFrame.aux1;
+        lastAux1 = packet.param(0);
         break;
     case 'S': // 0x53
         SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
-        sio_status();
+        sio_status(packet);
         break;
     default:
         SYSTEM_BUS.transaction_error();

--- a/lib/device/sio/voice.h
+++ b/lib/device/sio/voice.h
@@ -17,8 +17,8 @@ protected:
     uint8_t samBuffer[121];
     void sio_write();
 
-    void sio_process(uint32_t commanddata, uint8_t checksum) override;
-    virtual void sio_status() override;
+    void sio_process(const FujiSIOPacket &packet) override;
+    void sio_status(const FujiSIOPacket &packet) override;
 
 private:
     bool sing = false;


### PR DESCRIPTION
Introduce `FujiSIOPacket`, a packet implementation that presents the same logical interface as `FujiBusPacket` while handling the two-phase SIO protocol.

Parameters are pulled from the SIO aux bytes, the payload data is read on demand when needed.

This also switches sioFuji over to using mixins.