### PR TITLE
fujiDevice doesn't need its own bootdisk virtualDevice

### DIFF
--- a/lib/bus/drivewire/drivewire.cpp
+++ b/lib/bus/drivewire/drivewire.cpp
@@ -123,7 +123,7 @@ void systemBus::op_reset()
 
     // When a reset transaction occurs, set the mounted disk image to the CONFIG disk image.
     platformFuji.boot_config = true;
-    platformFuji.insert_boot_device(Config.get_general_boot_mode(), MEDIATYPE_UNKNOWN, &platformFuji.bootdisk);
+    platformFuji.insert_boot_device(Config.get_general_boot_mode(), MEDIATYPE_UNKNOWN, platformFuji.FUJI_BOOTDISK);
     if (pNamedObjFp != NULL)
     {
         fclose(pNamedObjFp);
@@ -198,11 +198,7 @@ void systemBus::op_readex()
 
         Debug_printf("OP_READ: DRIVE %3u - SECTOR %8lu\n", drive_num, lsn);
 
-        if (theFuji->boot_config && drive_num == 0)
-            d = &theFuji->bootdisk;
-        else
-            d = &theFuji->get_disk(drive_num)->disk_dev;
-
+        d = &theFuji->get_disk(drive_num)->disk_dev;
         if (!d)
         {
             Debug_printv("Invalid drive #%3u", drive_num);

--- a/lib/bus/rs232/rs232.cpp
+++ b/lib/bus/rs232/rs232.cpp
@@ -137,23 +137,14 @@ void systemBus::_rs232_process_cmd()
     _activePacket = tempFrame.get();
     _activeDev = nullptr;
 
-    if (tempFrame->device() == FUJI_DEVICEID::DISK && _fujiDev != nullptr
-        && _fujiDev->boot_config)
+    // find device, ack and pass control
+    // or go back to WAIT
+    for (auto devicep : _daisyChain)
     {
-        _activeDev = &_fujiDev->bootdisk;
-        Debug_println("FujiNet CONFIG boot");
-    }
-    else
-    {
-        // find device, ack and pass control
-        // or go back to WAIT
-        for (auto devicep : _daisyChain)
+        if (tempFrame->device() == devicep->_devnum)
         {
-            if (tempFrame->device() == devicep->_devnum)
-            {
-                _activeDev = devicep;
-                break;
-            }
+            _activeDev = devicep;
+            break;
         }
     }
 

--- a/lib/bus/sio/sio.cpp
+++ b/lib/bus/sio/sio.cpp
@@ -255,7 +255,7 @@ void systemBus::_sio_process_cmd()
 #endif
         if (tmpFrame.device() == FUJI_DEVICEID::DISK && _fujiDev != nullptr && _fujiDev->boot_config)
         {
-            _activeDev = &_fujiDev->bootdisk;
+            _activeDev = _fujiDev->FUJI_BOOTDISK;
 
             // Boot-priority logic: if enabled, ignore the first few
             // SIO status calls (of the 26 Atari sends) so a real D1:

--- a/lib/device/adamnet/adamFuji.cpp
+++ b/lib/device/adamnet/adamFuji.cpp
@@ -147,30 +147,6 @@ void adamFuji::adamnet_new_disk(const FujiAdamPacket &packet)
     SYSTEM_BUS.transaction_success();
 }
 
-// Mounts the desired boot disk number
-void adamFuji::insert_boot_device(uint8_t d)
-{
-    const char *config_atr = "/autorun.ddp";
-    const char *mount_all_atr = "/mount-and-boot.ddp";
-    fnFile *fBoot;
-
-    switch (d)
-    {
-    case 0:
-        fBoot = fsFlash.fnfile_open(config_atr);
-        _fnDisks[0].disk_dev.mount(fBoot, config_atr, 262144, DISK_ACCESS_MODE_READ, MEDIATYPE_DDP);
-        break;
-    case 1:
-
-        fBoot = fsFlash.fnfile_open(mount_all_atr);
-        _fnDisks[0].disk_dev.mount(fBoot, mount_all_atr, 262144, DISK_ACCESS_MODE_READ, MEDIATYPE_DDP);
-        break;
-    }
-
-    _fnDisks[0].disk_dev.is_config_device = true;
-    _fnDisks[0].disk_dev.device_active = true;
-}
-
 void adamFuji::adamnet_enable_device(const FujiAdamPacket &packet)
 {
     fujiDeviceID_t d = static_cast<fujiDeviceID_t>(packet.param8(0));

--- a/lib/device/drivewire/drivewireFuji.cpp
+++ b/lib/device/drivewire/drivewireFuji.cpp
@@ -175,7 +175,7 @@ void drivewireFuji::setup()
 
     populate_slots_from_config();
 
-    insert_boot_device(Config.get_general_boot_mode(), MEDIATYPE_UNKNOWN, &bootdisk);
+    insert_boot_device(Config.get_general_boot_mode(), MEDIATYPE_UNKNOWN, FUJI_BOOTDISK);
 
     // Disable booting from CONFIG if our settings say to turn it off
     boot_config = Config.get_general_config_enabled();

--- a/lib/device/fujiDevice/fujiDevice.cpp
+++ b/lib/device/fujiDevice/fujiDevice.cpp
@@ -46,7 +46,6 @@ fujiDevice::fujiDevice(unsigned int numDisk, std::string extension,
                        std::optional<std::string> lobbyURL)
     : _totalDiskDevices(numDisk), _diskImageExtension(extension), _lobbyDiskURL(lobbyURL)
 {
-    bootdisk._devnum = FUJI_DEVICEID::DISK;
     // Helpful for debugging
     for (int i = 0; i < MAX_HOSTS; i++)
         _fnHosts[i].slotid = i;
@@ -127,7 +126,7 @@ fujiDevice::fujiDevice(unsigned int numDisk, std::string extension,
             fujicmd_random();
         } },
         { CMD::FUJI_SET_BOOT_MODE, [this](const FUJI_COMMAND_PACKET &packet) {
-            fujicmd_set_boot_mode(packet.param(0), MEDIATYPE_UNKNOWN, &bootdisk);
+            fujicmd_set_boot_mode(packet.param(0), MEDIATYPE_UNKNOWN, FUJI_BOOTDISK);
         } },
         { CMD::FUJI_MOUNT_ALL, [this](const FUJI_COMMAND_PACKET &packet) {
             fujicmd_mount_all_success();

--- a/lib/device/fujiDevice/fujiDevice.h
+++ b/lib/device/fujiDevice/fujiDevice.h
@@ -28,6 +28,8 @@
 
 #define STATUS_MOUNT_TIME       0x01
 
+#define FUJI_BOOTDISK get_disk_dev(0)
+
 #define ADAPTER_CONFIG_FIELDS \
     char ssid[33]; \
     char hostname[64]; \
@@ -206,7 +208,6 @@ protected:
 
 public:
     bool boot_config = true;
-    DISK_DEVICE bootdisk; // special disk drive just for configuration
 
     fujiDevice(unsigned int numDisk, std::string extension,
                std::optional<std::string> lobbyURL);

--- a/lib/device/rs232/rs232Fuji.cpp
+++ b/lib/device/rs232/rs232Fuji.cpp
@@ -35,7 +35,7 @@ void rs232Fuji::setup()
 
     populate_slots_from_config();
 
-    insert_boot_device(Config.get_general_boot_mode(), MEDIATYPE_UNKNOWN, &bootdisk);
+    insert_boot_device(Config.get_general_boot_mode(), MEDIATYPE_UNKNOWN, FUJI_BOOTDISK);
 
     // Disable booting from CONFIG if our settings say to turn it off
     boot_config = Config.get_general_config_enabled();
@@ -71,9 +71,6 @@ void rs232Fuji::rs232_status(FujiStatusReq reqType)
 
         for (idx = 0; idx < MAX_DISK_DEVICES; idx++)
             mount_status[idx] = _fnDisks[idx].disk_dev.mount_time();
-
-        if (boot_config)
-            mount_status[0] = bootdisk.mount_time();
 
         SYSTEM_BUS.transaction_send((uint8_t *) mount_status, sizeof(mount_status), false);
     }
@@ -388,7 +385,7 @@ void rs232Fuji::rs232_process(const FujiBusPacket &packet)
             SYSTEM_BUS.transaction_error();
         }
         else
-            fujicmd_set_boot_mode(packet.param(0), MEDIATYPE_UNKNOWN, &bootdisk);
+            fujicmd_set_boot_mode(packet.param(0), MEDIATYPE_UNKNOWN, FUJI_BOOTDISK);
         break;
     case CMD::FUJI_DEVICE_READY:
         Debug_printf("FUJICMD DEVICE TEST\n");

--- a/lib/device/sio/sioFuji.cpp
+++ b/lib/device/sio/sioFuji.cpp
@@ -561,7 +561,7 @@ void sioFuji::setup()
     // set up Fuji device
     populate_slots_from_config();
 
-    insert_boot_device(Config.get_general_boot_mode(), MEDIATYPE_UNKNOWN, &bootdisk);
+    insert_boot_device(Config.get_general_boot_mode(), MEDIATYPE_UNKNOWN, FUJI_BOOTDISK);
 
     // Disable booting from CONFIG if our settings say to turn it off
     boot_config = Config.get_general_config_enabled();


### PR DESCRIPTION
Removed `fujiDevice::bootdisk`. It was an extra virtual device that wasn't really part of the bus/daisyChain. Apple II and Adam had already proven that using disk drive 0 worked fine and didn't need an extra virtualDevice.