### PR TITLE
[sio] reattach SAM disk swap as an override.

### DIFF
--- a/lib/device/fujiDevice/fujiDevice.cpp
+++ b/lib/device/fujiDevice/fujiDevice.cpp
@@ -213,6 +213,24 @@ void fujiDevice::shutdown()
     _startup_mount_lock.store(false);
 }
 
+// Derived from the device IDs rather than tracked separately, so it stays
+// correct across mounts and unmounts between rotations.
+int fujiDevice::get_rotate_slot()
+{
+    int count = 0;
+    while (count < (int)_totalDiskDevices && _fnDisks[count].fileh != nullptr)
+        count++;
+
+    if (count < 2)
+        return -1;
+
+    for (int i = 0; i < count; i++)
+        if (get_disk_dev(i)->id() == FUJI_DEVICEID_DISK)
+            return i;
+
+    return -1;
+}
+
 // Disk Image Rotate
 /*
   We rotate disks my changing their disk device ID's. That prevents
@@ -228,9 +246,6 @@ void fujiDevice::fujicmd_image_rotate()
 
     if (count > 1)
     {
-        _active_rotate_slot = (_active_rotate_slot + 1) % count;
-        fnLedManager.blink(LED_BUS, _active_rotate_slot + 1);
-
         count--;
 
         // Save the device ID of the disk in the last slot
@@ -246,22 +261,13 @@ void fujiDevice::fujicmd_image_rotate()
         // The first slot gets the device ID of the last slot
         SYSTEM_BUS.changeDeviceId(get_disk_dev(0), last_id);
 
-#if ENABLE_SPEECH
-        // FIXME - make this work
-
-        // Say whatever disk is in D1:
-        if (Config.get_general_rotation_sounds())
+        // Blink out which slot is now drive 1
+        int rotate_slot = get_rotate_slot();
+        if (rotate_slot >= 0)
         {
-            for (int i = 0; i <= count; i++)
-            {
-                if (_fnDisks[i].disk_dev.id() == 0x31)
-                {
-                    say_swap_label();
-                    say_number(i + 1); // because i starts from 0
-                }
-            }
+            _active_rotate_slot = rotate_slot;
+            fnLedManager.blink(LED_BUS, rotate_slot + 1);
         }
-#endif /* ENABLE_SPEECH */
     }
 }
 

--- a/lib/device/fujiDevice/fujiDevice.cpp
+++ b/lib/device/fujiDevice/fujiDevice.cpp
@@ -261,12 +261,13 @@ void fujiDevice::fujicmd_image_rotate()
         // The first slot gets the device ID of the last slot
         SYSTEM_BUS.changeDeviceId(get_disk_dev(0), last_id);
 
-        // Blink out which slot is now drive 1
+        // Blink out which slot is now drive 1, then let the platform announce it
         int rotate_slot = get_rotate_slot();
         if (rotate_slot >= 0)
         {
             _active_rotate_slot = rotate_slot;
             fnLedManager.blink(LED_BUS, rotate_slot + 1);
+            announce_rotation(rotate_slot);
         }
     }
 }

--- a/lib/device/fujiDevice/fujiDevice.h
+++ b/lib/device/fujiDevice/fujiDevice.h
@@ -207,6 +207,10 @@ public:
     virtual DISK_DEVICE *get_disk_dev(int i) { return &_fnDisks[i].disk_dev; }
     int get_disk_id(int drive_slot) { return _fnDisks[drive_slot].disk_dev.id(); }
 
+    // Slot holding the disk that currently answers as drive 1, or -1 when
+    // fewer than two disks are mounted and rotation is a no-op.
+    int get_rotate_slot();
+
     void populate_slots_from_config();
     void populate_config_from_slots();
     fujiHost *set_slot_hostname(int host_slot, char *hostname);
@@ -226,7 +230,7 @@ public:
     void fujicmd_net_get_wifi_enabled();
     virtual success_is_true fujicmd_mount_disk_image_success(uint8_t deviceSlot, disk_access_flags_t access_mode);
     success_is_true fujicmd_unmount_disk_image_success(uint8_t deviceSlot);
-    void fujicmd_image_rotate();
+    virtual void fujicmd_image_rotate();
     success_is_true fujicmd_open_directory_success(uint8_t hostSlot);
     virtual void fujicmd_close_directory();
     virtual void fujicmd_read_directory_entry(size_t maxlen, uint8_t addtl);

--- a/lib/device/fujiDevice/fujiDevice.h
+++ b/lib/device/fujiDevice/fujiDevice.h
@@ -178,6 +178,21 @@ protected:
         return disk_dev->mount(disk.fileh, disk.filename, disk.disk_size, mode);
     }
 
+    // Slot holding the disk that currently answers as drive 1, or -1 when
+    // fewer than two disks are mounted and rotation is a no-op.
+    int get_rotate_slot();
+
+    // Platform hook for fujicmd_image_rotate(): announce the newly selected
+    // drive 1. Atari speaks it through SAM; everyone else stays quiet.
+    //
+    // This is a hook rather than an override of fujicmd_image_rotate() itself
+    // so that method can stay non-virtual. IEC declares
+    // systemBus::changeDeviceId() without ever defining it, and only survives
+    // linking because --gc-sections drops fujicmd_image_rotate() -- nothing on
+    // that target calls it. Making it virtual pins it into the vtable and the
+    // undefined reference comes back.
+    virtual void announce_rotation(int drive_slot) {}
+
     // ============ Validation of inputs ============
     success_is_true validate_host_slot(uint8_t slot, const char *dmsg=nullptr);
     success_is_true validate_device_slot(uint8_t slot, const char *dmsg = nullptr);
