### PR TITLE
Highscore write-read fixes

### DIFF
--- a/lib/FileSystem/fnFile.h
+++ b/lib/FileSystem/fnFile.h
@@ -23,6 +23,9 @@ public:
     virtual size_t write(const void *ptr, size_t size, size_t n) = 0;
     virtual int flush() = 0;
     virtual int eof() {return 0;}; // TODO!
+
+    // Drop cached content after the file was modified via another handle
+    virtual void invalidate_cache() {};
 };
 
 #endif // FN_FILE_H

--- a/lib/FileSystem/fnFileTNFS.cpp
+++ b/lib/FileSystem/fnFileTNFS.cpp
@@ -155,6 +155,17 @@ size_t FileHandlerTNFS::write(const void *ptr, size_t size, size_t count)
 }
 
 
+void FileHandlerTNFS::invalidate_cache()
+{
+    Debug_println("FileHandlerTNFS::invalidate_cache");
+    tnfsFileHandleInfo *pFileInf = _mountinfo == nullptr
+                                 ? nullptr : _mountinfo->get_filehandleinfo(_handle);
+    if (pFileInf == nullptr)
+        return;
+    tnfs_lseek(_mountinfo, _handle, pFileInf->cached_pos, SEEK_SET, nullptr, true); // skip_cache
+}
+
+
 int FileHandlerTNFS::flush()
 {
     Debug_println("FileHandlerTNFS::flush");

--- a/lib/FileSystem/fnFileTNFS.h
+++ b/lib/FileSystem/fnFileTNFS.h
@@ -26,6 +26,7 @@ public:
     virtual size_t read(void *ptr, size_t size, size_t count) override;
     virtual size_t write(const void *ptr, size_t size, size_t count) override;
     virtual int flush() override;
+    virtual void invalidate_cache() override;
 };
 
 

--- a/lib/FileSystem/fnio.h
+++ b/lib/FileSystem/fnio.h
@@ -60,6 +60,9 @@ namespace fnio
     static inline int fclose(fnFile *f)
     { return std::fclose(f); }
 
+    static inline void finvalidate_cache(fnFile *f)
+    { (void)f; }
+
 #else
     static inline size_t fread(void *ptr, size_t size, size_t n, fnFile *f) 
     { return f->read(ptr, size, n); }
@@ -81,6 +84,9 @@ namespace fnio
 
     static inline int fclose(fnFile *f)
     { return f->close(); }
+
+    static inline void finvalidate_cache(fnFile *f)
+    { f->invalidate_cache(); }
 
 #endif
 

--- a/lib/media/drivewire/mediaTypeDSK.cpp
+++ b/lib/media/drivewire/mediaTypeDSK.cpp
@@ -35,7 +35,8 @@ error_is_true MediaTypeDSK::read(uint32_t blockNum, uint16_t *readcount)
 
     bool err = false;
     // Perform a seek if we're not reading the sector after the last one we read
