### PR TITLE
[adam] Move all bus handling out of devices

### DIFF
--- a/fujinet_pc.cmake
+++ b/fujinet_pc.cmake
@@ -452,6 +452,7 @@ if(FUJINET_TARGET STREQUAL "ADAM")
     lib/printer-emulator/coleco_printer.h lib/printer-emulator/coleco_printer.cpp
 
     lib/bus/adamnet/adamnet.h lib/bus/adamnet/adamnet.cpp
+    lib/bus/adamnet/AdamNetPhase.h lib/bus/adamnet/AdamNetPhase.cpp
     lib/bus/adamnet/FujiAdamPacket.h lib/bus/adamnet/FujiAdamPacket.cpp
     lib/hardware/BoIPChannel.h lib/hardware/BoIPChannel.cpp
 

--- a/lib/bus/adamnet/AdamNetPhase.cpp
+++ b/lib/bus/adamnet/AdamNetPhase.cpp
@@ -1,0 +1,243 @@
+#ifdef BUILD_ADAM
+
+#include "AdamNetPhase.h"
+#include "debug.h"
+
+inline const char* AdamNetPhase::phase_to_string(PHASE state)
+{
+    switch (state)
+    {
+    case PHASE::IDLE:         return "IDLE";
+    case PHASE::NEED_ACK:     return "NEED_ACK";
+    case PHASE::DID_ACK:      return "DID_ACK";
+    case PHASE::DID_NAK:      return "DID_NAK";
+    case PHASE::DID_IGNORE:   return "DID_IGNORE";
+    case PHASE::HAVE_PAYLOAD: return "HAVE_PAYLOAD";
+    case PHASE::GOT_PAYLOAD:  return "GOT_PAYLOAD";
+    case PHASE::NEED_STATUS:  return "NEED_STATUS";
+    case PHASE::SENT_STATUS:  return "SENT_STATUS";
+    case PHASE::FEED_ME:      return "FEED_ME";
+    case PHASE::BEEN_FED:     return "BEEN_FED";
+    default:                  return "UNKNOWN_PHASE";
+    }
+}
+
+const char* AdamNetPhase::type_to_string(adamPacketType_t type)
+{
+    switch (type)
+    {
+    case APT::MN_RESET:   return "MN_RESET";
+    case APT::MN_STATUS:  return "MN_STATUS";
+    case APT::MN_ACK:     return "MN_ACK";
+    case APT::MN_CLR:     return "MN_CLR";
+    case APT::MN_RECEIVE: return "MN_RECEIVE";
+    case APT::MN_CANCEL:  return "MN_CANCEL";
+    case APT::MN_SEND:    return "MN_SEND";
+    case APT::MN_NAK:     return "MN_NAK";
+    case APT::MN_READY:   return "MN_READY";
+
+    case APT::NM_STATUS:  return "NM_STATUS";
+    case APT::NM_ACK:     return "NM_ACK";
+    case APT::NM_CANCEL:  return "NM_CANCEL";
+    case APT::NM_SEND:    return "NM_SEND";
+    case APT::NM_NAK:     return "NM_NAK";
+    default:              return "UNKNOWN_TYPE";
+    }
+}
+
+const char* AdamNetPhase::device_to_string(fujiDeviceID_t device)
+{
+    switch (device)
+    {
+    case FUJI_DEVICEID_FUJINET:      return "FUJINET";
+    case FUJI_DEVICEID_KEYBOARD:     return "KEYBOARD";
+    case FUJI_DEVICEID_PRINTER:      return "PRINTER";
+    case FUJI_DEVICEID_DISK:         return "DISK";
+    case FUJI_DEVICEID_DISK2:        return "DISK2";
+    case FUJI_DEVICEID_DISK3:        return "DISK3";
+    case FUJI_DEVICEID_DISK4:        return "DISK4";
+    case FUJI_DEVICEID_TAPE:         return "TAPE";
+    case FUJI_DEVICEID_NETWORK:      return "NETWORK";
+    case FUJI_DEVICEID_NETWORK_LAST: return "NETWORK_LAST";
+    default:                return "UNKNOWN_DEVICE";
+    }
+}
+
+inline bool AdamNetPhase::bus_expected_state(const FujiAdamPacket &packet, PHASE actual,
+                                             std::initializer_list<PHASE> expected_list)
+{
+    for (auto expected : expected_list)
+    {
+        if (actual == expected)
+        {
+            return true;
+        }
+    }
+
+    // Print an explicit block detailing what went wrong using Debug_printf
+    Debug_printf("\n=== BUS STATE ASSERTION FAILED ===\n");
+    Debug_printf("Actual State:   %s (%d)\n", phase_to_string(actual), static_cast<int>(actual));
+
+    Debug_printf("Expected one of:\n");
+    for (auto expected : expected_list)
+    {
+        Debug_printf("  - %s\n", phase_to_string(expected));
+    }
+
+    Debug_printf("Packet device: %s (0x%02x)  type: %s (0x%02x)\n",
+                 device_to_string(packet.device()), packet.device(),
+                 type_to_string(packet.type()), packet.type());
+    if ((packet.device() == FUJI_DEVICEID_FUJINET || packet.device() == FUJI_DEVICEID_NETWORK)
+        && packet.type() == APT::MN_SEND)
+        Debug_printf("Fuji command: 0x%02x\n", packet.command());
+
+    Debug_printf("==================================\n\n");
+
+    return false;
+}
+
+void AdamNetPhase::begin(const FujiAdamPacket &packet)
+{
+    _packet = &packet;
+
+    switch (_packet->type())
+    {
+    case APT::MN_STATUS:  // 0x01
+        // No payload, no ACK, expects AdamNetPacket reply
+        _busPhase = PHASE::NEED_STATUS;
+        break;
+
+    case APT::MN_SEND:    // 0x06
+        // Payload needs to be read
+        _busPhase = PHASE::HAVE_PAYLOAD;
+        break;
+
+    case APT::MN_RECEIVE: // 0x04
+        // Expects ACK if data is available, IGNORE if still fetching, NAK if no more data
+        _busPhase = PHASE::NEED_ACK;
+        break;
+
+    case APT::MN_READY:   // 0x0d
+        // Expects ACK if device is ready for a command, otherwise IGNORE (or NAK?)
+        _busPhase = PHASE::NEED_ACK;
+        break;
+
+    case APT::MN_CLR:     // 0x03
+        // Expects data to be sent
+        _busPhase = PHASE::FEED_ME;
+        break;
+
+    case APT::MN_ACK:     // 0x02
+    case APT::MN_NAK:     // 0x07
+        // These can be ignored, there's no way to respond to them
+        break;
+
+    case APT::MN_RESET:   // 0x00
+        // Doesn't change current phase
+        break;
+
+    case APT::MN_CANCEL:  // 0x05
+        Debug_printf("PACKET device=0x%02x type=0x%02x\n", packet.device(), packet.type());
+        abort();
+        break;
+
+    default:
+        //Debug_printf("PACKET invalid dest\n");
+        break;
+    }
+
+    return;
+}
+
+void AdamNetPhase::finish()
+{
+    // Make sure device finished
+    switch (_packet->type()) {
+    case APT::MN_STATUS:  // 0x01
+        assert(bus_expected_state(*_packet, _busPhase, {PHASE::SENT_STATUS,
+                                                               PHASE::DID_IGNORE}));
+        _busPhase = PHASE::IDLE;
+        break;
+
+    case APT::MN_RECEIVE: // 0x04
+    case APT::MN_SEND:    // 0x06
+    case APT::MN_READY:   // 0x0d
+        assert(bus_expected_state(*_packet, _busPhase,
+                                  {PHASE::DID_ACK, PHASE::DID_NAK,
+                                   PHASE::DID_IGNORE}));
+        _busPhase = PHASE::IDLE;
+        break;
+
+    case APT::MN_CLR:     // 0x03
+        assert(bus_expected_state(*_packet, _busPhase, {PHASE::BEEN_FED}));
+        _busPhase = PHASE::IDLE;
+        break;
+
+    case APT::MN_ACK:     // 0x02
+    case APT::MN_NAK:     // 0x07
+        // These can be ignored, there's no way to respond to them
+        _busPhase = PHASE::IDLE;
+        break;
+
+    case APT::NM_STATUS:
+    case APT::NM_ACK:
+    case APT::NM_CANCEL:
+    case APT::NM_SEND:
+    case APT::NM_NAK:
+        // Are these echoes of our own reply? We shouldn't ever see these.
+        break;
+
+    default:
+        Debug_printf("UNHANDLED device=0x%02x type=0x%02x\n",
+                     _packet->device(), _packet->type());
+        //abort();
+        break;
+    }
+
+    return;
+}
+
+void AdamNetPhase::didAck()
+{
+    assert(bus_expected_state(*_packet, _busPhase, {PHASE::NEED_ACK, PHASE::GOT_PAYLOAD}));
+    _busPhase = PHASE::DID_ACK;
+    return;
+}
+
+void AdamNetPhase::didNak()
+{
+    assert(bus_expected_state(*_packet, _busPhase, {PHASE::NEED_ACK, PHASE::GOT_PAYLOAD}));
+    _busPhase = PHASE::DID_NAK;
+    return;
+}
+
+void AdamNetPhase::didIgnore()
+{
+    assert(bus_expected_state(*_packet, _busPhase, {PHASE::NEED_ACK, PHASE::NEED_STATUS}));
+    _busPhase = PHASE::DID_IGNORE;
+    return;
+}
+
+void AdamNetPhase::sentStatus()
+{
+    assert(bus_expected_state(*_packet, _busPhase, {PHASE::NEED_STATUS}));
+    _busPhase = PHASE::SENT_STATUS;
+    return;
+}
+
+void AdamNetPhase::sentData()
+{
+    assert(bus_expected_state(*_packet, _busPhase, {PHASE::FEED_ME, PHASE::NEED_STATUS}));
+    if (_busPhase == PHASE::FEED_ME)
+        _busPhase = PHASE::BEEN_FED;
+    return;
+}
+
+void AdamNetPhase::gotPayload()
+{
+    assert(bus_expected_state(*_packet, _busPhase, {PHASE::HAVE_PAYLOAD}));
+    _busPhase = PHASE::GOT_PAYLOAD;
+    return;
+}
+
+#endif /* BUILD_ADAM */

