### PR TITLE
Changing fujiDevice mixins to return a list commands they accept.

### DIFF
--- a/lib/device/Base64Mixin.cpp
+++ b/lib/device/Base64Mixin.cpp
@@ -4,8 +4,10 @@
 
 #ifdef FUJI_BASE64_MIXIN_ENABLED
 
-void Base64Mixin::encode_input(uint16_t len)
+void Base64Mixin::encode_input(const FUJI_COMMAND_PACKET &packet)
 {
+    uint16_t len = packet.param(0);
+
     SYSTEM_BUS.transaction_accept(TRANS_STATE::WILL_GET);
 
     Debug_printf("Base64Mixin: enode_input\n");
@@ -23,7 +25,7 @@ void Base64Mixin::encode_input(uint16_t len)
     SYSTEM_BUS.transaction_success();
 }
 
-void Base64Mixin::encode_compute()
+void Base64Mixin::encode_compute(const FUJI_COMMAND_PACKET &packet)
 {
     size_t out_len;
 
@@ -48,7 +50,7 @@ void Base64Mixin::encode_compute()
     SYSTEM_BUS.transaction_success();
 }
 
-void Base64Mixin::encode_length()
+void Base64Mixin::encode_length(const FUJI_COMMAND_PACKET &packet)
 {
     SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
     Debug_printf("Base64Mixin: ENCODE LENGTH\n");
@@ -64,8 +66,10 @@ void Base64Mixin::encode_length()
     SYSTEM_BUS.transaction_send(&response, sizeof(response), false);
 }
 
-void Base64Mixin::encode_output(uint16_t len)
+void Base64Mixin::encode_output(const FUJI_COMMAND_PACKET &packet)
 {
+    uint16_t len = packet.param(0);
+
     SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
     Debug_printf("Base64Mixin: ENCODE OUTPUT\n");
 
@@ -92,8 +96,10 @@ void Base64Mixin::encode_output(uint16_t len)
     base64.base64_buffer.shrink_to_fit();
 }
 
-void Base64Mixin::decode_input(uint16_t len)
+void Base64Mixin::decode_input(const FUJI_COMMAND_PACKET &packet)
 {
+    uint16_t len = packet.param(0);
+
     SYSTEM_BUS.transaction_accept(TRANS_STATE::WILL_GET);
 
     Debug_printf("Base64Mixin: DECODE INPUT\n");
@@ -111,7 +117,7 @@ void Base64Mixin::decode_input(uint16_t len)
     SYSTEM_BUS.transaction_success();
 }
 
-void Base64Mixin::decode_compute()
+void Base64Mixin::decode_compute(const FUJI_COMMAND_PACKET &packet)
 {
     size_t out_len;
 
@@ -134,7 +140,7 @@ void Base64Mixin::decode_compute()
     SYSTEM_BUS.transaction_success();
 }
 
-void Base64Mixin::decode_length()
+void Base64Mixin::decode_length(const FUJI_COMMAND_PACKET &packet)
 {
     SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
     Debug_printf("Base64Mixin: DECODE LENGTH\n");
@@ -150,8 +156,10 @@ void Base64Mixin::decode_length()
     SYSTEM_BUS.transaction_send(&response, sizeof(response), false);
 }
 
-void Base64Mixin::decode_output(uint16_t len)
+void Base64Mixin::decode_output(const FUJI_COMMAND_PACKET &packet)
 {
+    uint16_t len = packet.param(0);
+
     SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
     Debug_printf("Base64Mixin: DECODE OUTPUT\n");
 
@@ -177,42 +185,6 @@ void Base64Mixin::decode_output(uint16_t len)
     base64.base64_buffer.erase(0, len);
     base64.base64_buffer.shrink_to_fit();
     SYSTEM_BUS.transaction_send(p.data(), len, false);
-}
-
-bool Base64Mixin::processCommand(const FUJI_COMMAND_PACKET &packet)
-{
-    switch (packet.command())
-    {
-    case FUJICMD_BASE64_ENCODE_INPUT:
-        encode_input(packet.param(0));
-        break;
-    case FUJICMD_BASE64_ENCODE_COMPUTE:
-        encode_compute();
-        break;
-    case FUJICMD_BASE64_ENCODE_LENGTH:
-        encode_length();
-        break;
-    case FUJICMD_BASE64_ENCODE_OUTPUT:
-        encode_output(packet.param(0));
-        break;
-    case FUJICMD_BASE64_DECODE_INPUT:
-        decode_input(packet.param(0));
-        break;
-    case FUJICMD_BASE64_DECODE_COMPUTE:
-        decode_compute();
-        break;
-    case FUJICMD_BASE64_DECODE_LENGTH:
-        decode_length();
-        break;
-    case FUJICMD_BASE64_DECODE_OUTPUT:
-        decode_output(packet.param(0));
-        break;
-
-    default:
-        return false;
-    }
-
-    return true;
 }
 
 #endif // FUJI_BASE64_MIXIN_ENABLED

