### PR TITLE
add device password + web UI to manage it

### DIFF
--- a/data/webui/template/www/index.tmpl.html
+++ b/data/webui/template/www/index.tmpl.html
@@ -1886,6 +1886,129 @@
 				</form>
 			</div>
 			{% endif %}
+			<div class="module" data-experimental>
+				<form id="password-form" action="/password" method="post">
+				<div class="settings">
+					<div class="settings-header">
+						SEC<span class="logowob"></span>URITY
+					</div>
+					<div class="settings-left">
+						<div class="svgicon">
+							<svg width="90%" height="90%" viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
+								<rect x="12" y="28" width="40" height="30" rx="4" fill="#f3a933" stroke="#000" stroke-width="3"/>
+								<path d="M22 28v-8a10 10 0 0 1 20 0v8" fill="none" stroke="#000" stroke-width="5"/>
+								<circle cx="32" cy="41" r="4.5"/>
+								<rect x="30" y="43" width="4" height="9"/>
+							</svg>
+						</div>
+					</div>
+					<div class="settings-content settings-45-55">
+						<div class="set">
+							<div class="settings-label">
+								<label>Device password</label>
+							</div>
+							<div class="settings-value">
+								<span id="password-state-indicator"></span>
+							</div>
+						</div>
+						<div class="set" id="password-current-row">
+							<div class="settings-label">
+								<label for="password_current">Current password</label>
+							</div>
+							<div class="settings-value">
+								<input type="password" name="current" id="password_current" autocomplete="current-password">
+							</div>
+						</div>
+						<div class="set">
+							<div class="settings-label">
+								<label for="password_new">New password</label>
+							</div>
+							<div class="settings-value">
+								<input type="password" name="new" id="password_new" autocomplete="new-password">
+							</div>
+						</div>
+						<div class="set">
+							<div class="settings-label">
+								<label for="password_confirm">Confirm new password</label>
+							</div>
+							<div class="settings-value">
+								<input type="password" name="confirm" id="password_confirm" autocomplete="new-password">
+							</div>
+						</div>
+						<hr>
+						<div class="settings-text">
+							<div>
+								The password is kept in flash, never on the SD card, and guards sensitive
+								operations such as the <a href="/private">Private</a> page.<br>
+								Re-flashing the firmware clears it.<br>
+								<span id="password-remove-hint">To remove the password, leave the new password blank.</span>
+							</div>
+							<div id="password-status"></div>
+						</div>
+					</div>
+					<div class="settings-footer">
+						<div class="save-button">
+							<button type="submit" value="Update">Update</button>
+						</div>
+					</div>
+				</div>
+				</form>
+				<script>
+					(function() {
+						var isSet = "<%FN_PASSWORD_SET%>" === "1";
+						var form = document.getElementById("password-form");
+						var statusEl = document.getElementById("password-status");
+						var indicator = document.getElementById("password-state-indicator");
+						var currentRow = document.getElementById("password-current-row");
+						var removeHint = document.getElementById("password-remove-hint");
+						var newInput = document.getElementById("password_new");
+						var confirmInput = document.getElementById("password_confirm");
+
+						function render() {
+							indicator.textContent = isSet ? "Set" : "Not set";
+							indicator.style.color = isSet ? "green" : "red";
+							currentRow.style.display = isSet ? "" : "none";
+							removeHint.style.display = isSet ? "" : "none";
+						}
+
+						form.addEventListener("submit", function(e) {
+							e.preventDefault();
+
+							// A blank new password on a device that has one means "remove it"
+							var clearing = isSet && newInput.value === "" && confirmInput.value === "";
+							var body = new URLSearchParams();
+							body.append("action", clearing ? "clear" : "set");
+							body.append("current", document.getElementById("password_current").value);
+							body.append("new", newInput.value);
+							body.append("confirm", confirmInput.value);
+							statusEl.textContent = "Saving...";
+							statusEl.style.color = "";
+							fetch("/password", {
+								method: "POST",
+								headers: {"Content-Type": "application/x-www-form-urlencoded"},
+								body: body.toString()
+							}).then(function(r) {
+								return r.json();
+							}).then(function(d) {
+								if (d.status === "ok") {
+									isSet = !!d.password_set;
+									form.reset();
+									render();
+									statusEl.style.color = "green";
+									statusEl.textContent = isSet ? "Password saved." : "Password removed.";
+								} else {
+									statusEl.style.color = "red";
+									statusEl.textContent = d.message || "Could not save the password.";
+								}
+							}).catch(function() {
+								statusEl.style.color = "red";
+								statusEl.textContent = "Could not reach FujiNet.";
+							});
+						});
+						render();
+					})();
+				</script>
+			</div>
 		</div>
 	</div>
 