--- a/lib/bus/adamnet/AdamNetPhase.h
+++ b/lib/bus/adamnet/AdamNetPhase.h
@@ -1,0 +1,55 @@
+#ifndef ADAMNETPHASE_H
+#define ADAMNETPHASE_H
+
+#ifdef BUILD_ADAM
+
+#include "FujiAdamPacket.h"
+
+class AdamNetPhase
+{
+public:
+    enum class PHASE {
+        IDLE,
+        NEED_ACK,
+        DID_ACK,
+        DID_NAK,
+        DID_IGNORE,
+        HAVE_PAYLOAD,
+        GOT_PAYLOAD,
+        NEED_STATUS,
+        SENT_STATUS,
+        FEED_ME,
+        BEEN_FED,
+    };
+
+    void begin(const FujiAdamPacket &packet);
+    void finish();
+
+    void didAck();
+    void didNak();
+    void didIgnore();
+
+    void sentStatus();
+    void sentData();
+
+    void gotPayload();
+
+    bool needAck() { return _busPhase == PHASE::NEED_ACK; }
+
+    static const char* type_to_string(adamPacketType_t type);
+    static const char* device_to_string(fujiDeviceID_t device);
+
+    PHASE phase() { return _busPhase; }
+
+private:
+    PHASE _busPhase = PHASE::IDLE;
+    const FujiAdamPacket *_packet;
+
+    const char* phase_to_string(PHASE state);
+    bool bus_expected_state(const FujiAdamPacket &packet, PHASE actual,
+                            std::initializer_list<PHASE> expected_list);
+};
+
+#endif /* BUILD_ADAM */
+
+#endif /* ADAMNETPHASE_H */

--- a/lib/bus/adamnet/FujiAdamPacket.cpp
+++ b/lib/bus/adamnet/FujiAdamPacket.cpp
@@ -1,7 +1,6 @@
 #ifdef BUILD_ADAM
 
 #include "FujiAdamPacket.h"
