### PR TITLE
[http] Accept a PUT body on the POST data channel

### DIFF
--- a/lib/network-protocol/HTTP.cpp
+++ b/lib/network-protocol/HTTP.cpp
@@ -652,7 +652,7 @@ fujiError_t NetworkProtocolHTTP::write_file_handle_set_header(uint8_t *buf, unsi
 
 fujiError_t NetworkProtocolHTTP::write_file_handle_send_post_data(uint8_t *buf, unsigned short len)
 {
-    if (httpMethod != HTTP_METHOD::POST)
+    if (httpMethod != HTTP_METHOD::POST && httpMethod != HTTP_METHOD::PUT)
     {
         error = NDEV_STATUS::INVALID_COMMAND;
         return FUJI_ERROR::UNSPECIFIED;


### PR DESCRIPTION
A channel opened as PUT that delivers its body through the SET_POST_DATA channel mode had that body discarded, leaving nothing to send, and the request was then abandoned rather than issued. Both fujinet-lib and fujinet-lib-experimental route network_http_put through network_http_post, which uses that channel mode, so every PUT made through either library was affected.

Widen the method check in write_file_handle_send_post_data to accept PUT as well as POST. Both write paths append to the same postData buffer and differ only in which method they admit, so this closes the gap that plain PUT fell through, without changing behavior for POST or PUT_H.