### PR TITLE
drivewire: network: send requested byte count and propagate read error

### DIFF
--- a/lib/device/drivewire/network.cpp
+++ b/lib/device/drivewire/network.cpp
@@ -206,9 +206,9 @@ void drivewireNetwork::read(uint16_t num_bytes)
     }
 
     // Do the channel read
-    read_channel(num_bytes);
+    fujiError_t err = read_channel(num_bytes);
 
-    SYSTEM_BUS.transaction_send(*receiveBuffer);
+    SYSTEM_BUS.transaction_send((uint8_t *)receiveBuffer->data(), num_bytes, err != FUJI_ERROR::NONE);
 
     // Remove from receive buffer and shrink.
     receiveBuffer->erase(0, num_bytes);


### PR DESCRIPTION
This fixes a problem with the current coco bounce-world client.