-#include "bus.h"
 
 namespace {
     // write `size` bytes of `value` (1,2,4) in little-endian
@@ -65,32 +64,21 @@ void FujiAdamPacket::fillParams(size_t count, size_t psize) const
 fujiCommandID_t FujiAdamPacket::command() const
 {
     if (!_command.has_value()) {
-        u16be_t len;
-        SYSTEM_BUS.read(&len, sizeof(len));
-        _command = static_cast<fujiCommandID_t>(SYSTEM_BUS.read());
-        setPayloadLength(len - 1);
+        _command = static_cast<fujiCommandID_t>((*_payload)[0]);
+        _payload->erase(_payload->begin(), _payload->begin() + 1);
     }
     return *_command;
 }
 
-void FujiAdamPacket::setPayloadLength(const size_t len) const
+error_is_true FujiAdamPacket::setPayload(ByteBuffer &payload, uint8_t checksum)
 {
-    size_t rlen;
-
-
+    assert(_type == APT::MN_SEND);
     assert(!_payload.has_value());
 
-    _payload.emplace(len, 0);
-    rlen = SYSTEM_BUS.read(_payload->data(), _payload->size());
-    if (rlen != len)
-        _payload->resize(rlen);
-    _payload_checksum = SYSTEM_BUS.read();
-    // FIXME - do something if checksum mismatch?
-    SYSTEM_BUS.start_time = GET_TIMESTAMP();
-    SYSTEM_BUS.write((((unsigned) APT::NM_ACK) << 4) | _device);
-    SYSTEM_BUS.flush();
+    _payload = payload;
+    _payload_checksum = checksum;
+    RETURN_ERROR_IF(_payload_checksum != calcChecksum(_payload.value()));
 }
-
 const std::optional<ByteBuffer>& FujiAdamPacket::data() const
 {
     if (!_data.has_value())
@@ -106,12 +94,14 @@ ByteBuffer FujiAdamPacket::serialize() const
 
     size_t dataSize = _data ? _data->size() : 0;
     size_t payloadSize = paramsSize + dataSize;
+    if (_command.has_value())
+        payloadSize++;
     bool hasPayload = payloadSize > 0;
     bool hasLen = hasPayload && (_type != APT::NM_STATUS);
 
     size_t totalSize = 1 /*dest*/
         + (hasLen ? 2 : 0)
-                + payloadSize
+        + payloadSize
         + (hasPayload ? 1 : 0 /*checksum*/);
 
     ByteBuffer output;
@@ -126,23 +116,22 @@ ByteBuffer FujiAdamPacket::serialize() const
         output.insert(output.end(), ptr, ptr + sizeof(len));
     }
 
-    size_t payloadStart = output.size();
+    ByteBuffer payload;
+    payload.reserve(payloadSize);
+
+    if (_command.has_value())
+        payload.push_back(static_cast<uint8_t>(*_command));
 
     for (const auto& p : _params)
-        write_le(output, p.value, p.size);
+        write_le(payload, p.value, p.size);
 
     if (_data)
-    {
-        output.insert(output.end(), _data->begin(), _data->end());
-    }
+        payload.insert(payload.end(), _data->begin(), _data->end());
 
     if (hasPayload)
     {
-        uint8_t ck = 0;
-        size_t idx, end;
-        for (idx = payloadStart, end = output.size(); idx < end; idx++)
-            ck ^= output[idx];
-        output.push_back(ck);
+        output.insert(output.end(), payload.begin(), payload.end());
+        output.push_back(calcChecksum(payload));
     }
 
     return output;

--- a/lib/bus/adamnet/FujiAdamPacket.h
+++ b/lib/bus/adamnet/FujiAdamPacket.h
@@ -22,14 +22,14 @@ typedef enum class APT {
     MN_RECEIVE = 0x04,  // command.control  (receive)
     MN_CANCEL  = 0x05,  // command.control  (cancel)
     MN_SEND    = 0x06,  // command.control  (send)
-    MN_NACK    = 0x07,  // command.control  (nack)
+    MN_NAK     = 0x07,  // command.control  (nak)
     MN_READY   = 0x0D,  // command.control  (ready)
 
     NM_STATUS  = 0x08,  // response.control (status)
     NM_ACK     = 0x09,  // response.control (ack)
     NM_CANCEL  = 0x0A,  // response.control (cancel)
     NM_SEND    = 0x0B,  // response.data    (send)
-    NM_NACK    = 0x0C,  // response.control (nack)
+    NM_NAK     = 0x0C,  // response.control (nak)
 } adamPacketType_t;
 
 /**
@@ -45,12 +45,6 @@ typedef enum class APT {
  * Parameters and data are therefore deserialized lazily as they are
  * requested. Parameter values are read from the bus on first access
  * and cached for subsequent accesses.
- *
- * The only API difference from FujiBusPacket is setPayloadLength(). The
- * trailing data field has no self-describing length, so its size must
- * be supplied before data() or dataAsString() can be used. Code using
- * the transaction_* helpers does not need to call setPayloadLength()
- * directly, as those helpers determine the length automatically.
  */
 
 class FujiAdamPacket
@@ -59,8 +53,8 @@ private:
     fujiDeviceID_t _device;
     adamPacketType_t _type;
     mutable std::optional<ByteBuffer> _payload;
-    mutable uint8_t _payload_checksum;
-    mutable std::optional<uint8_t> _unit;
+    mutable std::uint8_t _payload_checksum;
+    mutable std::optional<std::uint8_t> _unit;
     mutable std::optional<fujiCommandID_t> _command;
     mutable std::vector<PacketParam> _params;
     mutable unsigned _paramSize;
@@ -69,7 +63,7 @@ private:
     using ParamProxy = PacketParamProxy<FujiAdamPacket>;
     friend ParamProxy;
 
-    uint32_t getParam(size_t index, size_t psize) const;
+    std::uint32_t getParam(size_t index, size_t psize) const;
     void fillParams(size_t count, size_t psize) const;
     std::uint8_t calcChecksum(const ByteBuffer& buf) const;
 
@@ -81,6 +75,7 @@ private:
     // Payload helpers
     void processArg(const ByteBuffer& buf) { _data = buf; }
     void processArg(ByteBuffer&& buf)      { _data = std::move(buf); }
+    void processArg(fujiCommandID_t cmd)   { _command = cmd; }
 
     // Convenience: allow passing a std::string payload; it’s treated as raw bytes
     void processArg(const std::string& s) {
@@ -89,7 +84,7 @@ private:
     }
 
 public:
-    FujiAdamPacket(uint8_t dest) : _device(static_cast<fujiDeviceID_t>(dest & 0x0F)),
+    FujiAdamPacket(std::uint8_t dest) : _device(static_cast<fujiDeviceID_t>(dest & 0x0F)),
                                    _type(static_cast<adamPacketType_t>(dest >> 4)) {};
     template<typename... Args>
     FujiAdamPacket(fujiDeviceID_t source, adamPacketType_t type, Args&&... args)
@@ -97,6 +92,21 @@ public:
         , _type(type)
     {
         (processArg(std::forward<Args>(args)), ...);  // fold expression
+    }
+
+    bool isReply(void) const {
+        switch (_type)
+        {
+        case APT::NM_STATUS:  // 0x08
+        case APT::NM_ACK:     // 0x09
+        case APT::NM_CANCEL:  // 0x0a
+        case APT::NM_SEND:    // 0x0b
+        case APT::NM_NAK:     // 0x0c
+            return true;
+
+        default:
+            return false;
+        }
     }
 
     ByteBuffer serialize() const;
@@ -107,9 +117,7 @@ public:
 
     ParamProxy param(size_t index) const { return ParamProxy{ index, this }; }
 
-    // Completes deserialization by reading the trailing data field once its
-    // length has been determined from command-specific context.
-    void setPayloadLength(const size_t len) const;
+    error_is_true setPayload(ByteBuffer &payload, std::uint8_t checksum);
 
     const std::optional<ByteBuffer>& data() const;
     const std::optional<const std::string> dataAsString() const {
@@ -119,9 +127,9 @@ public:
 
     // Explicit alternatives to the implicit ParamProxy conversions.
     // These may be preferred where the destination type is not obvious.
-    uint8_t  param8(int idx)  const { return (uint8_t)param(idx); }
-    uint16_t param16(int idx) const { return (uint16_t)param(idx); }
-    uint32_t param32(int idx) const { return (uint32_t)param(idx); }
+    std::uint8_t  param8(int idx)  const { return (std::uint8_t)param(idx); }
+    std::uint16_t param16(int idx) const { return (std::uint16_t)param(idx); }
+    std::uint32_t param32(int idx) const { return (std::uint32_t)param(idx); }
 
     // Delete copy semantics to prevent pass-by-value bugs
     FujiAdamPacket(const FujiAdamPacket&) = delete;

--- a/lib/bus/adamnet/adamnet.cpp
+++ b/lib/bus/adamnet/adamnet.cpp
@@ -77,14 +77,19 @@ static void adamnet_reset_intr_task(void *arg)
 static void adamnet_bus_task(void *arg)
 {
     systemBus *b = (systemBus *)arg;
+    b->adamnet_handle_bus_task();
+}
+
+void systemBus::adamnet_handle_bus_task(void)
+{
     int64_t last = GET_TIMESTAMP();
     for (;;)
     {
         int64_t now = GET_TIMESTAMP();
 
-        if (now - last > ADAMNET_STALL_RESYNC_US && b->available())
-            b->wait_for_idle();
-        b->service();
+        if (now - last > ADAMNET_STALL_RESYNC_US && _port->available())
+            wait_for_idle();
+        service();
         last = GET_TIMESTAMP();
         taskYIELD(); // cooperative; returns at once when no other core-1 task is ready
     }
@@ -101,11 +106,22 @@ void systemBus::transaction_success()
 {
     assert(_transaction_state == TRANS_STATE::NO_GET
            || _transaction_state == TRANS_STATE::DID_GET);
+    // Data was requested but didn't go through transaction_send
+    if (_activePacket->type() == APT::MN_RECEIVE)
+        busPhase.didIgnore();
+    else if (busPhase.needAck())
+        sendAckPacket();
     _transaction_state = TRANS_STATE::INVALID;
 }
 
 void systemBus::transaction_error()
 {
+    if (busPhase.needAck())
+    {
+        wait_for_idle();
+        _start_time = GET_TIMESTAMP();
+        sendNakPacket();
+    }
     _transaction_state = TRANS_STATE::INVALID;
 }
 
@@ -113,9 +129,8 @@ success_is_true systemBus::transaction_get(void *data, size_t len)
 {
     assert(_transaction_state == TRANS_STATE::WILL_GET);
     _transaction_state = TRANS_STATE::DID_GET;
-    if (_activePacket->data()->size() != len)
-        RETURN_ERROR_AS_FALSE();
-    std::copy(_activePacket->data()->begin(), _activePacket->data()->end(),
+    len = std::min(len, _activePacket->data()->size());
+    std::copy(_activePacket->data()->begin(), _activePacket->data()->begin() + len,
               static_cast<uint8_t *>(data));
     RETURN_SUCCESS_AS_TRUE();
 }
@@ -123,71 +138,90 @@ success_is_true systemBus::transaction_get(void *data, size_t len)
 void systemBus::transaction_send(const void *data, size_t len, bool err)
 {
     assert(_transaction_state == TRANS_STATE::NO_GET);
-    memcpy(_activeDev->response, data, len);
-    _activeDev->response_len = len;
+    const uint8_t *ptr = static_cast<const uint8_t*>(data);
+    FujiAdamPacket packet(_activeDev->id(), APT::NM_SEND, ByteBuffer(ptr, ptr + len));
+    _transaction_reply_encoded = packet.serialize();
+
+    // FIXME - won't this always ack? Is the if needed?
+    if (busPhase.needAck())
+        sendAckPacket();
+
     _transaction_state = TRANS_STATE::INVALID;
 }
 
-void virtualDevice::adamnet_send(uint8_t b)
+bool systemBus::sendReplyPacket(bool ack, const void *data, size_t length)
 {
-    // Write the byte
-    SYSTEM_BUS.write(b);
-    SYSTEM_BUS.flush();
-}
+    adamPacketType_t ptype;
 
-void virtualDevice::adamnet_send_buffer(const void *buf, unsigned short len)
-{
-    SYSTEM_BUS.write(buf, len);
-    SYSTEM_BUS.flush();
-}
 
-uint8_t virtualDevice::adamnet_recv()
-{
-    uint8_t b;
-    int64_t start = GET_TIMESTAMP();
-
-    while (SYSTEM_BUS.available() <= 0)
+    switch (_activePacket->type())
     {
-        if (GET_TIMESTAMP() - start > ADAMNET_RECV_TIMEOUT_US)
-        {
-            SYSTEM_BUS.frame_error = true;
-            return 0;
-        }
-        fnSystem.yield();
+    case APT::MN_STATUS:
+        ptype = APT::NM_STATUS;
+        break;
+
+    case APT::MN_SEND:
+    case APT::MN_RECEIVE:
+    case APT::MN_READY:
+        ptype = ack ? APT::NM_ACK : APT::NM_NAK;
+        break;
+
+    case APT::MN_CLR:
+        ptype = APT::NM_SEND;
+        break;
+
+    default:
+        abort();
     }
 
-    b = SYSTEM_BUS.read();
+    std::optional<FujiAdamPacket> packet;
+    if (ack && data)
+    {
+        const uint8_t *ptr = static_cast<const uint8_t*>(data);
+        packet.emplace(_activeDev->id(), ptype, ByteBuffer(ptr, ptr + length));
+    }
+    else
+        packet.emplace(_activeDev->id(), ptype);
 
-    return b;
+    return writeBusPacket(*packet);
 }
 
-uint16_t virtualDevice::adamnet_recv_length()
+void systemBus::sendResponsePacket(void)
 {
-    unsigned short s = 0;
-    s = adamnet_recv() << 8;
-    s |= adamnet_recv();
+    if (!_transaction_reply_encoded.has_value())
+        return;
 
-    return s;
+#ifdef ESP_PLATFORM
+    // Real bus only: answer only inside the window of opportunity
+    if (GET_TIMESTAMP() - _start_time >= ADAMNET_RESPONSE_DEADLINE_US)
+    {
+        busPhase.didIgnore();
+        return;
+    }
+#endif /* ESP_PLATFORM */
+
+    _port->write(_transaction_reply_encoded->data(), _transaction_reply_encoded->size());
+    _port->flushOutput();
+    busPhase.sentData();
+    _transaction_reply_encoded.reset();
 }
 
-void virtualDevice::adamnet_send_length(uint16_t l)
+bool systemBus::writeBusPacket(const FujiAdamPacket &packet)
 {
-    adamnet_send(l >> 8);
-    adamnet_send(l & 0xFF);
-}
+    ByteBuffer encoded = packet.serialize();
+#ifdef ESP_PLATFORM
+    // Real bus only: answer only inside the window of opportunity
+    if (GET_TIMESTAMP() - _start_time >= ADAMNET_RESPONSE_DEADLINE_US)
+        return false;
+#endif /* ESP_PLATFORM */
 
-unsigned short virtualDevice::adamnet_recv_buffer(uint8_t *buf, unsigned short len)
-{
-    return SYSTEM_BUS.read(buf, len);
-}
-
-uint32_t virtualDevice::adamnet_recv_blockno()
-{
-    unsigned char x[4] = {0x00, 0x00, 0x00, 0x00};
-
-    adamnet_recv_buffer(x, 4);
-
-    return x[3] << 24 | x[2] << 16 | x[1] << 8 | x[0];
+    _port->write(encoded.data(), encoded.size());
+    _port->flushOutput();
+#ifdef DEBUG_RAW_PACKET
+    Debug_printv("Sent %d:\n%s", encoded.size(),
+                 util_hexdump(encoded.data(), encoded.size()).c_str());
+#endif // DEBUG_RAW_PACKET
+    return true;
 }
 
 void virtualDevice::reset()
@@ -195,35 +229,14 @@ void virtualDevice::reset()
     Debug_printf("No Reset implemented for device %u\n", _devnum);
 }
 
-void virtualDevice::adamnet_response_ack(bool doNotWaitForIdle)
-{
-    if (!doNotWaitForIdle)
-        SYSTEM_BUS.min_turnaround();
-
-#ifdef ESP_PLATFORM
-    // Real bus only: don't answer past the master's window. BoIP just waits.
-    if (GET_TIMESTAMP() - SYSTEM_BUS.start_time >= ADAMNET_RESPONSE_DEADLINE_US)
-        return;
-#endif
-    adamnet_send(0x90 | _devnum);
-}
-
-void virtualDevice::adamnet_response_nack(bool doNotWaitForIdle)
-{
-    if (!doNotWaitForIdle)
-        SYSTEM_BUS.min_turnaround();
-
-#ifdef ESP_PLATFORM
-    // Real bus only: don't answer past the master's window. BoIP just waits.
-    if (GET_TIMESTAMP() - SYSTEM_BUS.start_time >= ADAMNET_RESPONSE_DEADLINE_US)
-        return;
-#endif
-    adamnet_send(0xC0 | _devnum);
-}
-
 void virtualDevice::adamnet_control_ready()
 {
-    adamnet_response_ack();
+    SYSTEM_BUS.sendAckPacket();
+}
+
+void virtualDevice::adamnet_control_receive()
+{
+    SYSTEM_BUS.sendAckPacket();
 }
 
 void systemBus::wait_for_idle()
@@ -232,38 +245,39 @@ void systemBus::wait_for_idle()
     fnSystem.yield();
 }
 
-void systemBus::wait_turnaround(uint32_t us)
+void systemBus::sendStatusPacket(const AdamNetStatus &status)
 {
 #ifdef ESP_PLATFORM
-    // Hold off the shared one-wire bus until `us` after the command.
-    int64_t dt = GET_TIMESTAMP() - start_time;
-    if (dt >= 0 && dt < (int64_t)us)
-        fnSystem.delay_microseconds(us - dt);
-#else
-    // BoIP has no shared wire, and usleep() can't honor sub-ms holds anyway.
-    (void)us;
+    // Real bus only: answer only inside the master's status
+    // window. This will prevent Adam from recognizing that device is
+    // online, it will not retry.
+    if (GET_TIMESTAMP() - _start_time >= ADAMNET_RESPONSE_DEADLINE_US)
+    {
+        busPhase.didIgnore();
+        return;
+    }
 #endif
-}
 
-void systemBus::min_turnaround()
-{
-    wait_turnaround(ADAMNET_TURNAROUND_US);
-}
-
-void virtualDevice::adamnet_control_clr()
-{
-    if (response_len == 0)
-    {
-        adamnet_response_nack();
-    }
+    if (sendReplyPacket(true, &status, sizeof(status)))
+        busPhase.sentStatus();
     else
-    {
-        FujiAdamPacket packet(_devnum, APT::NM_SEND,
-                              ByteBuffer(response, response + response_len));
-        auto encoded = packet.serialize();
-        adamnet_send_buffer(encoded.data(), encoded.size());
-        response_len = 0;
-    }
+        busPhase.didIgnore();
+}
+
+void systemBus::sendAckPacket()
+{
+    if (sendReplyPacket(true))
+        busPhase.didAck();
+    else
+        busPhase.didIgnore();
+}
+
+void systemBus::sendNakPacket()
+{
+    if (sendReplyPacket(false))
+        busPhase.didNak();
+    else
+        busPhase.didIgnore();
 }
 
 void virtualDevice::adamnet_idle()
@@ -271,37 +285,68 @@ void virtualDevice::adamnet_idle()
     // Not implemented in base class
 }
 
-//void virtualDevice::adamnet_status()
-//{
-//    fnDebugConsole.printf("adamnet_status() not implemented yet for this device.\n");
-//}
-
 void systemBus::_adamnet_process_cmd()
 {
-    uint8_t dest = _port->read();
     int64_t cmd_start = GET_TIMESTAMP();
-    start_time = cmd_start;
+    _start_time = cmd_start;
     frame_error = false;
-    stall_silent = false;
+    _stall_silent = false;
 
-    auto tmpPacket = FujiAdamPacket(dest);
+    auto tmpPacket = FujiAdamPacket(_port->read());
+    auto it = _daisyChain.find(tmpPacket.device());
+    if (it != _daisyChain.end() && it->second->device_active == true)
+    {
+        busPhase.begin(tmpPacket);
 
-    // Find device ID and pass control to it
-    if (_daisyChain.count(tmpPacket.device()) < 1)
-    {
-    }
-    else if (_daisyChain[tmpPacket.device()]->device_active == true)
-    {
         // turn on AdamNet Indicator LED
         fnLedManager.set(eLed::LED_BUS, true);
-        _activeDev = _daisyChain[tmpPacket.device()];
+
+        _activeDev = it->second;
         _activePacket = &tmpPacket;
+
+        if (tmpPacket.type() == APT::MN_SEND)
+        {
+            u16be_t len, rlen;
+            ByteBuffer buffer;
+            uint8_t ck;
+
+            _port->read(&len, sizeof(len));
+            buffer.resize(len);
+            rlen = _port->read(buffer.data(), buffer.size());
+            if (rlen != len)
+                buffer.resize(rlen);
+            ck = _port->read();
+            busPhase.gotPayload();
+
+            // Reset window of opportunity after reading last byte of payload;
+            _start_time = GET_TIMESTAMP();
+
+            if (tmpPacket.setPayload(buffer, ck).is_error())
+            {
+                // At this stage the Adam only wants to know if we received the packet ok.
+                sendNakPacket();
+                goto done;
+            }
+
+            sendAckPacket();
+        }
+
         _adamnet_dispatch(tmpPacket);
+
+    done:
         // turn off AdamNet Indicator LED
         fnLedManager.set(eLed::LED_BUS, false);
+
+
+#ifdef DEBUG_FINAL_PACKET_STATE
+        Debug_printf("packet complete device=0x%x type=0x%x phase=%d\n",
+                     tmpPacket.device(), tmpPacket.type(), busPhase.phase());
+#endif
+
+        busPhase.finish();
     }
 
-    if (stall_silent && (GET_TIMESTAMP() - cmd_start <= ADAMNET_LONG_CMD_US))
+    if (_stall_silent && (GET_TIMESTAMP() - cmd_start <= ADAMNET_LONG_CMD_US))
         fnSystem.yield();
     else
         wait_for_idle();
@@ -310,29 +355,35 @@ void systemBus::_adamnet_process_cmd()
 // Handle the five stages of AdamNet bus protocol
 void systemBus::_adamnet_dispatch(const FujiAdamPacket &packet)
 {
+#ifdef DEBUG_DISPATCH
+    Debug_printf("Dispatching device: %s (0x%02x)  type: %s (0x%02x)\n",
+                 AdamNetPhase::device_to_string(packet.device()), packet.device(),
+                 AdamNetPhase::type_to_string(packet.type()), packet.type());
+    if ((packet.device() == FUJI_DEVICEID_FUJINET || packet.device() == FUJI_DEVICEID_NETWORK)
+        && packet.type() == APT::MN_SEND)
+        Debug_printf("Fuji command: 0x%02x\n", packet.command());
+#endif // DEBUG_DISPATCH
+
     switch (packet.type())
     {
     case APT::MN_STATUS:
         // Get device capablities/check if it is alive
         {
-            AdamNetStatus status = _activeDev->deviceStatus();
-            const uint8_t *ptr = (const uint8_t *) &status;
-            FujiAdamPacket packet(_activeDev->id(), APT::NM_STATUS,
-                                  ByteBuffer(ptr, ptr + sizeof(status)));
-            auto encoded = packet.serialize();
-            SYSTEM_BUS.start_time=GET_TIMESTAMP();
-            _activeDev->adamnet_send_buffer(encoded.data(), encoded.size());
+            sendStatusPacket(_activeDev->deviceStatus());
         }
         break;
 
     case APT::MN_CLR:
         // Fetch the data from a previous read()/readBlock() request
-        _activeDev->adamnet_control_clr();
+        SYSTEM_BUS.sendResponsePacket();
         break;
 
     case APT::MN_RECEIVE:
         // read() or readBlock()
-        _activeDev->adamnet_control_receive();
+        if (_transaction_reply_encoded.has_value())
+            sendAckPacket();
+        else
+            _activeDev->adamnet_control_receive();
         break;
 
     case APT::MN_SEND:
@@ -348,6 +399,7 @@ void systemBus::_adamnet_dispatch(const FujiAdamPacket &packet)
     case APT::MN_RESET:
         _activeDev->reset();
         break;
+
     default:
         break;
     }
@@ -477,13 +529,9 @@ void systemBus::addDevice(virtualDevice *pDevice, fujiDeviceID_t device_id)
 
     switch (device_id)
     {
-    case FUJI_DEVICEID_PRINTER:
-        _printerDev = (adamPrinter *)pDevice;
-        break;
     case FUJI_DEVICEID_FUJINET:
         _fujiDev = dynamic_cast<adamFuji*>(pDevice);
         break;
-
     default:
         break;
     }

--- a/lib/bus/adamnet/adamnet.h
+++ b/lib/bus/adamnet/adamnet.h
@@ -6,6 +6,7 @@
  */
 
 #include "bus.h"
+#include "AdamNetPhase.h"
 #include "FujiAdamPacket.h"
 #include "UARTChannel.h"
 #include "BoIPChannel.h"
@@ -89,72 +90,12 @@ class virtualDevice
 
 protected:
     /**
-     * @brief Send Byte to AdamNet
-     * @param b Byte to send via AdamNet
-     * @return was byte sent?
-     */
-    void adamnet_send(uint8_t b);
-
-    /**
-     * @brief Send buffer to AdamNet
-     * @param buf Buffer to send to AdamNet
-     * @param len Length of buffer
-     * @return number of bytes sent.
-     */
-    void adamnet_send_buffer(const void *buf, unsigned short len);
-
-    /**
-     * @brief Receive byte from AdamNet
-     * @return byte received
-     */
-    uint8_t adamnet_recv();
-
-    /**
-     * @brief convenience function to recieve length
-     * @return short containing length.
-     */
-    uint16_t adamnet_recv_length();
-
-    /**
-     * @brief convenience function to receive block number
-     * @return ulong containing block num.
-     */
-    uint32_t adamnet_recv_blockno();
-
-    /**
-     * @brief covenience function to send length
-     * @param l Length.
-     */
-    void adamnet_send_length(uint16_t l);
-
-    /**
-     * @brief Receive desired # of bytes into buffer from AdamNet
-     * @param buf Buffer in which to receive
-     * @param len length of buffer
-     * @return # of bytes received.
-     */
-    unsigned short adamnet_recv_buffer(uint8_t *buf, unsigned short len);
-
-    /**
      * @brief Perform reset of device
      */
     virtual void reset();
 
-    /**
-     * @brief acknowledge, but not if cmd took too long.
-     * @param doNotWaitForIdle do not wait for idle if true.
-     */
-    virtual void adamnet_response_ack(bool doNotWaitForIdle=false);
-
-    /**
-     * @brief non-acknowledge, but not if cmd took too long
-     * param doNotWaitForIdle do not wait for idle if true.
-     */
-    virtual void adamnet_response_nack(bool doNotWaitForIdle=false);
-
-    virtual void adamnet_control_ready();       // Check if device is ready for command
-    virtual void adamnet_control_receive() = 0; // Tell device to queue up data
-    virtual void adamnet_control_clr();         // Send queued up data
+    virtual void adamnet_control_ready();   // Check if device is ready for command
+    virtual void adamnet_control_receive(); // Tell device to queue up data
     virtual void adamnet_control_send(const FujiAdamPacket &packet) = 0; // Send data to device
 
     virtual AdamNetStatus deviceStatus() = 0;
@@ -174,16 +115,6 @@ protected:
      * @brief Do any tasks that can only be done when the bus is quiet
      */
     virtual void adamnet_idle();
-
-    /**
-     * Response buffer
-     */
-    uint8_t response[1024];
-
-    /**
-     * Response length
-     */
-    uint16_t response_len;
 
 public:
 
@@ -216,7 +147,6 @@ private:
     virtualDevice *_activeDev = nullptr;
     const FujiAdamPacket *_activePacket;
     adamFuji *_fujiDev = nullptr;
-    adamPrinter *_printerDev = nullptr;
 
     // _port = UART on hardware, or a TCP socket to an emulator on PC (Bus over IP).
     UARTChannel _serial;
@@ -231,6 +161,26 @@ private:
 #endif /* ESP_PLATFORM */
     void _adamnet_dispatch(const FujiAdamPacket &packet);
 
+    std::optional<ByteBuffer> _transaction_reply_encoded;
+    bool _stall_silent = false;
+    AdamNetPhase busPhase;
+
+    /**
+     * @brief Wait for AdamNet bus to become idle.
+     */
+    void wait_for_idle();
+
+    bool sendReplyPacket(bool ack, const void *data, size_t length);
+    inline bool sendReplyPacket(bool ack, const ByteBuffer &data) {
+        return sendReplyPacket(ack, data.data(), data.size());
+    }
+    inline bool sendReplyPacket(bool ack) {
+        return sendReplyPacket(ack, NULL, 0);
+    }
+    void sendStatusPacket(const AdamNetStatus &status);
+    void sendResponsePacket(void);
+    bool writeBusPacket(const FujiAdamPacket &packet);
+
 public:
     void setup();
     void service();
@@ -241,28 +191,9 @@ public:
     void reset();
 
     /**
-     * @brief Wait for AdamNet bus to become idle.
-     */
-    void wait_for_idle();
-
-    /**
-     * @brief Hold off driving the shared one-wire bus until at least
-     *        ADAMNET_TURNAROUND_US after the current command, so the response
-     *        doesn't collide with the master still releasing the line.
-     */
-    void min_turnaround();
-
-    /**
-     * @brief Hold off driving the wire until at least @p us microseconds after
-     *        the current command (measured from start_time). Lets a device pace
-     *        its response to match real hardware's turnaround.
-     */
-    void wait_turnaround(uint32_t us);
-
-    /**
      * stopwatch
      */
-    int64_t start_time;
+    int64_t _start_time;
 
     /**
      * @brief Set true when a multi-byte receive times out mid-packet, so a
@@ -278,7 +209,10 @@ public:
      *        to drain, and it must NOT discardInput() (that 180us FIFO-clear eats
      *        the master's re-poll). Cleared at the start of each command.
      */
-    bool stall_silent = false;
+    void stall_silent() {
+        _stall_silent = false;
+        busPhase.didIgnore();
+    }
 
     int numDevices();
     void addDevice(virtualDevice *pDevice, fujiDeviceID_t device_id);
@@ -304,24 +238,13 @@ public:
     using SystemBusBase::transaction_send;
     void transaction_send(const void *data, size_t len, bool is_error=false) override;
 
-    // Everybody thinks "oh I know how a serial port works, I'll just
-    // access it directly and bypass the bus!" ಠ_ಠ
-    size_t read(void *buffer, size_t length) { return _port->read(buffer, length); }
-    size_t read() { return _port->read(); }
-    size_t write(const void *buffer, size_t length) { return _port->write(buffer, length); }
-    size_t write(int n) { return _port->write(n); }
-    size_t available() { return _port->available(); }
-    void flush() { _port->flushOutput(); }
+    void sendAckPacket();
+    void sendNakPacket();
 
-    // Protect a large response (a 1028-byte disk block) while it streams.
-    void quiet_rx_for_send(bool on) {
 #ifdef ESP_PLATFORM
-        _serial.setRXThreshold(on ? 120 : 1);
-#endif
-    }
-    size_t print(int n, int base = 10) { return _port->print(n, base); }
-    size_t print(const char *str) { return _port->print(str); }
-    size_t print(const std::string &str) { return _port->print(str); }
+    void adamnet_handle_bus_task();
+#endif /* ESP_PLATFORM */
+
 };
 
 extern systemBus SYSTEM_BUS;

--- a/lib/device/adamnet/adamFuji.cpp
+++ b/lib/device/adamnet/adamFuji.cpp
@@ -146,7 +146,6 @@ void adamFuji::adamnet_new_disk(const FujiAdamPacket &packet)
     if (new_disk_completed)
     {
         new_disk_completed = false;
-        SYSTEM_BUS.start_time = GET_TIMESTAMP();
         SYSTEM_BUS.transaction_error();
         return;
     }
@@ -197,8 +196,6 @@ void adamFuji::adamnet_enable_device(const FujiAdamPacket &packet)
 
     Debug_printf("FUJI ENABLE DEVICE %02x\n", d);
 
-    SYSTEM_BUS.start_time = GET_TIMESTAMP();
-
     SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
 
     switch (d)
@@ -234,7 +231,6 @@ void adamFuji::adamnet_disable_device(const FujiAdamPacket &packet)
 
     Debug_printf("FUJI DISABLE DEVICE %02x\n", d);
 
-    SYSTEM_BUS.start_time = GET_TIMESTAMP();
     SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
 
     switch (d)
@@ -322,22 +318,16 @@ void adamFuji::setup()
 
 void adamFuji::adamnet_random_number()
 {
-    int *p = (int *)&response[0];
+    int val = rand();
 
-
-    SYSTEM_BUS.start_time = GET_TIMESTAMP();
     SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
-
-    response_len = sizeof(int);
-    *p = rand();
-    SYSTEM_BUS.transaction_success();
+    SYSTEM_BUS.transaction_send(&val, sizeof(val));
 }
 
 void adamFuji::adamnet_get_time()
 {
     Debug_println("FUJI GET TIME");
 
-    SYSTEM_BUS.start_time = GET_TIMESTAMP();
     SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
 
     time_t tt = time(nullptr);
@@ -346,37 +336,38 @@ void adamFuji::adamnet_get_time()
     tzset();
 
     struct tm *now = localtime(&tt);
+    struct {
+        uint8_t century;
+        uint8_t year;
+        uint8_t month;
+        uint8_t day;
+        uint8_t hour;
+        uint8_t minute;
+        uint8_t second;
+    } cur_time;
+    cur_time.century = (now->tm_year) / 100 + 19;
+    cur_time.year = now->tm_year % 100;
+    cur_time.month = now->tm_mon + 1;
+    cur_time.day = now->tm_mday;
+    cur_time.hour = now->tm_hour;
+    cur_time.minute = now->tm_min;
+    cur_time.second = now->tm_sec;
 
-        /*
-     NWD order has changed to match apple format
-     Previously:
-        response[0] = now->tm_mday;
-        response[1] = now->tm_mon;
-        response[2] = now->tm_year;
-        response[3] = now->tm_hour;
-        response[4] = now->tm_min;
-        response[5] = now->tm_sec;
-    */
-
-        response[0] = (now->tm_year) / 100 + 19;
-        response[1] = now->tm_year % 100;
-        response[2] = now->tm_mon + 1;
-        response[3] = now->tm_mday;
-        response[4] = now->tm_hour;
-        response[5] = now->tm_min;
-        response[6] = now->tm_sec;
-
-        response_len = 7;
-
-    Debug_printf("Sending %02X %02X %02X %02X %02X %02X %02X\n", response[0], response[1], response[2], response[3], response[4], response[5], response[6]);
-    SYSTEM_BUS.transaction_success();
+    Debug_printf("Sending %02X %02X %02X %02X %02X %02X %02X\n",
+                 cur_time.century,
+                 cur_time.year,
+                 cur_time.month,
+                 cur_time.day,
+                 cur_time.hour,
+                 cur_time.minute,
+                 cur_time.second);
+    SYSTEM_BUS.transaction_send(&cur_time, sizeof(cur_time));
 }
 
 void adamFuji::adamnet_device_enable_status(const FujiAdamPacket &packet)
 {
     uint8_t d = packet.param(0);
 
-    SYSTEM_BUS.start_time = GET_TIMESTAMP();
     SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
 
     if (SYSTEM_BUS.deviceExists(d))
@@ -384,8 +375,7 @@ void adamFuji::adamnet_device_enable_status(const FujiAdamPacket &packet)
     else
         SYSTEM_BUS.transaction_error();
 
-    response_len = 1;
-    response[0] = SYSTEM_BUS.deviceEnabled(d);
+    SYSTEM_BUS.transaction_send(SYSTEM_BUS.deviceEnabled(d));
 }
 
 void adamFuji::adamnet_control_send(const FujiAdamPacket &packet)
@@ -537,29 +527,13 @@ void adamFuji::adamnet_control_send(const FujiAdamPacket &packet)
         break;
     default:
         Debug_printv("Unknown command: %02x\n", packet.command());
+        SYSTEM_BUS.transaction_error();
         break;
     }
 }
 
-void adamFuji::adamnet_control_clr()
-{
-    FujiAdamPacket packet(_devnum, APT::NM_SEND,
-                          ByteBuffer(response, response + response_len));
-    auto encoded = packet.serialize();
-    adamnet_send_buffer(encoded.data(), encoded.size());
-    response_len = 0;
-}
-
 void adamFuji::fujicmd_read_directory_entry(size_t maxlen, uint8_t addtl)
 {
-    if (response_len)
-    {
-        // Still have queued up data that needs to be read, ignore this request
-        SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
-        SYSTEM_BUS.transaction_success();
-        return;
-    }
-
     SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
     Debug_printf("Fuji cmd: READ DIRECTORY ENTRY (max=%hu) (addtl=%02x)\n", maxlen, addtl);
 
@@ -616,7 +590,7 @@ void adamFuji::fujicmd_read_directory_entry(size_t maxlen, uint8_t addtl)
     if (current_entry->size() < maxlen)
         current_entry->resize(maxlen, '\0');
 
-    Debug_printf("%s\n", util_hexdump(current_entry->data(), maxlen).c_str());
+    Debug_printf("\n%s", util_hexdump(current_entry->data(), maxlen).c_str());
     SYSTEM_BUS.transaction_send(current_entry->data(), maxlen);
 }
 

--- a/lib/device/adamnet/adamFuji.h
+++ b/lib/device/adamnet/adamFuji.h
@@ -32,8 +32,6 @@ protected:
     void adamnet_test_command();
 
     void adamnet_control_send(const FujiAdamPacket &packet) override;
-    void adamnet_control_receive() override { adamnet_response_ack(); }
-    void adamnet_control_clr() override;
 
     AdamNetStatus deviceStatus() override;
 

--- a/lib/device/adamnet/disk.cpp
+++ b/lib/device/adamnet/disk.cpp
@@ -109,98 +109,37 @@ error_is_true adamDisk::write_blank(fnFile *fileh, uint32_t numBlocks)
     RETURN_SUCCESS_AS_FALSE();
 }
 
