### PR TITLE
Move PacketParam and PacketParamProxy into their own .h files

### DIFF
--- a/lib/bus/PacketParam.h
+++ b/lib/bus/PacketParam.h
@@ -1,0 +1,34 @@
+#ifndef PACKETPARAM_H
+#define PACKETPARAM_H
+
+#include <cassert>
+#include <cstdint>
+#include <type_traits>
+
+struct PacketParam
+{
+    std::uint32_t value;
+    std::uint8_t  size;   // 1, 2, or 4 bytes
+
+    template<typename T>
+    PacketParam(T v)
+        : value(static_cast<std::uint32_t>(v))
+        , size(static_cast<std::uint8_t>(sizeof(T)))
+    {
+        static_assert(
+                      std::is_same_v<T, std::uint8_t>  ||
+                      std::is_same_v<T, std::uint16_t> ||
+                      std::is_same_v<T, std::uint32_t>,
+                      "Param can only be uint8_t, uint16_t, or uint32_t"
+                      );
+    }
+
+    PacketParam(std::uint32_t v, std::uint8_t s)
+        : value(v)
+        , size(s)
+    {
+        assert(s == 1 || s == 2 || s == 4);
+    }
+};
+
+#endif /* PACKETPARAM_H */

--- a/lib/bus/PacketParamProxy.h
+++ b/lib/bus/PacketParamProxy.h
@@ -1,0 +1,85 @@
+#ifndef PACKETPARAMPROXY_H
+#define PACKETPARAMPROXY_H
+
+#include <cstdint>
+
+/**
+ * Proxy object returned by param().
+ *
+ * The proxy exists because parameter decoding requires two pieces of
+ * information that are not available at the same time:
+ *
+ *   - param(index) knows which parameter is being requested, but not
+ *     the integer width the caller expects.
+ *   - The conversion operator knows the requested integer width, but
+ *     would otherwise have no way to identify which parameter to decode.
+ *
+ * The proxy preserves the parameter index until the compiler selects
+ * the appropriate conversion operator. At that point the packet knows
+ * both the parameter index and the requested width, allowing it to:
+ *
+ *   - Read the correct number of bytes from the bus.
+ *   - Convert Adam's big-endian encoding to native byte order.
+ *   - Cache the decoded value for subsequent accesses.
+ *
+ * Example:
+ *
+ *   uint16_t length = packet.param(0);
+ *   uint8_t  mode   = packet.param(1);
+ *
+ * The compiler selects the conversion operator based on the destination
+ * type (or an explicit cast). Subsequent accesses return the cached
+ * value rather than reading from the bus again.
+ */
+
+#include <cstddef>
+
+template <typename Packet>
+class PacketParamProxy
+{
+private:
+    std::size_t _index;
+    const Packet *_packet;
+
+    PacketParamProxy(std::size_t index, const Packet *packet)
+        : _index(index)
+        , _packet(packet)
+    {
+    }
+
+public:
+    operator std::uint8_t() const {
+        return _packet->getParam(_index, sizeof(std::uint8_t));
+    }
+
+    operator std::uint16_t() const {
+        return _packet->getParam(_index, sizeof(std::uint16_t));
+    }
+
+    operator std::uint32_t() const {
+        return _packet->getParam(_index, sizeof(std::uint32_t));
+    }
+
+    operator bool() const {
+        return static_cast<uint8_t>(*this) != 0;
+    }
+
+    bool operator==(std::uint8_t value) const {
+        return static_cast<std::uint8_t>(*this) == value;
+    }
+
+    bool operator==(std::uint16_t value) const {
+        return static_cast<std::uint16_t>(*this) == value;
+    }
+
+    bool operator==(std::uint32_t value) const {
+        return static_cast<std::uint32_t>(*this) == value;
+    }
+
+    template <typename>
+    friend class PacketParamProxy;
+
+    friend Packet;
+};
+
+#endif /* PACKETPARAMPROXY_H */

--- a/lib/bus/adamnet/FujiAdamPacket.h
+++ b/lib/bus/adamnet/FujiAdamPacket.h
@@ -1,8 +1,9 @@
+#ifndef FUJIADAMPACKET_H
+#define FUJIADAMPACKET_H
+
 #ifdef BUILD_ADAM
 
-#ifndef DRIVEWIREPACKET_H
-#define DRIVEWIREPACKET_H
-
+#include "PacketParamProxy.h"
 #include "fujiDeviceID.h"
 #include "fujiCommandID.h"
 #include "global_types.h"
