### PR TITLE
GUID: Fix seeding of random numbers for GUID generation.

### DIFF
--- a/lib/device/fujiDevice/fujiDevice.cpp
+++ b/lib/device/fujiDevice/fujiDevice.cpp
@@ -1556,11 +1556,11 @@ void fujiDevice::fujicmd_generate_guid()
 
         case 19:
             /* UUID variant: 8, 9, a, or b */
-            uuid_str[i] = hex[(rand() & 0x3) | 0x8];
+            uuid_str[i] = hex[(fnSystem.random() & 0x3) | 0x8];
             break;
 
         default:
-            uuid_str[i] = hex[rand() & 0xF];
+            uuid_str[i] = hex[fnSystem.random() & 0xF];
             break;
         }
     }

--- a/lib/hardware/fnSystem.cpp
+++ b/lib/hardware/fnSystem.cpp
@@ -249,6 +249,11 @@ int IRAM_ATTR SystemManager::digital_read(uint8_t pin)
 }
 
 #ifdef ESP_PLATFORM
+uint32_t SystemManager::random()
+{
+    return esp_random();
+}
+
 // from esp32-hal-misc.c
 unsigned long IRAM_ATTR SystemManager::micros()
 {
@@ -267,6 +272,20 @@ void SystemManager::delay(uint32_t ms)
     vTaskDelay(ms / portTICK_PERIOD_MS);
 }
 #else
+uint32_t SystemManager::random()
+{
+    /* rand() repeats the same sequence from process start unless seeded */
+    static bool seeded = false;
+
+    if (!seeded)
+    {
+        srand((unsigned)time(NULL));
+        seeded = true;
+    }
+
+    return (uint32_t)rand();
+}
+
 uint64_t SystemManager::micros()
 {
     struct timeval tv;

--- a/lib/hardware/fnSystem.cpp
+++ b/lib/hardware/fnSystem.cpp
@@ -16,6 +16,7 @@
 #include <esp_idf_version.h>
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0)
 #include <esp_chip_info.h>
+#include <esp_random.h>
 #include <hal/gpio_ll.h>
 #include "esp_adc/adc_oneshot.h"
 #include "esp_adc/adc_cali.h"

--- a/lib/hardware/fnSystem.h
+++ b/lib/hardware/fnSystem.h
@@ -133,6 +133,7 @@ public:
     uint64_t millis();
     uint64_t micros();
 #endif
+    uint32_t random();
     void delay_microseconds(uint32_t us);
     void delay(uint32_t ms);
 


### PR DESCRIPTION
GUIDs were not being seeded properly. Every time the firmware restarted, it would give the exact same sequence of GUIDs again.  Fixed and tested.