### PR TITLE
[rs232] Make the N: filesystem commands work

### DIFF
--- a/lib/device/rs232/network.cpp
+++ b/lib/device/rs232/network.cpp
@@ -1185,11 +1185,31 @@ void rs232Network::rs232_set_timer_rate(int newRate)
 
 void rs232Network::process_fs(const FujiBusPacket &packet)
 {
+    /* The FS commands are sent without aux bytes, so there may be no
+     * parameter to read. param() throws when the index is absent. */
+    fileAccessMode_t access = static_cast<fileAccessMode_t>(
+        packet.paramCount() > 0 ? packet.param(0) : 0);
+
+    SYSTEM_BUS.transaction_accept(TRANS_STATE::WILL_GET);
+
+    /* The FS commands carry their own devicespec, so this operation gets its
+     * own protocol rather than whatever an earlier open left behind. */
+    if (protocol != nullptr)
+    {
+        protocol->close();
+        protocol.reset();
+    }
+
+    parse_and_instantiate_protocol(access);
+
     // Make sure this is really a FS protocol instance
     NetworkProtocolFS *fs = dynamic_cast<NetworkProtocolFS *>(protocol.get());
     if (!fs)
     {
-        SYSTEM_BUS.transaction_error();
+        // transaction_error() was already called from
+        // parse_and_instantiate_protocol()
+        if (protocol != nullptr)
+            SYSTEM_BUS.transaction_error();
         return;
     }
 

--- a/lib/device/rs232/network.cpp
+++ b/lib/device/rs232/network.cpp
@@ -1206,8 +1206,8 @@ void rs232Network::process_fs(const FujiBusPacket &packet)
     NetworkProtocolFS *fs = dynamic_cast<NetworkProtocolFS *>(protocol.get());
     if (!fs)
     {
-        // transaction_error() was already called from
-        // parse_and_instantiate_protocol()
+        /* protocol is null if parse_and_instantiate_protocol() failed,
+         * and it signalled the error itself. */
         if (protocol != nullptr)
             SYSTEM_BUS.transaction_error();
         return;


### PR DESCRIPTION
mkdir, rmdir, delete, rename, lock and unlock always failed on this bus. No request ever reached the server and nothing was logged to say why.

process_fs() now reads the devicespec off the wire and instantiates a protocol for it, instead of reusing whatever an earlier open had left behind. Each command carries the path it acts on, so it has to be read before the operation can be pointed at the right target.