@@ -31,23 +32,23 @@ typedef enum class APT {
 } adamPacketType_t;
 
 /**
- * DriveWire implementation of the RS232 FujiBusPacket interface.
+ * AdamNet implementation of the RS232 FujiBusPacket interface.
  *
  * This class provides the same logical interface as FujiBusPacket
  * (command(), param(), data(), and dataAsString()) so device handlers
- * can process DriveWire packets using the same abstractions as other
+ * can process AdamNet packets using the same abstractions as other
  * buses.
  *
- * Unlike other packet formats, DriveWire does not encode enough
+ * Unlike other packet formats, AdamNet does not encode enough
  * structural information to deserialize a complete packet up front.
  * Parameters and data are therefore deserialized lazily as they are
  * requested. Parameter values are read from the bus on first access
  * and cached for subsequent accesses.
  *
- * The only API difference from FujiBusPacket is setDataLength(). The
+ * The only API difference from FujiBusPacket is setPayloadLength(). The
  * trailing data field has no self-describing length, so its size must
  * be supplied before data() or dataAsString() can be used. Code using
- * the transaction_* helpers does not need to call setDataLength()
+ * the transaction_* helpers does not need to call setPayloadLength()
  * directly, as those helpers determine the length automatically.
  */
 
@@ -64,74 +65,8 @@ private:
     mutable unsigned _paramSize;
     mutable std::optional<ByteBuffer> _data;
 
-    struct PacketParamProxy
-    {
-        /**
-         * Proxy object returned by param().
-         *
-         * The proxy exists because parameter decoding requires two pieces of
-         * information that are not available at the same time:
-         *
-         *   - param(index) knows which parameter is being requested, but not
-         *     the integer width the caller expects.
-         *   - The conversion operator knows the requested integer width, but
-         *     would otherwise have no way to identify which parameter to decode.
-         *
-         * The proxy preserves the parameter index until the compiler selects
-         * the appropriate conversion operator. At that point the packet knows
-         * both the parameter index and the requested width, allowing it to:
-         *
-         *   - Read the correct number of bytes from the bus.
-         *   - Convert DriveWire's big-endian encoding to native byte order.
-         *   - Cache the decoded value for subsequent accesses.
-         *
-         * Example:
-         *
-         *   uint16_t length = packet.param(0);
-         *   uint8_t  mode   = packet.param(1);
-         *
-         * The compiler selects the conversion operator based on the destination
-         * type (or an explicit cast). Subsequent accesses return the cached
-         * value rather than reading from the bus again.
-         *
-         * The param8(), param16(), and param32() methods provide explicit
-         * alternatives when the implicit conversion is undesirable or the
-         * destination type is not obvious.
-         */
-
-        size_t index;
-        const FujiAdamPacket *packet;
-
-        // These tell the compiler: "Run this code if the destination matches my type"
-        operator bool() const {
-            return static_cast<uint8_t>(*this) != 0;
-        }
-
-        // These tell the compiler exactly how to handle direct equality checks
-        // against any integer type without triggering conversion rule debates.
-
-        bool operator==(uint8_t val) const {
-            return static_cast<uint8_t>(*this) == val;
-        }
-
-        bool operator==(uint16_t val) const {
-            return static_cast<uint16_t>(*this) == val;
-        }
-
-        inline operator uint8_t() const {
-            return packet->getParam(index, sizeof(uint8_t));
-        }
-
-        inline operator uint16_t() const {
-            return packet->getParam(index, sizeof(uint16_t));
-        }
-
-        inline operator uint32_t() const {
-            return packet->getParam(index, sizeof(uint32_t));
-        }
-    };
-
-    friend PacketParamProxy;
+    using ParamProxy = PacketParamProxy<FujiAdamPacket>;
+    friend ParamProxy;
 
     uint32_t getParam(size_t index, size_t psize) const;
     void fillParams(size_t count, size_t psize) const;
@@ -144,7 +79,7 @@ public:
     adamPacketType_t type() const { return _type; }
     fujiCommandID_t command() const;
 
-    PacketParamProxy param(size_t index) const { return PacketParamProxy{ index, this }; }
+    ParamProxy param(size_t index) const { return ParamProxy{ index, this }; }
 
     // Completes deserialization by reading the trailing data field once its
     // length has been determined from command-specific context.
@@ -156,7 +91,7 @@ public:
         return std::string(reinterpret_cast<const char *>(d->data()), d->size());
     }
 
