### PR TITLE
Config: add 76800 baud option to RS232 serial port

### DIFF
--- a/data/webui/template/www/index.tmpl.html
+++ b/data/webui/template/www/index.tmpl.html
@@ -1754,6 +1754,7 @@
 									<option value="28800">28800</option>
 									<option value="38400">38400</option>
 									<option value="57600">57600</option>
+									<option value="76800">76800</option>
 									<option value="115200">115200</option>
 								</select>
 								<span class="focus"></span>


### PR DESCRIPTION
## Summary

Adds **76800** to the RS232 serial-port **Baud Rate** dropdown in the web UI.

## Motivation

76800 baud is commonly supported by vintage **S-100 bus** serial boards, so it's a useful rate for RS232 FujiNet builds. The firmware already accepts and runs at 76800 — only the web UI couldn't represent it.

## The bug this also fixes

The RS232 baud `<select>` offered a fixed list: `9600 / 19200 / 28800 / 38400 / 57600 / 115200`. When the configured rate isn't one of those (e.g. 76800), `selectListValue()` (`js/settings.tmpl.js`) finds no matching `<option>` and leaves the dropdown on its first entry, **9600**. Result:

- the Config page misreports the actual configured baud, and
- saving that page silently overwrites the real 76800 with 9600.

Adding the option makes the configured value display correctly and prevents the accidental downgrade on save.

## Change

One line in `data/webui/template/www/index.tmpl.html`, inserted in ascending order between 57600 and 115200 in the `RS232` platform block. COCO/ATARI blocks are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)