### PR TITLE
fix mbedtls for later 4.x builds.

### DIFF
--- a/fujinet_pc.cmake
+++ b/fujinet_pc.cmake
@@ -569,13 +569,22 @@ option(BUILD_SHARED_LIBS "Build shared libraries" OFF)
 # - to use library package (Ubuntu deb package is old, does not support cmake/find_package)
 # find_package(MbedTLS)
 # - try to find necessary files in system ...
+# Mbed TLS 4.x removed the legacy crypto headers (mbedtls/sha256.h, md5.h, ...)
+# this code and the bundled libraries still use, so probe for sha256.h instead
+# of ssl.h: that skips a 4.x install in favour of a side-by-side 3.x package
+# (e.g. Arch's mbedtls3, in /usr/include/mbedtls3 and /usr/lib/mbedtls3).
 set(_MBEDTLS_ROOT_HINTS $ENV{MBEDTLS_ROOT_DIR} ${MBEDTLS_ROOT_DIR})
 set(_MBEDTLS_ROOT_PATHS "$ENV{PROGRAMFILES}/libmbedtls")
-set(_MBEDTLS_ROOT_HINTS_AND_PATHS HINTS ${_MBEDTLS_ROOT_HINTS} PATHS ${_MBEDTLS_ROOT_PATHS})
-find_library(MBEDTLS_STATIC_LIB libmbedtls.a HINTS ${_MBEDTLS_ROOT_HINTS_AND_PATHS})
-find_library(MBEDX509_STATIC_LIB libmbedx509.a HINTS ${_MBEDTLS_ROOT_HINTS_AND_PATHS})
-find_library(MBEDCRYPTO_STATIC_LIB libmbedcrypto.a HINTS ${_MBEDTLS_ROOT_HINTS_AND_PATHS})
-find_path(MBEDTLS_INCLUDE_DIR mbedtls/ssl.h HINTS ${_MBEDTLS_ROOT_HINTS_AND_PATHS} PATH_SUFFIXES include)
+set(_MBEDTLS_LIB_HINTS ${_MBEDTLS_ROOT_HINTS} /usr/lib/mbedtls3 /usr/lib64/mbedtls3 /usr/local/lib/mbedtls3)
+set(_MBEDTLS_INC_HINTS ${_MBEDTLS_ROOT_HINTS} /usr/include/mbedtls3 /usr/local/include/mbedtls3)
+find_library(MBEDTLS_STATIC_LIB libmbedtls.a HINTS ${_MBEDTLS_LIB_HINTS} PATHS ${_MBEDTLS_ROOT_PATHS})
+find_library(MBEDX509_STATIC_LIB libmbedx509.a HINTS ${_MBEDTLS_LIB_HINTS} PATHS ${_MBEDTLS_ROOT_PATHS})
+find_library(MBEDCRYPTO_STATIC_LIB libmbedcrypto.a HINTS ${_MBEDTLS_LIB_HINTS} PATHS ${_MBEDTLS_ROOT_PATHS})
+find_path(MBEDTLS_INCLUDE_DIR mbedtls/sha256.h HINTS ${_MBEDTLS_INC_HINTS} PATHS ${_MBEDTLS_ROOT_PATHS} PATH_SUFFIXES include)
+
+if(NOT MBEDTLS_INCLUDE_DIR)
+    message(FATAL_ERROR "Mbed TLS headers not found (mbedtls/sha256.h). Mbed TLS 4.x is not supported - install a 2.x/3.x package (e.g. 'mbedtls3' on Arch) or set MBEDTLS_ROOT_DIR.")
+endif()
 
 set(CRYPTO_LIBS ${MBEDTLS_STATIC_LIB} ${MBEDX509_STATIC_LIB} ${MBEDCRYPTO_STATIC_LIB})
 

--- a/lib/bus/adamnet/FujiAdamPacket.h
+++ b/lib/bus/adamnet/FujiAdamPacket.h
@@ -125,6 +125,12 @@ public:
         return std::string(reinterpret_cast<const char *>(d->data()), d->size());
     }
 
+    // A C string field arrives padded out to the driver's fixed buffer size.
+    const std::optional<const std::string> dataAsCString() const {
+        auto s = dataAsString();
+        return s->substr(0, s->find('\0'));
+    }
+
     // Explicit alternatives to the implicit ParamProxy conversions.
     // These may be preferred where the destination type is not obvious.
     std::uint8_t  param8(int idx)  const { return (std::uint8_t)param(idx); }

--- a/lib/device/adamnet/network.cpp
+++ b/lib/device/adamnet/network.cpp
@@ -15,17 +15,6 @@
 using namespace std;
 
 /**
- * The devicespec (and every other C string) as the client meant it, without
- * the padding that follows it on the wire.
- */
-static string packet_string(const FujiAdamPacket &packet)
-{
-    string s = packet.dataAsString().value();
-    return s.substr(0, s.find('\0'));
-}
-
-
-/**
  * Constructor
  */
 adamNetwork::adamNetwork()
@@ -120,7 +109,7 @@ void adamNetwork::open(const FujiAdamPacket &packet)
 
     // Parse and instantiate protocol
     bool is_dir = (fileAccessMode_t) packet.param8(0) == ACCESS_MODE::DIRECTORY;
