### PR TITLE
[adam] Read the HTTP channel mode from aux2

### DIFF
--- a/lib/device/adamnet/network.cpp
+++ b/lib/device/adamnet/network.cpp
@@ -994,6 +994,15 @@ void adamNetwork::process_tcp(fujiCommandID_t cmd)
 
 void adamNetwork::process_http(fujiCommandID_t cmd)
 {
+    /* The HTTP channel mode arrives in aux2, as on every other bus (sio,
+     * iwm and rs232 all read param(1)); aux1 is padding. Reading a single
+     * byte here took the padding as the mode and consumed the real mode
+     * byte as the checksum, leaving the mode stuck at DATA.
+     *
+     * Only reachable via NETCMD_SET_CHANNEL_MODE (0x4D). The JSON/SGML
+     * mode is NETCMD_CHANNEL_MODE (0xFC), handled by channel_mode(),
+     * which does take a single byte and is unchanged. */
+    adamnet_recv();                     // aux1, unused
     unsigned char m = adamnet_recv();
     adamnet_recv(); // CK
 


### PR DESCRIPTION
adamnet read it from aux1, which is always 0, so the mode never left DATA and POST bodies were discarded. sio, iwm and rs232 all read aux2.