### PR TITLE
[qrcode] Measure capacity in bits so a symbol holds its full payload

### DIFF
--- a/lib/qrcode/qrcode.c
+++ b/lib/qrcode/qrcode.c
@@ -163,6 +163,37 @@ static char getModeBits(uint8_t version, uint8_t mode) {
     return result;
 }
 
+// Total bits a segment occupies once encoded: the 4-bit mode indicator, the
+// character count indicator (whose width getModeBits() gives, and which widens
+// at versions 10 and 27), and the packed payload.
+//
+// This mirrors encodeDataCodewords() exactly and is the only correct way to ask
+// "does this fit?". Note getModeBits() returns the width of the count
+// *indicator*, not bits per character -- conflating the two overestimates
+// alphanumeric data by roughly 60%.
+static uint16_t getEncodedBits(uint8_t version, uint8_t mode, uint16_t length) {
+    uint16_t bits = 4 + getModeBits(version, mode);
+
+    switch (mode) {
+        case MODE_NUMERIC:
+            // Groups of 3 digits in 10 bits; a trailing 1 or 2 digits in 4 or 7.
+            bits += 10 * (length / 3);
+            if (length % 3) { bits += 3 * (length % 3) + 1; }
+            break;
+
+        case MODE_ALPHANUMERIC:
+            // Pairs of characters in 11 bits; a trailing single in 6.
+            bits += 11 * (length / 2);
+            if (length % 2) { bits += 6; }
+            break;
+
+        default: // MODE_BYTE
+            bits += 8 * length;
+            break;
+    }
+
+    return bits;
+}
 
 
 typedef struct BitBucket {
@@ -772,14 +803,25 @@ uint8_t qrcode_initBytes(QRCode *qrcode, uint8_t *data, uint16_t length) {
     // If Version is 0, choose the smallest version that can hold the data
     if (qrcode->version == VERSION_AUTO) {
         qrcode->version = qrcode_minVersion(qrcode, (char*)data, length);
+
+        // Nothing from version 1 to 40 could hold it. Bail out before the
+        // capacity lookup below, whose tables are only indexed to 40.
+        if (qrcode->version > 40) {
+            return 3; // Bad Length
+        }
     }
     else if (qrcode->version > 40 || qrcode->ecc > 3)
     {
         return 2; // Bad Version
     }
 
-    // If length is too big, return error
-    if (length > (qrcode_dataCapacity(qrcode->version, qrcode->ecc) - 2)) {
+    // If the encoded data will not fit the chosen version and ECC, return an
+    // error. This has to be measured in bits, for the mode actually selected:
+    // comparing a raw character count against the byte-mode codeword capacity
+    // rejects data that fits comfortably. A version 1 / ECC LOW symbol holds 25
+    // alphanumeric characters, but the old check capped it at 17.
+    if (getEncodedBits(qrcode->version, qrcode->mode, length) >
+        (uint16_t)(qrcode_dataCapacity(qrcode->version, qrcode->ecc) * 8)) {
         return 3; // Bad Length
     }
 
@@ -903,15 +945,18 @@ uint8_t qrcode_minVersion(QRCode *qrcode, const char *data, uint16_t length) {
 
     uint8_t version = 1;
     uint8_t ecc = ECC_HIGH;
-    uint8_t lengthMode = getModeBits(version, qrcode->mode);
-    uint16_t lengthMax;
 
-    uint16_t lengthEncoded = (length * lengthMode) / 8;
+    // Walk versions upward, and within each version try the strongest error
+    // correction first, dropping it until the data fits. That yields the
+    // smallest symbol, with the best ECC that symbol can carry.
+    //
+    // Both sides must be measured in bits: getEncodedBits() also depends on
+    // version, because the character count indicator widens at versions 10
+    // and 27, so it cannot be hoisted out of the loop.
     do {
-        lengthMax = qrcode_dataCapacity(version, ecc) - 2;
-        //printf("Testing version[%d] ecc[%d] len[%d] lengthMode[%d] encoded[%d] max[%d]\n", version, ecc, length, lengthMode, lengthEncoded, lengthMax);
-        if (lengthEncoded > lengthMax) {
-            if (ecc == 0)
+        if (getEncodedBits(version, qrcode->mode, length) >
+            (uint16_t)(qrcode_dataCapacity(version, ecc) * 8)) {
+            if (ecc == ECC_LOW)
             {
                 version++;
                 ecc = ECC_HIGH;
@@ -923,7 +968,8 @@ uint8_t qrcode_minVersion(QRCode *qrcode, const char *data, uint16_t length) {
         }
     } while (version <= 40);
 
-    //printf("Set version[%d] ecc[%d] len[%d] lengthMode[%d] encoded[%d] max[%d]\n", version, ecc, length, lengthMode, lengthEncoded, lengthMax);
+    // Callers must treat a return of 41 as "does not fit any version"; the
+    // capacity tables are only indexed to 40.
     qrcode->ecc = ecc;
     return version;
 }


### PR DESCRIPTION
> **Updated after review.** This originally also changed `FujiSIOPacket::getParam`. That was wrong on both counts — `sioFuji::qr_encode` already overrides the handler and unpacks `shorten` from the upper nibble of aux2, so there was no out-of-bounds read; and defaulting a parameter the frame never carried would have made the packet class misrepresent its own contents. Dropped. This is now a single commit touching only `lib/qrcode/qrcode.c`.

`qrcode_initBytes()` gated on a raw character count against byte-mode codeword capacity:

```c
if (length > (qrcode_dataCapacity(version, ecc) - 2))
```

That is not the right comparison. Capacity is a **bit** budget, and the payload's bit cost depends on the mode actually selected. The result was a flat 17-character cap at version 1 / ECC LOW for *every* mode.

`qrcode_minVersion()` had the same error in a second form: it used `getModeBits()` — the width of the character *count indicator* — as though it were bits per character, overestimating alphanumeric data by ~60%.

Adds `getEncodedBits()`, mirroring `encodeDataCodewords()` exactly, and uses it for both checks.

## Capacity: version 1 / ECC LOW, max accepted input

| mode | before | after | QR spec |
|---|---|---|---|
| numeric | 17 | **41** | 41 |
| alphanumeric | 17 | **25** | 25 |
| byte | 17 | **17** | 17 |

## Error correction gets *stronger*, not weaker

The policy is unchanged — lowest version first, then the strongest ECC that fits. But because the old estimate over-counted, auto mode was dropping ECC further than it needed to. Correcting the measurement raises the selected level:

| input | before | after |
|---|---|---|
| 10 alphanumeric | v1 QUARTILE | v1 **HIGH** |
| 15 alphanumeric | v1 **LOW** | v1 **QUARTILE** |
| 20 alphanumeric | v2 MEDIUM | **v1** MEDIUM |
| 25 alphanumeric | v2 LOW | **v1** LOW |
| 15 numeric | v2 QUARTILE | **v1 HIGH** |
| 30 numeric | v3 MEDIUM | **v1** MEDIUM |

Byte mode is identical throughout — 8 bits per character is the one case the old estimate computed correctly by accident.

Also guards the version-41 case: when nothing from v1–40 fits, `qrcode_minVersion()` returns 41 and the capacity lookup below it would index `NUM_RAW_DATA_MODULES[40]` on a 40-element table.

## Verification

Compiled the real `lib/qrcode/qrcode.c` on the host, at this branch and at `origin/master`, and compared against libqrencode and zbar:

- **Capacities** now match the QR spec exactly for all three modes.
- **No regressions**: swept 462 inputs across numeric/alphanumeric/byte at lengths 1–600, in both auto and explicit-version modes. Nothing `master` accepts is rejected here.
- **Auto-selected versions** now agree with libqrencode's choice on every sampled length and mode.
- **Output decodes**: rendered the encoder's own module matrix to PBM and ran `zbarimg` over it — 36 cases across the range, including the v10 byte-mode boundary (where master accepts 272 bytes against a spec limit of 271), all round-trip correctly.
- `./build.sh -p ATARI` builds clean with no new warnings; `ctest` passes.

Not tested on hardware.

## Why it matters

A 21×21 version 1 symbol is the largest some 8-bit targets can render — on the Intellivision it is the only size that fits the STIC colored-squares grid at one module per square. With this change a URL of up to 25 uppercase characters fits one, which stock firmware rejects at 18.

## Not included

`FUJICMD_QRCODE_CLEAR` is still missing — stubbed out under `#if 0` in `QRMixin.h` with a FIXME, and no command ID allocated. `qr_input()` appends, so a sequence abandoned between INPUT and ENCODE leaves stale data that corrupts the next symbol. Needs a protocol addition rather than a local fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012b4pARGeBH9MMkhipCob55