-    parse_and_instantiate_protocol(packet_string(packet), is_dir);
+    parse_and_instantiate_protocol(packet.dataAsCString().value(), is_dir);
 
     if (protocol == nullptr)
     {
@@ -302,7 +291,7 @@ void adamNetwork::get_prefix()
  */
 void adamNetwork::set_prefix(const FujiAdamPacket &packet)
 {
-    auto prefixSpec_str = packet_string(packet);
+    auto prefixSpec_str = packet.dataAsCString().value();
     prefixSpec_str = prefixSpec_str.substr(prefixSpec_str.find_first_of(":") + 1);
     Debug_printf("adamNetwork::adamnet_set_prefix(%s)\n", prefixSpec_str.c_str());
 
@@ -354,7 +343,7 @@ void adamNetwork::set_prefix(const FujiAdamPacket &packet)
  */
 void adamNetwork::set_login(const FujiAdamPacket &packet)
 {
-    login = packet_string(packet);
+    login = packet.dataAsCString().value();
 }
 
 /**
@@ -362,7 +351,7 @@ void adamNetwork::set_login(const FujiAdamPacket &packet)
  */
 void adamNetwork::set_password(const FujiAdamPacket &packet)
 {
-    password = packet_string(packet);
+    password = packet.dataAsCString().value();
 }
 
 void adamNetwork::channel_mode(const FujiAdamPacket &packet)
@@ -385,7 +374,7 @@ void adamNetwork::channel_mode(const FujiAdamPacket &packet)
 
 void adamNetwork::json_query(const FujiAdamPacket &packet)
 {
-    std::string query = packet_string(packet);
+    std::string query = packet.dataAsCString().value();
     json.setReadQuery(query, 0);
     Debug_printv("adamNetwork::json_query(%s)\n", query.c_str());
     SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
@@ -403,7 +392,7 @@ void adamNetwork::json_parse()
 
 void adamNetwork::sgml_query(const FujiAdamPacket &packet)
 {
-    std::string query = packet_string(packet);
+    std::string query = packet.dataAsCString().value();
     sgml.setReadQuery(query, 0);
     Debug_printv("adamNetwork::json_query(%s)\n", query.c_str());
     SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
@@ -696,7 +685,7 @@ void adamNetwork::adamnet_set_timer_rate()
 
 void adamNetwork::process_fs(const FujiAdamPacket &packet)
 {
-    parse_and_instantiate_protocol(packet_string(packet), false);
+    parse_and_instantiate_protocol(packet.dataAsCString().value(), false);
 
     // Make sure this is really a FS protocol instance
     NetworkProtocolFS *fs = dynamic_cast<NetworkProtocolFS *>(protocol.get());

--- a/lib/device/adamnet/network.cpp
+++ b/lib/device/adamnet/network.cpp
@@ -15,6 +15,17 @@
 using namespace std;
 
 /**
+ * The devicespec (and every other C string) as the client meant it, without
+ * the padding that follows it on the wire.
+ */
+static string packet_string(const FujiAdamPacket &packet)
+{
+    string s = packet.dataAsString().value();
+    return s.substr(0, s.find('\0'));
+}
+
+
+/**
  * Constructor
  */
 adamNetwork::adamNetwork()
@@ -109,7 +120,7 @@ void adamNetwork::open(const FujiAdamPacket &packet)
 
     // Parse and instantiate protocol
     bool is_dir = (fileAccessMode_t) packet.param8(0) == ACCESS_MODE::DIRECTORY;
-    parse_and_instantiate_protocol(packet.dataAsString().value(), is_dir);
+    parse_and_instantiate_protocol(packet_string(packet), is_dir);
 
     if (protocol == nullptr)
     {
@@ -291,7 +302,7 @@ void adamNetwork::get_prefix()
  */
 void adamNetwork::set_prefix(const FujiAdamPacket &packet)
 {
-    auto prefixSpec_str = packet.dataAsString().value();
+    auto prefixSpec_str = packet_string(packet);
     prefixSpec_str = prefixSpec_str.substr(prefixSpec_str.find_first_of(":") + 1);
     Debug_printf("adamNetwork::adamnet_set_prefix(%s)\n", prefixSpec_str.c_str());
 
@@ -343,7 +354,7 @@ void adamNetwork::set_prefix(const FujiAdamPacket &packet)
  */
 void adamNetwork::set_login(const FujiAdamPacket &packet)
 {
-    login = packet.dataAsString().value();
+    login = packet_string(packet);
 }
 
 /**
@@ -351,7 +362,7 @@ void adamNetwork::set_login(const FujiAdamPacket &packet)
  */
 void adamNetwork::set_password(const FujiAdamPacket &packet)
 {
-    password = packet.dataAsString().value();
+    password = packet_string(packet);
 }
 
 void adamNetwork::channel_mode(const FujiAdamPacket &packet)
@@ -374,7 +385,7 @@ void adamNetwork::channel_mode(const FujiAdamPacket &packet)
 
 void adamNetwork::json_query(const FujiAdamPacket &packet)
 {
-    std::string query = packet.dataAsString().value();
+    std::string query = packet_string(packet);
     json.setReadQuery(query, 0);
     Debug_printv("adamNetwork::json_query(%s)\n", query.c_str());
     SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
@@ -392,7 +403,7 @@ void adamNetwork::json_parse()
 
 void adamNetwork::sgml_query(const FujiAdamPacket &packet)
 {
-    std::string query = packet.dataAsString().value();
+    std::string query = packet_string(packet);
     sgml.setReadQuery(query, 0);
     Debug_printv("adamNetwork::json_query(%s)\n", query.c_str());
     SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
@@ -685,7 +696,7 @@ void adamNetwork::adamnet_set_timer_rate()
 
 void adamNetwork::process_fs(const FujiAdamPacket &packet)
 {
-    parse_and_instantiate_protocol(packet.dataAsString().value(), false);
+    parse_and_instantiate_protocol(packet_string(packet), false);
 
     // Make sure this is really a FS protocol instance
     NetworkProtocolFS *fs = dynamic_cast<NetworkProtocolFS *>(protocol.get());


### PR DESCRIPTION
mbedtls headers changed again, adding additional rules so it builds on all systems involved.