--- a/fujinet_pc.cmake
+++ b/fujinet_pc.cmake
@@ -162,6 +162,7 @@ set(INCLUDE_DIRS include
 
 set(SOURCES src/main.cpp
     lib/config/fnConfig.h lib/config/fnConfig.cpp
+    lib/config/fnPassword.h lib/config/fnPassword.cpp
     lib/config/fnc_bt.cpp
     lib/config/fnc_cassette.cpp
     lib/config/fnc_cpm.cpp

--- a/lib/config/fnPassword.cpp
+++ b/lib/config/fnPassword.cpp
@@ -1,0 +1,398 @@
+#include "fnPassword.h"
+
+#include <cctype>
+#include <cstdio>
+#include <cstring>
+
+#include <mbedtls/sha256.h>
+#include <mbedtls/version.h>
+
+#include "../../include/debug.h"
+#include "../../include/version.h"
+#include "base64.h"
+
+#ifdef ESP_PLATFORM
+#include <esp_app_desc.h>
+#include <esp_random.h>
+#include <nvs.h>
+#else
+#include <random>
+#include "fsFlash.h"
+#endif
+
+#if MBEDTLS_VERSION_NUMBER >= 0x03000000 || MBEDTLS_VERSION_NUMBER < 0x02070000
+#define COMPAT_MBEDTLS_SHA256 mbedtls_sha256
+#else
+#define COMPAT_MBEDTLS_SHA256 mbedtls_sha256_ret
+#endif
+
+// Number of SHA-256 rounds used to derive the stored digest. High enough to
+// make an offline attack on a dumped flash image tedious, low enough that a
+// single HTTP request can afford one derivation.
+#define PASSWORD_HASH_ROUNDS 4096
+
+#define PASSWORD_SALT_BYTES 16
+
+#ifdef ESP_PLATFORM
+#define PASSWORD_NVS_NAMESPACE "fnpassword"
+#define PASSWORD_NVS_KEY_FWID "fwid"
+#define PASSWORD_NVS_KEY_SALT "salt"
+#define PASSWORD_NVS_KEY_HASH "hash"
+#else
+#define PASSWORD_FILENAME "/fnpassword"
+#endif
+
+FNPassword fnPassword;
+
+static std::string bytes_to_hex(const uint8_t *bytes, size_t len)
+{
+    static const char digits[] = "0123456789abcdef";
+    std::string out;
+    out.reserve(len * 2);
+    for (size_t i = 0; i < len; i++)
+    {
+        out += digits[bytes[i] >> 4];
+        out += digits[bytes[i] & 0x0F];
+    }
+    return out;
+}
+
+static size_t hex_to_bytes(const std::string &hex, uint8_t *out, size_t outsize)
+{
+    size_t n = hex.size() / 2;
+    if (n > outsize)
+        n = outsize;
+    for (size_t i = 0; i < n; i++)
+    {
+        unsigned int v = 0;
+        if (sscanf(hex.c_str() + i * 2, "%2x", &v) != 1)
+            return i;
+        out[i] = (uint8_t)v;
+    }
+    return n;
+}
+
+// Compare without leaking how many leading characters matched.
+static bool constant_time_equals(const std::string &a, const std::string &b)
+{
+    if (a.size() != b.size())
+        return false;
+    unsigned char diff = 0;
+    for (size_t i = 0; i < a.size(); i++)
+        diff |= (unsigned char)(a[i] ^ b[i]);
+    return diff == 0;
+}
+
+std::string FNPassword::firmware_id()
+{
+#ifdef ESP_PLATFORM
+    // SHA-256 of the running app's ELF - changes with every firmware image.
+    char sha[65] = {0};
+    if (esp_app_get_elf_sha256(sha, sizeof(sha)) > 0)
+        return std::string(sha);
+    return std::string(FN_VERSION_FULL) + "/" + FN_VERSION_BUILD;
+#else
+    // FujiNet-PC has no app partition to fingerprint; the build identity of
+    // this translation unit is the closest equivalent.
+    return std::string(FN_VERSION_FULL) + "/" + FN_VERSION_BUILD + "/" __DATE__ " " __TIME__;
+#endif
+}
+
+std::string FNPassword::make_salt()
+{
+    uint8_t salt[PASSWORD_SALT_BYTES];
+#ifdef ESP_PLATFORM
+    esp_fill_random(salt, sizeof(salt));
+#else
+    std::random_device rd;
+    for (size_t i = 0; i < sizeof(salt); i++)
+        salt[i] = (uint8_t)(rd() & 0xFF);
+#endif
+    return bytes_to_hex(salt, sizeof(salt));
+}
+
+std::string FNPassword::derive(const std::string &salt_hex, const std::string &password)
+{
+    uint8_t salt[PASSWORD_SALT_BYTES] = {0};
+    size_t saltlen = hex_to_bytes(salt_hex, salt, sizeof(salt));
+
+    // Round 0 hashes salt || password, every later round re-hashes salt || digest.
+    uint8_t digest[32];
+    std::string seed(reinterpret_cast<const char *>(salt), saltlen);
+    seed += password;
+    COMPAT_MBEDTLS_SHA256(reinterpret_cast<const uint8_t *>(seed.data()), seed.size(), digest, 0);
+
+    uint8_t block[PASSWORD_SALT_BYTES + sizeof(digest)];
+    memcpy(block, salt, saltlen);
+    for (int i = 1; i < PASSWORD_HASH_ROUNDS; i++)
+    {
+        memcpy(block + saltlen, digest, sizeof(digest));
+        COMPAT_MBEDTLS_SHA256(block, saltlen + sizeof(digest), digest, 0);
+    }
+
+    return bytes_to_hex(digest, sizeof(digest));
+}
+
+void FNPassword::setup()
+{
+    load();
+
+    if (_hash.empty())
+        return;
+
+    std::string current = firmware_id();
+    if (_fwid != current)
+    {
+        Debug_println("Device password was set by different firmware - clearing");
+        wipe();
+        return;
+    }
+
+    Debug_println("Device password is set");
+}
+
+bool FNPassword::verify(const std::string &password) const
+{
+    if (_hash.empty())
+        return false;
+    return constant_time_equals(_hash, derive(_salt, password));
+}
+
+bool FNPassword::change(const std::string &old_password, const std::string &new_password, std::string &error)
+{
+    if (is_set() && !verify(old_password))
+    {
+        error = "Current password is incorrect";
+        return false;
+    }
+    if (new_password.size() < MIN_LENGTH)
+    {
+        error = "New password must be at least " + std::to_string(MIN_LENGTH) + " characters";
+        return false;
+    }
+    if (new_password.size() > MAX_LENGTH)
+    {
+        error = "New password must be at most " + std::to_string(MAX_LENGTH) + " characters";
+        return false;
+    }
+
+    std::string salt = make_salt();
+    std::string hash = derive(salt, new_password);
+
+    std::string prev_fwid = _fwid, prev_salt = _salt, prev_hash = _hash;
+    _fwid = firmware_id();
+    _salt = salt;
+    _hash = hash;
+
+    if (!store())
+    {
+        _fwid = prev_fwid;
+        _salt = prev_salt;
+        _hash = prev_hash;
+        error = "Could not save the new password to flash";
+        return false;
+    }
+
+    Debug_println("Device password changed");
+    return true;
+}
+
+bool FNPassword::remove(const std::string &old_password, std::string &error)
+{
+    if (!is_set())
+    {
+        error = "No password is set";
+        return false;
+    }
+    if (!verify(old_password))
+    {
+        error = "Current password is incorrect";
+        return false;
+    }
+
+    wipe();
+    Debug_println("Device password removed");
+    return true;
+}
+
+bool FNPassword::check_basic_auth(const char *header_value) const
+{
+    if (!is_set() || header_value == nullptr)
+        return false;
+
+    // Expect: Basic <base64 of "username:password">
+    while (*header_value == ' ')
+        header_value++;
+    static const char scheme[] = "basic";
+    for (size_t i = 0; i < sizeof(scheme) - 1; i++)
+    {
+        if (tolower((unsigned char)header_value[i]) != scheme[i])
+            return false;
+    }
+    const char *b64 = header_value + sizeof(scheme) - 1;
+    while (*b64 == ' ')
+        b64++;
+
+    // Trim any trailing whitespace the header may carry.
+    size_t b64len = strlen(b64);
+    while (b64len > 0 && isspace((unsigned char)b64[b64len - 1]))
+        b64len--;
+    if (b64len == 0)
+        return false;
+
+    size_t decoded_len = 0;
+    auto decoded = Base64::decode(b64, b64len, &decoded_len);
+    if (decoded == nullptr || decoded_len == 0)
+        return false;
+
+    std::string creds(reinterpret_cast<const char *>(decoded.get()), decoded_len);
+    size_t colon = creds.find(':');
+    if (colon == std::string::npos)
+        return false;
+
+    // Username is deliberately not checked - only the password matters.
+    return verify(creds.substr(colon + 1));
+}
+
+#ifdef ESP_PLATFORM
+
+static bool nvs_read_str(nvs_handle_t handle, const char *key, std::string &out)
+{
+    size_t len = 0;
+    if (nvs_get_str(handle, key, nullptr, &len) != ESP_OK || len == 0)
+        return false;
+    std::string buf(len, '\0');
+    if (nvs_get_str(handle, key, &buf[0], &len) != ESP_OK)
+        return false;
+    buf.resize(len > 0 ? len - 1 : 0); // drop the NUL nvs counts in len
+    out = buf;
+    return true;
+}
+
+void FNPassword::load()
+{
+    _fwid.clear();
+    _salt.clear();
+    _hash.clear();
+
+    nvs_handle_t handle;
+    if (nvs_open(PASSWORD_NVS_NAMESPACE, NVS_READONLY, &handle) != ESP_OK)
+        return; // namespace does not exist yet - no password set
+
+    if (!nvs_read_str(handle, PASSWORD_NVS_KEY_HASH, _hash) ||
+        !nvs_read_str(handle, PASSWORD_NVS_KEY_SALT, _salt) ||
+        !nvs_read_str(handle, PASSWORD_NVS_KEY_FWID, _fwid))
+    {
+        _fwid.clear();
+        _salt.clear();
+        _hash.clear();
+    }
+
+    nvs_close(handle);
+}
+
+bool FNPassword::store()
+{
+    nvs_handle_t handle;
+    esp_err_t e = nvs_open(PASSWORD_NVS_NAMESPACE, NVS_READWRITE, &handle);
+    if (e != ESP_OK)
+    {
+        Debug_printf("fnPassword: nvs_open failed, err = %d\r\n", e);
+        return false;
+    }
+
+    bool ok = nvs_set_str(handle, PASSWORD_NVS_KEY_FWID, _fwid.c_str()) == ESP_OK &&
+              nvs_set_str(handle, PASSWORD_NVS_KEY_SALT, _salt.c_str()) == ESP_OK &&
+              nvs_set_str(handle, PASSWORD_NVS_KEY_HASH, _hash.c_str()) == ESP_OK &&
+              nvs_commit(handle) == ESP_OK;
+    if (!ok)
+        Debug_println("fnPassword: failed to write password to NVS");
+
+    nvs_close(handle);
+    return ok;
+}
+
+void FNPassword::wipe()
+{
+    _fwid.clear();
+    _salt.clear();
+    _hash.clear();
+
+    nvs_handle_t handle;
+    if (nvs_open(PASSWORD_NVS_NAMESPACE, NVS_READWRITE, &handle) != ESP_OK)
+        return;
+    nvs_erase_all(handle);
+    nvs_commit(handle);
+    nvs_close(handle);
+}
+
+#else // !ESP_PLATFORM
+
+void FNPassword::load()
+{
+    _fwid.clear();
+    _salt.clear();
+    _hash.clear();
+
+    if (!fsFlash.exists(PASSWORD_FILENAME))
+        return;
+
+    FILE *fin = fsFlash.file_open(PASSWORD_FILENAME, "r");
+    if (fin == nullptr)
+    {
+        Debug_println("fnPassword: could not open password file");
+        return;
+    }
+
+    char line[256];
+    while (fgets(line, sizeof(line), fin) != nullptr)
+    {
+        std::string s(line);
+        while (!s.empty() && (s.back() == '\n' || s.back() == '\r'))
+            s.pop_back();
+        size_t eq = s.find('=');
+        if (eq == std::string::npos)
+            continue;
+        std::string key = s.substr(0, eq);
+        std::string value = s.substr(eq + 1);
+        if (key == "fwid")
+            _fwid = value;
+        else if (key == "salt")
+            _salt = value;
+        else if (key == "hash")
+            _hash = value;
+    }
+    fclose(fin);
+
+    if (_salt.empty() || _hash.empty())
+    {
+        _fwid.clear();
+        _salt.clear();
+        _hash.clear();
+    }
+}
+
+bool FNPassword::store()
+{
+    FILE *fout = fsFlash.file_open(PASSWORD_FILENAME, "w");
+    if (fout == nullptr)
+    {
+        Debug_println("fnPassword: could not write password file");
+        return false;
+    }
+    fprintf(fout, "fwid=%s\nsalt=%s\nhash=%s\n", _fwid.c_str(), _salt.c_str(), _hash.c_str());
+    fclose(fout);
+    return true;
+}
+
+void FNPassword::wipe()
+{
+    _fwid.clear();
+    _salt.clear();
+    _hash.clear();
+
+    if (fsFlash.exists(PASSWORD_FILENAME))
+        fsFlash.remove(PASSWORD_FILENAME);
+}
+
+#endif // ESP_PLATFORM

--- a/lib/config/fnPassword.h
+++ b/lib/config/fnPassword.h
@@ -1,0 +1,64 @@
+/* FujiNet device password
+
+Guards sensitive operations (currently the password-protected web pages).
+
+The password is never kept in the clear and never touches the SD card: only a
+random salt and a salted, iterated SHA-256 digest are stored, in flash. On
+ESP32 that means the NVS partition; on FujiNet-PC it means a small file in the
+flash filesystem directory.
+
+Each stored record is stamped with the identity of the firmware that wrote it
+(the app image's ELF SHA-256 on ESP32). On startup a record written by a
+different firmware image is discarded, so re-flashing the firmware clears any
+previously set password.
+*/
+#ifndef FNPASSWORD_H
+#define FNPASSWORD_H
+
+#include <cstddef>
+#include <string>
+
+class FNPassword
+{
+public:
+    static const size_t MIN_LENGTH = 4;
+    static const size_t MAX_LENGTH = 64;
+
+    // Load the stored password record, discarding it if it belongs to a
+    // different firmware image. Call once at startup, after fsFlash.start().
+    void setup();
+
+    bool is_set() const { return !_hash.empty(); }
+
+    // True only when a password is set and 'password' matches it.
+    bool verify(const std::string &password) const;
+
+    // Set or change the password. 'old_password' is ignored when no password
+    // is currently set. On failure 'error' describes why.
+    bool change(const std::string &old_password, const std::string &new_password, std::string &error);
+
+    // Remove the password. Requires the current one.
+    bool remove(const std::string &old_password, std::string &error);
+
+    // Check the value of an HTTP "Authorization" header (e.g. "Basic dTpw").
+    // The username is not checked - any value, including an empty one, is
+    // accepted - so only the password matters. False when no password is set.
+    bool check_basic_auth(const char *header_value) const;
+
+private:
+    std::string _fwid; // firmware image the stored record belongs to
+    std::string _salt; // hex
+    std::string _hash; // hex
+
+    void load();
+    bool store();
+    void wipe();
+
+    static std::string firmware_id();
+    static std::string make_salt();
+    static std::string derive(const std::string &salt_hex, const std::string &password);
+};
+
+extern FNPassword fnPassword;
+
+#endif // FNPASSWORD_H

--- a/lib/http/httpService.cpp
+++ b/lib/http/httpService.cpp
@@ -17,12 +17,14 @@
 
 #include "fnSystem.h"
 #include "fnConfig.h"
+#include "fnPassword.h"
 #include "fnWiFi.h"
 #include "fsFlash.h"
 #include "../device/modem.h"
 #include "printer.h"
 #include "httpServiceConfigurator.h"
 #include "httpServiceParser.h"
+#include "privatePage.h"
 #include "fujiDevice.h"
 #ifdef BUILD_ATARI
 #include "sio/sioFuji.h"
@@ -1296,7 +1298,115 @@ esp_err_t fnHttpService::post_handler_config(httpd_req_t *req)
     return ESP_OK;
 }
 
+// ─── Device password ─────────────────────────────────────────────────────────
 
+static void password_send_json(httpd_req_t *req, const char *status_line, cJSON *body)
+{
+    char *json = cJSON_PrintUnformatted(body);
+    httpd_resp_set_status(req, status_line);
+    httpd_resp_set_type(req, "application/json");
+    httpd_resp_sendstr(req, json != nullptr ? json : "{}");
+    if (json != nullptr)
+        cJSON_free(json);
+    cJSON_Delete(body);
+}
+
+static void password_send_error(httpd_req_t *req, const char *status_line, const std::string &message)
+{
+    cJSON *out = cJSON_CreateObject();
+    cJSON_AddStringToObject(out, "status", "error");
+    cJSON_AddStringToObject(out, "message", message.c_str());
+    password_send_json(req, status_line, out);
+}
+
+esp_err_t fnHttpService::post_handler_password(httpd_req_t *req)
+{
+    if (req->content_len == 0 || req->content_len > FNWS_RECV_BUFF_SIZE)
+    {
+        password_send_error(req, "400 Bad Request", "Bad password request");
+        return ESP_OK;
+    }
+
+    std::vector<char> buf(req->content_len);
+    int ret = httpd_req_recv(req, buf.data(), buf.size());
+    if (ret <= 0)
+    {
+        Debug_printf("Error (%d) receiving posted password data\n", ret);
+        password_send_error(req, "400 Bad Request", MSG_ERR_RECEIVE_FAILURE);
+        return ESP_OK;
+    }
+
+    std::map<std::string, std::string> postvals =
+        fnHttpServiceConfigurator::parse_postdata_decoded(buf.data(), (size_t)ret);
+    // Don't leave the plaintext password sitting in the receive buffer
+    memset(buf.data(), 0, buf.size());
+
+    std::string error;
+    bool ok;
+    if (postvals["action"] == "clear")
+    {
+        ok = fnPassword.remove(postvals["current"], error);
+    }
+    else if (postvals["new"] != postvals["confirm"])
+    {
+        ok = false;
+        error = "New password and confirmation do not match";
+    }
+    else
+    {
+        ok = fnPassword.change(postvals["current"], postvals["new"], error);
+    }
+
+    if (!ok)
+    {
+        password_send_error(req, "400 Bad Request", error);
+        return ESP_OK;
+    }
+
+    cJSON *out = cJSON_CreateObject();
+    cJSON_AddStringToObject(out, "status", "ok");
+    cJSON_AddBoolToObject(out, "password_set", fnPassword.is_set());
+    password_send_json(req, "200 OK", out);
+    return ESP_OK;
+}
+
+/* Returns true when the request may proceed. Otherwise a challenge or an
+   explanatory page has already been sent and the handler should return. */
+static bool require_device_password(httpd_req_t *req)
+{
+    if (!fnPassword.is_set())
+    {
+        httpd_resp_set_status(req, "403 Forbidden");
+        httpd_resp_set_type(req, "text/html");
+        httpd_resp_sendstr(req, PRIVATE_NO_PASSWORD_HTML);
+        return false;
+    }
+
+    size_t hdrlen = httpd_req_get_hdr_value_len(req, "Authorization");
+    if (hdrlen > 0 && hdrlen < 1024)
+    {
+        std::vector<char> hdr(hdrlen + 1);
+        if (httpd_req_get_hdr_value_str(req, "Authorization", hdr.data(), hdr.size()) == ESP_OK &&
+            fnPassword.check_basic_auth(hdr.data()))
+            return true;
+    }
+
+    httpd_resp_set_status(req, "401 Unauthorized");
+    httpd_resp_set_hdr(req, "WWW-Authenticate", PRIVATE_AUTH_REALM);
+    httpd_resp_set_type(req, "text/html");
+    httpd_resp_sendstr(req, PRIVATE_UNAUTHORIZED_HTML);
+    return false;
+}
+
+esp_err_t fnHttpService::get_handler_private(httpd_req_t *req)
+{
+    if (!require_device_password(req))
+        return ESP_OK;
+
+    httpd_resp_set_type(req, "text/html");
+    httpd_resp_sendstr(req, PRIVATE_PAGE_HTML);
+    return ESP_OK;
+}
 
 // ─── Google Drive OAuth2 relay-based authorization-code-flow handlers ────────
 //
@@ -2352,6 +2462,20 @@ httpd_handle_t fnHttpService::start_server(serverstate &state)
         {.uri = "/config",
          .method = HTTP_POST,
          .handler = post_handler_config,
+         .user_ctx = NULL,
+         .is_websocket = false,
+         .handle_ws_control_frames = false,
+         .supported_subprotocol = nullptr},
+        {.uri = "/password",
+         .method = HTTP_POST,
+         .handler = post_handler_password,
+         .user_ctx = NULL,
+         .is_websocket = false,
+         .handle_ws_control_frames = false,
+         .supported_subprotocol = nullptr},
+        {.uri = "/private",
+         .method = HTTP_GET,
+         .handler = get_handler_private,
          .user_ctx = NULL,
          .is_websocket = false,
          .handle_ws_control_frames = false,

--- a/lib/http/httpService.h
+++ b/lib/http/httpService.h
@@ -154,6 +154,10 @@ public:
 
     static esp_err_t post_handler_config(httpd_req_t *req);
 
+    // Device password management and password-protected pages
+    static esp_err_t post_handler_password(httpd_req_t *req);
+    static esp_err_t get_handler_private(httpd_req_t *req);
+
     // Google Drive OAuth2 relay-based endpoints
     static esp_err_t get_handler_gdrive_auth(httpd_req_t *req);
     static esp_err_t get_handler_gdrive_poll(httpd_req_t *req);
@@ -188,6 +192,10 @@ public:
     static int get_handler_eject(mg_connection *c, mg_http_message *hm);
 
     static int post_handler_config(struct mg_connection *c, struct mg_http_message *hm);
+
+    // Device password management and password-protected pages
+    static int post_handler_password(struct mg_connection *c, struct mg_http_message *hm);
+    static int get_handler_private(struct mg_connection *c, struct mg_http_message *hm);
 
     static int get_handler_browse(mg_connection *c, mg_http_message *hm);
     static int get_handler_shorturl(mg_connection *c, mg_http_message *hm);

--- a/lib/http/httpServiceConfigurator.cpp
+++ b/lib/http/httpServiceConfigurator.cpp
@@ -1,5 +1,7 @@
 #include "httpServiceConfigurator.h"
 
+#include <cstring>
+
 #include "../../include/debug.h"
 
 #include "printer.h"
@@ -124,6 +126,27 @@ std::map<std::string, std::string> fnHttpServiceConfigurator::parse_postdata(con
             break;
         }
     }
+
+    return results;
+}
+
+static std::string url_decode_string(const std::string &encoded)
+{
+    if (encoded.empty())
+        return encoded;
+
+    std::string decoded(encoded.size() + 1, '\0');
+    fnHttpServiceConfigurator::url_decode(&decoded[0], encoded.c_str(), encoded.size());
+    decoded.resize(strlen(decoded.c_str()));
+    return decoded;
+}
+
+std::map<std::string, std::string> fnHttpServiceConfigurator::parse_postdata_decoded(const char *postdata, size_t postlen)
+{
+    std::map<std::string, std::string> results;
+
+    for (std::pair<const std::string, std::string> &kv : parse_postdata(postdata, postlen))
+        results[url_decode_string(kv.first)] = url_decode_string(kv.second);
 
     return results;
 }