-void adamDisk::adamnet_control_clr()
+void adamDisk::adamnet_control_send_block_num(const FujiAdamPacket &packet)
 {
-#ifdef ESP_PLATFORM
-    // Real bus only: stream the block only inside the master's window.
-    if (GET_TIMESTAMP() - SYSTEM_BUS.start_time >= 1500)
-        return;
-#endif
-    adamnet_response_send();
-}
+    u32le_t num;
 
-void adamDisk::adamnet_control_receive()
-{
-    if (_media == nullptr)
-        return;
+    SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
+    memcpy(&num, packet.data()->data(), sizeof(num));
+    blockNum = num;
 
-    // Already ACKed this block's RECEIVE. The master re-polls RECEIVE while we
-    // read; a second ACK would desync the next block, so stay silent until a new
-    // block number resets us. (stall_silent: yield without discardInput().)
-    if (_receive_acked)
-    {
-        SYSTEM_BUS.stall_silent = true;
+    if (_media == nullptr) {
+        SYSTEM_BUS.transaction_error();
         return;
     }
-
-    // Seek emulation.
-    if (GET_TIMESTAMP() < _seek_deadline)
-    {
-        _seek_is_read = true;
-        _media->read(blockNum, nullptr);
-        SYSTEM_BUS.stall_silent = true;
-        return;
-    }
-
-    bool err = _media->read(blockNum, nullptr);
-
-    // Match a real drive's RECEIVE->ACK turnaround so the master masks
-    // interrupts for the coming block before we answer.
-    SYSTEM_BUS.wait_turnaround(ADAMNET_DISK_RECV_TURNAROUND_US);
-
-    if (err)
-        adamnet_response_nack(true);
-    else
-        adamnet_response_ack(true);
-
-    // Exactly one ACK per block: suppress the master's surplus re-poll RECEIVEs.
-    _receive_acked = true;
-}
-
-void adamDisk::adamnet_control_send_block_num()
-{
-    uint8_t x[8];
-
-    for (uint16_t i = 0; i < 5; i++)
-        x[i] = adamnet_recv();
-
-    adamnet_recv(); // CK -- consume the trailing checksum so the packet is fully read
-
-    blockNum = x[3] << 24 | x[2] << 16 | x[1] << 8 | x[0];
-
-    if (_media == nullptr)
-        return;
 
     if (_media->num_blocks() < 0x10000UL) // Smaller than 64MB?
     {
         blockNum &= 0xFFFF; // Mask off upper bits
     }
 
+    Debug_printf("BLOCK: %lu\n", blockNum);
+
     if (blockNum == 0xFACE)
     {
         _media->format(NULL);
     }
 
-    SYSTEM_BUS.start_time=GET_TIMESTAMP();
-
-    adamnet_response_ack();
-
-    Debug_printf("BLOCK: %lu\n", blockNum);
-
-    int64_t now = GET_TIMESTAMP();
-    // Each new block# starts unclassified; a following RECEIVE marks it a read.
-    _seek_is_read = false;
-    // New block operation: allow exactly one ACK for its RECEIVE sequence again.
-    _receive_acked = false;
-
-    bool already_cached = (_media->_media_last_block == blockNum);
-    if (blockNum != _seek_block ||
-        (now - _last_blocknum_us > ADAMNET_DISK_SEEK_NEWOP_US && !already_cached))
+    if (_media->read(blockNum, nullptr).is_error())
     {
-        _seek_block = blockNum;
-        _seek_deadline = now + ADAMNET_DISK_SEEK_US;
+        SYSTEM_BUS.transaction_error();
+        return;
     }
-    _last_blocknum_us = now;
+    SYSTEM_BUS.transaction_send(_media->_media_blockbuff, DDP_BLOCK_SIZE);
 }
 
 void adamDisk::adamnet_control_send_block_data()
@@ -208,16 +147,15 @@ void adamDisk::adamnet_control_send_block_data()
     if (_media == nullptr)
         return;
 
-    adamnet_recv_buffer(_media->_media_blockbuff, DDP_BLOCK_SIZE);
-    adamnet_recv(); // CK -- consume the trailing checksum so the packet is fully read
-    SYSTEM_BUS.start_time = GET_TIMESTAMP();
-    adamnet_response_ack();
+    SYSTEM_BUS.transaction_accept(TRANS_STATE::WILL_GET);
+    SYSTEM_BUS.transaction_get(_media->_media_blockbuff, DDP_BLOCK_SIZE);
 
     if (is_config_device)
     {
         Debug_printf("Refusing spurious write to read-only config device, block %lu\n", blockNum);
         blockNum = 0xFFFFFFFF;
         _media->_media_last_block = 0xFFFFFFFE;
+        SYSTEM_BUS.transaction_error();
         return;
     }
 
@@ -227,15 +165,14 @@ void adamDisk::adamnet_control_send_block_data()
 
     blockNum = 0xFFFFFFFF;
     _media->_media_last_block = 0xFFFFFFFE;
+    SYSTEM_BUS.transaction_success();
 }
 
 void adamDisk::adamnet_control_send(const FujiAdamPacket &packet)
 {
-    uint16_t s = adamnet_recv_length();
-
-    if (s == 5)
-        adamnet_control_send_block_num();
-    else if (s == DDP_BLOCK_SIZE)
+    if (packet.data()->size() == 5)
+        adamnet_control_send_block_num(packet);
+    else if (packet.data()->size() == DDP_BLOCK_SIZE)
         adamnet_control_send_block_data();
 }
 
