### PR TITLE
[intv] Support paged, oversized and low-mapped homebrew cartridges

### DIFF
--- a/lib/media/rs232/diskTypeROM.cpp
+++ b/lib/media/rs232/diskTypeROM.cpp
@@ -64,15 +64,13 @@ static bool push_stream(fnFile *f, uint16_t stream_id, uint32_t expected_size)
 {
     uint8_t buf[DISK_SECTORBUF_SIZE];
 
-    char open_payload[5] = {
-        (char)(uint8_t)stream_id,
-        (char)(uint8_t)(expected_size & 0xFF),
-        (char)(uint8_t)((expected_size >> 8) & 0xFF),
-        (char)(uint8_t)((expected_size >> 16) & 0xFF),
-        (char)(uint8_t)((expected_size >> 24) & 0xFF),
-    };
+    struct { uint8_t id; u32le_t size; } open_hdr;
+    static_assert(sizeof(open_hdr) == 5, "OPEN header must not be padded");
+    open_hdr.id = (uint8_t)stream_id;
+    open_hdr.size = expected_size;
+
     auto reply = SYSTEM_BUS.sendCommand(FUJI_DEVICEID_DBC, NETCMD_OPEN,
-                                        std::string(open_payload, sizeof(open_payload)));
+                                        std::string((const char *)&open_hdr, sizeof(open_hdr)));
     if (!reply || reply->command() != FUJICMD_ACK)
     {
         Debug_printv("MediaTypeROM: failed to open DBC stream %u (%lu bytes)\n",

--- a/lib/media/rs232/diskTypeROM.cpp
+++ b/lib/media/rs232/diskTypeROM.cpp
@@ -43,13 +43,20 @@ void MediaTypeROM::status(uint8_t statusbuff[4])
 // push_stream: reads `f` from its current position in DISK_SECTORBUF_SIZE
 // chunks and relays each one to the RP2040 as NETCMD_WRITE frames on DBC
 // stream `stream_id` (0 = ROM, 1 = a .cfg sibling -- the RP2040's
-// dbc_inbound_handler() demuxes on this same id). Sent as one PAYLOAD byte,
-// not a param: FujiBusPacket::processArg(uint16_t) encodes bare integer
+// dbc_inbound_handler() demuxes on this same id). Sent as PAYLOAD bytes,
+// not params: FujiBusPacket::processArg(uint16_t) encodes bare integer
 // arguments as wire params, but the RP2040's minimal fujibus.c client
 // parses the descriptor chain only far enough to skip past it to find the
 // payload -- it never surfaces decoded param values. The payload path is
 // the one it actually exposes to callers (fb_reply_t.data/data_len), so
-// that's what carries the stream id here.
+// that's what carries the OPEN header here.
+//
+// OPEN payload is the stream id followed by the stream's total size as 4
+// little-endian bytes. The RP2040 uses the size to refuse a ROM too large
+// for its cart.ROM[] before we drag the whole thing over TNFS, and to draw
+// an exact progress bar; an older RP2040 build reads data[0] and ignores
+// the rest, so this stays compatible in both directions.
+//
 // Always sends NETCMD_CLOSE so the RP2040's stream state doesn't wedge; a
 // failed transfer's CLOSE carries a 0x01 abort payload so partial data
 // isn't booted.
@@ -57,12 +64,19 @@ static bool push_stream(fnFile *f, uint16_t stream_id, uint32_t expected_size)
 {
     uint8_t buf[DISK_SECTORBUF_SIZE];
 
-    uint8_t open_payload = (uint8_t)stream_id;
+    char open_payload[5] = {
+        (char)(uint8_t)stream_id,
+        (char)(uint8_t)(expected_size & 0xFF),
+        (char)(uint8_t)((expected_size >> 8) & 0xFF),
+        (char)(uint8_t)((expected_size >> 16) & 0xFF),
+        (char)(uint8_t)((expected_size >> 24) & 0xFF),
+    };
     auto reply = SYSTEM_BUS.sendCommand(FUJI_DEVICEID_DBC, NETCMD_OPEN,
-                                        std::string(1, (char)open_payload));
+                                        std::string(open_payload, sizeof(open_payload)));
     if (!reply || reply->command() != FUJICMD_ACK)
     {
-        Debug_printv("MediaTypeROM: failed to open DBC stream %u\n", stream_id);
+        Debug_printv("MediaTypeROM: failed to open DBC stream %u (%lu bytes)\n",
+                     stream_id, (unsigned long)expected_size);
         return false;
     }
 

--- a/pico/intellivision/firmware/CMakeLists.txt
+++ b/pico/intellivision/firmware/CMakeLists.txt
@@ -193,6 +193,7 @@ if(CONFIG_FUJINET)
       ${CMAKE_CURRENT_LIST_DIR}/src/fujibus_usb.c
       ${CMAKE_CURRENT_LIST_DIR}/src/fujinet.c
       ${CMAKE_CURRENT_LIST_DIR}/src/fujiboot.c
+      ${CMAKE_CURRENT_LIST_DIR}/src/bootmap.c
    )
 endif()
 

--- a/pico/intellivision/firmware/host_test/test_bootmap.c
+++ b/pico/intellivision/firmware/host_test/test_bootmap.c
@@ -1,0 +1,280 @@
+// Host-buildable test driver for bootmap.c -- no RP2040/pico-sdk involved.
+// Feeds real cartridge files through the same calls dbc_inbound_handler()
+// makes, in the same 512-byte chunks MediaTypeROM::push_stream() sends, then
+// commits the resulting plan into an mm_map_t and dumps what the bus would
+// actually see. This is the regression gate for the network boot path: the
+// cart itself only needs flashing once the output here is right.
+//
+// Build and run (from this directory):
+//   gcc -Wall -Wextra -I../include -o /tmp/test_bootmap test_bootmap.c ../src/bootmap.c ../src/memory.c ../src/utils.c
+//   /tmp/test_bootmap "$HOME/tnfs/INTV/sample roms/"*.bin "$HOME/tnfs/INTV/sample roms/"*.rom
+//
+// --rom-words N picks the board profile (default 220160 = fujicard's
+// 1024*215; pass 100352 for pirto_ii_default's 1024*98).
+//
+// Expected verdicts for the sample set, on the fujicard profile:
+//
+//   DK Arcade.bin              OK   4 segs, no paging
+//   pensate.bin                OK   2 segs, [vars] metadata ignored
+//   Unlucky Pony.bin           OK   2 segs
+//   frantic 4.bin              OK  17 segs, 11 paged, jlp=1
+//   Cloudfire.bin              OK  24 segs, 13 paged, jlp=3 jlpflash=2 ecs=1
+//   Pacmanthology.bin          OK  30 segs, 27 paged, jlp=1; 3 segs shadowed
+//                                   away by the JLP window, 27 committed
+//   Missile Domination.rom     OK   3 segs + RAM $8000-$81FF
+//   Maria.rom                  OK   5 segs incl. $2100-$2FFF
+//   Space Intruders (2026) 3.rom OK 4 segs incl. $2100-$2FFF
+//   unlucky_pony_2024.rom      OK   4 segs incl. $2000-$2FFF
+//
+// On the pirto_ii_default profile Cloudfire and Pacmanthology instead
+// report TOOBIG -- that board's cart.ROM[] cannot hold them.
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <strings.h>
+
+#include "bootmap.h"
+#include "memory.h"
+
+#define PUSH_CHUNK 512          // DISK_SECTORBUF_SIZE on the ESP32 side
+#define STAGE_BASE 0x2600u      // FUJI_STAGE_BASE
+#define RAM_WORDS  0x2800u      // RAMSIZE
+
+static uint16_t *rom_buf;
+static uint32_t  rom_words = 1024 * 215;
+
+extern mm_map_t m;              // the live map, defined in memory.c
+
+static const char *err_name(int e)
+{
+    switch (e) {
+    case 0:                       return "OK";
+    case FUJI_BOOT_ERR_REJECTED:  return "REJECTED";
+    case FUJI_BOOT_ERR_TRUNCATED: return "TRUNCATED";
+    case FUJI_BOOT_ERR_NOMAP:     return "NOMAP";
+    case FUJI_BOOT_ERR_MAILBOX:   return "MAILBOX";
+    case FUJI_BOOT_ERR_CFGBAD:    return "CFGBAD";
+    case FUJI_BOOT_ERR_RAM:       return "RAM";
+    case FUJI_BOOT_ERR_TOOBIG:    return "TOOBIG";
+    case FUJI_BOOT_ERR_BANKSW:    return "BANKSW";
+    default:                      return "?";
+    }
+}
+
+// Reads a whole file. Returns NULL (without complaint) if it isn't there --
+// a missing .cfg sibling is the normal case for a .rom.
+static uint8_t *slurp(const char *path, long *len_out)
+{
+    FILE *f = fopen(path, "rb");
+    if (!f)
+        return NULL;
+    fseek(f, 0, SEEK_END);
+    long len = ftell(f);
+    fseek(f, 0, SEEK_SET);
+    uint8_t *buf = malloc(len > 0 ? (size_t)len : 1);
+    if (len > 0 && fread(buf, 1, (size_t)len, f) != (size_t)len) {
+        fclose(f);
+        free(buf);
+        return NULL;
+    }
+    fclose(f);
+    *len_out = len;
+    return buf;
+}
+
+// Same-basename .cfg sibling, trying both cases like MediaTypeROM::mount().
+static uint8_t *load_cfg_sibling(const char *rompath, long *len_out, char *namebuf,
+                                 size_t namesz)
+{
+    snprintf(namebuf, namesz, "%s", rompath);
+    char *base = namebuf;
+    for (char *p = namebuf; *p; p++)
+        if (*p == '/')
+            base = p + 1;
+    char *dot = strrchr(base, '.');
+    if (!dot)
+        return NULL;
+
+    strcpy(dot, ".cfg");
+    uint8_t *d = slurp(namebuf, len_out);
+    if (d)
+        return d;
+    strcpy(dot, ".CFG");
+    return slurp(namebuf, len_out);
+}
+
+// Walks the committed map through mm_lookup(), coalescing runs that share a
+// kind and stay contiguous in the source. This is what the bus sees, not
+// what the plan said -- which is the point.
+static void dump_coverage(void)
+{
+    static const char *kn[] = { "----", "ROM ", "RAM8", "RAM16" };
+
+    for (int page = 0; page < MM_NUM_PLANES; page++) {
+        if (page > 0 && memcmp(m.map[page], m.map[0], MM_NUM_BLOCKS) == 0)
+            continue;   // identical to the fixed plane -- nothing paged here
+
+        char header[32];
+        snprintf(header, sizeof(header), "  page %X   :", page);
+        bool printed = false;
+
+        uint32_t a = 0;
+        while (a <= 0xFFFF) {
+            uint32_t off;
+            mm_kind_t k = mm_lookup(&m, (uint16_t)a, (uint8_t)page, &off);
+            if (k == MM_NONE) {
+                a++;
+                continue;
+            }
+            uint32_t start = a, start_off = off;
+            while (a + 1 <= 0xFFFF) {
+                uint32_t noff;
+                mm_kind_t nk = mm_lookup(&m, (uint16_t)(a + 1), (uint8_t)page, &noff);
+                if (nk != k || noff != off + 1)
+                    break;
+                a++;
+                off = noff;
+            }
+            printf("%s $%04X-$%04X %s @%05X\n", printed ? "             " : header,
+                   start, a, kn[k], start_off);
+            printed = true;
+            a++;
+        }
+        if (!printed)
+            printf("%s (nothing mapped)\n", header);
+    }
+}
+
+static int run_one(const char *path)
+{
+    long romlen = 0;
+    uint8_t *rom = slurp(path, &romlen);
+    if (!rom) {
+        printf("=== %s\n  CANNOT READ\n", path);
+        return 1;
+    }
+
+    const char *base = strrchr(path, '/');
+    printf("=== %s\n", base ? base + 1 : path);
+
+    bootmap_init(rom_buf, rom_words, STAGE_BASE, RAM_WORDS);
+
+    char cfgname[1024];
+    long cfglen = 0;
+    uint8_t *cfg = load_cfg_sibling(path, &cfglen, cfgname, sizeof(cfgname));
+    if (cfg) {
+        const char *cb = strrchr(cfgname, '/');
+        printf("  cfg      : %s (%ld bytes)\n", cb ? cb + 1 : cfgname, cfglen);
+        bootmap_cfg_begin();
+        for (long i = 0; i < cfglen; i += PUSH_CHUNK) {
+            long n = cfglen - i < PUSH_CHUNK ? cfglen - i : PUSH_CHUNK;
+            bootmap_cfg_data(cfg + i, (uint16_t)n);
+        }
+        bootmap_cfg_end(false);
+        free(cfg);
+    } else {
+        printf("  cfg      : (none)\n");
+    }
+
+    printf("  rom      : %ld bytes, %ld words\n", romlen, romlen / 2);
+
+    int err = bootmap_rom_begin((uint32_t)romlen);
+    if (!err) {
+        for (long i = 0; i < romlen; i += PUSH_CHUNK) {
+            long n = romlen - i < PUSH_CHUNK ? romlen - i : PUSH_CHUNK;
+            bootmap_rom_data(rom + i, (uint16_t)n);
+        }
+    }
+    free(rom);
+
+    bm_plan_t *plan;
+    int end_err = bootmap_rom_end(&plan);
+    if (!err)
+        err = end_err;
+
+    printf("  result   : %s\n", err_name(err));
+    if (err)
+        return 1;
+
+    printf("  vars     : jlp=%d jlpflash=%d ecs=%d voice=%d paging=%s\n",
+           plan->jlp, plan->jlpflash, plan->ecs, plan->voice, plan->paging ? "yes" : "no");
+
+    // fujinet.c's apply_boot_mapping() does this before committing: the JLP
+    // RAM window shadows any cartridge ROM mapped underneath it.
+    if (plan->jlp || plan->jlpflash) {
+        int dropped = bootmap_shadow_range(plan, 0x8000, 0x9FFF);
+        if (dropped)
+            printf("  shadowed : %d segment(s) dropped under the JLP window\n", dropped);
+    }
+
+    printf("  segments : %d\n", plan->nseg);
+    for (int i = 0; i < plan->nseg; i++) {
+        printf("    [%02d] $%04X", i, plan->seg[i].cpu);
+        if (plan->seg[i].page != MM_NO_PAGE)
+            printf(" page %X", plan->seg[i].page);
+        else
+            printf("       ");
+        printf("  rom[%05X..%05X]  %u words\n", plan->seg[i].rom_off, plan->seg[i].rom_end,
+               (unsigned)(plan->seg[i].rom_end - plan->seg[i].rom_off + 1));
+    }
+    printf("  ram      : %d\n", plan->nram);
+    for (int i = 0; i < plan->nram; i++)
+        printf("    [%02d] $%04X-$%04X  RAM %u\n", i, plan->ram[i].lo, plan->ram[i].hi,
+               plan->ram[i].width);
+
+    // Commit exactly the way apply_boot_mapping() does.
+    int commit = 0;
+    mm_init(&m);
+    for (int i = 0; i < plan->nseg; i++) {
+        int r = mm_add(&m, plan->seg[i].rom_off, plan->seg[i].rom_end,
+                       plan->seg[i].cpu, plan->seg[i].page);
+        if (r < 0 && !commit)
+            commit = r;
+    }
+    for (int i = 0; i < plan->nram; i++) {
+        int r = mm_add_ram(&m, plan->ram[i].lo, plan->ram[i].hi, plan->ram[i].width);
+        if (r < 0 && !commit)
+            commit = r;
+    }
+    if (mm_finalize(&m) < 0 && !commit)
+        commit = -99;
+
+    if (commit) {
+        printf("  commit   : FAILED (mm err %d)\n", commit);
+        return 1;
+    }
+    printf("  commit   : ok (entries=%d splits=%u ram_words=%u)\n",
+           m.count, m.n_splits, (unsigned)m.ram_words);
+    dump_coverage();
+    return 0;
+}
+
+int main(int argc, char **argv)
+{
+    int first = 1;
+    if (argc > 2 && strcmp(argv[1], "--rom-words") == 0) {
+        rom_words = (uint32_t)strtoul(argv[2], NULL, 0);
+        first = 3;
+    }
+    if (first >= argc) {
+        fprintf(stderr, "usage: %s [--rom-words N] <rom|bin>...\n", argv[0]);
+        return 2;
+    }
+
+    rom_buf = calloc(rom_words, sizeof(uint16_t));
+    if (!rom_buf) {
+        fprintf(stderr, "out of memory for a %u-word cart.ROM[]\n", (unsigned)rom_words);
+        return 2;
+    }
+    printf("cart.ROM[] = %u words, stage base $%04X\n\n", (unsigned)rom_words, STAGE_BASE);
+
+    int failures = 0;
+    for (int i = first; i < argc; i++) {
+        failures += run_one(argv[i]);
+        printf("\n");
+    }
+
+    printf("%d file(s), %d without a usable map\n", argc - first, failures);
+    free(rom_buf);
+    return 0;
+}

--- a/pico/intellivision/firmware/include/bootmap.h
+++ b/pico/intellivision/firmware/include/bootmap.h
@@ -1,0 +1,109 @@
+// bootmap: the pure half of the network ROM-boot path -- the jzintv .cfg
+// parser, the Intellicart/CC3 .rom stream decoder, and the segment/RAM plan
+// they both produce. No pico-sdk, no tusb, no Cartridge: it writes ROM words
+// through a caller-supplied pointer and hands back a bm_plan_t, so the whole
+// thing is reachable from a host build (see host_test/test_bootmap.c).
+//
+// fujinet.c owns everything this deliberately does not: USB framing and
+// ACK/NAK, the mailbox progress cells, the mailbox/JLP overlap policy, and
+// the mm_init()/mm_add()/mm_finalize() commit.
+//
+// Streams arrive incrementally, one NETCMD_WRITE payload at a time, and are
+// decoded straight into their staging destination -- there is no buffer
+// holding a whole ROM anywhere. Call order per mount:
+//
+//     bootmap_init(...)                       once, at power-on
+//     bootmap_cfg_begin / _data... / _end     if a .cfg sibling exists
+//     bootmap_rom_begin / _data... / _end     always
+//
+// A .cfg pushed for a mount survives until that mount's ROM stream closes;
+// bootmap_rom_end() consumes it either way.
+#ifndef BOOTMAP_H
+#define BOOTMAP_H
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#include "memory.h"        // MM_NO_PAGE, MM_MAX_ENTRIES
+#include "fuji_mailbox.h"  // FUJI_BOOT_ERR_*
+
+// BM_MAX_SEGS + BM_MAX_RAM must stay within MM_MAX_ENTRIES (64): every
+// segment and RAM area becomes one mm_add()/mm_add_ram() entry. 48 covers
+// the widest collection .cfg seen in the wild (Pacmanthology, 30 lines)
+// with room to spare.
+#define BM_MAX_SEGS 48
+#define BM_MAX_RAM   8
+#if BM_MAX_SEGS + BM_MAX_RAM > MM_MAX_ENTRIES
+#error "BM_MAX_SEGS + BM_MAX_RAM exceeds MM_MAX_ENTRIES"
+#endif
+
+// One [mapping] line, or one .rom segment. Offsets are word offsets into
+// the ROM buffer and are final by the time bootmap_rom_end() returns --
+// already staged, clamped at EOF and biased past CONFIG.
+typedef struct {
+    uint32_t rom_off;   // first word, inclusive
+    uint32_t rom_end;   // last word, inclusive
+    uint16_t cpu;       // Intellivision bus address rom_off appears at
+    int8_t   page;      // 0..15 for a PAGE-qualified line, else MM_NO_PAGE
+} bm_seg_t;
+
+// One [memattr] RAM line, or one writable range from a .rom's enable tables.
+typedef struct {
+    uint16_t lo, hi;    // inclusive bus addresses
+    uint8_t  width;     // 8 or 16
+} bm_ram_t;
+
+typedef struct {
+    bm_seg_t seg[BM_MAX_SEGS];
+    int      nseg;
+    bm_ram_t ram[BM_MAX_RAM];
+    int      nram;
+
+    // [vars]. 0 = not requested. ecs/voice are recorded even on builds that
+    // can't act on them, so the parser stays board-independent.
+    int  jlp, jlpflash, ecs, voice;
+
+    bool     paging;    // at least one PAGE-qualified mapping line
+    uint32_t rom_bytes; // bytes actually received on the ROM stream
+} bm_plan_t;
+
+// rom/rom_words: the cart ROM buffer and its length in words.
+// stage_base: first word a push may write (CONFIG lives below it).
+// ram_words: the cart RAM budget a plan's [memattr] total must fit in.
+void bootmap_init(uint16_t *rom, uint32_t rom_words, uint32_t stage_base,
+                  uint32_t ram_words);
+
+void bootmap_cfg_begin(void);
+void bootmap_cfg_data(const uint8_t *d, uint16_t n);
+void bootmap_cfg_end(bool aborted);
+
+// expected_bytes: the stream's total size if the peer sent one, else 0.
+// Returns 0, or FUJI_BOOT_ERR_TOOBIG if it cannot possibly fit.
+int  bootmap_rom_begin(uint32_t expected_bytes);
+void bootmap_rom_data(const uint8_t *d, uint16_t n);
+
+// Finishes the stream and resolves the mapping source (a self-describing
+// .rom header, else a pushed .cfg, else a bare-size guess). Returns 0, or a
+// FUJI_BOOT_ERR_* code. Consumes any pushed .cfg.
+//
+// *out is left pointing at bootmap's own plan rather than a copy of it: a
+// bm_plan_t is ~650 bytes and the caller is a cartridge with 264 KB of SRAM
+// that is already 99% spoken for. It stays valid, and writable (see
+// bootmap_shadow_range), until the next bootmap_rom_begin().
+int  bootmap_rom_end(bm_plan_t **out);
+
+// Abandon an in-flight ROM stream (abort-CLOSE); also consumes the .cfg.
+void bootmap_rom_abort(void);
+
+// 0-99 while a stream is in flight. Exact once the peer sends a size,
+// otherwise a saturating guess against a nominal 32K-byte cartridge.
+uint8_t bootmap_pct(void);
+
+// Removes [lo, hi] from a plan's segments: a segment wholly inside the
+// range is dropped, one that overlaps an edge is truncated away from it,
+// one that straddles both keeps its lower part. Used for the JLP RAM
+// window, which shadows cartridge ROM mapped underneath it. Returns the
+// number of segments dropped outright.
+int bootmap_shadow_range(bm_plan_t *p, uint16_t lo, uint16_t hi);
+
+#endif /* BOOTMAP_H */

--- a/pico/intellivision/firmware/include/fuji_mailbox.h
+++ b/pico/intellivision/firmware/include/fuji_mailbox.h
@@ -87,6 +87,8 @@
 #define FUJI_BOOT_ERR_MAILBOX   4 // a JLP game's segment/RAM overlaps its own $8000-$9FFF window
 #define FUJI_BOOT_ERR_CFGBAD    5 // a .cfg stream arrived but had no usable mapping line
 #define FUJI_BOOT_ERR_RAM       6 // declared RAM exceeds the cart's RAMSIZE budget
+#define FUJI_BOOT_ERR_TOOBIG    7 // ROM larger than this board's cart.ROM[] can stage
+#define FUJI_BOOT_ERR_BANKSW    8 // .rom enable tables flag bank-switched banks (unsupported)
 
 #define FUJI_MB_TX         (FUJI_MB_BASE + 0x40)  // Inty: request payload
 #define FUJI_MB_TX_MAX     256                    // fujicmd.bas sends fixed 256-byte

--- a/pico/intellivision/firmware/include/fujiboot.h
+++ b/pico/intellivision/firmware/include/fujiboot.h
@@ -1,6 +1,15 @@
 #ifndef FUJIBOOT_H
 #define FUJIBOOT_H
 
+// First cart.ROM[] word a network push may write. CONFIG's image occupies
+// 0x0000-0x2537 (9528 words) and the console is still executing out of it
+// while the ESP32 streams a game in, so everything staged during a push has
+// to land above it; the committed map biases its ROM offsets by this much.
+// 0x2600 is the next 256-word boundary past CONFIG -- fujiboot.c static-
+// asserts that against the real _bootrom size, which is where this must be
+// re-checked if CONFIG ever grows.
+#define FUJI_STAGE_BASE 0x2600u
+
 // Boots the Intellivision straight into the FujiNet CONFIG program
 // (fujiconfigrom.h) -- the only boot ROM this firmware runs. Replaces
 // Minty's own RunLauncher() (removed; see PROVENANCE.md/README.md).

--- a/pico/intellivision/firmware/src/bootmap.c
+++ b/pico/intellivision/firmware/src/bootmap.c
@@ -1,0 +1,704 @@
+// See bootmap.h for the call contract and what deliberately isn't here.
+//
+// Both stream formats decode straight into the ROM buffer as bytes arrive,
+// packed sequentially from stage_base. Nothing is identity-mapped: a .rom
+// segment's bus address and its staged offset are unrelated, which is what
+// lets a segment live below $4000 (Maria, Space Intruders and friends all
+// start at $2000/$2100) without touching the CONFIG image the console is
+// still executing out of underneath the transfer.
+#include <stdio.h>
+#include <string.h>
+
+#include "bootmap.h"
+#include "utils.h"
+
+// Lowest bus address a cartridge may claim. Below this is EXEC ROM
+// ($1000-$1FFF), system RAM and the STIC/PSG registers -- all console-
+// decoded, so mapping there is bus contention on every instruction fetch
+// and means we misparsed the stream rather than that the ROM wants it.
+// $2000-$2FFF is legitimate cartridge space and is used by real titles.
+#define BM_CART_LO 0x2000u
+
+// Longest .cfg line worth keeping. Real ones run ~40 bytes; the rest of an
+// over-length line is discarded and the boot fails TRUNCATED rather than
+// acting on half a mapping.
+#define CFG_LINE_MAX 128
+
+static uint16_t *bm_rom;
+static uint32_t  bm_rom_words;
+static uint32_t  bm_stage_base;
+static uint32_t  bm_ram_words;
+
+// The .cfg is parsed as it streams, one line at a time, straight into
+// `plan` -- there is no buffer holding the whole file. A 4 KB one used to
+// live here, which is a lot of .bss to spend re-reading something already
+// bounded by BM_MAX_SEGS on a board that links at 99% of RAM.
+typedef enum { SEC_NONE, SEC_MAPPING, SEC_MEMATTR, SEC_VARS } cfg_section_t;
+static char          cfg_line[CFG_LINE_MAX];
+static unsigned      cfg_line_len;
+static bool          cfg_line_over;   // this line overflowed; skip to newline
+static cfg_section_t cfg_section;
+static bool          cfg_open;
+static bool          have_cfg;
+
+// Sticky failure reasons. cfg_err survives the ROM stream's own OPEN (a
+// .cfg is pushed first, and its overflow must not be forgotten by the time
+// the ROM closes); rom_err is cleared per ROM stream.
+static int cfg_err;
+static int rom_err;
+
+static bm_plan_t plan;
+
+// Next free word in the ROM buffer. Both formats append here.
+static uint32_t stage_wp;
+
+typedef enum { ROMFMT_UNKNOWN, ROMFMT_FLAT, ROMFMT_HDR, ROMFMT_REJECTED } romfmt_t;
+static romfmt_t rom_fmt;
+static uint8_t  rom_hdrbuf[3];
+static unsigned rom_hdrlen;
+static uint32_t rom_total_bytes;
+static uint32_t rom_expected_bytes;
+static bool     rom_open;
+
+// ROMFMT_FLAT: big-endian words, no structure at all.
+static bool    flat_have_hi;
+static uint8_t flat_hi;
+
+// ROMFMT_HDR: incremental Intellicart/CC3 .rom decode, one segment at a
+// time. Reference: jzIntv's src/icart/icartrom.c icartrom_decode(). Layout
+// per segment: 2 bytes (lo, hi) giving an inclusive page range (word
+// address = page<<8, hi's page is the start of its last 256-word block),
+// then 2*(wordcount) bytes of big-endian ROM data, then a 2-byte CRC-16
+// (received but not validated).
+typedef enum { RH_SEG_ADDR, RH_SEG_DATA, RH_SEG_CRC } rh_state_t;
+static rh_state_t rh_state;
+static uint8_t    rh_nseg, rh_seg_i;
+static uint8_t    rh_addrbuf[2];
+static unsigned   rh_addrlen;
+static unsigned   rh_lo, rh_hi;
+static uint32_t   rh_words_left;
+static uint32_t   rh_cur_addr;
+static bool       rh_have_hi;
+static uint8_t    rh_hi_byte;
+static unsigned   rh_crclen;
+
+// Trailing attribute/fine-address ("enable") tables: 16 attribute bytes +
+// 32 fine-address bytes, collected once the last segment's CRC is consumed
+// (their own CRC-16 is received but not validated). decode_enable_tables()
+// turns these into plan.ram entries -- this is the only place a .rom
+// declares its RAM (e.g. cart scratch at $8000-$9BFF), so ignoring them
+// boots a game whose RAM silently reads/writes nothing.
+#define RH_TBL_LEN 48
+static uint8_t  rh_tbl[RH_TBL_LEN];
+static unsigned rh_tbl_len;
+
+// .rom banks flagged bank-switched, which this decoder cannot follow.
+static bool rh_banksw;
+
+void bootmap_init(uint16_t *rom, uint32_t rom_words, uint32_t stage_base,
+                  uint32_t ram_words)
+{
+    bm_rom = rom;
+    bm_rom_words = rom_words;
+    bm_stage_base = stage_base;
+    bm_ram_words = ram_words;
+
+    cfg_line_len = 0;
+    cfg_line_over = false;
+    cfg_section = SEC_NONE;
+    cfg_open = false;
+    have_cfg = false;
+    cfg_err = 0;
+    rom_err = 0;
+    rom_open = false;
+    rom_fmt = ROMFMT_UNKNOWN;
+}
+
+////////////////////////////////////////////////////////////////////////////
+//                              .cfg parsing
+////////////////////////////////////////////////////////////////////////////
+
+// parse_cfg_line: one whole .cfg line, already terminated. Whitespace- and
+// case-tolerant, and comment-stripping, matching load_cfg() (intellicart.c)
+// -- the reference parser every local-storage board has always used.
+//
+// [macro]/poke lines stay unsupported over the network: an unrecognized
+// section switches to SEC_NONE so its body is ignored rather than
+// misparsed. Segment offsets recorded here are file-relative;
+// bootmap_rom_end() clamps them at EOF and biases them past CONFIG.
+static void parse_cfg_line(char *tmp)
+{
+    // Strip the comment before anything else looks at the line: jzintv
+    // comments run to end of line, and one saying "...page 2 of the
+    // manual" would otherwise read as a paging qualifier below.
+    char *semi = strchr(tmp, ';');
+    if (semi != NULL)
+        *semi = 0;
+    to_lower(tmp);
+
+    char *s = tmp;
+    while (*s == ' ' || *s == '\t' || *s == '\r')
+        s++;
+
+    if (strstr(s, "[mapping]") != NULL) {
+        cfg_section = SEC_MAPPING;
+    } else if (strstr(s, "[memattr]") != NULL) {
+        cfg_section = SEC_MEMATTR;
+    } else if (strstr(s, "[vars]") != NULL) {
+        cfg_section = SEC_VARS;
+    } else if (s[0] == '[') {
+        cfg_section = SEC_NONE;
+    } else if (cfg_section == SEC_MAPPING && s[0] == '$') {
+        unsigned int from = 0, to = 0, rom = 0, pg = 0;
+        if (sscanf(s, " $%x - $%x = $%x", &from, &to, &rom) != 3)
+            return;
+        if (rom > 0xFFFF || rom < BM_CART_LO || to < from)
+            return; // console space or nonsense -- drop the line
+
+        int8_t page = MM_NO_PAGE;
+        const char *pp = strstr(s, "page");
+        if (pp != NULL && sscanf(pp + 4, " %x", &pg) == 1 && pg <= 15) {
+            page = (int8_t)pg;
+            plan.paging = true;
+        }
+
+        if (plan.nseg < BM_MAX_SEGS) {
+            plan.seg[plan.nseg].rom_off = from;
+            plan.seg[plan.nseg].rom_end = to;
+            plan.seg[plan.nseg].cpu = (uint16_t)rom;
+            plan.seg[plan.nseg].page = page;
+            plan.nseg++;
+        } else {
+            cfg_err = FUJI_BOOT_ERR_TRUNCATED;
+        }
+    } else if (cfg_section == SEC_MEMATTR && s[0] == '$') {
+        unsigned int from = 0, to = 0, width = 0;
+        char type[8];
+        // Only "RAM" lines allocate. A "ROM" line marks a range read-only,
+        // which a preloaded segment already is.
+        if (sscanf(s, " $%x - $%x = %7s %u", &from, &to, type, &width) == 4 &&
+            (width == 8 || width == 16) && strcmp(type, "ram") == 0 &&
+            from <= to && to <= 0xFFFF) {
+            if (plan.nram < BM_MAX_RAM) {
+                plan.ram[plan.nram].lo = (uint16_t)from;
+                plan.ram[plan.nram].hi = (uint16_t)to;
+                plan.ram[plan.nram].width = (uint8_t)width;
+                plan.nram++;
+            } else {
+                cfg_err = FUJI_BOOT_ERR_TRUNCATED;
+            }
+        }
+    } else if (cfg_section == SEC_VARS) {
+        int v;
+        if (sscanf(s, " jlp = %d", &v) == 1 ||
+            sscanf(s, " jlp_accel = %d", &v) == 1 ||
+            sscanf(s, " jlpaccel = %d", &v) == 1) {
+            plan.jlp = v;
+        } else if (sscanf(s, " jlp_flash = %d", &v) == 1 ||
+                   sscanf(s, " jlpflash = %d", &v) == 1) {
+            plan.jlpflash = v;
+        } else if (sscanf(s, " ecs = %d", &v) == 1) {
+            plan.ecs = v;
+        } else if (sscanf(s, " voice = %d", &v) == 1) {
+            plan.voice = v;
+        }
+        // Everything else (name, author, year, ecs_compat, ...) is
+        // metadata for humans -- ignored, and must stay harmless.
+    }
+}
+
+// Ends the line being assembled and parses it, unless it overflowed.
+static void cfg_flush_line(void)
+{
+    if (cfg_line_over) {
+        cfg_err = FUJI_BOOT_ERR_TRUNCATED; // clipped line, map would be a guess
+    } else if (cfg_line_len > 0) {
+        cfg_line[cfg_line_len] = 0;
+        parse_cfg_line(cfg_line);
+    }
+    cfg_line_len = 0;
+    cfg_line_over = false;
+}
+
+void bootmap_cfg_begin(void)
+{
+    // The .cfg is the first thing pushed for a mount, so this is where the
+    // plan starts; bootmap_rom_begin() leaves it alone when one arrived.
+    memset(&plan, 0, sizeof(plan));
+    cfg_line_len = 0;
+    cfg_line_over = false;
+    cfg_section = SEC_NONE;
+    cfg_open = true;
+    have_cfg = false;
+    cfg_err = 0;
+}
+
+void bootmap_cfg_data(const uint8_t *d, uint16_t n)
+{
+    if (!cfg_open)
+        return;
+    for (uint16_t i = 0; i < n; i++) {
+        char c = (char)d[i];
+        if (c == '\n') {
+            cfg_flush_line();
+        } else if (cfg_line_len < CFG_LINE_MAX - 1) {
+            cfg_line[cfg_line_len++] = c;
+        } else {
+            cfg_line_over = true;
+        }
+    }
+}
+
+void bootmap_cfg_end(bool aborted)
+{
+    cfg_open = false;
+    if (aborted) {
+        memset(&plan, 0, sizeof(plan));
+        cfg_line_len = 0;
+        cfg_line_over = false;
+        cfg_err = 0;
+        have_cfg = false;
+        return;
+    }
+    cfg_flush_line();   // a file not ending in a newline still has a last line
+    have_cfg = true;
+}
+
+////////////////////////////////////////////////////////////////////////////
+//                            ROM stream decode
+////////////////////////////////////////////////////////////////////////////
+
+int bootmap_rom_begin(uint32_t expected_bytes)
+{
+    if (!have_cfg)
+        memset(&plan, 0, sizeof(plan)); // else it holds this mount's .cfg
+    rom_fmt = ROMFMT_UNKNOWN;
+    rom_hdrlen = 0;
+    rom_total_bytes = 0;
+    rom_expected_bytes = expected_bytes;
+    rom_open = true;
+    rom_err = 0;
+    stage_wp = bm_stage_base;
+    rh_banksw = false;
+
+    // Cheapest possible early-out: a stream this large cannot fit however
+    // it's laid out, so refuse before pulling it over TNFS. The exact
+    // per-format bound is enforced as the stream decodes.
+    if (expected_bytes / 2 > bm_rom_words) {
+        rom_fmt = ROMFMT_REJECTED;
+        rom_err = FUJI_BOOT_ERR_TOOBIG;
+        return FUJI_BOOT_ERR_TOOBIG;
+    }
+    return 0;
+}
+
+// rom_start_segment: called the instant an HDR segment's address range is
+// known. Stages the segment at the current write pointer and records the
+// mapping right away -- there's no buffer of decoded segments to batch this
+// from later.
+static void rom_start_segment(void)
+{
+    uint32_t words = rh_hi - rh_lo;
+
+    if (stage_wp + words > bm_rom_words) {
+        rom_fmt = ROMFMT_REJECTED;
+        rom_err = FUJI_BOOT_ERR_TOOBIG;
+        return;
+    }
+
+    if (plan.nseg < BM_MAX_SEGS) {
+        plan.seg[plan.nseg].rom_off = stage_wp;
+        plan.seg[plan.nseg].rom_end = stage_wp + words - 1;
+        plan.seg[plan.nseg].cpu = (uint16_t)rh_lo;
+        plan.seg[plan.nseg].page = MM_NO_PAGE;
+        plan.nseg++;
+    } else {
+        rom_err = FUJI_BOOT_ERR_TRUNCATED;
+    }
+
+    rh_cur_addr = stage_wp;
+    stage_wp += words;
+}
+
+// feed_rom_byte: one byte of a NETCMD_WRITE payload on the ROM stream.
+// Format is decided from the first 3 bytes; everything after is interpreted
+// incrementally, writing each completed word straight to its staged home.
+static void feed_rom_byte(uint8_t b)
+{
+    rom_total_bytes++;
+
+    if (rom_fmt == ROMFMT_UNKNOWN) {
+        rom_hdrbuf[rom_hdrlen++] = b;
+        if (rom_hdrlen < 3)
+            return;
+        if ((rom_hdrbuf[0] == 0xA8 || rom_hdrbuf[0] == 0x41 || rom_hdrbuf[0] == 0x61) &&
+            rom_hdrbuf[1] > 0 && (uint8_t)(rom_hdrbuf[1] ^ rom_hdrbuf[2]) == 0xFF) {
+            rom_fmt = ROMFMT_HDR;
+            rh_nseg = rom_hdrbuf[1];
+            rh_seg_i = 0;
+            rh_state = RH_SEG_ADDR;
+            rh_addrlen = 0;
+            rh_tbl_len = 0;
+            plan.nseg = 0;
+        } else {
+            rom_fmt = ROMFMT_FLAT;
+            flat_have_hi = false;
+            // A flat image needs its whole word count staged contiguously,
+            // and with a size from the peer that's known now rather than
+            // 200 KB into the transfer.
+            if (rom_expected_bytes != 0 &&
+                bm_stage_base + rom_expected_bytes / 2 > bm_rom_words) {
+                rom_fmt = ROMFMT_REJECTED;
+                rom_err = FUJI_BOOT_ERR_TOOBIG;
+                return;
+            }
+            // The 3 header-probe bytes are real file data in flat mode --
+            // replay them now that the format is known. All 3 were already
+            // counted by the natural calls that got us here, and each replay
+            // call counts itself again, so back out all 3 first.
+            rom_total_bytes -= 3;
+            feed_rom_byte(rom_hdrbuf[0]);
+            feed_rom_byte(rom_hdrbuf[1]);
+            feed_rom_byte(rom_hdrbuf[2]);
+        }
+        return;
+    }
+
+    if (rom_fmt == ROMFMT_REJECTED)
+        return;
+
+    if (rom_fmt == ROMFMT_FLAT) {
+        if (!flat_have_hi) {
+            flat_hi = b;
+            flat_have_hi = true;
+        } else {
+            if (stage_wp < bm_rom_words) {
+                bm_rom[stage_wp++] = ((uint16_t)flat_hi << 8) | b;
+            } else {
+                rom_fmt = ROMFMT_REJECTED; // don't wrap silently
+                rom_err = FUJI_BOOT_ERR_TOOBIG;
+            }
+            flat_have_hi = false;
+        }
+        return;
+    }
+
+    // ROMFMT_HDR
+    if (rh_seg_i >= rh_nseg) {
+        // Collect the enable tables for decode_enable_tables(); their
+        // CRC-16 and any metadata tags after them are ignored.
+        if (rh_tbl_len < RH_TBL_LEN)
+            rh_tbl[rh_tbl_len++] = b;
+        return;
+    }
+
+    switch (rh_state) {
+    case RH_SEG_ADDR:
+        rh_addrbuf[rh_addrlen++] = b;
+        if (rh_addrlen < 2)
+            return;
+        rh_lo = ((unsigned int)rh_addrbuf[0]) << 8;
+        rh_hi = (((unsigned int)rh_addrbuf[1]) << 8) + 0x100;
+        rh_addrlen = 0;
+        if (rh_hi <= rh_lo || rh_lo < BM_CART_LO || rh_hi > 0x10000u) {
+            rom_fmt = ROMFMT_REJECTED; // malformed header, not a size problem
+            return;
+        }
+        rom_start_segment();
+        if (rom_fmt == ROMFMT_REJECTED)
+            return;
+        rh_words_left = rh_hi - rh_lo;
+        rh_have_hi = false;
+        rh_state = RH_SEG_DATA;
+        return;
+    case RH_SEG_DATA:
+        if (!rh_have_hi) {
+            rh_hi_byte = b;
+            rh_have_hi = true;
+        } else {
+            bm_rom[rh_cur_addr++] = ((uint16_t)rh_hi_byte << 8) | b;
+            rh_have_hi = false;
+            rh_words_left--;
+            if (rh_words_left == 0) {
+                rh_state = RH_SEG_CRC;
+                rh_crclen = 0;
+            }
+        }
+        return;
+    case RH_SEG_CRC:
+        rh_crclen++; // received but not validated
+        if (rh_crclen < 2)
+            return;
+        rh_seg_i++;
+        rh_state = RH_SEG_ADDR;
+        rh_addrlen = 0;
+        return;
+    }
+}
+
+void bootmap_rom_data(const uint8_t *d, uint16_t n)
+{
+    if (!rom_open)
+        return;
+    for (uint16_t i = 0; i < n; i++)
+        feed_rom_byte(d[i]);
+}
+
+uint8_t bootmap_pct(void)
+{
+    uint32_t total = rom_expected_bytes ? rom_expected_bytes : 32768;
+    uint32_t pct = (rom_total_bytes * 100) / total;
+    return pct > 99 ? 99 : (uint8_t)pct;
+}
+
+void bootmap_rom_abort(void)
+{
+    rom_open = false;
+    have_cfg = false;
+    cfg_err = 0;
+}
+
+// decode_enable_tables: translate the .rom's attribute/fine-address tables
+// (rh_tbl) into plan.ram entries. Layout, per jzIntv's icartrom_decode():
+// for 2K bank i (bus address i<<11), the attribute nibble is rh_tbl[i>>1]
+// (low nibble = even bank, high = odd), and the fine-address byte is
+// rh_tbl[16 + ((i>>1) | ((i&1)<<4))] -- even banks in bytes 16-31's first
+// half, odd banks in the second -- whose high nibble is the bank's first
+// active 256-word block and low nibble its last. Attribute bits: 1 =
+// readable, 2 = writable, 4 = narrow (8-bit), 8 = bank-switched.
+//
+// Writable, non-bank-switched ranges become RAM (8-bit when narrow, else
+// 16-bit); read-only ranges are already covered by the staged segments.
+// Adjacent same-width ranges are merged so a typical game's whole scratch
+// window costs one slot.
+static void decode_enable_tables(void)
+{
+    for (unsigned i = 0; i < 32; i++) {
+        unsigned attr = 0xF & (rh_tbl[i >> 1] >> ((i & 1) * 4));
+        uint8_t lohi = rh_tbl[16 + ((i >> 1) | ((i & 1) << 4))];
+        unsigned lo = (lohi >> 4) & 0x7;
+        unsigned hi = (lohi & 0x7) + 1;
+
+        if (attr & 0x8) {
+            // This decoder cannot follow bank switching, so a game relying
+            // on it would run with only the banks it happened to list.
+            rh_banksw = true;
+            continue;
+        }
+        if (!(attr & 0x2) || hi <= lo)
+            continue;
+
+        unsigned int from = (i << 11) + (lo << 8);
+        unsigned int to = (i << 11) + (hi << 8) - 1;
+        uint8_t width = (attr & 0x4) ? 8 : 16;
+
+        // never serve RAM over console space -- bus contention
+        if (to < 0x4000)
+            continue;
+        if (from < 0x4000)
+            from = 0x4000;
+
+        if (plan.nram > 0 &&
+            (unsigned int)plan.ram[plan.nram - 1].hi + 1 == from &&
+            plan.ram[plan.nram - 1].width == width) {
+            plan.ram[plan.nram - 1].hi = (uint16_t)to;
+        } else if (plan.nram < BM_MAX_RAM) {
+            plan.ram[plan.nram].lo = (uint16_t)from;
+            plan.ram[plan.nram].hi = (uint16_t)to;
+            plan.ram[plan.nram].width = width;
+            plan.nram++;
+        } else {
+            rom_err = FUJI_BOOT_ERR_TRUNCATED;
+        }
+    }
+}
+
+// A bare .bin with no .cfg: the same file-order layouts bin2rom assumes for
+// the handful of sizes the original cartridge library actually used.
+// Anything else is refused rather than guessed at.
+static bool guess_by_size(uint32_t bytes)
+{
+    uint32_t words = bytes / 2;
+
+    plan.nseg = 1;
+    plan.seg[0].rom_off = 0;
+    plan.seg[0].rom_end = words > 0 ? words - 1 : 0;
+    plan.seg[0].cpu = 0x5000;
+    plan.seg[0].page = MM_NO_PAGE;
+
+    switch (bytes) {
+    case 4096:
+    case 8192:
+    case 12288:
+    case 16384:
+        return true;
+    case 24576:
+        plan.nseg = 2;
+        plan.seg[0].rom_off = 0;      plan.seg[0].rom_end = 0x1FFF; plan.seg[0].cpu = 0x5000;
+        plan.seg[1].rom_off = 0x2000; plan.seg[1].rom_end = 0x2FFF; plan.seg[1].cpu = 0xD000;
+        break;
+    case 32768:
+        plan.nseg = 3;
+        plan.seg[0].rom_off = 0;      plan.seg[0].rom_end = 0x1FFF; plan.seg[0].cpu = 0x5000;
+        plan.seg[1].rom_off = 0x2000; plan.seg[1].rom_end = 0x2FFF; plan.seg[1].cpu = 0xD000;
+        plan.seg[2].rom_off = 0x3000; plan.seg[2].rom_end = 0x3FFF; plan.seg[2].cpu = 0xF000;
+        break;
+    case 40960: // 20K words: 8K at $5000, 12K contiguous at $D000
+        plan.nseg = 2;
+        plan.seg[0].rom_off = 0;      plan.seg[0].rom_end = 0x1FFF; plan.seg[0].cpu = 0x5000;
+        plan.seg[1].rom_off = 0x2000; plan.seg[1].rom_end = 0x4FFF; plan.seg[1].cpu = 0xD000;
+        break;
+    case 49152: // 24K words: the common INTV shape, 8K/12K/4K
+        plan.nseg = 3;
+        plan.seg[0].rom_off = 0;      plan.seg[0].rom_end = 0x1FFF; plan.seg[0].cpu = 0x5000;
+        plan.seg[1].rom_off = 0x2000; plan.seg[1].rom_end = 0x4FFF; plan.seg[1].cpu = 0x9000;
+        plan.seg[2].rom_off = 0x5000; plan.seg[2].rom_end = 0x5FFF; plan.seg[2].cpu = 0xD000;
+        break;
+    default:
+        plan.nseg = 0;
+        return false;
+    }
+    for (int i = 1; i < plan.nseg; i++)
+        plan.seg[i].page = MM_NO_PAGE;
+    return true;
+}
+
+int bootmap_rom_end(bm_plan_t **out)
+{
+    rom_open = false;
+
+    int err = 0;
+
+    if (rom_fmt == ROMFMT_UNKNOWN || rom_fmt == ROMFMT_REJECTED) {
+        err = rom_err ? rom_err : FUJI_BOOT_ERR_REJECTED;
+    } else if (rom_expected_bytes != 0 && rom_total_bytes != rom_expected_bytes) {
+        err = FUJI_BOOT_ERR_TRUNCATED;
+    } else if (rom_fmt == ROMFMT_HDR) {
+        // A header-format image is self-describing: RAM comes from its own
+        // enable tables, and a .cfg sibling is neither needed nor consulted.
+        // The tables are formally optional, so a stream that ended without
+        // them simply boots with no RAM.
+        plan.nram = 0;
+        plan.jlp = plan.jlpflash = 0;
+        plan.ecs = plan.voice = 0;
+        if (rh_seg_i != rh_nseg || plan.nseg == 0) {
+            err = FUJI_BOOT_ERR_TRUNCATED; // ended mid-segment, or before any
+        } else {
+            if (rh_tbl_len >= RH_TBL_LEN)
+                decode_enable_tables();
+            if (rh_banksw)
+                err = FUJI_BOOT_ERR_BANKSW;
+        }
+    } else if (have_cfg && plan.nseg > 0) {
+        ; // parse_cfg_line() already filled the plan in
+    } else if (!guess_by_size(rom_total_bytes)) {
+        err = have_cfg ? FUJI_BOOT_ERR_CFGBAD : FUJI_BOOT_ERR_NOMAP;
+    }
+
+    // Consume the .cfg either way, so the next push starts clean.
+    have_cfg = false;
+
+    if (!err && (cfg_err || rom_err))
+        err = cfg_err ? cfg_err : rom_err;
+    cfg_err = 0;
+
+    if (err) {
+        plan.rom_bytes = rom_total_bytes;
+        *out = &plan;
+        return err;
+    }
+
+    // Flat images carry file-relative offsets from the .cfg or the size
+    // guess. Clamp mappings at EOF (bin2rom semantics -- collection cfgs
+    // describe each title's largest layout and expect ranges past EOF to
+    // fall away), then bias into the staging area.
+    if (rom_fmt == ROMFMT_FLAT) {
+        uint32_t words = rom_total_bytes / 2;
+        int kept = 0;
+        for (int i = 0; i < plan.nseg; i++) {
+            if (plan.seg[i].rom_off >= words)
+                continue; // wholly past EOF -- drop
+            if (plan.seg[i].rom_end >= words)
+                plan.seg[i].rom_end = words - 1;
+            plan.seg[kept] = plan.seg[i];
+            plan.seg[kept].rom_off += bm_stage_base;
+            plan.seg[kept].rom_end += bm_stage_base;
+            kept++;
+        }
+        plan.nseg = kept;
+        if (plan.nseg == 0) {
+            plan.rom_bytes = rom_total_bytes;
+            *out = &plan;
+            return FUJI_BOOT_ERR_CFGBAD;
+        }
+    }
+
+    // Recompute from what actually survived the clamp, not from what the
+    // .cfg asked for: cart.pagingSupport costs a test on every bus write,
+    // so don't arm it for a map with no paged entries left.
+    plan.paging = false;
+    for (int i = 0; i < plan.nseg; i++)
+        if (plan.seg[i].page != MM_NO_PAGE)
+            plan.paging = true;
+
+    // RAM sanitation: nothing below $4000 (bus contention), total within
+    // the cart's RAM budget.
+    {
+        uint32_t total_ram = 0;
+        int kept = 0;
+        for (int i = 0; i < plan.nram; i++) {
+            uint16_t lo = plan.ram[i].lo, hi = plan.ram[i].hi;
+            if (hi < 0x4000)
+                continue;
+            if (lo < 0x4000)
+                lo = 0x4000;
+            if (hi < lo)
+                continue;
+            total_ram += (uint32_t)(hi - lo) + 1;
+            plan.ram[kept].lo = lo;
+            plan.ram[kept].hi = hi;
+            plan.ram[kept].width = plan.ram[i].width;
+            kept++;
+        }
+        plan.nram = kept;
+        if (total_ram > bm_ram_words) {
+            plan.rom_bytes = rom_total_bytes;
+            *out = &plan;
+            return FUJI_BOOT_ERR_RAM;
+        }
+    }
+
+    plan.rom_bytes = rom_total_bytes;
+    *out = &plan;
+    return 0;
+}
+
+int bootmap_shadow_range(bm_plan_t *p, uint16_t lo, uint16_t hi)
+{
+    int kept = 0, dropped = 0;
+
+    for (int i = 0; i < p->nseg; i++) {
+        bm_seg_t s = p->seg[i];
+        uint32_t len = s.rom_end - s.rom_off;   // words - 1
+        uint32_t s_lo = s.cpu, s_hi = s.cpu + len;
+
+        if (s_hi < lo || s_lo > hi) {
+            p->seg[kept++] = s;                 // clear of the window
+        } else if (s_lo >= lo && s_hi <= hi) {
+            dropped++;                          // wholly shadowed
+        } else if (s_lo < lo) {
+            // Overlaps the bottom edge, and possibly out the top too --
+            // either way the part below the window is what survives.
+            s.rom_end = s.rom_off + (lo - 1 - s_lo);
+            p->seg[kept++] = s;
+        } else {
+            // Overlaps the top edge: skip past the window.
+            uint32_t skip = hi + 1 - s_lo;
+            s.rom_off += skip;
+            s.cpu = (uint16_t)(hi + 1);
+            p->seg[kept++] = s;
+        }
+    }
+    p->nseg = kept;
+    return dropped;
+}

--- a/pico/intellivision/firmware/src/fujiboot.c
+++ b/pico/intellivision/firmware/src/fujiboot.c
@@ -11,6 +11,7 @@
 // .bas sources), not something to parse at boot time.
 #include <string.h>
 
+#include "bootmap.h"
 #include "fujiboot.h"
 #include "fujiconfigrom.h"
 #include "fuji_mailbox.h"
@@ -19,6 +20,11 @@
 
 extern Cartridge cart;
 extern mm_map_t m;
+
+// A network push stages above CONFIG so it can't clobber the image the
+// console is executing while the transfer runs -- see FUJI_STAGE_BASE.
+_Static_assert(sizeof(_bootrom) / 2 <= FUJI_STAGE_BASE,
+               "CONFIG ROM outgrew FUJI_STAGE_BASE -- raise it");
 
 // fuji_config_map: (re)build CONFIG's map and mailbox ident; also the
 // network boot path's recovery after a failed mm commit.
@@ -53,6 +59,13 @@ void RunFujiConfig(void)
         cart.ROM[i] = _bootrom[(i * 2) + 1] | (_bootrom[i * 2] << 8);
 
     fuji_config_map();
+
+    // Hand bootmap.c the buffer a network push decodes into, and the floor
+    // it must stay above so a transfer can't disturb the CONFIG image the
+    // console runs out of while the transfer is happening. The cast drops
+    // volatile: staged words are written once here and only read back after
+    // resetCart() swaps in the new map, so core1 never sees them in flight.
+    bootmap_init((uint16_t *)cart.ROM, MAX_ROM_SIZE, FUJI_STAGE_BASE, RAMSIZE);
 
     cart.FujiSupport = true;
     cart.MailboxActive = true;

--- a/pico/intellivision/firmware/src/fujinet.c
+++ b/pico/intellivision/firmware/src/fujinet.c
@@ -8,10 +8,11 @@
 // cartridge's memory map with mm_map_t (memory.c) -- mm_init()/mm_add()/
 // mm_add_ram() -- rather than PiRTO II's flat mapfrom/mapto/maprom arrays.
 // apply_boot_mapping() below builds an mm_map_t the same way load_cfg()
-// does for a local file. The mailbox's own RAM claim is NOT part of that
-// map -- see cartridge.c's window branch, driven by cart.FujiSupport --
-// so, unlike the original, this never needs to re-add the mailbox as its
-// own RAM segment after loading a game.
+// does for a local file, from the bm_plan_t bootmap.c hands it. The
+// mailbox's own RAM claim is NOT part of that map -- see cartridge.c's
+// window branch, driven by cart.FujiSupport -- so, unlike the original,
+// this never needs to re-add the mailbox as its own RAM segment after
+// loading a game.
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
@@ -24,6 +25,7 @@
 #include "interface.h"
 #include "memory.h"
 #include "intellicart.h"
+#include "bootmap.h"
 #include "fuji_mailbox.h"
 #include "fujibus.h"
 #include "fujibus_usb.h"
@@ -32,6 +34,10 @@
 
 extern Cartridge cart;
 extern mm_map_t m;
+#if CONFIG_ECS_AUDIO || CONFIG_INTELLIVOICE
+extern uint8_t ecs_present;
+extern uint8_t voice_present;
+#endif
 
 // sleep_ms() that keeps USB alive; gapped per fujibus_usb.c so core1 isn't starved.
 void fuji_wait_ms_pumped(uint32_t ms)
@@ -60,31 +66,31 @@ void fuji_wait_ms_pumped(uint32_t ms)
 // each one individually -- the ESP32 side's sendCommand() is a per-frame
 // round trip (one OPEN, then one WRITE per ~512-byte chunk, then CLOSE).
 //
-// SCOPE NOTE: no staging buffer -- data decodes into cart.ROM[] as it
-// streams, above CONFIG's live offsets so a failed push can't hang CONFIG.
+// SCOPE NOTE: no staging buffer -- bootmap.c decodes into cart.ROM[] as the
+// data streams, above CONFIG's live offsets (FUJI_STAGE_BASE) so a failed
+// push can't hang the CONFIG image the console is executing meanwhile.
 //
-// Mapping precedence, decided in apply_boot_mapping() once CLOSE arrives on
-// the ROM stream: a self-describing non-bankswitched Intellicart/CC3 .rom
-// header (feed_rom_byte() detects and decodes this live) takes priority; if
-// the stream isn't that format, a pushed .cfg sibling's [mapping] and
-// [memattr] lines and VARS jlp/jlp_flash settings, if one was pushed; else
-// a same-file-order size table for a bare .bin. Only the .cfg path can
-// enable JLP -- a self-describing .rom or a bare-size-guessed .bin never
-// carries VARS, matching the local-storage load_cfg() precedent where JLP
-// is only ever turned on by an explicit .cfg.
+// All parsing lives in bootmap.c, which knows nothing about USB, the
+// mailbox or the Cartridge: it turns the two streams into a bm_plan_t.
+// This file owns everything around that -- framing and ACK/NAK below,
+// mapping precedence being bootmap_rom_end()'s business, and the mailbox/
+// JLP policy plus the mm_*() commit in apply_boot_mapping().
 //
-// NETCMD_OPEN's payload byte selects the stream: 1 = the .cfg sibling
-// (pushed first, so its mapping/JLP settings are known before the ROM's own
-// CLOSE triggers the boot), 0 = the ROM itself.
+// NETCMD_OPEN's payload selects the stream: 1 = the .cfg sibling (pushed
+// first, so its mapping/JLP settings are known before the ROM's own CLOSE
+// triggers the boot), 0 = the ROM itself. Peers from this revision on
+// append the stream's total size as 4 little-endian bytes, which lets an
+// oversized ROM be refused before it's pulled over TNFS and makes the
+// progress bar exact; older peers send the id alone and everything still
+// works, just blind.
 
-#define CFG_BUF_MAX 4096
-static char cfg_buf[CFG_BUF_MAX];
-static uint32_t cfg_wp = 0;
-static bool cfg_open = false;
-static bool have_cfg = false;
+#define DBC_STREAM_ROM 0
+#define DBC_STREAM_CFG 1
+static int dbc_stream = -1; // stream id currently open, -1 for none
 
-// a receiver limit dropped data -- fail TRUNCATED, never boot a partial map
-static bool boot_truncated = false;
+// the plan bootmap_rom_end() produced for this mount -- points into
+// bootmap.c's own storage, valid until the next push starts
+static bm_plan_t *boot_plan;
 
 // failed commit rebuilt CONFIG's map; handler must reset the console into it
 static bool need_config_reset = false;
@@ -97,76 +103,6 @@ static bool need_config_reset = false;
 // from, since a network push otherwise has no filesystem path of its own.
 // Populated in fuji_mailbox_service(), consumed in apply_boot_mapping().
 static char last_boot_path[256];
-
-#define BOOT_MAX_SEGS 16
-static unsigned int boot_mapfrom[BOOT_MAX_SEGS]; // ROM word offset, inclusive
-static unsigned int boot_mapto[BOOT_MAX_SEGS];   // ROM word offset, inclusive
-static unsigned int boot_maprom[BOOT_MAX_SEGS];  // destination bus address
-static int boot_nsegs = 0;
-
-// [memattr] RAM lines from a pushed .cfg, applied after the ROM segments.
-#define BOOT_MAX_RAM 8
-static unsigned int boot_ramfrom[BOOT_MAX_RAM];
-static unsigned int boot_ramto[BOOT_MAX_RAM];
-static uint8_t boot_ramwidth[BOOT_MAX_RAM];
-static int boot_nram = 0;
-
-// [vars] jlp/jlp_flash from a pushed .cfg. 0 = not requested.
-static int boot_jlp_value = 0;
-static int boot_jlpflash_value = 0;
-
-// ROM-stream decode state -- see feed_rom_byte(). Format is detected from
-// the first 3 bytes received; everything after that is interpreted
-// incrementally, one byte at a time, writing words straight into their
-// final cart.ROM[] destination as soon as each is complete.
-typedef enum { ROMFMT_UNKNOWN, ROMFMT_FLAT, ROMFMT_HDR, ROMFMT_REJECTED } romfmt_t;
-static romfmt_t rom_fmt;
-static uint8_t rom_hdrbuf[3];
-static unsigned rom_hdrlen;
-static uint32_t rom_total_bytes;
-static bool rom_open = false;
-
-// ROMFMT_FLAT: big-endian words staged at FLAT_STAGE_BASE (mapping offsets
-// biased at commit) -- offset 0 would clobber the CONFIG image the console
-// is still executing. HDR streams land identity-mapped >= $4000, no staging.
-#define FLAT_STAGE_BASE 0x4000u
-_Static_assert(MAX_ROM_SIZE >= FLAT_STAGE_BASE + 0x8000,
-               "cart.ROM[] too small to stage a 32K-word flat image");
-static uint32_t flat_wp;
-static bool flat_have_hi;
-static uint8_t flat_hi;
-
-// ROMFMT_HDR: incremental Intellicart/CC3 .rom decode, one segment at a
-// time. Reference: jzIntv's src/icart/icartrom.c icartrom_decode(), which
-// this is a byte-for-byte port of the relevant (non-bankswitched) subset
-// of. Layout per segment: 2 bytes (lo, hi) giving an inclusive page range
-// (word address = page<<8, hi's page is the start of its last 256-word
-// block), then 2*(wordcount) bytes of big-endian ROM data for that exact
-// range (written directly at that bus address -- identity mapped, see
-// rom_start_segment_slot()), then a 2-byte CRC-16 (received but not
-// validated).
-typedef enum { RH_SEG_ADDR, RH_SEG_DATA, RH_SEG_CRC } rh_state_t;
-static rh_state_t rh_state;
-static uint8_t rh_nseg, rh_seg_i;
-static uint8_t rh_addrbuf[2];
-static unsigned rh_addrlen;
-static unsigned int rh_lo, rh_hi;
-static uint32_t rh_words_left;
-static uint32_t rh_cur_addr;
-static bool rh_have_hi;
-static uint8_t rh_hi_byte;
-static unsigned rh_crclen;
-
-// Trailing attribute/fine-address ("enable") tables: 16 attribute bytes +
-// 32 fine-address bytes, collected once the last segment's CRC is consumed
-// (their own CRC-16, like the segment CRCs, is received but not
-// validated). decode_enable_tables() turns these into boot_ram* entries at
-// CLOSE time -- this is the only place a .rom declares its RAM (e.g. cart
-// scratch at $8000-$9BFF), so ignoring them boots a game whose RAM
-// silently reads/writes nothing.
-#define RH_TBL_LEN 48
-static uint8_t rh_tbl[RH_TBL_LEN];
-static unsigned rh_tbl_len;
 
 // Sends a bare ACK/NAK reply frame for one DBC command, over the same
 // tud_cdc link fujibus_transact() itself uses to send requests. This runs
@@ -200,429 +136,63 @@ static bool mailbox_overlap(unsigned int from, unsigned int to, bool jlp_pending
     return !(to < lo || from > hi);
 }
 
-// parse_pushed_cfg: minimal in-memory .cfg parser over cfg_buf, covering
-// [mapping] (`$xxxx - $yyyy = $zzzz`), [memattr] (`$xxxx - $yyyy = RAM w`)
-// and [vars] (`jlp = N` / `jlp_accel = N` / `jlpaccel = N`, `jlp_flash = N`
-// / `jlpflash = N`) lines, whitespace-tolerant. Unlike load_cfg() (the
-// local-storage parser, which reads from a FatFs/LittleFS FIL handle), this
-// operates on the buffer dbc_inbound_handler() already filled. No paging
-// support (`p`-suffixed mapping lines) and no MACRO/poke lines -- a
-// network-pushed mapping is limited to what a game actually needs to run.
-static bool parse_pushed_cfg(void)
-{
-    boot_nsegs = 0;
-    boot_nram = 0;
-    boot_jlp_value = 0;
-    boot_jlpflash_value = 0;
-
-    typedef enum { SEC_NONE, SEC_MAPPING, SEC_MEMATTR, SEC_VARS } section_t;
-    section_t section = SEC_NONE;
-
-    const char *p = cfg_buf;
-    const char *end = cfg_buf + cfg_wp;
-
-    while (p < end) {
-        const char *nl = memchr(p, '\n', (size_t)(end - p));
-        const char *line_end = nl ? nl : end;
-        size_t linelen = (size_t)(line_end - p);
-
-        char tmp[96];
-        size_t copylen = linelen < sizeof(tmp) - 1 ? linelen : sizeof(tmp) - 1;
-        memcpy(tmp, p, copylen);
-        tmp[copylen] = 0;
-
-        if (strstr(tmp, "[mapping]") != NULL) {
-            section = SEC_MAPPING;
-        } else if (strstr(tmp, "[memattr]") != NULL) {
-            section = SEC_MEMATTR;
-        } else if (strstr(tmp, "[vars]") != NULL) {
-            section = SEC_VARS;
-        } else if (linelen > 0 && tmp[0] == '[') {
-            section = SEC_NONE; // [macro] or anything else -- not supported over the network
-        } else if (section == SEC_MAPPING && linelen > 0 && tmp[0] == '$') {
-            unsigned int from = 0, to = 0, rom = 0;
-            if (sscanf(tmp, " $%x - $%x = $%x", &from, &to, &rom) == 3) {
-                if (boot_nsegs < BOOT_MAX_SEGS) {
-                    boot_mapfrom[boot_nsegs] = from;
-                    boot_mapto[boot_nsegs] = to;
-                    boot_maprom[boot_nsegs] = rom;
-                    boot_nsegs++;
-                } else {
-                    boot_truncated = true;
-                }
-            }
-        } else if (section == SEC_MEMATTR && linelen > 0 && tmp[0] == '$') {
-            unsigned int from = 0, to = 0, width = 0;
-            char type[4];
-            if (sscanf(tmp, " $%x - $%x = %3s %u", &from, &to, type, &width) == 4 &&
-                (width == 8 || width == 16)) {
-                if (boot_nram < BOOT_MAX_RAM) {
-                    boot_ramfrom[boot_nram] = from;
-                    boot_ramto[boot_nram] = to;
-                    boot_ramwidth[boot_nram] = (uint8_t)width;
-                    boot_nram++;
-                } else {
-                    boot_truncated = true;
-                }
-            }
-        } else if (section == SEC_VARS) {
-            int v;
-            if (sscanf(tmp, " jlp = %d", &v) == 1 ||
-                sscanf(tmp, " jlp_accel = %d", &v) == 1 ||
-                sscanf(tmp, " jlpaccel = %d", &v) == 1) {
-                boot_jlp_value = v;
-            } else if (sscanf(tmp, " jlp_flash = %d", &v) == 1 ||
-                       sscanf(tmp, " jlpflash = %d", &v) == 1) {
-                boot_jlpflash_value = v;
-            }
-        }
-
-        p = nl ? nl + 1 : end;
-    }
-
-    return boot_nsegs > 0;
-}
-
-// rom_start_segment_slot: called the instant a ROMFMT_HDR segment's
-// address range is known, registering it as a boot_* mapping entry right
-// away -- there's no separate buffer holding decoded segments to batch
-// this from later. Identity mapped (rom offset == bus address): see the
-// section banner.
-static void rom_start_segment_slot(void)
-{
-    if (boot_nsegs < BOOT_MAX_SEGS) {
-        boot_mapfrom[boot_nsegs] = rh_lo;
-        boot_mapto[boot_nsegs] = rh_hi - 1;
-        boot_maprom[boot_nsegs] = rh_lo;
-        boot_nsegs++;
-    }
-}
-
-// feed_rom_byte: the incremental ROM-stream decoder. Called once per byte
-// of every NETCMD_WRITE payload on the ROM stream (stream 0).
-//
-// KNOWN LIMITATION: bank-switched .rom images are not handled -- the
-// attribute/fine-address tables are decoded (writable ranges become RAM,
-// see decode_enable_tables()), but banks flagged bank-switched there are
-// skipped, so a title that relies on bank-switching to reach code outside
-// its listed segments will not run correctly.
-static void feed_rom_byte(uint8_t b)
-{
-    rom_total_bytes++;
-
-    if (rom_fmt == ROMFMT_UNKNOWN) {
-        rom_hdrbuf[rom_hdrlen++] = b;
-        if (rom_hdrlen < 3)
-            return;
-        if ((rom_hdrbuf[0] == 0xA8 || rom_hdrbuf[0] == 0x41 || rom_hdrbuf[0] == 0x61) &&
-            rom_hdrbuf[1] > 0 && (uint8_t)(rom_hdrbuf[1] ^ rom_hdrbuf[2]) == 0xFF) {
-            rom_fmt = ROMFMT_HDR;
-            rh_nseg = rom_hdrbuf[1];
-            rh_seg_i = 0;
-            rh_state = RH_SEG_ADDR;
-            rh_addrlen = 0;
-            rh_tbl_len = 0;
-            boot_nsegs = 0;
-        } else {
-            rom_fmt = ROMFMT_FLAT;
-            flat_wp = 0;
-            flat_have_hi = false;
-            // The 3 header-probe bytes are real file data in flat mode --
-            // replay them now that the format is known. All 3 bytes were
-            // already counted by the natural calls that got us here, and
-            // each replay call will count itself again, so back out all 3
-            // (not just this call's own +1) first.
-            rom_total_bytes -= 3;
-            feed_rom_byte(rom_hdrbuf[0]);
-            feed_rom_byte(rom_hdrbuf[1]);
-            feed_rom_byte(rom_hdrbuf[2]);
-        }
-        return;
-    }
-
-    if (rom_fmt == ROMFMT_REJECTED)
-        return;
-
-    if (rom_fmt == ROMFMT_FLAT) {
-        if (!flat_have_hi) {
-            flat_hi = b;
-            flat_have_hi = true;
-        } else {
-            if (FLAT_STAGE_BASE + flat_wp < (uint32_t)MAX_ROM_SIZE)
-                cart.ROM[FLAT_STAGE_BASE + flat_wp++] = ((uint16_t)flat_hi << 8) | b;
-            else
-                rom_fmt = ROMFMT_REJECTED; // oversized stream, don't wrap silently
-            flat_have_hi = false;
-        }
-        return;
-    }
-
-    // ROMFMT_HDR
-    if (rh_seg_i >= rh_nseg) {
-        // Collect the enable tables for decode_enable_tables(); their
-        // CRC-16 and any metadata tags after them are ignored.
-        if (rh_tbl_len < RH_TBL_LEN)
-            rh_tbl[rh_tbl_len++] = b;
-        return;
-    }
-
-    switch (rh_state) {
-    case RH_SEG_ADDR:
-        rh_addrbuf[rh_addrlen++] = b;
-        if (rh_addrlen < 2)
-            return;
-        rh_lo = ((unsigned int)rh_addrbuf[0]) << 8;
-        rh_hi = (((unsigned int)rh_addrbuf[1]) << 8) + 0x100;
-        rh_addrlen = 0;
-        // < $4000 is console space and would overwrite CONFIG's live image
-        if (rh_hi <= rh_lo || rh_lo < 0x4000 || rh_hi > (unsigned int)MAX_ROM_SIZE) {
-            rom_fmt = ROMFMT_REJECTED;
-            return;
-        }
-        rom_start_segment_slot();
-        rh_words_left = rh_hi - rh_lo;
-        rh_cur_addr = rh_lo;
-        rh_have_hi = false;
-        rh_state = RH_SEG_DATA;
-        return;
-    case RH_SEG_DATA:
-        if (!rh_have_hi) {
-            rh_hi_byte = b;
-            rh_have_hi = true;
-        } else {
-            cart.ROM[rh_cur_addr++] = ((uint16_t)rh_hi_byte << 8) | b;
-            rh_have_hi = false;
-            rh_words_left--;
-            if (rh_words_left == 0) {
-                rh_state = RH_SEG_CRC;
-                rh_crclen = 0;
-            }
-        }
-        return;
-    case RH_SEG_CRC:
-        rh_crclen++; // received but not validated
-        if (rh_crclen < 2)
-            return;
-        rh_seg_i++;
-        rh_state = RH_SEG_ADDR;
-        rh_addrlen = 0;
-        return;
-    }
-}
-
-// decode_enable_tables: translate the .rom's attribute/fine-address tables
-// (rh_tbl) into boot_ram* entries. Layout, per jzIntv's icartrom_decode()
-// (the reference this decoder is ported from): for 2K bank i (bus address
-// i<<11), the attribute nibble is rh_tbl[i>>1] (low nibble = even bank,
-// high = odd), and the fine-address byte is rh_tbl[16 + ((i>>1) |
-// ((i&1)<<4))] -- even banks in bytes 16-31's first half, odd banks in the
-// second -- whose high nibble is the bank's first active 256-word block
-// and low nibble its last. Attribute bits: 1 = readable, 2 = writable,
-// 4 = narrow (8-bit), 8 = bank-switched.
-//
-// Writable, non-bank-switched ranges become RAM (8-bit when narrow, else
-// 16-bit); read-only ranges are already covered by the preloaded segments,
-// and bank-switched banks stay unsupported (see feed_rom_byte()'s KNOWN
-// LIMITATION). Adjacent same-width ranges are merged so a typical game's
-// whole scratch window costs one boot_ram slot; ranges past BOOT_MAX_RAM
-// are dropped, matching parse_pushed_cfg()'s own silent cap.
-static void decode_enable_tables(void)
-{
-    for (unsigned i = 0; i < 32; i++) {
-        unsigned attr = 0xF & (rh_tbl[i >> 1] >> ((i & 1) * 4));
-        uint8_t lohi = rh_tbl[16 + ((i >> 1) | ((i & 1) << 4))];
-        unsigned lo = (lohi >> 4) & 0x7;
-        unsigned hi = (lohi & 0x7) + 1;
-
-        if (!(attr & 0x2) || (attr & 0x8) || hi <= lo)
-            continue;
-
-        unsigned int from = (i << 11) + (lo << 8);
-        unsigned int to = (i << 11) + (hi << 8) - 1;
-        uint8_t width = (attr & 0x4) ? 8 : 16;
-
-        // never serve RAM over console space -- bus contention
-        if (to < 0x4000)
-            continue;
-        if (from < 0x4000)
-            from = 0x4000;
-
-        if (boot_nram > 0 &&
-            boot_ramto[boot_nram - 1] + 1 == from &&
-            boot_ramwidth[boot_nram - 1] == width) {
-            boot_ramto[boot_nram - 1] = to;
-        } else if (boot_nram < BOOT_MAX_RAM) {
-            boot_ramfrom[boot_nram] = from;
-            boot_ramto[boot_nram] = to;
-            boot_ramwidth[boot_nram] = width;
-            boot_nram++;
-        } else {
-            boot_truncated = true;
-        }
-    }
-}
-
 // apply_boot_mapping: called once the ROM stream's CLOSE arrives.
-// cart.ROM[]'s final bytes are already in place by now (feed_rom_byte()
-// wrote them there live). Decides the mapping source, validates every
-// segment against the RAM window that would be active once this boot
-// completes, and only then commits: builds a fresh mm_map_t and, if a
-// pushed .cfg requested it, turns on JLP (which also updates the window --
-// see update_ram_window() in intellicart.c).
+// cart.ROM[]'s final bytes are already in place by now (bootmap.c wrote
+// them there live). bootmap_rom_end() picks the mapping source and hands
+// back a finished plan; what's left here is the part that needs to know
+// about this cartridge -- reconciling the plan with the RAM window that
+// will be active once the boot completes, committing an mm_map_t, and
+// turning on JLP (which also moves the window -- see update_ram_window()
+// in intellicart.c).
 static bool apply_boot_mapping(void)
 {
-    if (rom_fmt == ROMFMT_UNKNOWN || rom_fmt == ROMFMT_REJECTED) {
-        cart.RAM[FUJI_MB_BOOT_ERR] = FUJI_BOOT_ERR_REJECTED;
+    int err = bootmap_rom_end(&boot_plan);
+    if (err) {
+        cart.RAM[FUJI_MB_BOOT_ERR] = (uint16_t)err;
         return false;
     }
 
-    bool jlp_pending = false;
-
-    if (rom_fmt == ROMFMT_HDR) {
-        if (rh_seg_i != rh_nseg || boot_nsegs == 0) {
-            cart.RAM[FUJI_MB_BOOT_ERR] = FUJI_BOOT_ERR_TRUNCATED;
-            return false; // stream ended mid-segment or before any completed
-        }
-        // A header-format image is self-describing: RAM comes from its own
-        // enable tables, and a .cfg sibling is neither needed nor
-        // consulted. The tables are formally optional, so a stream that
-        // ended without them simply boots with no RAM (the pre-decode
-        // behavior for every .rom).
-        boot_nram = 0;
-        boot_jlp_value = 0;
-        boot_jlpflash_value = 0;
-        if (rh_tbl_len >= RH_TBL_LEN)
-            decode_enable_tables();
-    } else if (have_cfg && parse_pushed_cfg()) {
-        // boot_mapfrom/mapto/maprom/ramfrom/ramto/ramwidth/jlp_value/
-        // jlpflash_value already populated by parse_pushed_cfg().
-        jlp_pending = (boot_jlp_value != 0) || (boot_jlpflash_value != 0);
-        if (boot_nsegs == 0) {
-            cart.RAM[FUJI_MB_BOOT_ERR] = FUJI_BOOT_ERR_CFGBAD;
-            return false;
-        }
-    } else {
-        uint32_t words = rom_total_bytes / 2;
-        boot_nsegs = 1;
-        boot_nram = 0;
-        boot_jlp_value = 0;
-        boot_jlpflash_value = 0;
-        boot_mapfrom[0] = 0;
-        boot_mapto[0] = words > 0 ? words - 1 : 0;
-        switch (rom_total_bytes) {
-        case 4096:  boot_maprom[0] = 0x5000; break;
-        case 8192:  boot_maprom[0] = 0x5000; break;
-        case 12288: boot_maprom[0] = 0x5000; break;
-        case 16384: boot_maprom[0] = 0x5000; break;
-        case 24576:
-            boot_nsegs = 2;
-            boot_mapfrom[0] = 0;      boot_mapto[0] = 0x1FFF; boot_maprom[0] = 0x5000;
-            boot_mapfrom[1] = 0x2000; boot_mapto[1] = 0x2FFF; boot_maprom[1] = 0xD000;
-            break;
-        case 32768:
-            boot_nsegs = 3;
-            boot_mapfrom[0] = 0;      boot_mapto[0] = 0x1FFF; boot_maprom[0] = 0x5000;
-            boot_mapfrom[1] = 0x2000; boot_mapto[1] = 0x2FFF; boot_maprom[1] = 0xD000;
-            boot_mapfrom[2] = 0x3000; boot_mapto[2] = 0x3FFF; boot_maprom[2] = 0xF000;
-            break;
-        case 40960: // 20K words: 8K at $5000, 12K contiguous at $D000
-            boot_nsegs = 2;
-            boot_mapfrom[0] = 0;      boot_mapto[0] = 0x1FFF; boot_maprom[0] = 0x5000;
-            boot_mapfrom[1] = 0x2000; boot_mapto[1] = 0x4FFF; boot_maprom[1] = 0xD000;
-            break;
-        case 49152: // 24K words: the common INTV shape, 8K/12K/4K
-            boot_nsegs = 3;
-            boot_mapfrom[0] = 0;      boot_mapto[0] = 0x1FFF; boot_maprom[0] = 0x5000;
-            boot_mapfrom[1] = 0x2000; boot_mapto[1] = 0x4FFF; boot_maprom[1] = 0x9000;
-            boot_mapfrom[2] = 0x5000; boot_mapto[2] = 0x5FFF; boot_maprom[2] = 0xD000;
-            break;
-        default:
-            cart.RAM[FUJI_MB_BOOT_ERR] = FUJI_BOOT_ERR_NOMAP;
-            return false; // no mapping source at all -- refuse to guess
-        }
-    }
-
-    if (boot_truncated) {
-        cart.RAM[FUJI_MB_BOOT_ERR] = FUJI_BOOT_ERR_TRUNCATED;
-        return false;
-    }
-
-    // Clamp mappings at EOF (bin2rom semantics) -- collection cfgs describe
-    // each title's largest layout and expect ranges past EOF to fall away.
-    uint32_t bias = 0;
-    if (rom_fmt == ROMFMT_FLAT) {
-        uint32_t words = rom_total_bytes / 2;
-        int kept = 0;
-        bias = FLAT_STAGE_BASE;
-        for (int i = 0; i < boot_nsegs; i++) {
-            if (boot_mapfrom[i] >= words)
-                continue; // wholly past EOF -- drop
-            if (boot_mapto[i] >= words)
-                boot_mapto[i] = words - 1;
-            boot_mapfrom[kept] = boot_mapfrom[i];
-            boot_mapto[kept] = boot_mapto[i];
-            boot_maprom[kept] = boot_maprom[i];
-            kept++;
-        }
-        boot_nsegs = kept;
-        if (boot_nsegs == 0) {
-            cart.RAM[FUJI_MB_BOOT_ERR] = FUJI_BOOT_ERR_CFGBAD;
-            return false;
-        }
-    }
-
-    // RAM sanitation: nothing below $4000 (bus contention), total within RAMSIZE
-    unsigned int total_ram = 0;
-    {
-        int kept = 0;
-        for (int i = 0; i < boot_nram; i++) {
-            if (boot_ramto[i] < 0x4000)
-                continue;
-            if (boot_ramfrom[i] < 0x4000)
-                boot_ramfrom[i] = 0x4000;
-            if (boot_ramto[i] < boot_ramfrom[i])
-                continue;
-            total_ram += boot_ramto[i] - boot_ramfrom[i] + 1;
-            boot_ramfrom[kept] = boot_ramfrom[i];
-            boot_ramto[kept] = boot_ramto[i];
-            boot_ramwidth[kept] = boot_ramwidth[i];
-            kept++;
-        }
-        boot_nram = kept;
-    }
-    if (total_ram > RAMSIZE) {
-        cart.RAM[FUJI_MB_BOOT_ERR] = FUJI_BOOT_ERR_RAM;
-        return false;
-    }
-
-    // Mailbox policy: JLP overlap is a genuine conflict (reject); anything
-    // else boots with the mailbox disabled for the session. Also disable if
-    // the game's RAM allocation would alias the mailbox cells' storage.
+    bool jlp_pending = (boot_plan->jlp != 0) || (boot_plan->jlpflash != 0);
     bool disable_mb = false;
+
     if (jlp_pending) {
-        for (int i = 0; i < boot_nsegs; i++) {
-            unsigned int len = boot_mapto[i] - boot_mapfrom[i];
-            if (mailbox_overlap(boot_maprom[i], boot_maprom[i] + len, true)) {
-                cart.RAM[FUJI_MB_BOOT_ERR] = FUJI_BOOT_ERR_MAILBOX;
-                return false;
-            }
+        // JLP claims all of $8000-$9FFF in cartridge.c's RAM-window branch,
+        // ahead of mm_lookup(), so cartridge ROM mapped under it can never
+        // be read. That's also what happens under jzintv, where the JLP
+        // peripheral outranks the cartridge mapping -- so drop the shadowed
+        // segments and boot, rather than refusing a .cfg that pairs `jlp`
+        // with a full-image [mapping] (Pacmanthology does exactly this).
+        bootmap_shadow_range(boot_plan, 0x8000, 0x9FFF);
+        if (boot_plan->nseg == 0) {
+            cart.RAM[FUJI_MB_BOOT_ERR] = FUJI_BOOT_ERR_CFGBAD;
+            return false;
         }
-        for (int i = 0; i < boot_nram; i++) {
-            if (mailbox_overlap(boot_ramfrom[i], boot_ramto[i], true)) {
+        // A [memattr] area under the window is a genuine collision, not
+        // shadowing: mm_add_ram() packs it into the same cart.RAM[] indices
+        // the window branch addresses directly as addr-0x8000. See the
+        // KNOWN LIMITATION note on cartridge.c's write path.
+        for (int i = 0; i < boot_plan->nram; i++) {
+            if (mailbox_overlap(boot_plan->ram[i].lo, boot_plan->ram[i].hi, true)) {
                 cart.RAM[FUJI_MB_BOOT_ERR] = FUJI_BOOT_ERR_MAILBOX;
                 return false;
             }
         }
     } else {
-        for (int i = 0; i < boot_nsegs; i++) {
-            unsigned int len = boot_mapto[i] - boot_mapfrom[i];
-            if (mailbox_overlap(boot_maprom[i], boot_maprom[i] + len, false))
+        // Anything overlapping the mailbox cells boots with the mailbox
+        // disabled for the session rather than failing.
+        unsigned int total_ram = 0;
+        for (int i = 0; i < boot_plan->nseg; i++) {
+            unsigned int len = boot_plan->seg[i].rom_end - boot_plan->seg[i].rom_off;
+            if (mailbox_overlap(boot_plan->seg[i].cpu, boot_plan->seg[i].cpu + len, false))
                 disable_mb = true;
         }
-        for (int i = 0; i < boot_nram; i++) {
-            if (mailbox_overlap(boot_ramfrom[i], boot_ramto[i], false))
+        for (int i = 0; i < boot_plan->nram; i++) {
+            if (mailbox_overlap(boot_plan->ram[i].lo, boot_plan->ram[i].hi, false))
                 disable_mb = true;
+            total_ram += boot_plan->ram[i].hi - boot_plan->ram[i].lo + 1;
         }
+        // mm_add_ram() allocates from cart.RAM[0] upward; past FUJI_MB_BASE
+        // it would alias the mailbox cells' own storage.
         if (total_ram > FUJI_MB_BASE)
             disable_mb = true;
     }
@@ -631,12 +201,13 @@ static bool apply_boot_mapping(void)
     // map can still fail -- recover by rebuilding CONFIG's map and resetting.
     bool commit_ok = true;
     mm_init(&m);
-    for (int i = 0; i < boot_nsegs; i++)
-        if (mm_add(&m, bias + boot_mapfrom[i], bias + boot_mapto[i],
-                   boot_maprom[i], MM_NO_PAGE) < 0)
+    for (int i = 0; i < boot_plan->nseg; i++)
+        if (mm_add(&m, boot_plan->seg[i].rom_off, boot_plan->seg[i].rom_end,
+                   boot_plan->seg[i].cpu, boot_plan->seg[i].page) < 0)
             commit_ok = false;
-    for (int i = 0; i < boot_nram; i++)
-        if (mm_add_ram(&m, boot_ramfrom[i], boot_ramto[i], boot_ramwidth[i]) < 0)
+    for (int i = 0; i < boot_plan->nram; i++)
+        if (mm_add_ram(&m, boot_plan->ram[i].lo, boot_plan->ram[i].hi,
+                       boot_plan->ram[i].width) < 0)
             commit_ok = false;
     if (mm_finalize(&m) < 0)
         commit_ok = false;
@@ -647,8 +218,20 @@ static bool apply_boot_mapping(void)
         return false;
     }
 
-    cart.len = rom_total_bytes;
+    cart.len = boot_plan->rom_bytes;
     cart.MailboxActive = !disable_mb;
+    // Set both ways: the page-select decode in cartridge.c's write path is
+    // gated on this, and it is otherwise only ever touched by load_cfg().
+    cart.pagingSupport = boot_plan->paging;
+
+#if CONFIG_ECS_AUDIO || CONFIG_INTELLIVOICE
+    // Same precedence load_cfg() uses: emulate only what the hardware
+    // itself isn't already providing.
+    if (ecs_present == 0)
+        cart.ECSSupport = (boot_plan->ecs != 0);
+    if (voice_present == 0)
+        cart.IntellivoiceSupport = (boot_plan->voice != 0);
+#endif
 
 #if CONFIG_JLP
     if (jlp_pending) {
@@ -657,7 +240,7 @@ static bool apply_boot_mapping(void)
         // last_boot_path's own comment. Fall back to a fixed name (must
         // contain a '.': config_jlp() does strrchr(filename,'.') with no
         // NULL check) if MOUNT_IMAGE somehow arrived without one.
-        config_jlp(boot_jlp_value, boot_jlpflash_value,
+        config_jlp(boot_plan->jlp, boot_plan->jlpflash,
                    last_boot_path[0] ? last_boot_path : "network.rom");
     } else {
         cart.JLPSupport = false;
@@ -681,44 +264,49 @@ bool dbc_inbound_handler(const fb_reply_t *req)
         return false;
 
     if (req->command == NETCMD_OPEN) {
+        // Payload: stream id, optionally followed by the stream's total
+        // size as 4 little-endian bytes (see this section's banner).
         unsigned stream = (req->data_len > 0) ? req->data[0] : 0;
-        if (stream == 1) {
-            cfg_wp = 0;
-            cfg_open = true;
-            have_cfg = false;
+        uint32_t total = 0;
+        if (req->data_len >= 5)
+            total = (uint32_t)req->data[1] | ((uint32_t)req->data[2] << 8) |
+                    ((uint32_t)req->data[3] << 16) | ((uint32_t)req->data[4] << 24);
+
+        dbc_stream = (stream == DBC_STREAM_CFG) ? DBC_STREAM_CFG : DBC_STREAM_ROM;
+
+        if (dbc_stream == DBC_STREAM_CFG) {
+            bootmap_cfg_begin();
             cart.RAM[FUJI_MB_BOOT_STATE] = FUJI_BOOT_OPENING;
         } else {
-            rom_fmt = ROMFMT_UNKNOWN;
-            rom_hdrlen = 0;
-            rom_total_bytes = 0;
-            rom_open = true;
-            boot_truncated = false;
             need_config_reset = false;
-            // have_cfg/cfg_wp survive -- this mount's cfg; consumed at CLOSE
+            // the pushed cfg survives -- this mount's, consumed at CLOSE
             cart.RAM[FUJI_MB_BOOT_STATE] = FUJI_BOOT_XFER;
             cart.RAM[FUJI_MB_BOOT_PCT] = 0;
             cart.RAM[FUJI_MB_BOOT_ERR] = 0;
+            int err = bootmap_rom_begin(total);
+            if (err) {
+                // Won't fit this board however it's laid out -- say so now
+                // rather than after the ESP32 drags the whole file over
+                // TNFS. push_stream() abandons a failed OPEN without ever
+                // sending CLOSE, so tear the stream down from this side.
+                bootmap_rom_abort();
+                dbc_stream = -1;
+                cart.RAM[FUJI_MB_BOOT_STATE] = FUJI_BOOT_FAILED;
+                cart.RAM[FUJI_MB_BOOT_ERR] = (uint16_t)err;
+                dbc_send_frame(FUJICMD_NAK);
+                return true;
+            }
         }
         dbc_send_frame(FUJICMD_ACK);
         return true;
     }
 
     if (req->command == NETCMD_WRITE) {
-        if (cfg_open) {
-            uint32_t room = CFG_BUF_MAX - cfg_wp;
-            uint32_t n = req->data_len < room ? req->data_len : room;
-            if (req->data_len > room)
-                boot_truncated = true; // cfg didn't fit -- don't boot a partial map
-            memcpy(cfg_buf + cfg_wp, req->data, n);
-            cfg_wp += n;
-        } else if (rom_open) {
-            for (uint16_t i = 0; i < req->data_len; i++)
-                feed_rom_byte(req->data[i]);
-            // Coarse progress: total size isn't known in advance, so this
-            // saturates near 100% rather than reaching it exactly until
-            // CLOSE -- good enough for a moving progress bar.
-            uint32_t pct = (rom_total_bytes * 100) / 32768;
-            cart.RAM[FUJI_MB_BOOT_PCT] = pct > 99 ? 99 : pct;
+        if (dbc_stream == DBC_STREAM_CFG) {
+            bootmap_cfg_data(req->data, req->data_len);
+        } else if (dbc_stream == DBC_STREAM_ROM) {
+            bootmap_rom_data(req->data, req->data_len);
+            cart.RAM[FUJI_MB_BOOT_PCT] = bootmap_pct();
         }
         dbc_send_frame(FUJICMD_ACK);
         return true;
@@ -728,27 +316,24 @@ bool dbc_inbound_handler(const fb_reply_t *req)
         // Abort-CLOSE (payload 0x01): unwedge the stream without booting
         // partial data. Bare CLOSE = commit, so old peers stay compatible.
         bool aborted = (req->data_len > 0 && req->data[0] == 0x01);
-        if (cfg_open) {
-            cfg_open = false;
-            have_cfg = !aborted && (cfg_wp > 0);
-            if (aborted)
-                cfg_wp = 0;
+        int stream = dbc_stream;
+        dbc_stream = -1;
+
+        if (stream == DBC_STREAM_CFG) {
+            bootmap_cfg_end(aborted);
             dbc_send_frame(FUJICMD_ACK);
-        } else if (rom_open) {
-            rom_open = false;
+        } else if (stream == DBC_STREAM_ROM) {
             if (aborted) {
+                bootmap_rom_abort();
                 cart.RAM[FUJI_MB_BOOT_STATE] = FUJI_BOOT_FAILED;
                 cart.RAM[FUJI_MB_BOOT_ERR] = FUJI_BOOT_ERR_TRUNCATED;
-                have_cfg = false;
-                cfg_wp = 0;
                 dbc_send_frame(FUJICMD_ACK); // the abort itself succeeded
                 return true;
             }
             cart.RAM[FUJI_MB_BOOT_STATE] = FUJI_BOOT_MAPPING;
+            // apply_boot_mapping() calls bootmap_rom_end(), which also
+            // consumes the pushed cfg so the next push starts clean.
             bool boot_ok = apply_boot_mapping();
-            // consume the cfg so the next push starts clean
-            have_cfg = false;
-            cfg_wp = 0;
             if (boot_ok) {
                 cart.RAM[FUJI_MB_BOOT_PCT] = 100;
                 dbc_send_frame(FUJICMD_ACK); // must go out before resetCart() tears down the link


### PR DESCRIPTION
Homebrew INTV cartridges failed to load in three unrelated ways:

- `BOOT_MAX_SEGS 16` rejected any `.cfg` with more mapping lines (frantic 4 has 17, Cloudfire 24, Pacmanthology 30). Now 48.
- `PAGE` mapping lines were silently mis-parsed — the 3-value `sscanf()` matches them and drops the qualifier, so every page painted over the last. `mm_add()` and cartridge.c's `$xFFF = $A5n` decode already handled paging; only the network parser didn't.
- `.rom` segments below `$4000` were rejected, since the decoder wrote at the bus address and would clobber the CONFIG image the console is executing mid-transfer. `$2000-$2FFF` is ordinary cart space (Maria, Space Intruders, unlucky_pony_2024 all start there). Both formats now stage sequentially above CONFIG and map by delta.

Parser split out of `fujinet.c` into `bootmap.c` (no pico-sdk/tusb/Cartridge), so `host_test/test_bootmap.c` can run real cartridge files through the same calls the USB handler makes and dump the resulting map — the sample set is checkable without flashing. Parser now matches `load_cfg()`: case-folded, comment-stripping, PAGE-aware, and streaming rather than buffering the whole `.cfg`.

`NETCMD_OPEN` now carries the stream size, so an oversized ROM is refused before it's pulled over TNFS and the progress bar is exact; older peers send the id alone and still work. New `TOOBIG` and `BANKSW` reason codes replace failures that previously reported something misleading.

A `.cfg` pairing `jlp` with ROM across `$8000-$9FFF` was a hard `ERR_MAILBOX` reject; JLP's window shadows that ROM anyway, as under jzintv, so those segments are dropped and the cart boots (Pacmanthology needs this). `[memattr]` RAM under the window is still a real collision and still rejected.

## Testing

Host test covers all ten sample cartridges plus synthetic cases for uppercase sections, CRLF, no trailing newline, and the size-guess/`NOMAP` paths:

```
cd pico/intellivision/firmware/host_test
gcc -Wall -Wextra -I../include -o /tmp/test_bootmap test_bootmap.c ../src/bootmap.c ../src/memory.c ../src/utils.c
/tmp/test_bootmap "$HOME/tnfs/INTV/sample roms/"*.bin "$HOME/tnfs/INTV/sample roms/"*.rom
```

`pirto_ii_default` (97.85% RAM, down from 99%), `fujicard` and `fujiversal-intv` all build. **Not yet tested on hardware.**

Cloudfire and Pacmanthology remain too large for `pirto_ii_default`'s `cart.ROM[]` — an RP2040 SRAM ceiling, not a bug; they now fail as `TOOBIG` rather than `REJECTED`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J3nfDqKnhQZGyHgayymWSB