### PR TITLE
[rs232][network] clear devicespec buffer on open

### DIFF
--- a/lib/device/rs232/network.cpp
+++ b/lib/device/rs232/network.cpp
@@ -936,6 +936,7 @@ success_is_true rs232Network::instantiate_protocol()
 void rs232Network::create_devicespec(fileAccessMode_t access)
 {
     // Get Devicespec from buffer, and put into primary devicespec string
+    memset(devicespecBuf, 0, sizeof(devicespecBuf));
     SYSTEM_BUS.transaction_get(devicespecBuf, sizeof(devicespecBuf));
     util_devicespec_fix_9b(devicespecBuf, sizeof(devicespecBuf));
     deviceSpec = string((char *)devicespecBuf);


### PR DESCRIPTION
## Summary
- Stale bytes from a previous, longer devicespec could leak into the next `deviceSpec` string if the new one was shorter
- One-line `memset` fix in `create_devicespec()`

Split out of #1508 (see that PR for context).

## Test plan
- [ ] `pio run -e fujinet-rs232-s3` (or fujiversal-rs232) builds
- [ ] Open a network device with a long devicespec, then a shorter one, and confirm no stale trailing bytes appear