@@ -253,22 +190,6 @@ AdamNetStatus adamDisk::deviceStatus()
         status.status |= _media->_media_controller_status;
 
     return status;
-}
-
-void adamDisk::adamnet_response_send()
-{
-    if (_media == nullptr)
-        return;
-
-    FujiAdamPacket packet(_devnum, APT::NM_SEND,
-                          ByteBuffer(_media->_media_blockbuff,
-                                     _media->_media_blockbuff + DDP_BLOCK_SIZE));
-    auto encoded = packet.serialize();
-
-    SYSTEM_BUS.wait_turnaround(ADAMNET_DISK_SEND_TURNAROUND_US);
-    SYSTEM_BUS.quiet_rx_for_send(true);
-    adamnet_send_buffer(encoded.data(), encoded.size());
-    SYSTEM_BUS.quiet_rx_for_send(false);
 }
 
 #endif /* BUILD_ADAM */

--- a/lib/device/adamnet/disk.h
+++ b/lib/device/adamnet/disk.h
@@ -30,12 +30,9 @@ private:
     bool _receive_acked = false;
 
     void adamnet_control_send(const FujiAdamPacket &packet) override;
-    void adamnet_control_receive() override;
-    void adamnet_control_clr() override;
 
-    void adamnet_control_send_block_num();
+    void adamnet_control_send_block_num(const FujiAdamPacket &packet);
     void adamnet_control_send_block_data();