--- a/lib/device/Base64Mixin.h
+++ b/lib/device/Base64Mixin.h
@@ -8,18 +8,34 @@
 
 class Base64Mixin : public FujiDeviceMixin
 {
-protected:
-    void encode_input(uint16_t len);
-    void encode_compute();
-    void encode_length();
-    void encode_output(uint16_t len);
-    void decode_input(uint16_t len);
-    void decode_compute();
-    void decode_length();
-    void decode_output(uint16_t len);
+private:
+    FujiMixinCommandHandlers handlers;
 
- public:
-    bool processCommand(const FUJI_COMMAND_PACKET &packet) override;
+protected:
+    FujiMixinCommandHandlers commandHandlers() override { return handlers; }
+
+    void encode_input(const FUJI_COMMAND_PACKET &packet);
+    void encode_compute(const FUJI_COMMAND_PACKET &packet);
+    void encode_length(const FUJI_COMMAND_PACKET &packet);
+    void encode_output(const FUJI_COMMAND_PACKET &packet);
+    void decode_input(const FUJI_COMMAND_PACKET &packet);
+    void decode_compute(const FUJI_COMMAND_PACKET &packet);
+    void decode_length(const FUJI_COMMAND_PACKET &packet);
+    void decode_output(const FUJI_COMMAND_PACKET &packet);
+
+public:
+    Base64Mixin() {
+        handlers = {
+            { FUJICMD_BASE64_ENCODE_INPUT,   FM_CMD_HANDLER(encode_input)   },
+            { FUJICMD_BASE64_ENCODE_COMPUTE, FM_CMD_HANDLER(encode_compute) },
+            { FUJICMD_BASE64_ENCODE_LENGTH,  FM_CMD_HANDLER(encode_length)  },
+            { FUJICMD_BASE64_ENCODE_OUTPUT,  FM_CMD_HANDLER(encode_output)  },
+            { FUJICMD_BASE64_DECODE_INPUT,   FM_CMD_HANDLER(decode_input)   },
+            { FUJICMD_BASE64_DECODE_COMPUTE, FM_CMD_HANDLER(decode_compute) },
+            { FUJICMD_BASE64_DECODE_LENGTH,  FM_CMD_HANDLER(decode_length)  },
+            { FUJICMD_BASE64_DECODE_OUTPUT,  FM_CMD_HANDLER(decode_output)  },
+        };
+    }
 };
 
 #endif // FUJI_MIXINS_ENABLED

--- a/lib/device/FujiDeviceMixin.h
+++ b/lib/device/FujiDeviceMixin.h
@@ -3,18 +3,43 @@
 
 #include "bus.h"
 
+#include <unordered_map>
+
 #ifdef FUJI_COMMAND_PACKET
 #define FUJI_MIXINS_ENABLED
 #endif
 
 #ifdef FUJI_MIXINS_ENABLED
 
-#include "bus.h"
+class FujiDeviceMixin;
+using FujiMixinCommandHandlers = std::unordered_map<
+    fujiCommandID_t,
+    void (FujiDeviceMixin::*)(const FUJI_COMMAND_PACKET&)
+    >;
+
+#define FM_CMD_HANDLER(Method) \
+    static_cast<void (FujiDeviceMixin::*)(const FUJI_COMMAND_PACKET&)>(&std::remove_pointer_t<decltype(this)>::Method)
+
 
 class FujiDeviceMixin : public virtual virtualDevice
 {
+protected:
+    virtual FujiMixinCommandHandlers commandHandlers() = 0;
+
 public:
-    virtual bool processCommand(const FUJI_COMMAND_PACKET &packet) { return false; }
+    bool recognizesCommand(const FUJI_COMMAND_PACKET &packet) {
+        auto handlers = commandHandlers();
+        return handlers.find(packet.command()) != handlers.end();
+    }
+    virtual bool processCommand(const FUJI_COMMAND_PACKET &packet) {
+        auto handlers = commandHandlers();
+        auto cmdHandler = handlers.find(packet.command());
+        if (cmdHandler == handlers.end())
+            return false;
+        auto cmdMethod = cmdHandler->second;
+        (this->*cmdMethod)(packet);
+        return true;
+    }
 };
 
 #endif // FUJI_MIXINS_ENABLED