-    // Explicit alternatives to the implicit PacketParamProxy conversions.
+    // Explicit alternatives to the implicit ParamProxy conversions.
     // These may be preferred where the destination type is not obvious.
     uint8_t  param8(int idx)  const { return (uint8_t)param(idx); }
     uint16_t param16(int idx) const { return (uint16_t)param(idx); }
@@ -167,32 +102,6 @@ public:
     FujiAdamPacket& operator=(const FujiAdamPacket&) = delete;
 };
 
-/**
- * Design notes:
- *
- * - Parameters are decoded lazily and cached on first access. Parameters
- *   may be requested in any order prior to calling data(). If a later
- *   parameter is requested first, all preceding parameters are
- *   automatically decoded and cached as needed.
- *
- * - This allows parameters to be passed directly to a function without
- *   first storing them in temporary variables, e.g.
- *
- *       device_method(frame.param(0), frame.param(1), frame.param(2));
- *
- *   The packet guarantees that parameters are read from the bus in
- *   protocol order regardless of the compiler's argument evaluation
- *   order.
- *
- * - Protocol-specific packet variations are handled transparently. For
- *   example, packet types that include a unit byte before the command
- *   byte are decoded correctly regardless of whether unit() or
- *   command() is accessed first.
- *
- * - Multi-byte parameters are automatically converted from DriveWire's
- *   big-endian encoding to the native host byte order.
- */
-
-#endif /* DRIVEWIREPACKET_H */
-
 #endif /* BUILD_ADAM */
+
+#endif /* FUJIADAMPACKET_H */

--- a/lib/bus/drivewire/FujiDWPacket.h
+++ b/lib/bus/drivewire/FujiDWPacket.h
@@ -1,8 +1,9 @@
+#ifndef FUJIDWPACKET_H
+#define FUJIDWPACKET_H
+
 #ifdef BUILD_COCO
 
-#ifndef DRIVEWIREPACKET_H
-#define DRIVEWIREPACKET_H
-
+#include "PacketParamProxy.h"
 #include "opcode.h"
 #include "fujiCommandID.h"
 #include "global_types.h"
@@ -43,74 +44,8 @@ private:
     mutable unsigned _paramSize;
     mutable std::optional<ByteBuffer> _data;
 
-    struct PacketParamProxy
-    {
-        /**
-         * Proxy object returned by param().
-         *
-         * The proxy exists because parameter decoding requires two pieces of
-         * information that are not available at the same time:
-         *
-         *   - param(index) knows which parameter is being requested, but not
-         *     the integer width the caller expects.
-         *   - The conversion operator knows the requested integer width, but
-         *     would otherwise have no way to identify which parameter to decode.
-         *
-         * The proxy preserves the parameter index until the compiler selects
-         * the appropriate conversion operator. At that point the packet knows
-         * both the parameter index and the requested width, allowing it to:
-         *
-         *   - Read the correct number of bytes from the bus.
-         *   - Convert DriveWire's big-endian encoding to native byte order.
-         *   - Cache the decoded value for subsequent accesses.
-         *
-         * Example:
-         *
-         *   uint16_t length = packet.param(0);
-         *   uint8_t  mode   = packet.param(1);
-         *
-         * The compiler selects the conversion operator based on the destination
-         * type (or an explicit cast). Subsequent accesses return the cached
-         * value rather than reading from the bus again.
-         *
-         * The param8(), param16(), and param32() methods provide explicit
-         * alternatives when the implicit conversion is undesirable or the
-         * destination type is not obvious.
-         */
-
-        size_t index;
-        const FujiDWPacket *packet;
-
-        // These tell the compiler: "Run this code if the destination matches my type"
-        operator bool() const {
-            return static_cast<uint8_t>(*this) != 0;
-        }
-
-        // These tell the compiler exactly how to handle direct equality checks
-        // against any integer type without triggering conversion rule debates.
-
-        bool operator==(uint8_t val) const {
-            return static_cast<uint8_t>(*this) == val;
-        }
-
-        bool operator==(uint16_t val) const {
-            return static_cast<uint16_t>(*this) == val;
-        }
-
-        inline operator uint8_t() const {
-            return packet->getParam(index, sizeof(uint8_t));
-        }
-
-        inline operator uint16_t() const {
-            return packet->getParam(index, sizeof(uint16_t));
-        }
-
-        inline operator uint32_t() const {
-            return packet->getParam(index, sizeof(uint32_t));
-        }
-    };
-
-    friend PacketParamProxy;
+    using ParamProxy = PacketParamProxy<FujiDWPacket>;
+    friend ParamProxy;
 
     uint32_t getParam(size_t index, size_t psize) const;
     void fillParams(size_t count, size_t psize) const;