-    void adamnet_response_send();
 
     AdamNetStatus deviceStatus() override;
 

--- a/lib/device/adamnet/keyboard.cpp
+++ b/lib/device/adamnet/keyboard.cpp
@@ -37,46 +37,28 @@ void adamKeyboard::adamnet_control_receive()
 {
     if (!client.connected() && server->hasClient())
     {
-        SYSTEM_BUS.wait_for_idle();
-        adamnet_send(0xC1); // NAK
+        SYSTEM_BUS.sendNakPacket();
         client = server->client();
     }
     else if (!client.connected())
     {
-        SYSTEM_BUS.wait_for_idle();
-        adamnet_send(0xC1); // NAK
-    }
-    else if (!kpQueue.empty())
-    {
-        SYSTEM_BUS.wait_for_idle();
-        adamnet_send(0x91); // ACK
+        SYSTEM_BUS.sendNakPacket();
     }
     else if (client.available() > 0)
     {
-        SYSTEM_BUS.wait_for_idle();
-        adamnet_send(0x91); // ACK
-        kpQueue.push(client.read());
+        SYSTEM_BUS.sendAckPacket();
+        SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
+        SYSTEM_BUS.transaction_send(client.read());
     }
     else
     {
-        SYSTEM_BUS.wait_for_idle();
-        adamnet_send(0xC1); // NAK
+        SYSTEM_BUS.sendNakPacket();
     }
-}
-
-void adamKeyboard::adamnet_control_clr()
-{
-    uint8_t r[5] = {0xB1, 0x00, 0x01, 0x00, 0x00};
-
-    r[3] = r[4] = kpQueue.front();
-    adamnet_send_buffer(r, sizeof(r));
-    kpQueue.pop();
 }
 
 void adamKeyboard::adamnet_control_ready()
 {
-    SYSTEM_BUS.wait_for_idle();
-    adamnet_send(0x91); // Ack
+    SYSTEM_BUS.sendAckPacket();
 }
 
 void adamKeyboard::shutdown()

