### PR TITLE
atari: netstream: use ephemeral port for localhost udp, fix regression

### DIFF
--- a/lib/device/sio/netstream.cpp
+++ b/lib/device/sio/netstream.cpp
@@ -6,6 +6,7 @@
 #include "../../include/pinmap.h"
 
 #include "cassette.h"
+#include "compat_inet.h"
 #include "fnSystem.h"
 #include "fnConfig.h"
 #include "utils.h"
@@ -371,8 +372,11 @@ void sioNetStream::sio_enable_netstream()
 
     if (netstreamMode == NetStreamMode::UDP)
     {
-        // Open the UDP connection
-        netStreamUdp.begin(netstream_port);
+        // Open the UDP connection. Use ephemeral port when targeting localhost.
+        uint32_t host_ip = ntohl((uint32_t)netstream_host_ip);
+        bool is_loopback = (host_ip & 0xFF000000u) == 0x7F000000u;
+        uint16_t local_port = is_loopback ? 0 : (uint16_t)netstream_port;
+        netStreamUdp.begin(local_port);
         if (netstreamRegisterEnabled)
         {
             const char* str = "REGISTER";

--- a/lib/device/sio/sioFuji.cpp
+++ b/lib/device/sio/sioFuji.cpp
@@ -634,7 +634,8 @@ void sioFuji::sio_enable_netstream(const FujiSIOPacket &packet)
     memcpy(host_out, host, copy_len);
     host_out[copy_len] = '\0';
 
-    uint16_t port = packet.param(0);
+    uint16_t port = (static_cast<uint16_t>(packet.param8(0)) << 8) |
+                    packet.param8(1);
 
     Debug_printf("Fuji cmd ENABLE NETSTREAM: HOST:%s PORT: %d\n", host_out, port);
 #ifdef DEBUG_NETSTREAM


### PR DESCRIPTION
This is really only useful for fujinet-pc, unless you are running a game server on the esp32 also :grin: 