--- a/lib/device/HashMixin.cpp
+++ b/lib/device/HashMixin.cpp
@@ -6,8 +6,10 @@
 
 constexpr uint8_t MODE_HEX = 1;
 
-void HashMixin::hash_input(uint16_t len)
+void HashMixin::hash_input(const FUJI_COMMAND_PACKET &packet)
 {
+    uint16_t len = packet.param(0);
+
     SYSTEM_BUS.transaction_accept(TRANS_STATE::WILL_GET);
 
     Debug_printf("HashMixin: INPUT\n");
@@ -25,8 +27,11 @@ void HashMixin::hash_input(uint16_t len)
     SYSTEM_BUS.transaction_success();
 }
 
-void HashMixin::hash_compute(bool clear_data, Hash::Algorithm algo)
+void HashMixin::hash_compute(const FUJI_COMMAND_PACKET &packet)
 {
+    Hash::Algorithm algo = Hash::to_algorithm(packet.param(0));
+    bool clear_data = packet.command() == FUJICMD_HASH_COMPUTE;
+
     SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
     Debug_printf("HashMixin: COMPUTE\n");
     _algorithm = algo;
@@ -34,16 +39,20 @@ void HashMixin::hash_compute(bool clear_data, Hash::Algorithm algo)
     SYSTEM_BUS.transaction_success();
 }
 
-void HashMixin::hash_length(bool as_hex)
+void HashMixin::hash_length(const FUJI_COMMAND_PACKET &packet)
 {
+    bool as_hex = packet.param(0) == MODE_HEX;
+
     SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
     Debug_printf("HashMixin: LENGTH\n");
     uint8_t r = hasher.hash_length(_algorithm, as_hex);
     SYSTEM_BUS.transaction_send(&r, 1, false);
 }
 
-void HashMixin::hash_output(bool as_hex)
+void HashMixin::hash_output(const FUJI_COMMAND_PACKET &packet)
 {
+    bool as_hex = packet.param(0) == MODE_HEX;
+
     SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
     Debug_printf("HashMixin: OUTPUT\n");
 
@@ -58,42 +67,12 @@ void HashMixin::hash_output(bool as_hex)
     SYSTEM_BUS.transaction_send(hashed_data.data(), hashed_data.size(), false);
 }
 
-void HashMixin::hash_clear()
+void HashMixin::hash_clear(const FUJI_COMMAND_PACKET &packet)
 {
     SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
     Debug_printf("HashMixin: CLEAR\n");
     hasher.clear();
     SYSTEM_BUS.transaction_success();
-}
-
-bool HashMixin::processCommand(const FUJI_COMMAND_PACKET &packet)
-{
-    switch (packet.command())
-    {
-    case FUJICMD_HASH_INPUT:
-        hash_input(packet.param(0));
-        break;
-    case FUJICMD_HASH_COMPUTE:
-        hash_compute(true, Hash::to_algorithm(packet.param(0)));
-        break;
-    case FUJICMD_HASH_COMPUTE_NO_CLEAR:
-        hash_compute(false, Hash::to_algorithm(packet.param(0)));
-        break;
-    case FUJICMD_HASH_LENGTH:
-        hash_length(packet.param(0) == MODE_HEX);
-        break;
-    case FUJICMD_HASH_OUTPUT:
-        hash_output(packet.param(0) == MODE_HEX);
-        break;
-    case FUJICMD_HASH_CLEAR:
-        hash_clear();
-        break;
-
-    default:
-        return false;
-    }
-
-    return true;
 }
 
 #endif // FUJI_HASH_MIXIN_ENABLED

