### PR TITLE
[wifi] Add optional multi_ap mode to select strongest AP by RSSI

### DIFF
--- a/lib/config/fnConfig.h
+++ b/lib/config/fnConfig.h
@@ -183,9 +183,11 @@ public:
     }
     void store_wifi_ssid(const char *ssid_octets, int num_octets);
     void store_wifi_passphrase(const char *passphrase_octets, int num_octets);
-    void reset_wifi() { _wifi.ssid.clear(); _wifi.passphrase.clear(); };
+    void reset_wifi() { _wifi.ssid.clear(); _wifi.passphrase.clear(); _wifi.multi_ap = false; };
     void store_wifi_enabled(bool status);
     bool get_wifi_enabled() { return _wifi.enabled; };
+    void store_wifi_multi_ap(bool status);
+    bool get_wifi_multi_ap() { return _wifi.multi_ap; };
 
     std::string get_wifi_stored_ssid(int index) { return _wifi_stored[index].ssid; }
     std::string get_wifi_stored_passphrase(int index) { return _wifi_stored[index].passphrase; }
@@ -447,6 +449,7 @@ private:
         std::string ssid;
         std::string passphrase;
         bool enabled = true;
+        bool multi_ap = false; // scan all channels and pick the strongest AP for the SSID
     };
 
     struct bt_info

--- a/lib/config/fnc_save.cpp
+++ b/lib/config/fnc_save.cpp
@@ -54,6 +54,7 @@ void fnConfig::save()
     ss << "enabled=" << _wifi.enabled << LINETERM;
     ss << "SSID=" << _wifi.ssid << LINETERM;
     ss << "passphrase=" << _wifi.passphrase << LINETERM;
+    ss << "multi_ap=" << _wifi.multi_ap << LINETERM;
 
     // WIFI STORED
     for (i = 0; i < MAX_WIFI_STORED; i++)

--- a/lib/config/fnc_wifi.cpp
+++ b/lib/config/fnc_wifi.cpp
@@ -52,6 +52,13 @@ void fnConfig::store_wifi_enabled(bool status)
     _dirty = true;
 }
 
+/* Stores whether multi-AP (all-channel, strongest-signal) scan is enabled */
+void fnConfig::store_wifi_multi_ap(bool status)
+{
+    _wifi.multi_ap = status;
+    _dirty = true;
+}
+
 void fnConfig::_read_section_wifi(std::stringstream &ss)
 {
     Debug_println("Reading wifi section");
@@ -85,6 +92,10 @@ void fnConfig::_read_section_wifi(std::stringstream &ss)
                     _wifi.enabled = true;
                 else
                     _wifi.enabled = false;
+            }
+            else if (strcasecmp(name.c_str(), "multi_ap") == 0)
+            {
+                _wifi.multi_ap = (strcasecmp(value.c_str(), "1") == 0);
             }
         }
     }

--- a/lib/hardware/fnWiFi.cpp
+++ b/lib/hardware/fnWiFi.cpp
@@ -173,6 +173,17 @@ int WiFiManager::connect(const char *ssid, const char *password)
         // Debug_printf("WiFi config double-check: \"%s\", \"%s\"\r\n", (char *)wifi_config.sta.ssid, (char *)wifi_config.sta.password );
 
         wifi_config.sta.pmf_cfg.capable = true;
+
+        // Optional multi-AP mode ([WiFi] multi_ap=1): in a meshed/multi-AP environment
+        // (several APs sharing one SSID) scan all channels and associate to the AP with
+        // the strongest signal. Default (multi_ap=0) keeps ESP-IDF's fast scan, which
+        // connects to the first AP found for the SSID.
+        if (Config.get_wifi_multi_ap())
+        {
+            wifi_config.sta.scan_method = WIFI_ALL_CHANNEL_SCAN;
+            wifi_config.sta.sort_method = WIFI_CONNECT_AP_BY_SIGNAL;
+        }
+
         ESP_ERROR_CHECK(esp_wifi_set_config(WIFI_IF_STA, &wifi_config));
     }
 
@@ -254,6 +265,14 @@ int WiFiManager::test_connect(const char *ssid, const char *password)
     // Debug_printf("wifi_config.sta.pass: >%s<\r\n", wifi_config.sta.password);
 
     wifi_config.sta.pmf_cfg.capable = true;