--- a/lib/http/httpServiceConfigurator.h
+++ b/lib/http/httpServiceConfigurator.h
@@ -46,6 +46,9 @@ class fnHttpServiceConfigurator
 public:
     static char * url_decode(char * dst, const char * src, size_t dstsize);
     static std::map<std::string, std::string> parse_postdata(const char * postdata, size_t postlen);
+    // Like parse_postdata(), but url-decodes each key and value after splitting
+    // rather than before, so values may legitimately contain '&' and '='.
+    static std::map<std::string, std::string> parse_postdata_decoded(const char * postdata, size_t postlen);
     static int process_config_post(const char * postdata, size_t postlen);
 };
 

--- a/lib/http/httpServiceParser.cpp
+++ b/lib/http/httpServiceParser.cpp
@@ -7,6 +7,7 @@
 
 #include "fnSystem.h"
 #include "fnConfig.h"
+#include "fnPassword.h"
 #include "fnWiFi.h"
 #include "fsFlash.h"
 #include "httpService.h"
@@ -155,6 +156,7 @@ const string fnHttpServiceParser::substitute_tag(const string &tag)
         FN_PCLINK_ENABLED,
         FN_GDRIVE_CONNECTED,
         FN_ONEDRIVE_CONNECTED,
+        FN_PASSWORD_SET,
         FN_LASTTAG
     };
 