@@ -129,7 +64,7 @@ public:
 
     uint8_t unit() const;
 
-    PacketParamProxy param(size_t index) const { return PacketParamProxy{ index, this }; }
+    ParamProxy param(size_t index) const { return ParamProxy{ index, this }; }
 
     // Completes deserialization by reading the trailing data field once its
     // length has been determined from command-specific context.
@@ -146,7 +81,7 @@ public:
         return std::string(_data->begin(), _data->end());
     }
 
-    // Explicit alternatives to the implicit PacketParamProxy conversions.
+    // Explicit alternatives to the implicit ParamProxy conversions.
     // These may be preferred where the destination type is not obvious.
     uint8_t  param8(int idx)  const { return (uint8_t)param(idx); }
     uint16_t param16(int idx) const { return (uint16_t)param(idx); }
@@ -183,6 +118,6 @@ public:
  *   big-endian encoding to the native host byte order.
  */
 
-#endif /* DRIVEWIREPACKET_H */
-
 #endif /* BUILD_COCO */
+
+#endif /* FUJIDWPACKET_H */

--- a/lib/bus/iwm/FujiIWMPacket.h
+++ b/lib/bus/iwm/FujiIWMPacket.h
@@ -1,6 +1,7 @@
 #ifndef FUJIIWMPACKET_H
 #define FUJIIWMPACKET_H
 
+#include "PacketParamProxy.h"
 #include "spCommandID.h"
 #include "spCode.h"
 #include "fujiCommandID.h"
@@ -53,41 +54,8 @@ private:
   mutable ByteBuffer _decoded;
   mutable std::optional<std::span<const uint8_t>> _data;
 
-  struct PacketParamProxy
-  {
-    size_t index;
-    const FujiIWMPacket *packet;
-
-    // These tell the compiler: "Run this code if the destination matches my type"
-    operator bool() const {
-      return static_cast<uint8_t>(*this) != 0;
-    }
-
-    // These tell the compiler exactly how to handle direct equality checks
-    // against any integer type without triggering conversion rule debates.
-
-    bool operator==(uint8_t val) const {
-      return static_cast<uint8_t>(*this) == val;
-    }
-
-    bool operator==(uint16_t val) const {
-      return static_cast<uint16_t>(*this) == val;
-    }
-
-    inline operator uint8_t() const {
-      return packet->getParam(index, sizeof(uint8_t));
-    }
-
-    inline operator uint16_t() const {
-      return packet->getParam(index, sizeof(uint16_t));
-    }
-
-    inline operator uint32_t() const {
-      return packet->getParam(index, sizeof(uint32_t));
-    }
-  };
-
-  friend PacketParamProxy;
+  using ParamProxy = PacketParamProxy<FujiIWMPacket>;
+  friend ParamProxy;
 
   uint32_t getParam(size_t index, size_t psize) const;
   void fillParams(size_t count, size_t psize) const;
@@ -102,7 +70,7 @@ public:
   uint8_t device() const { return frame.sp_dev_id; }
   fujiCommandID_t command() const { return frame.control_status.fuji.command; }
 
-  PacketParamProxy param(size_t index) const { return PacketParamProxy{ index, this }; }
+  ParamProxy param(size_t index) const { return ParamProxy{ index, this }; }
 
   const std::optional<std::span<const std::uint8_t>>& data() const;
   const std::optional<const std::string> dataAsString() const {
@@ -110,7 +78,7 @@ public:
     return std::string(reinterpret_cast<const char *>(d->data()), d->size());
   }
 
-  // Explicit alternatives to the implicit PacketParamProxy conversions.
+  // Explicit alternatives to the implicit ParamProxy conversions.
   // These may be preferred where the destination type is not obvious.
   uint8_t  param8(size_t index)  const { return (uint8_t) param(index); }
   uint16_t param16(size_t index) const { return (uint16_t) param(index); }
@@ -119,7 +87,6 @@ public:
   // Delete copy semantics to prevent pass-by-value bugs
   FujiIWMPacket(const FujiIWMPacket&) = delete;
   FujiIWMPacket& operator=(const FujiIWMPacket&) = delete;
-
 };
 
 #endif /* FUJIIWMPACKET_H */

--- a/lib/bus/rs232/FujiBusPacket.h
+++ b/lib/bus/rs232/FujiBusPacket.h
@@ -1,6 +1,7 @@
 #ifndef FUJIBUSPACKET_H
 #define FUJIBUSPACKET_H
 