--- a/lib/device/adamnet/keyboard.h
+++ b/lib/device/adamnet/keyboard.h
@@ -12,7 +12,6 @@ class adamKeyboard : public virtualDevice
 {
 protected:
     void adamnet_control_receive() override;
-    void adamnet_control_clr() override;
     void adamnet_control_ready() override;
 
     void shutdown() override;
@@ -25,7 +24,6 @@ public:
 private:
     fnTcpServer *server;
     fnTcpClient client;
-    std::queue<uint8_t> kpQueue;
 };
 
 #endif /* ADAM_KEYBOARD_H */

--- a/lib/device/adamnet/network.cpp
+++ b/lib/device/adamnet/network.cpp
@@ -513,44 +513,24 @@ void adamNetwork::adamnet_control_send(const FujiAdamPacket &packet)
     }
 }
 
-void adamNetwork::adamnet_control_clr()
-{
-    adamnet_response_send();
-
-    if (channelMode == CHANNEL_MODE::JSON)
-        jsonRecvd = false;
-    else if (channelMode == CHANNEL_MODE::SGML)
-        sgmlRecvd = false;
-}
-
 std::optional<ByteBuffer> adamNetwork::adamnet_control_receive_channel_json()
 {
     NetworkStatus ns;
 
-    if (jsonRecvd == false)
-    {
-        auto len = json.readValueLen();
-        ByteBuffer buffer(len);
-        json.readValue(buffer.data(), buffer.size());
-        jsonRecvd = true;
-        return buffer;
-    }
-    return std::nullopt;
+    auto len = json.readValueLen();
+    ByteBuffer buffer(len);
+    json.readValue(buffer.data(), buffer.size());
+    return buffer;
 }
 
 std::optional<ByteBuffer> adamNetwork::adamnet_control_receive_channel_sgml()
 {
     NetworkStatus ns;
 
-    if (sgmlRecvd == false)
-    {
-        auto len = sgml.readValueLen();
-        ByteBuffer buffer(len);
-        sgml.readValue(buffer.data(), buffer.size());
-        sgmlRecvd = true;
-        return buffer;
-    }
-    return std::nullopt;
+    auto len = sgml.readValueLen();
+    ByteBuffer buffer(len);
+    sgml.readValue(buffer.data(), buffer.size());
+    return buffer;
 }
 
 std::optional<ByteBuffer> adamNetwork::adamnet_control_receive_channel_protocol()