@@ -207,10 +222,6 @@ public:
     virtual DISK_DEVICE *get_disk_dev(int i) { return &_fnDisks[i].disk_dev; }
     int get_disk_id(int drive_slot) { return _fnDisks[drive_slot].disk_dev.id(); }
 
-    // Slot holding the disk that currently answers as drive 1, or -1 when
-    // fewer than two disks are mounted and rotation is a no-op.
-    int get_rotate_slot();
-
     void populate_slots_from_config();
     void populate_config_from_slots();
     fujiHost *set_slot_hostname(int host_slot, char *hostname);
@@ -230,7 +241,7 @@ public:
     void fujicmd_net_get_wifi_enabled();
     virtual success_is_true fujicmd_mount_disk_image_success(uint8_t deviceSlot, disk_access_flags_t access_mode);
     success_is_true fujicmd_unmount_disk_image_success(uint8_t deviceSlot);
-    virtual void fujicmd_image_rotate();
+    void fujicmd_image_rotate();
     success_is_true fujicmd_open_directory_success(uint8_t hostSlot);
     virtual void fujicmd_close_directory();
     virtual void fujicmd_read_directory_entry(size_t maxlen, uint8_t addtl);

--- a/lib/device/fujiDevice/fujiDevice.h
+++ b/lib/device/fujiDevice/fujiDevice.h
@@ -185,12 +185,6 @@ protected:
     // Platform hook for fujicmd_image_rotate(): announce the newly selected
     // drive 1. Atari speaks it through SAM; everyone else stays quiet.
     //
-    // This is a hook rather than an override of fujicmd_image_rotate() itself
-    // so that method can stay non-virtual. IEC declares
-    // systemBus::changeDeviceId() without ever defining it, and only survives
-    // linking because --gc-sections drops fujicmd_image_rotate() -- nothing on
-    // that target calls it. Making it virtual pins it into the vtable and the
-    // undefined reference comes back.
     virtual void announce_rotation(int drive_slot) {}
 
     // ============ Validation of inputs ============

--- a/lib/device/sio/sioFuji.cpp
+++ b/lib/device/sio/sioFuji.cpp
@@ -108,17 +108,14 @@ void say_swap_label()
     util_sam_say("DIHSK7Q ", true);
 }
 
-// Rotate, then announce the new D1: through SAM on SIO pin 11
-void sioFuji::fujicmd_image_rotate()
+// Announce the new D1: through SAM, out SIO pin 11
+void sioFuji::announce_rotation(int drive_slot)
 {
-    fujiDevice::fujicmd_image_rotate();
+    if (!Config.get_general_rotation_sounds())
+        return;
 
-    int rotate_slot = get_rotate_slot();
-    if (rotate_slot >= 0 && Config.get_general_rotation_sounds())
-    {
-        say_swap_label();
-        say_number(rotate_slot + 1); // because slots start from 0
-    }
+    say_swap_label();
+    say_number(drive_slot + 1); // because slots start from 0
 }
 
 // Constructor

--- a/lib/device/sio/sioFuji.cpp
+++ b/lib/device/sio/sioFuji.cpp
@@ -108,6 +108,19 @@ void say_swap_label()
     util_sam_say("DIHSK7Q ", true);
 }
 
+// Rotate, then announce the new D1: through SAM on SIO pin 11
+void sioFuji::fujicmd_image_rotate()
+{
+    fujiDevice::fujicmd_image_rotate();
+
+    int rotate_slot = get_rotate_slot();
+    if (rotate_slot >= 0 && Config.get_general_rotation_sounds())
+    {
+        say_swap_label();
+        say_number(rotate_slot + 1); // because slots start from 0
+    }
+}
+
 // Constructor
 sioFuji::sioFuji() : fujiDevice(MAX_DISK_DEVICES, IMAGE_EXTENSION, LOBBY_URL)
 {

--- a/lib/device/sio/sioFuji.h
+++ b/lib/device/sio/sioFuji.h
@@ -53,6 +53,7 @@ public:
     ByteBuffer appkey_read() override;
     void appkey_write(const FUJI_COMMAND_PACKET &packet) override;
     void fujicmd_net_scan_networks() override;
+    void fujicmd_image_rotate() override;
     void qr_encode(const FUJI_COMMAND_PACKET &packet) override {
         fujiDevice::qr_encode(((uint8_t) packet.param(0)) & 0x7f,
                               (qr_ecc_t) (((uint8_t) packet.param(1)) & 0x03),

--- a/lib/device/sio/sioFuji.h
+++ b/lib/device/sio/sioFuji.h
@@ -33,6 +33,8 @@ protected:
 
     void fujicmd_set_sio_external_clock(uint16_t speed);
 
+    void announce_rotation(int drive_slot) override;
+
 public:
     sioFuji();
     void setup() override;
@@ -53,7 +55,6 @@ public:
     ByteBuffer appkey_read() override;
     void appkey_write(const FUJI_COMMAND_PACKET &packet) override;
     void fujicmd_net_scan_networks() override;
-    void fujicmd_image_rotate() override;
     void qr_encode(const FUJI_COMMAND_PACKET &packet) override {
         fujiDevice::qr_encode(((uint8_t) packet.param(0)) & 0x7f,
                               (qr_ecc_t) (((uint8_t) packet.param(1)) & 0x03),


### PR DESCRIPTION
PR #1108 and #1133 caused this to be compiled out. It's added back in as an override.
-Thom