--- a/lib/device/HashMixin.h
+++ b/lib/device/HashMixin.h
@@ -9,17 +9,32 @@
 
 class HashMixin : public FujiDeviceMixin
 {
+private:
+    FujiMixinCommandHandlers handlers = {
+    };
+
 protected:
     Hash::Algorithm _algorithm = Hash::Algorithm::UNKNOWN;
 
-    void hash_input(uint16_t len);
-    void hash_compute(bool clear_data, Hash::Algorithm algo);
-    void hash_length(bool as_hex);
-    void hash_output(bool as_hex);
-    void hash_clear();
+    FujiMixinCommandHandlers commandHandlers() override { return handlers; }
+
+    void hash_input(const FUJI_COMMAND_PACKET &packet);
+    void hash_compute(const FUJI_COMMAND_PACKET &packet);
+    void hash_length(const FUJI_COMMAND_PACKET &packet);
+    void hash_output(const FUJI_COMMAND_PACKET &packet);
+    void hash_clear(const FUJI_COMMAND_PACKET &packet);
 
 public:
-    bool processCommand(const FUJI_COMMAND_PACKET &packet) override;
+    HashMixin() {
+        handlers = {
+            { FUJICMD_HASH_INPUT,            FM_CMD_HANDLER(hash_input)   },
+            { FUJICMD_HASH_COMPUTE,          FM_CMD_HANDLER(hash_compute) },
+            { FUJICMD_HASH_COMPUTE_NO_CLEAR, FM_CMD_HANDLER(hash_compute) },
+            { FUJICMD_HASH_LENGTH,           FM_CMD_HANDLER(hash_length)  },
+            { FUJICMD_HASH_OUTPUT,           FM_CMD_HANDLER(hash_output)  },
+            { FUJICMD_HASH_CLEAR,            FM_CMD_HANDLER(hash_clear)   },
+        };
+    }
 };
 
 #endif // FUJI_MIXINS_ENABLED

--- a/lib/device/QRMixin.cpp
+++ b/lib/device/QRMixin.cpp
@@ -6,8 +6,10 @@
 #include "debug.h"
 #include "../qrcode/qrmanager.h"
 
-void QRMixin::qr_input(uint16_t len)
+void QRMixin::qr_input(const FUJI_COMMAND_PACKET &packet)
 {
+    uint16_t len = packet.param(0);
+
     SYSTEM_BUS.transaction_accept(TRANS_STATE::WILL_GET);
 
     Debug_printf("QRMixin: INPUT (len: %d)\n", len);
@@ -25,16 +27,18 @@ void QRMixin::qr_input(uint16_t len)
     SYSTEM_BUS.transaction_success();
 }
 
-void QRMixin::qr_encode(uint8_t version, uint8_t ecc_raw, uint8_t shorten_raw)
+void QRMixin::qr_encode(const FUJI_COMMAND_PACKET &packet)
 {
-    SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
+    uint8_t version = ((uint8_t) packet.param(0)) & 0x7f;
+    qr_ecc_t ecc = (qr_ecc_t) (((uint8_t) packet.param(1)) & 0x03);
+#ifdef BUILD_ATARI
+    // SIO only has aux1/aux2 so shorten is store in high nybble of 2nd param
+    bool shorten = (uint8_t) packet.param(1) >> 4;
+#else
+    bool shorten = (uint8_t) packet.param(2);
+#endif
 
-    // Platforms with 3 free params send ecc and shorten as separate bytes; those
-    // limited to 2 params merge shorten into the high nibble of the ecc byte.
-    // Accept either so every bus's client encoding works.
-    version &= 0x7f;
-    uint8_t ecc = ecc_raw & 0x03;
-    bool shorten = (shorten_raw & 0x01) || ((ecc_raw >> 4) & 0x01);
+    SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
 
     Debug_printf("QRMixin: ENCODE (version: %d, ecc: %d, shorten: %s)\n", version, ecc, shorten ? "Y" : "N");
 
@@ -42,7 +46,7 @@ void QRMixin::qr_encode(uint8_t version, uint8_t ecc_raw, uint8_t shorten_raw)
         qrManager.data = fnHTTPD.shorten_url(qrManager.data);
 
     qrManager.version(version);
-    qrManager.ecc((qr_ecc_t)ecc);
+    qrManager.ecc(ecc);
     qrManager.output_mode = QR_OUTPUT_MODE_BINARY;
     qrManager.encode();
 
@@ -61,8 +65,10 @@ void QRMixin::qr_encode(uint8_t version, uint8_t ecc_raw, uint8_t shorten_raw)
     SYSTEM_BUS.transaction_success();
 }
 
-void QRMixin::qr_length(uint8_t output_mode)
+void QRMixin::qr_length(const FUJI_COMMAND_PACKET &packet)
 {
+    uint8_t output_mode = packet.param(0);
+
     SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
     Debug_printf("QRMixin: LENGTH (output mode: %d)\n", output_mode);
 
@@ -85,8 +91,10 @@ void QRMixin::qr_length(uint8_t output_mode)
     SYSTEM_BUS.transaction_send(&response, sizeof(response), false);
 }
 
