### PR TITLE
[fujiDevice] fail MOUNT_IMAGE when mount() returns MEDIATYPE_UNKNOWN

### DIFF
--- a/lib/device/fujiDevice/fujiDevice.cpp
+++ b/lib/device/fujiDevice/fujiDevice.cpp
@@ -520,6 +520,12 @@ success_is_true fujiDevice::fujicore_mount_disk_image_success(uint8_t deviceSlot
     disk.disk_type = disk_dev->mount(disk.fileh, disk.filename, disk.disk_size, access_mode);
     disk_dev->is_config_device = false;
 
+    // mount() returns MEDIATYPE_UNKNOWN on failure -- without this check that
+    // failure was silently swallowed and MOUNT_IMAGE ACKed as if it had
+    // succeeded.
+    if (disk.disk_type == MEDIATYPE_UNKNOWN)
+        RETURN_ERROR_AS_FALSE();
+
     RETURN_SUCCESS_AS_TRUE();
 }
 


### PR DESCRIPTION
## Summary
- `mount()` already signals failure by returning `MEDIATYPE_UNKNOWN` (e.g. media detection failing, or a platform's `mount()` rejecting the file), but `fujicore_mount_disk_image_success()` never checked the return value, so `MOUNT_IMAGE` was ACKed as successful regardless
- Adds the missing check

Split out of #1508 (see that PR for context). This is a genuine cross-platform behavior change: a platform that today returns `MEDIATYPE_UNKNOWN` on a mount the caller currently tolerates will start failing. #1512 (the Intellivision ROM media type) depends on this landing first, since a failed ROM push needs to surface as a MOUNT_IMAGE failure.

## Test plan
- [ ] `pio run` for a couple of affected platforms builds
- [ ] Mount a deliberately bad image on the Atari build and confirm MOUNT_IMAGE now returns an error rather than a false ACK
- [ ] Confirm normal ATR/XEX mounts still succeed on Atari and Adam