### PR TITLE
[rs232] ROM media type: push cartridge images to the RP2040

### DIFF
--- a/fujinet_pc.cmake
+++ b/fujinet_pc.cmake
@@ -479,6 +479,7 @@ if(FUJINET_TARGET STREQUAL "RS232")
 
     lib/media/rs232/diskType.h lib/media/rs232/diskType.cpp
     lib/media/rs232/diskTypeImg.h lib/media/rs232/diskTypeImg.cpp
+    lib/media/rs232/diskTypeROM.h lib/media/rs232/diskTypeROM.cpp
 
     lib/device/rs232/apetime.cpp lib/device/rs232/apetime.h
     lib/device/rs232/disk.cpp lib/device/rs232/disk.h

--- a/lib/device/fujiDevice/fujiDevice.cpp
+++ b/lib/device/fujiDevice/fujiDevice.cpp
@@ -517,7 +517,7 @@ success_is_true fujiDevice::fujicore_mount_disk_image_success(uint8_t deviceSlot
     // We need the file size for loading XEX files and for CASSETTE, so get that too
     disk.disk_size = host.file_size(disk.fileh);
     DISK_DEVICE *disk_dev = get_disk_dev(deviceSlot);
-    disk.disk_type = disk_dev->mount(disk.fileh, disk.filename, disk.disk_size, access_mode);
+    disk.disk_type = mount_media(disk_dev, disk, host, access_mode);
     disk_dev->is_config_device = false;
 
     // mount() returns MEDIATYPE_UNKNOWN on failure -- without this check that

--- a/lib/device/fujiDevice/fujiDevice.h
+++ b/lib/device/fujiDevice/fujiDevice.h
@@ -192,6 +192,20 @@ protected:
                                                    uint8_t maxlen) = 0;
     dirEntryDetails _additional_direntry_details(fsdir_entry_t *f);
 
+    // Platform hook for fujicore_mount_disk_image_success(): the base
+    // implementation calls DISK_DEVICE::mount() with its original 5-arg
+    // signature, so this stays the only call site that needs a
+    // platform-specific override rather than a #ifdef BUILD_* (banned here,
+    // see tests/check_no_build_ifdefs.py). rs232Fuji overrides this to pass
+    // `host` through to rs232Disk::mount(), which MediaTypeROM needs to open
+    // a same-named .cfg sibling through the same fujiHost the ROM itself
+    // came from -- see lib/media/rs232/diskTypeROM.cpp.
+    virtual mediatype_t mount_media(DISK_DEVICE *disk_dev, fujiDisk &disk, fujiHost &host,
+                                    disk_access_flags_t mode)
+    {
+        return disk_dev->mount(disk.fileh, disk.filename, disk.disk_size, mode);
+    }
+
     // ============ Validation of inputs ============
     success_is_true validate_host_slot(uint8_t slot, const char *dmsg=nullptr);
     success_is_true validate_device_slot(uint8_t slot, const char *dmsg = nullptr);

