### PR TITLE
[intv] Keep USB device stack on for pirto_ii_duo Release builds

### DIFF
--- a/pico/intellivision/firmware/boards/pirto_ii_duo.cmake
+++ b/pico/intellivision/firmware/boards/pirto_ii_duo.cmake
@@ -11,9 +11,12 @@ option(CONFIG_JLP "Enable JLP" ON)
 option(CONFIG_ECS_AUDIO "Enable ECS audio" OFF)
 option(CONFIG_INTELLIVOICE "Enable Intellivoice" OFF)
 
+# FujiNet needs the USB CDC link to the ESP32-S3 live in Release too -- it's
+# not just a debug convenience here, it's the whole point (see fujicard.cmake,
+# which needs the same thing for the same reason).
 if(CMAKE_BUILD_TYPE STREQUAL "Release")
-   set(CONFIG_USB_DEVICE 0)
-   set(MAX_ROM_SIZE 1024*228)    # ~456 kb
+   set(CONFIG_USB_DEVICE 1)
+   set(MAX_ROM_SIZE 1024*225)    # ~450 kb
 endif()
 
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")


### PR DESCRIPTION
## Summary
- `boards/pirto_ii_duo.cmake` turned USB device support off for Release builds, which is fine for stock Minty (USB is debug-only there) but breaks `-DCONFIG_FUJINET=ON`, since the FujiNet USB CDC link to the ESP32-S3 needs to be live in Release too — it's the whole point of that build, not a debug convenience.
- Mirrors what `boards/fujicard.cmake` already does for its own board (`CONFIG_USB_DEVICE` forced on unconditionally).
- `MAX_ROM_SIZE` drops to the same 1024*225 figure Debug already used, to pay for the USB device stack now being compiled into Release too.

Follow-up from documenting `pirto_ii_duo` + FujiNet in the wiki ([DIY FujiNet for the Intellivision](https://github.com/FujiNetWIFI/fujinet-firmware/wiki/DIY-FujiNet-for-the-Intellivision)), which previously had to tell readers to hand-edit this file before building. Once this merges I'll update that page to drop the manual-edit step.

## Test plan
- [x] `cmake -B build-pirto_ii_duo -DPICO_BOARD=pirto_ii_duo -DCMAKE_BUILD_TYPE=Release -DCONFIG_FUJINET=ON -G Ninja && ninja -C build-pirto_ii_duo` — links cleanly, `Minty_pirto_ii_duo.uf2` produced (FLASH 2.98%, RAM 96.71%)
- [x] Confirmed pre-fix: same command failed with `fatal error: tusb.h: No such file or directory` in `src/cartridge.c`/`src/fujinet.c`
- [ ] Not yet verified on real PiRTO II DUO hardware — see `pico/intellivision/README.md` status section, this Minty-based port hasn't been flashed to real silicon yet

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HCxy4KuLo917yxEKxgKEYf