@@ -292,6 +294,7 @@ const string fnHttpServiceParser::substitute_tag(const string &tag)
         "FN_PCLINK_ENABLED",
         "FN_GDRIVE_CONNECTED",
         "FN_ONEDRIVE_CONNECTED",
+        "FN_PASSWORD_SET",
     };
 
     stringstream resultstream;
@@ -687,6 +690,9 @@ const string fnHttpServiceParser::substitute_tag(const string &tag)
         break;
     case FN_ONEDRIVE_CONNECTED:
         resultstream << (Config.get_onedrive_refresh_token().empty() ? "0" : "1");
+        break;
+    case FN_PASSWORD_SET:
+        resultstream << (fnPassword.is_set() ? "1" : "0");
         break;
     default:
         resultstream << tag;

--- a/lib/http/mgHttpService.cpp
+++ b/lib/http/mgHttpService.cpp
@@ -12,6 +12,7 @@
 
 #include "fnSystem.h"
 #include "fnConfig.h"
+#include "fnPassword.h"
 #include "fnWiFi.h"
 #include "fsFlash.h"
 #include "modem.h"
@@ -28,6 +29,7 @@
 #include "httpServiceConfigurator.h"
 #include "httpServiceParser.h"
 #include "httpServiceBrowser.h"
+#include "privatePage.h"
 
 #include "../../include/debug.h"
 