+
+    // Match connect(): in multi-AP mode prefer the strongest AP for the SSID.
+    if (Config.get_wifi_multi_ap())
+    {
+        wifi_config.sta.scan_method = WIFI_ALL_CHANNEL_SCAN;
+        wifi_config.sta.sort_method = WIFI_CONNECT_AP_BY_SIGNAL;
+    }
+
     ESP_ERROR_CHECK(esp_wifi_set_config(WIFI_IF_STA, &wifi_config));
 
     ESP_ERROR_CHECK(esp_wifi_start());
@@ -672,7 +691,17 @@ void WiFiManager::_wifi_event_handler(void *arg, esp_event_base_t event_base,
             Debug_println("WIFI_EVENT_STA_STOP");
             break;
         case WIFI_EVENT_STA_CONNECTED:
-            Debug_println("WIFI_EVENT_STA_CONNECTED");
+        {
+            wifi_event_sta_connected_t *conn = (wifi_event_sta_connected_t *)event_data;
+            wifi_ap_record_t apinfo;
+            int8_t rssi = 0;
+            if (esp_wifi_sta_get_ap_info(&apinfo) == ESP_OK)
+                rssi = apinfo.rssi;
+            Debug_printf("WIFI_EVENT_STA_CONNECTED ssid: %s, bssid: %02x:%02x:%02x:%02x:%02x:%02x, "
+                         "channel: %u, rssi: %hd\r\n",
+                         (char *)conn->ssid, conn->bssid[0], conn->bssid[1], conn->bssid[2],
+                         conn->bssid[3], conn->bssid[4], conn->bssid[5], conn->channel, rssi);
+        }
             pFnWiFi->_reconnect_attempts = 0;
             if (pFnWiFi->_trying_stored)
             {


### PR DESCRIPTION
## Summary

Fixes #1575.

ESP-IDF's default `WIFI_FAST_SCAN` associates to the **first** AP that answers for the configured SSID, ignoring signal strength. In a meshed / multi-AP SSID (extenders/repeaters, mixed 2.4/5 GHz), a stationary FujiNet can latch onto a weak/distant AP and stay there — flaky throughput and periodic disconnects even when a much stronger same-SSID AP is available.

## Approach: opt-in via config, fast scan stays the default

This adds a **`multi_ap`** option to the existing `[WiFi]` section of `fnconfig.ini` (default **`0`**). Behavior is unchanged unless it's turned on.

```ini
[WiFi]
...
multi_ap=1
```

When enabled, `WiFiManager::connect()` and `test_connect()` set an all-channel, signal-sorted scan before `esp_wifi_set_config`:

```cpp
if (Config.get_wifi_multi_ap())
{
    wifi_config.sta.scan_method = WIFI_ALL_CHANNEL_SCAN;
    wifi_config.sta.sort_method = WIFI_CONNECT_AP_BY_SIGNAL;
}
```

so the strongest same-SSID AP is chosen at connect time. No minimum-RSSI threshold is set, so a lone weak AP stays usable.

It also logs `bssid` / `channel` / `rssi` on `WIFI_EVENT_STA_CONNECTED` (unconditional — useful in both scan modes) so the selected AP is visible in the debug output.

## Why opt-in

`WIFI_ALL_CHANNEL_SCAN` scans every channel before associating, so connection setup is somewhat slower than fast scan. Rather than change the default connect path for everyone, this leaves fast scan as the default and lets users in meshed/multi-AP environments opt in.

## Changes

- `lib/hardware/fnWiFi.cpp` — gate the all-channel/signal-sorted scan on `Config.get_wifi_multi_ap()` in `connect()` and `test_connect()`; log AP bssid/channel/rssi on connect. (ESP-only; the PC build uses `fnDummyWiFi`.)
- `lib/config/fnConfig.h`, `fnc_wifi.cpp`, `fnc_save.cpp` — `wifi_info.multi_ap` field, `get/store_wifi_multi_ap()`, and parse/save in the existing `[WiFi]` section.

## Testing

- FujiNet-PC RS232 build + ctest suite green (config plumbing compiles; `fnc_wifi`/`fnc_save` exercised by the build).
- ESP behavioral verification of the scan modes is still worth a real-hardware check in a multi-AP setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GXyRJPxQQxGYBUHJRJG6JY