-    if (blockNum != _media_last_block + 1)
+    // (INVALID_SECTOR_VALUE + 1 wraps to 0, which would skip the seek for block 0)
+    if (_media_last_block == INVALID_SECTOR_VALUE || blockNum != _media_last_block + 1)
     {
         uint32_t offset = _block_to_offset(blockNum);
         err = fnio::fseek(_media_fileh, offset, SEEK_SET) != 0;
@@ -119,6 +120,7 @@ error_is_true MediaTypeDSK::write(uint32_t blockNum, bool verify)
     {
         fnio::fclose(hsFileh);
         _media_fileh = oldFileh;
+        fnio::finvalidate_cache(_media_fileh); // write went via hsFileh, not this handle
     }
 
     _media_last_block = INVALID_SECTOR_VALUE;

--- a/lib/media/drivewire/mediaTypeMRM.cpp
+++ b/lib/media/drivewire/mediaTypeMRM.cpp
@@ -35,7 +35,8 @@ error_is_true MediaTypeMRM::read(uint32_t blockNum, uint16_t *readcount)
 
     bool err = false;
     // Perform a seek if we're not reading the sector after the last one we read
-    if (blockNum != _media_last_block + 1)
+    // (INVALID_SECTOR_VALUE + 1 wraps to 0, which would skip the seek for block 0)
+    if (_media_last_block == INVALID_SECTOR_VALUE || blockNum != _media_last_block + 1)
     {
         uint32_t offset = _block_to_offset(blockNum);
         err = fnio::fseek(_media_fileh, offset, SEEK_SET) != 0;

--- a/lib/media/drivewire/mediaTypeVDK.cpp
+++ b/lib/media/drivewire/mediaTypeVDK.cpp
@@ -37,7 +37,8 @@ error_is_true MediaTypeVDK::read(uint32_t blockNum, uint16_t *readcount)
 
     bool err = false;
     // Perform a seek if we're not reading the sector after the last one we read
-    if (blockNum != _media_last_block + 1)
+    // (INVALID_SECTOR_VALUE + 1 wraps to 0, which would skip the seek for block 0)
+    if (_media_last_block == INVALID_SECTOR_VALUE || blockNum != _media_last_block + 1)
     {
         uint32_t offset = _block_to_offset(blockNum);
         err = fnio::fseek(_media_fileh, offset, SEEK_SET) != 0;

--- a/lib/media/h89/mediaTypeIMG.cpp
+++ b/lib/media/h89/mediaTypeIMG.cpp
@@ -171,7 +171,7 @@ bool MediaTypeIMG::read(uint16_t sectornum, uint16_t *readcount)
 
     bool err = false;
     // Perform a seek if we're not reading the sector after the last one we read
-    if (sectornum != _media_last_sector + 1)
+    if (_media_last_sector == INVALID_SECTOR_VALUE || sectornum != _media_last_sector + 1)
     {
         uint32_t offset = _sector_to_offset(sectornum);
         err = fseek(_media_fileh, offset, SEEK_SET) != 0;
@@ -209,7 +209,7 @@ bool MediaTypeIMG::write(uint16_t sectornum, bool verify)
 
     // Perform a seek if we're writing to the sector after the last one
     int e;
-    if (sectornum != _media_last_sector + 1)
+    if (_media_last_sector == INVALID_SECTOR_VALUE || sectornum != _media_last_sector + 1)
     {
         e = fseek(_media_fileh, offset, SEEK_SET);
         if (e != 0)

--- a/lib/media/lynx/mediaTypeROM.cpp
+++ b/lib/media/lynx/mediaTypeROM.cpp
@@ -34,7 +34,7 @@ error_is_true MediaTypeROM::read(uint32_t blockNum, uint16_t *readcount)
 
     bool err = false;
     // // Perform a seek if we're not reading the sector after the last one we read
-     if (blockNum != _media_last_block + 1)
+     if (_media_last_block == INVALID_SECTOR_VALUE || blockNum != _media_last_block + 1)
      {
         uint32_t offset = _block_to_offset(blockNum);
         err = fseek(_media_fileh, offset, SEEK_SET) != 0;

--- a/lib/media/new/mediaTypeDDP.cpp
+++ b/lib/media/new/mediaTypeDDP.cpp
@@ -34,7 +34,7 @@ bool MediaTypeDDP::read(uint32_t blockNum, uint16_t *readcount)
 
     bool err = false;
     // Perform a seek if we're not reading the sector after the last one we read
-    if (blockNum != _media_last_block + 1)
+    if (_media_last_block == INVALID_SECTOR_VALUE || blockNum != _media_last_block + 1)
     {
         uint32_t offset = _block_to_offset(blockNum);
         err = fseek(_media_fileh, offset, SEEK_SET) != 0;
@@ -64,7 +64,7 @@ bool MediaTypeDDP::write(uint32_t blockNum, bool verify)
 
     // Perform a seek if we're writing to the sector after the last one
     int e;
-//    if (blockNum != _media_last_block + 1)
+//    if (_media_last_block == INVALID_SECTOR_VALUE || blockNum != _media_last_block + 1)
 //    {
         e = fseek(_media_fileh, offset, SEEK_SET);
         if (e != 0)

--- a/lib/media/rc2014/mediaTypeIMG.cpp
+++ b/lib/media/rc2014/mediaTypeIMG.cpp
@@ -170,7 +170,7 @@ error_is_true MediaTypeIMG::read(uint16_t sectornum, uint16_t *readcount)
 
     bool err = false;
     // Perform a seek if we're not reading the sector after the last one we read
-    if (sectornum != _media_last_sector + 1)
+    if (_media_last_sector == INVALID_SECTOR_VALUE || sectornum != _media_last_sector + 1)
     {
         uint32_t offset = _sector_to_offset(sectornum);
         err = fseek(_media_fileh, offset, SEEK_SET) != 0;
@@ -207,7 +207,7 @@ error_is_true MediaTypeIMG::write(uint16_t sectornum, bool verify)
 
     // Perform a seek if we're writing to the sector after the last one
     int e;
-    if (sectornum != _media_last_sector + 1)
+    if (_media_last_sector == INVALID_SECTOR_VALUE || sectornum != _media_last_sector + 1)
     {
         e = fseek(_media_fileh, offset, SEEK_SET);
         if (e != 0)


### PR DESCRIPTION
- Fix stale sector reads after a high-score write on a read-only mount. The write is issued through a temporary read-write handle, so tnfs_write invalidated that handle's cache rather than the mount handle's. Subsequent reads of the sector returned pre-write contents while reporting success.
- Add FileHandler::invalidate_cache() (no-op by default, implemented for TNFS) plus an fnio wrapper, so a handle can drop cached content when the file is modified through another handle.
- Fix sector 0 being read without a seek. After a write, _media_last_block / _media_last_sector is set to INVALID_SECTOR_VALUE (0xFFFFFFFF); the sequential-access test adds one to that, wrapping to 0, so block 0 was mistaken for the next sequential block and read from whatever offset the previous operation left behind.
- The same wraparound affected the write path in the H89 and RC2014 IMG media types, where a write to sector 0 could be issued at the wrong file offset.
- Apply the sentinel guard to every media type using the sequential-access optimisation with a 0xFFFFFFFF sentinel: DriveWire DSK/VDK/MRM, H89 IMG, RC2014 IMG, Lynx ROM, new DDP.
- Observed symptom on CoCo: a game's high-score table was rewritten from scratch on every save, retaining only the most recent score, because the stale read failed the table's signature check.