-void QRMixin::qr_output(uint16_t len)
+void QRMixin::qr_output(const FUJI_COMMAND_PACKET &packet)
 {
+    uint16_t len = packet.param(0);
+
     SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
     Debug_printf("QRMixin: OUTPUT (len: %d)\n", len);
 
@@ -106,35 +114,6 @@ void QRMixin::qr_output(uint16_t len)
     SYSTEM_BUS.transaction_send(qrManager.code.data(), len, false);
     qrManager.code.erase(qrManager.code.begin(), qrManager.code.begin() + len);
     qrManager.code.shrink_to_fit();
-}
-
-bool QRMixin::processCommand(const FUJI_COMMAND_PACKET &packet)
-{
-    switch (packet.command())
-    {
-    case FUJICMD_QRCODE_INPUT:
-        qr_input(packet.param(0));
-        break;
-    case FUJICMD_QRCODE_ENCODE:
-#ifdef BUILD_ATARI
-        // SIO only has aux1/aux2 so shorten is store in high nybble of 2nd param
-        qr_encode(packet.param(0), packet.param(1), (uint8_t)packet.param(1)>>4);
-#else
-        qr_encode(packet.param(0), packet.param(1), packet.param(2));
-#endif
-        break;
-    case FUJICMD_QRCODE_LENGTH:
-        qr_length(packet.param(0));
-        break;
-    case FUJICMD_QRCODE_OUTPUT:
-        qr_output(packet.param(0));
-        break;
-
-    default:
-        return false;
-    }
-
-    return true;
 }
 
 #endif // FUJI_QR_MIXIN_ENABLED

--- a/lib/device/QRMixin.h
+++ b/lib/device/QRMixin.h
@@ -8,14 +8,32 @@
 
 class QRMixin : public FujiDeviceMixin
 {
+private:
+    FujiMixinCommandHandlers handlers = {
+    };
+
 protected:
-    void qr_input(uint16_t len);
-    void qr_encode(uint8_t version, uint8_t ecc_raw, uint8_t shorten_raw);
-    void qr_length(uint8_t output_mode);
-    void qr_output(uint16_t len);
+    FujiMixinCommandHandlers commandHandlers() override { return handlers; }
+
+    void qr_input(const FUJI_COMMAND_PACKET &packet);
+    void qr_encode(const FUJI_COMMAND_PACKET &packet);
+    void qr_length(const FUJI_COMMAND_PACKET &packet);
+    void qr_output(const FUJI_COMMAND_PACKET &packet);
 
 public:
-    bool processCommand(const FUJI_COMMAND_PACKET &packet) override;
+    QRMixin() {
+        handlers = {
+            { FUJICMD_QRCODE_INPUT,            FM_CMD_HANDLER(qr_input)   },
+            { FUJICMD_QRCODE_ENCODE,          FM_CMD_HANDLER(qr_encode) },
+            { FUJICMD_QRCODE_LENGTH,           FM_CMD_HANDLER(qr_length)  },
+            { FUJICMD_QRCODE_OUTPUT,           FM_CMD_HANDLER(qr_output)  },
+
+#if 0
+            // FIXME - this is missing
+            { FUJICMD_QRCODE_CLEAR,            FM_CMD_HANDLER(qr_clear)   },
+#endif
+        };
+    }
 };
 
 #endif // FUJI_MIXINS_ENABLED

--- a/lib/device/fujiDevice.h
+++ b/lib/device/fujiDevice.h
@@ -142,6 +142,10 @@ class FujiDeviceChain : public FujiDeviceMixins...
         // Try each mixin's processCommand() until one returns true
         return (FujiDeviceMixins::processCommand(packet) || ...);
     }
+    bool checkAllMixins(const FUJI_COMMAND_PACKET &packet) {
+        // Try each mixin's processCommand() until one returns true
+        return (FujiDeviceMixins::recognizesCommand(packet) || ...);
+    }
 
  public:
     bool processCommand(const FUJI_COMMAND_PACKET &packet) override {
@@ -203,7 +207,11 @@ public:
 
 #ifdef FUJI_MIXINS_ENABLED
     // Return true if command was handled here
-    bool processCommand(const FUJI_COMMAND_PACKET &packet) override {
+    bool processCommand(const FUJI_COMMAND_PACKET &packet) {
+        return tryAllMixins(packet);
+    }
+    // Return true if command is one that can be handled
+    bool recognizesCommand(const FUJI_COMMAND_PACKET &packet) {
         return tryAllMixins(packet);
     }
 #endif // FUJI_MIXINS_ENABLED


### PR DESCRIPTION
Changing fujiDevice mixins to return a list of all the commands they accept. This removes the giant switch statement and makes it possible to check to see if a command is supported before trying to call it.