### PR TITLE
[rs232][bus] properly set shuttingDown in case being used in-process.

### DIFF
--- a/lib/bus/rs232/rs232.cpp
+++ b/lib/bus/rs232/rs232.cpp
@@ -197,6 +197,10 @@ void systemBus::service()
 // Setup RS232 bus
 void systemBus::setup()
 {
+    // shutdown() latches this true; left set across an in-process restart,
+    // TNFS's poll loop bails out on its first check and fakes success.
+    shuttingDown = false;
+
     Debug_printf("RS232 SETUP: Baud rate: %u\n",Config.get_serial_baud());
 
     // Set up UART


### PR DESCRIPTION
fujinet-go-desktop-intv wasn't surviving a session change (e.g. when changing settings), because tnfslib wasn't shutting down completely.