@@ -606,42 +586,17 @@ inline void adamNetwork::adamnet_control_receive()
 
     if (buffer.has_value())
     {
+        SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
         if (buffer->size())
-        {
-            SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
             SYSTEM_BUS.transaction_send(buffer.value());
-        }
         else
-            SYSTEM_BUS.stall_silent = true;
+            SYSTEM_BUS.transaction_success();
     }
     else
     {
         Debug_printf("No data\n");
         SYSTEM_BUS.transaction_error();
     }
-}
-
-void adamNetwork::adamnet_response_send()
-{
-    if (response_len)
-    {
-        // response_len can be a full 1024 bytes; on the half-duplex bus that whole
-        // burst echoes back into our own RX and, at rxThreshold=1, storms the shared
-        // UART ISR enough to jitter the outgoing bytes. Coalesce the echo for the
-        // duration of the send (same fix as the disk block stream).
-        SYSTEM_BUS.quiet_rx_for_send(true);
-        FujiAdamPacket packet(_devnum, APT::NM_SEND,
-                              ByteBuffer(response, response + response_len));
-        auto encoded = packet.serialize();
-        adamnet_send_buffer(encoded.data(), encoded.size());
-        response_len = 0;
-        SYSTEM_BUS.quiet_rx_for_send(false);
-    }
-    else
-        adamnet_send(0xC0 | _devnum); // NAK!
-
-    memset(response, 0, response_len);
-    response_len = 0;
 }
 
 /** PRIVATE METHODS ************************************************************/

--- a/lib/device/adamnet/network.h
+++ b/lib/device/adamnet/network.h
@@ -81,9 +81,6 @@ public:
 
     void adamnet_control_send(const FujiAdamPacket &packet) override;
     void adamnet_control_receive() override;
-    void adamnet_control_clr() override;
-
-    void adamnet_response_send();
 
     AdamNetStatus deviceStatus() override;
     std::optional<ByteBuffer> adamnet_control_receive_channel_json();
@@ -158,19 +155,9 @@ private:
     FNJSON json;
 
     /**
-     * Has JSON been sent via CLR?
-     */
-    bool jsonRecvd = false;
-
-    /**
      * SGML Object (HTML/XML via CSS selector)
      */
     FNSGML sgml;
-
-    /**
-     * Has SGML been sent via CLR?
-     */
-    bool sgmlRecvd = false;
 
     /**
      * The Receive buffer for this N: device

--- a/lib/device/adamnet/printer.cpp
+++ b/lib/device/adamnet/printer.cpp
@@ -112,50 +112,40 @@ void adamPrinter::adamnet_control_send(const FujiAdamPacket &packet)
 {
     PrintItem pi;
 
-    pi.len = adamnet_recv_length();
-    if (pi.len > sizeof(pi.buf)) // clamp wire length to buffer
-        pi.len = sizeof(pi.buf);
-    adamnet_recv_buffer(pi.buf, pi.len);
-    adamnet_recv(); // ck
-
-    // AdamNet.start_time = GET_TIMESTAMP();
-    adamnet_response_ack();
-
+    pi.len = std::min(packet.data()->size(), sizeof(pi.buf));
+    SYSTEM_BUS.transaction_accept(TRANS_STATE::WILL_GET);
+    SYSTEM_BUS.transaction_get(pi.buf, pi.len);
     xQueueSend(pxq, &pi, portMAX_DELAY);
 
     _last_ms = fnSystem.millis();
+    SYSTEM_BUS.transaction_success();
 }
 #else
 void adamPrinter::adamnet_control_send(const FujiAdamPacket &packet)
 {
-    size_t len = adamnet_recv_length();
+    size_t len = packet.data()->size();
     uint8_t *pbuf = _pptr->provideBuffer();
 
-    adamnet_recv_buffer(pbuf, len);
-    adamnet_recv(); // ck
-
-    // AdamNet.start_time = GET_TIMESTAMP();
-    adamnet_response_ack();
-
+    SYSTEM_BUS.transaction_accept(TRANS_STATE::WILL_GET);
+    SYSTEM_BUS.transaction_get(pbuf, len);
     if (len)
         _pptr->process(len,0,0);
 
     _last_ms = fnSystem.millis();
+    SYSTEM_BUS.transaction_success();
 }
 #endif /* ESP_PLATFORM */
 
 void adamPrinter::adamnet_control_ready()
 {
-    SYSTEM_BUS.start_time = GET_TIMESTAMP();
-
     if (getPrinterPtr()->is_printing)
-        adamnet_response_nack();
+        SYSTEM_BUS.sendNakPacket();
 #ifdef ESP_PLATFORM
     else if (!uxQueueSpacesAvailable(pxq))
-        adamnet_response_nack();
+        SYSTEM_BUS.sendNakPacket();
 #endif /* ESP_PLATFORM */
     else
-        adamnet_response_ack();
+        SYSTEM_BUS.sendAckPacket();
 }
 
 void adamPrinter::shutdown()

--- a/lib/device/adamnet/printer.h
+++ b/lib/device/adamnet/printer.h
@@ -33,8 +33,6 @@ protected:
 
     void adamnet_control_send(const FujiAdamPacket &packet) override;
     void adamnet_control_ready() override;
-    void adamnet_control_receive() override {}
-    void adamnet_control_clr() override {}
 
     AdamNetStatus deviceStatus() override;
 

--- a/lib/device/adamnet/serial.cpp
+++ b/lib/device/adamnet/serial.cpp
@@ -12,7 +12,6 @@
 adamSerial::adamSerial()
 {
     Debug_printf("Serial Start\n");
-    response_len = 0;
 #ifdef ESP_PLATFORM
     serial_out_queue = xQueueCreate(16, sizeof(SendData));
 #endif /* ESP_PLATFORM */
@@ -42,14 +41,12 @@ AdamNetStatus adamSerial::deviceStatus()
 
 void adamSerial::adamnet_control_ready()
 {
-    SYSTEM_BUS.start_time=GET_TIMESTAMP();
-
 #ifdef ESP_PLATFORM
     if (uxQueueMessagesWaiting(serial_out_queue))
-        adamnet_response_nack();
+        SYSTEM_BUS.sendNakPacket();
     else
 #endif /* ESP_PLATFORM */
-        adamnet_response_ack();
+        SYSTEM_BUS.sendAckPacket();
 }
 
 void adamSerial::adamnet_idle()
@@ -58,16 +55,8 @@ void adamSerial::adamnet_idle()
 
 void adamSerial::adamnet_control_send(const FujiAdamPacket &packet)
 {
-    next.len = adamnet_recv_length();
-
-    if (next.len > sizeof(next.data)) // clamp wire length to buffer
-        next.len = sizeof(next.data);
-
-    adamnet_recv_buffer(next.data, next.len);
-    adamnet_recv();
-
-    SYSTEM_BUS.start_time = GET_TIMESTAMP();
-    adamnet_response_ack();
+    memcpy(next.data, packet.data()->data(),
+           std::min(sizeof(next.data), packet.data()->size()));
 
 #ifdef UNUSED
     // There is no matching xQueueReceive()


### PR DESCRIPTION
* Added AdamNetPhase class to keep track of current bus phase
* Remove direct port access from FujiAdamPacket
* Bus handles reading & writing packets, not devices
* Pre-compute the encoded reply packet for fastest response to MN_SEND