### PR TITLE
[pico][intellivision] fix mailbox size.

### DIFF
--- a/pico/intellivision/firmware/include/fuji_mailbox.h
+++ b/pico/intellivision/firmware/include/fuji_mailbox.h
@@ -100,6 +100,20 @@
                                                    // 256-byte host-slot block and the
                                                    // 240-byte AdapterConfigExtended
 
+// fujibus_transact()'s raw USB receive buffer (fuji_mailbox_service()'s
+// rxbuf) has to be sized separately from FUJI_MB_RX_MAX above: that constant
+// bounds the mailbox's cart.RAM-resident reply window (a real address-space
+// budget), but the same buffer also has to hold every complete SLIP-encoded
+// frame the ESP32 pushes to FUJI_DEVICEID_DBC mid-MOUNT_IMAGE --
+// MediaTypeROM::push_stream() (rs232/diskTypeROM.cpp) streams ROM/.cfg data
+// in DISK_SECTORBUF_SIZE (512) byte NETCMD_WRITE chunks. Decoded that's a
+// 6-byte header + 512 bytes of payload = 518, and SLIP escaping can double
+// that worst-case plus the two frame-delimiter bytes -- 1038 minimum.
+// Undersizing this silently truncates every ROM push's WRITE frames, which
+// fujibus_transact() and the ESP32 side both see as a timed-out/malformed
+// reply rather than anything pointing at the real cause.
+#define FUJIBUS_RAW_RX_MAX 1088
+
 #define FUJI_MB_STATUS_IDLE  0
 #define FUJI_MB_STATUS_BUSY  1
 #define FUJI_MB_STATUS_OK    2

--- a/pico/intellivision/firmware/src/fujinet.c
+++ b/pico/intellivision/firmware/src/fujinet.c
@@ -596,7 +596,7 @@ bool dbc_inbound_handler(const fb_reply_t *req)
 // full interlock rationale.
 void fuji_mailbox_service(void)
 {
-    static uint8_t rxbuf[FUJI_MB_RX_MAX];
+    static uint8_t rxbuf[FUJIBUS_RAW_RX_MAX];
     static uint8_t txbuf[FUJI_MB_TX_MAX];
 
     // BOOTSEL doorbell -- see fuji_mailbox.h. Checked every call, independent
@@ -675,7 +675,14 @@ void fuji_mailbox_service(void)
 
     cart.RAM[FUJI_MB_ERR] = (uint16_t)st;
     if (st == FB_OK) {
-        uint16_t rxlen = reply.data_len; // already bounded by rx_cap == sizeof(rxbuf)
+        // reply.data_len is bounded by sizeof(rxbuf) (FUJIBUS_RAW_RX_MAX),
+        // which is now larger than the mailbox's own RX window -- clamp
+        // before copying into cart.RAM so an oversized reply can't overrun
+        // FUJI_MB_RX_MAX. Real mailbox replies never exceed FUJI_MB_RX_MAX
+        // today; this only guards the address space.
+        uint16_t rxlen = reply.data_len;
+        if (rxlen > FUJI_MB_RX_MAX)
+            rxlen = FUJI_MB_RX_MAX;
         for (uint16_t i = 0; i < rxlen; i++)
             cart.RAM[FUJI_MB_RX + i] = reply.data[i];
         cart.RAM[FUJI_MB_RXLEN_LO] = rxlen & 0xFF;


### PR DESCRIPTION
INTV was failing because the DBC packets were being truncated.