+#include "PacketParam.h"
 #include "fujiDeviceID.h"
 #include "fujiCommandID.h"
 
@@ -21,31 +22,6 @@ enum {
 
 // Raw byte buffer for on-the-wire data
 using ByteBuffer = std::vector<std::uint8_t>;
-
-struct PacketParam {
-    std::uint32_t value;
-    std::uint8_t  size;   // 1, 2, or 4 bytes
-
-    template<typename T>
-    PacketParam(T v)
-        : value(static_cast<std::uint32_t>(v))
-        , size(static_cast<std::uint8_t>(sizeof(T)))
-    {
-        static_assert(
-            std::is_same_v<T, std::uint8_t>  ||
-            std::is_same_v<T, std::uint16_t> ||
-            std::is_same_v<T, std::uint32_t>,
-            "Param can only be uint8_t, uint16_t, or uint32_t"
-        );
-    }
-
-    PacketParam(std::uint32_t v, std::uint8_t s)
-        : value(v)
-        , size(s)
-    {
-        assert(s == 1 || s == 2 || s == 4);
-    }
-};
 
 class FujiBusPacket
 {
@@ -97,7 +73,7 @@ public:
     fujiCommandID_t command() const { return _command; }
 
     std::uint32_t param(unsigned int index) const {
-        return _params[index].value;
+        return _params.at(index).value;
     }
 
     unsigned int paramCount() const {

--- a/lib/bus/sio/FujiSIOPacket.h
+++ b/lib/bus/sio/FujiSIOPacket.h
@@ -1,6 +1,7 @@
 #ifndef FUJISIOPACKET_H
 #define FUJISIOPACKET_H
 
+#include "PacketParamProxy.h"
 #include "cmdFrame.h"
 
 #include <optional>
@@ -15,37 +16,8 @@ private:
     mutable std::optional<ByteBuffer> _data;
     mutable unsigned _paramSize;
 
-    struct PacketParamProxy
-    {
-        size_t index;
-        const FujiSIOPacket *packet;
-
-        // These tell the compiler: "Run this code if the destination matches my type"
-        operator bool() const {
-            return static_cast<uint8_t>(*this) != 0;
-        }
-
-        // These tell the compiler exactly how to handle direct equality checks
-        // against any integer type without triggering conversion rule debates.
-
-        bool operator==(uint8_t val) const {
-            return static_cast<uint8_t>(*this) == val;
-        }
-
-        bool operator==(uint16_t val) const {
-            return static_cast<uint16_t>(*this) == val;
-        }
-
-        inline operator uint8_t() const {
-            return packet->getParam(index, sizeof(uint8_t));
-        }
-
-        inline operator uint16_t() const {
-            return packet->getParam(index, sizeof(uint16_t));
-        }
-    };
-
-    friend PacketParamProxy;
+    using ParamProxy = PacketParamProxy<FujiSIOPacket>;
+    friend ParamProxy;
 
     uint16_t getParam(size_t index, size_t psize) const;
 
@@ -59,7 +31,7 @@ public:
     fujiDeviceID_t device() const { return frame.device; }
     fujiCommandID_t command() const { return frame.comnd; }
 
-    PacketParamProxy param(size_t index) const { return PacketParamProxy{ index, this }; }
+    ParamProxy param(size_t index) const { return ParamProxy{ index, this }; }
 
     // Completes deserialization by reading the trailing data field once its
     // length has been determined from command-specific context.
@@ -74,7 +46,7 @@ public:
         return std::string(reinterpret_cast<const char *>(d->data()), d->size());
     }
 
-    // Explicit alternatives to the implicit PacketParamProxy conversions.
+    // Explicit alternatives to the implicit ParamProxy conversions.
     // These may be preferred where the destination type is not obvious.
     uint8_t  param8(size_t index)  const { return (uint8_t) param(index); }
     uint16_t param16(size_t index) const { return (uint16_t) param(index); }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,6 +8,7 @@ add_executable(fujibuspacket_tests
 target_include_directories(fujibuspacket_tests PRIVATE
     ${CMAKE_SOURCE_DIR}/include/      # for debug.h, etc.
     ${CMAKE_SOURCE_DIR}/lib/
+    ${CMAKE_SOURCE_DIR}/lib/bus/
     ${CMAKE_SOURCE_DIR}/components_pc/
 )
 


### PR DESCRIPTION
Move PacketParam and PacketParamProxy into their own .h files since they are shared by so many different bus packets.