### PR TITLE
[coco] close() must complete the transaction with no protocol open

### DIFF
--- a/lib/device/drivewire/network.cpp
+++ b/lib/device/drivewire/network.cpp
@@ -136,6 +136,7 @@ void drivewireNetwork::close()
     // If no protocol enabled, we just signal complete, and return.
     if (protocol == nullptr)
     {
+        SYSTEM_BUS.transaction_success();
         return;
     }
 


### PR DESCRIPTION
Closing a channel whose open failed left the transaction accepted but never completed, so the next command tripped the transaction_accept assertion and aborted. The comment already said it should signal complete.