### PR TITLE
atari: netstream: switch to SIO baud when MTR not active

### DIFF
--- a/lib/bus/sio/sio.cpp
+++ b/lib/bus/sio/sio.cpp
@@ -369,6 +369,13 @@ void systemBus::service()
     bool is_motor_asserted = false;
     is_motor_asserted = motor_asserted();
 
+    if (_streamDev != nullptr && _streamDev->netstreamActive && !is_motor_asserted
+        && getCurrentBaudrate() != getBaudrate())
+    {
+        Debug_printf("NETSTREAM: MOTOR de-assert, restoring baud %d\n", getBaudrate());
+        setBaudrate(getBaudrate());
+    }
+
     if (_streamDev != nullptr && _streamDev->netstreamActive && is_motor_asserted)
     {
         if (commandAsserted())


### PR DESCRIPTION
This allows apps to briefly switch back to regular SIO command mode if they need to load from disk or other device by deasserting MOTOR while still keeping the Netstream connection alive on FujiNet. This sets whatever baud was used for SIO before Netstream was enabled.