--- a/lib/device/rs232/disk.cpp
+++ b/lib/device/rs232/disk.cpp
@@ -180,7 +180,8 @@ void rs232Disk::rs232_write_percom_block()
    Return value is MEDIATYPE_UNKNOWN in case of failure.
 */
 mediatype_t rs232Disk::mount(fnFile *f, const char *filename, uint32_t disksize,
-                             disk_access_flags_t access_mode, mediatype_t disk_type)
+                             disk_access_flags_t access_mode, mediatype_t disk_type,
+                             fujiHost *host)
 {
     // TAPE or CASSETTE: use this function to send file info to cassette device
     //  MediaType::discover_mediatype(filename) can detect CAS and WAV files
@@ -197,14 +198,14 @@ mediatype_t rs232Disk::mount(fnFile *f, const char *filename, uint32_t disksize,
     if (disk_type == MEDIATYPE_UNKNOWN && filename != nullptr)
         disk_type = MediaType::discover_mediatype(filename);
 
-    // TODO: Stupid hack to treat ROM-sized files as ROMs and not disks. Should be
-    // replaced with proper ROM-handling logic
-    if (disksize == 8192 || disksize == 16384 || disksize == 32768)
-        return mountROM(f, filename, disksize, disk_type);
-
     // Now mount based on MediaType
     switch (disk_type)
     {
+    case MEDIATYPE_ROM:
+        device_active = true;
+        _mount_time = time(NULL);
+        _disk = new MediaTypeROM();
+        return _disk->mount(f, disksize, host, filename);
     case MEDIATYPE_IMG:
     case MEDIATYPE_UNKNOWN:
     default:
@@ -219,38 +220,6 @@ mediatype_t rs232Disk::mount_disk_media(fnFile *f, const char *filename, uint32_
                                          mediatype_t disk_type)
 {
     return mount(f, filename, disksize, DISK_ACCESS_MODE_READ, disk_type);
-}
-
-mediatype_t rs232Disk::mountROM(fnFile *f, const char *filename, uint32_t disksize, mediatype_t disk_type)
-{
-    uint32_t offset, rlen, sectorNum;
-    MediaTypeImg romImage;
-
-
-    romImage.mount(f, disksize);
-
-    Debug_printv("Attempting to send ROM contents to pico");
-    // "open" RAM in bank
-    if (!SYSTEM_BUS.sendCommand(FUJI_DEVICEID_DBC, NETCMD_OPEN, (uint16_t) 0)) {
-        Debug_printv("Failed to open pico");
-        return (mediatype_t) -1;
-    }
-
-    for (offset = sectorNum = 0; offset < disksize; offset += rlen, sectorNum++)
-    {
-        if (romImage.read(sectorNum, &rlen) != 0)
-            break;
-        if (!SYSTEM_BUS.sendCommand(FUJI_DEVICEID_DBC, NETCMD_WRITE,
-                                    std::string((char *) romImage._disk_sectorbuff, rlen))) {
-            Debug_printv("Failed to send block");
-            break;
-        }
-    }
-
-    // "closing" RAM will make the bank active
-    SYSTEM_BUS.sendCommand(FUJI_DEVICEID_DBC, NETCMD_CLOSE);
-
-    return disk_type;
 }
 
 // Destructor

--- a/lib/device/rs232/disk.h
+++ b/lib/device/rs232/disk.h
@@ -7,6 +7,8 @@
 #include "bus.h"
 #include "media.h"
 
+class fujiHost;
+
 class rs232Disk : public virtualDevice
 {
 private:
@@ -28,11 +30,10 @@ public:
     rs232Disk();
     mediatype_t mount(fnFile *f, const char *filename, uint32_t disksize,
                       disk_access_flags_t access_mode,
-                      mediatype_t disk_type = MEDIATYPE_UNKNOWN);
+                      mediatype_t disk_type = MEDIATYPE_UNKNOWN,
+                      fujiHost *host = nullptr);
     mediatype_t mount_disk_media(fnFile *f, const char *filename, uint32_t disksize,
                                  mediatype_t disk_type);
-    mediatype_t mountROM(fnFile *f, const char *filename, uint32_t disksize,
-                         mediatype_t disk_type);
     void unmount();
     success_is_true write_blank(fnFile *f, uint16_t sectorSize, uint16_t numSectors);
 

--- a/lib/device/rs232/rs232Fuji.h
+++ b/lib/device/rs232/rs232Fuji.h
@@ -14,6 +14,15 @@ protected:
     size_t set_additional_direntry_details(fsdir_entry_t *f, uint8_t *dest,
                                            uint8_t maxlen) override;
 
+    // Passes `host` through so MediaTypeROM can open a same-named .cfg
+    // sibling through it -- see fujiDevice::mount_media().
+    mediatype_t mount_media(DISK_DEVICE *disk_dev, fujiDisk &disk, fujiHost &host,
+                            disk_access_flags_t mode) override
+    {
+        return disk_dev->mount(disk.fileh, disk.filename, disk.disk_size, mode,
+                               MEDIATYPE_UNKNOWN, &host);
+    }
+
     void rs232_net_set_ssid(bool save);    // 0xFB
     void rs232_new_disk();                 // 0xE7
     void rs232_test();                     // 0x00

--- a/lib/media/media.h
+++ b/lib/media/media.h
@@ -11,6 +11,7 @@
 #ifdef BUILD_RS232
 # include "rs232/diskType.h"
 # include "rs232/diskTypeImg.h"
+# include "rs232/diskTypeROM.h"
 #endif
 
 #ifdef BUILD_IEC

--- a/lib/media/rs232/diskType.cpp
+++ b/lib/media/rs232/diskType.cpp
@@ -68,6 +68,20 @@ mediatype_t MediaType::discover_mediatype(const char *filename)
         {
             return MEDIATYPE_IMG;
         }
+        // BIN/ROM/INT/ITV are all "load this straight into cart memory and
+        // reset" formats on every current BUILD_RS232 platform (Intellivision
+        // .bin+.cfg pairs and Intellicart .rom images, Atari 2600 .bin
+        // homebrew, CoCo cartridge images) -- there is no disk-image
+        // convention on any of them that also uses these extensions, so
+        // detecting MEDIATYPE_ROM by extension alone is unambiguous. This
+        // replaces the previous disksize==8192||16384||32768 heuristic
+        // (rs232Disk::mount()), which misfired on any file of those exact
+        // sizes regardless of extension and missed every other ROM size.
+        if (strcasecmp(ext, "ROM") == 0 || strcasecmp(ext, "BIN") == 0 ||
+            strcasecmp(ext, "INT") == 0 || strcasecmp(ext, "ITV") == 0)
+        {
+            return MEDIATYPE_ROM;
+        }
     }
     return MEDIATYPE_UNKNOWN;
 }

--- a/lib/media/rs232/diskType.h
+++ b/lib/media/rs232/diskType.h
@@ -5,6 +5,8 @@
 #include "fnio.h"
 #include "global_types.h"
 
+class fujiHost;
+
 #define INVALID_SECTOR_VALUE 65536
 
 #define DISK_SECTORBUF_SIZE 512
@@ -36,6 +38,7 @@ enum mediatype_t
 {
     MEDIATYPE_UNKNOWN = 0,
     MEDIATYPE_IMG,
+    MEDIATYPE_ROM,
     MEDIATYPE_COUNT
 };
 
@@ -70,7 +73,14 @@ public:
 
     mediatype_t _disktype = MEDIATYPE_UNKNOWN;
 
-    virtual mediatype_t mount(fnFile *f, uint32_t disksize) = 0;
+    // `host` and `filename` are only used by MediaTypeROM: `filename` to
+    // derive a same-named .cfg sibling's path, `host` to open it through
+    // the same fujiHost the ROM itself came from (so it works identically
+    // whether the ROM is on TNFS, SD, etc.). Every other mount() ignores
+    // both; they default so existing callers and overrides don't need to
+    // change.
+    virtual mediatype_t mount(fnFile *f, uint32_t disksize, fujiHost *host = nullptr,
+                              const char *filename = nullptr) = 0;
     virtual void unmount();
 
     // Returns TRUE if an error condition occurred

--- a/lib/media/rs232/diskTypeImg.cpp
+++ b/lib/media/rs232/diskTypeImg.cpp
@@ -152,7 +152,7 @@ error_is_true MediaTypeImg::format(uint32_t *responsesize)
  
  07-0F have two possible interpretations but are no critical for our use
 */
-mediatype_t MediaTypeImg::mount(fnFile *f, uint32_t disksize)
+mediatype_t MediaTypeImg::mount(fnFile *f, uint32_t disksize, fujiHost *host, const char *filename)
 {
     Debug_print("IMG MOUNT\r\n");
 

--- a/lib/media/rs232/diskTypeROM.cpp
+++ b/lib/media/rs232/diskTypeROM.cpp
@@ -1,0 +1,142 @@
+#ifdef BUILD_RS232 // temporary
+
+#include "diskTypeROM.h"
+
+#include <cstdio>
+#include <cstring>
+#include <string>
+
+#include "../../include/debug.h"
+#include "../../include/fujiCommandID.h"
+#include "../../fuji/fujiDisk.h"
+#include "../../fuji/fujiHost.h"
+
+#include "bus.h"
+#include "compat_string.h"
+#include "fujiCommandID.h"
+
+#define ROM_PUSH_STREAM_CFG 1
+#define ROM_PUSH_STREAM_ROM 0
+
+error_is_true MediaTypeROM::read(uint32_t sectornum, uint32_t *readcount)
+{
+    Debug_print("ROM READ not supported\r\n");
+    RETURN_ERROR_AS_TRUE();
+}
+
+error_is_true MediaTypeROM::write(uint32_t sectornum, bool verify)
+{
+    Debug_print("ROM WRITE not supported\r\n");
+    RETURN_ERROR_AS_TRUE();
+}
+
+error_is_true MediaTypeROM::format(uint32_t *responsesize)
+{
+    RETURN_ERROR_AS_TRUE();
+}
+
+void MediaTypeROM::status(uint8_t statusbuff[4])
+{
+    memset(statusbuff, 0, 4);
+}
+
+// push_stream: reads `f` from its current position in DISK_SECTORBUF_SIZE
+// chunks and relays each one to the RP2040 as NETCMD_WRITE frames on DBC
+// stream `stream_id` (0 = ROM, 1 = a .cfg sibling -- the RP2040's
+// dbc_inbound_handler() demuxes on this same id). Sent as one PAYLOAD byte,
+// not a param: FujiBusPacket::processArg(uint16_t) encodes bare integer
+// arguments as wire params, but the RP2040's minimal fujibus.c client
+// parses the descriptor chain only far enough to skip past it to find the
+// payload -- it never surfaces decoded param values. The payload path is
+// the one it actually exposes to callers (fb_reply_t.data/data_len), so
+// that's what carries the stream id here.
+// Always sends NETCMD_CLOSE, even on failure, so the RP2040's per-stream
+// state doesn't wedge for the next OPEN.
+static bool push_stream(fnFile *f, uint16_t stream_id)
+{
+    uint8_t buf[DISK_SECTORBUF_SIZE];
+
+    uint8_t open_payload = (uint8_t)stream_id;
+    auto reply = SYSTEM_BUS.sendCommand(FUJI_DEVICEID_DBC, NETCMD_OPEN,
+                                        std::string(1, (char)open_payload));
+    if (!reply || reply->command() != FUJICMD_ACK)
+    {
+        Debug_printv("MediaTypeROM: failed to open DBC stream %u\n", stream_id);
+        return false;
+    }
+
+    bool ok = true;
+    size_t got;
+    while ((got = fnio::fread(buf, 1, sizeof(buf), f)) > 0)
+    {
+        reply = SYSTEM_BUS.sendCommand(FUJI_DEVICEID_DBC, NETCMD_WRITE,
+                                       std::string((char *)buf, got));
+        if (!reply || reply->command() != FUJICMD_ACK)
+        {
+            Debug_printv("MediaTypeROM: failed to send stream %u block\n", stream_id);
+            ok = false;
+            break;
+        }
+    }
+
+    reply = SYSTEM_BUS.sendCommand(FUJI_DEVICEID_DBC, NETCMD_CLOSE);
+    if (!reply || reply->command() != FUJICMD_ACK)
+    {
+        Debug_printv("MediaTypeROM: stream %u close failed/rejected\n", stream_id);
+        ok = false;
+    }
+    return ok;
+}
+
+mediatype_t MediaTypeROM::mount(fnFile *f, uint32_t disksize, fujiHost *host, const char *filename)
+{
+    Debug_printv("MediaTypeROM MOUNT %s (%lu bytes)\n",
+                 filename ? filename : "?", (unsigned long)disksize);
+
+    _disk_fileh = f;
+    _disk_image_size = disksize;
+    _disktype = MEDIATYPE_ROM;
+
+    // Push a same-named .cfg sibling first, if one exists, so the RP2040
+    // knows the file's memory mapping before the ROM push's CLOSE frame
+    // triggers the actual boot. Best-effort: a missing .cfg (the normal
+    // case for a self-describing .rom, or a bare .bin the RP2040 will
+    // fall back to guessing a mapping for) is not an error.
+    if (host != nullptr && filename != nullptr)
+    {
+        char cfgpath[MAX_FILENAME_LEN];
+        strlcpy(cfgpath, filename, sizeof(cfgpath));
+        char *dot = strrchr(cfgpath, '.');
+        if (dot != nullptr)
+            strlcpy(dot, ".cfg", sizeof(cfgpath) - (dot - cfgpath));
+        else
+            strlcat(cfgpath, ".cfg", sizeof(cfgpath));
+
+        if (host->file_exists(cfgpath))
+        {
+            char resolved[MAX_FILENAME_LEN];
+            strlcpy(resolved, cfgpath, sizeof(resolved));
+            fnFile *cfgf = host->fnfile_open(cfgpath, resolved, sizeof(resolved), "rb");
+            if (cfgf != nullptr)
+            {
+                push_stream(cfgf, ROM_PUSH_STREAM_CFG);
+                fnio::fclose(cfgf);
+            }
+            else
+            {
+                Debug_printv("MediaTypeROM: .cfg sibling exists but failed to open: %s\n", cfgpath);
+            }
+        }
+    }
+
+    fnio::fseek(f, 0, SEEK_SET);
+    if (!push_stream(f, ROM_PUSH_STREAM_ROM))
+    {
+        Debug_printv("MediaTypeROM: ROM push failed\n");
+        return MEDIATYPE_UNKNOWN;
+    }
+
+    return _disktype;
+}
+
+#endif // BUILD_RS232

--- a/lib/media/rs232/diskTypeROM.h
+++ b/lib/media/rs232/diskTypeROM.h
@@ -1,13 +1,15 @@
-#ifndef _MEDIATYPE_IMG
-#define _MEDIATYPE_IMG
+#ifndef _MEDIATYPE_ROM_RS232
+#define _MEDIATYPE_ROM_RS232
 
 #include "diskType.h"
 
-class MediaTypeImg : public MediaType
+// Pushes a ROM-shaped file (Intellivision .bin+.cfg pair, Intellicart
+// .rom, Atari 2600 .bin, CoCo cartridge image, ...) to the RP2040 over the
+// same USB-CDC/FujiBus link used for ordinary mailbox transactions,
+// addressed to FUJI_DEVICEID_DBC. See diskTypeROM.cpp for the wire
+// sequence.
+class MediaTypeROM : public MediaType
 {
-private:
-    uint32_t _sector_to_offset(uint32_t sectorNum);
-
 public:
     error_is_true read(uint32_t sectornum, uint32_t *readcount) override;
     error_is_true write(uint32_t sectornum, bool verify) override;
@@ -18,9 +20,6 @@ public:
                       const char *filename = nullptr) override;
 
     void status(uint8_t statusbuff[4]) override;
-
-    static success_is_true create(fnFile *f, uint16_t sectorSize, uint32_t numSectors);
 };
 
-
-#endif // _MEDIATYPE_IMG
+#endif // _MEDIATYPE_ROM_RS232


### PR DESCRIPTION
## Summary
Adds `MEDIATYPE_ROM`, detected by extension (`.rom`/`.bin`/`.int`/`.itv`) in `MediaType::discover_mediatype()`. These formats mean "load straight into cart memory and reset" on every current `BUILD_RS232` platform (Intellivision `.bin`+`.cfg` / Intellicart `.rom`, Atari 2600 `.bin`, CoCo cartridge images), so detecting by extension alone is unambiguous. Replaces `rs232Disk::mount()`'s `disksize==8192||16384||32768` heuristic, which misfired on any file of those exact sizes regardless of extension and missed every other ROM size (e.g. `battleship.bin` at 17730 bytes).

`MediaTypeROM` (`lib/media/rs232/diskTypeROM.{h,cpp}`) streams the file to the RP2040 over FujiBus, addressed to `FUJI_DEVICEID_DBC`: a same-named `.cfg` sibling first (best-effort, so the RP2040 knows the memory mapping), then the ROM itself, each as `NETCMD_OPEN`/`WRITE`.../`CLOSE` on its own DBC stream id. `NETCMD_CLOSE` on the ROM stream triggers the actual boot.

`MediaTypeROM` needs a `fujiHost*` to open that `.cfg` sibling through the same host the ROM came from (TNFS, SD, ...), but `fujicore_mount_disk_image_success()` is shared by every platform and `lib/device/fujiDevice/` bans `#ifdef BUILD_*` (`tests/check_no_build_ifdefs.py`) — platform customization goes through a subclass override instead. Adds a protected virtual `fujiDevice::mount_media()` hook whose base implementation is the original 5-arg `mount()` call (used unmodified by sio/iec/iwm/adamnet/comlynx/cx16_i2c/rc2014/s100spi/h89/drivewire); `rs232Fuji` overrides it to pass `host` through to `rs232Disk::mount()`, the only platform that gained a trailing `fujiHost*` parameter.

## Scope
Split out of #1522, which mixed this in with an unrelated `pico/` vendor import (Minty firmware, now in #1524). This PR touches only `lib/` + `fujinet_pc.cmake`.

## Verification
- `tests/check_no_build_ifdefs.py lib/device/fujiDevice` passes clean
- Confirmed byte-identical to the ROM-media portion of #1522 (diffed against the exact set of files this commit touches)
- Build note: `fujinet-rs232-rev0` and `fujinet-rs232-s3` currently fail to build on `origin/master` itself (unrelated `PIN_ADAMNET_RESET` / `-Werror=format` issues in adamnet code) — verified pre-existing by building `origin/master` directly with none of these changes applied