@@ -508,6 +510,91 @@ int fnHttpService::post_handler_config(struct mg_connection *c, struct mg_http_m
     return 0; //ESP_OK;
 }
 
+// ─── Device password ─────────────────────────────────────────────────────────
+
+static void password_send_error(struct mg_connection *c, int code, const std::string &message)
+{
+    cJSON *out = cJSON_CreateObject();
+    cJSON_AddStringToObject(out, "status", "error");
+    cJSON_AddStringToObject(out, "message", message.c_str());
+    char *json = cJSON_PrintUnformatted(out);
+    mg_http_reply(c, code, "Content-Type: application/json\r\n", "%s", json != nullptr ? json : "{}");
+    if (json != nullptr) cJSON_free(json);
+    cJSON_Delete(out);
+}
+
+int fnHttpService::post_handler_password(struct mg_connection *c, struct mg_http_message *hm)
+{
+    Debug_println("Post_password request handler");
+
+    std::map<std::string, std::string> postvals =
+        fnHttpServiceConfigurator::parse_postdata_decoded(hm->body.buf, hm->body.len);
+
+    std::string error;
+    bool ok;
+    if (postvals["action"] == "clear")
+    {
+        ok = fnPassword.remove(postvals["current"], error);
+    }
+    else if (postvals["new"] != postvals["confirm"])
+    {
+        ok = false;
+        error = "New password and confirmation do not match";
+    }
+    else
+    {
+        ok = fnPassword.change(postvals["current"], postvals["new"], error);
+    }
+
+    if (!ok)
+    {
+        password_send_error(c, 400, error);
+        return -1;
+    }
+
+    cJSON *out = cJSON_CreateObject();
+    cJSON_AddStringToObject(out, "status", "ok");
+    cJSON_AddBoolToObject(out, "password_set", fnPassword.is_set());
+    char *json = cJSON_PrintUnformatted(out);
+    mg_http_reply(c, 200, "Content-Type: application/json\r\n", "%s", json != nullptr ? json : "{}");
+    if (json != nullptr) cJSON_free(json);
+    cJSON_Delete(out);
+    return 0;
+}
+
+/* Returns true when the request may proceed. Otherwise a challenge or an
+   explanatory page has already been sent and the handler should return. */
+static bool require_device_password(struct mg_connection *c, struct mg_http_message *hm)
+{
+    if (!fnPassword.is_set())
+    {
+        mg_http_reply(c, 403, "Content-Type: text/html\r\n", "%s", PRIVATE_NO_PASSWORD_HTML);
+        return false;
+    }
+
+    struct mg_str *auth = mg_http_get_header(hm, "Authorization");
+    if (auth != nullptr && auth->len > 0 && auth->len < 1024)
+    {
+        std::string header(auth->buf, auth->len);
+        if (fnPassword.check_basic_auth(header.c_str()))
+            return true;
+    }
+
+    mg_http_reply(c, 401,
+                  "WWW-Authenticate: " PRIVATE_AUTH_REALM "\r\nContent-Type: text/html\r\n",
+                  "%s", PRIVATE_UNAUTHORIZED_HTML);
+    return false;
+}
+
+int fnHttpService::get_handler_private(struct mg_connection *c, struct mg_http_message *hm)
+{
+    if (!require_device_password(c, hm))
+        return -1;
+
+    mg_http_reply(c, 200, "Content-Type: text/html\r\n", "%s", PRIVATE_PAGE_HTML);
+    return 0;
+}
+
 
 int fnHttpService::get_handler_browse(mg_connection *c, mg_http_message *hm)
 {
@@ -963,6 +1050,19 @@ void fnHttpService::cb(struct mg_connection *c, int ev, void *ev_data)
             {
                 mg_http_reply(c, 400, "", "Bad config request\n");
             }
+        }
+        else if (mg_match(hm->uri, mg_str("/password"), NULL))
+        {
+            // device password change/clear handler
+            if (hm->method.len == 4 && strncasecmp(hm->method.buf, "POST", 4) == 0)
+                post_handler_password(c, hm);
+            else
+                mg_http_reply(c, 405, "", "Method Not Allowed\n");
+        }
+        else if (mg_match(hm->uri, mg_str("/private"), NULL))
+        {
+            // password-protected page
+            get_handler_private(c, hm);
         }
         else if (mg_match(hm->uri, mg_str("/print"), NULL))
         {

--- a/lib/http/privatePage.h
+++ b/lib/http/privatePage.h
@@ -1,0 +1,42 @@
+/* Shared markup for the password-protected area of the FujiNet web server.
+
+Only one of httpService.cpp (ESP32) / mgHttpService.cpp (FujiNet-PC) is
+compiled for a given build, so plain file-scope arrays are fine here.
+*/
+#ifndef PRIVATEPAGE_H
+#define PRIVATEPAGE_H
+
+// Stub content served once Basic Auth succeeds.
+static const char PRIVATE_PAGE_HTML[] =
+    "<!DOCTYPE html><html><head><meta charset=\"utf-8\">"
+    "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\">"
+    "<title>FujiNet - Private</title></head><body>"
+    "<h1>Private</h1>"
+    "<p>You are authenticated with the FujiNet device password.</p>"
+    "<p>This page is a placeholder for password-protected functionality.</p>"
+    "<p><a href=\"/\">Back to the FujiNet web UI</a></p>"
+    "</body></html>";
+
+// Sent instead of a Basic Auth challenge when no device password exists, so
+// the page fails closed rather than becoming publicly readable.
+static const char PRIVATE_NO_PASSWORD_HTML[] =
+    "<!DOCTYPE html><html><head><meta charset=\"utf-8\">"
+    "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\">"
+    "<title>FujiNet - Private</title></head><body>"
+    "<h1>No device password set</h1>"
+    "<p>This page is protected by the FujiNet device password, and no password "
+    "has been set yet.</p>"
+    "<p>Set one under <strong>Security</strong> in the "
+    "<a href=\"/\">FujiNet web UI</a>, then reload this page.</p>"
+    "</body></html>";
+
+static const char PRIVATE_UNAUTHORIZED_HTML[] =
+    "<!DOCTYPE html><html><head><meta charset=\"utf-8\">"
+    "<title>401 Unauthorized</title></head><body>"
+    "<h1>401 Unauthorized</h1>"
+    "<p>The FujiNet device password is required to view this page.</p>"
+    "</body></html>";
+
+#define PRIVATE_AUTH_REALM "Basic realm=\"FujiNet\", charset=\"UTF-8\""
+
+#endif // PRIVATEPAGE_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -22,6 +22,7 @@
 
 #include "fnSystem.h"
 #include "fnConfig.h"
+#include "fnPassword.h"
 #include "fnWiFi.h"
 
 #include "fsFlash.h"
@@ -232,6 +233,9 @@ void main_setup(int argc, char *argv[])
 
     // Load our stored configuration
     Config.load();
+
+    // Load the device password (kept in flash, separate from the config file)
+    fnPassword.setup();
 
     // WiFi/BT auto connect moved to app_main()
 


### PR DESCRIPTION
This is a prerequisite for potentially sensitive features, like an appkey viewer/manager.

It stores the password salted + hashed in flash, so should be relatively safe. However the current plan is to just use the stubbed out function to protect certain web ui routes with Basic Auth, so not super secure but better than nothing.

<img width="713" height="457" alt="Screenshot 2026-08-09 at 10 30 07 PM" src="https://github.com/user-attachments/assets/2b0ff9ab-f838-4dda-b9aa-3e396828f98b" />
