### PR TITLE
Add A8CAS "fsk " chunk playback to Atari cassette (FUJI path)

### DIFF
--- a/.kiro/specs/a8cas-fsk-chunk-playback/.config.kiro
+++ b/.kiro/specs/a8cas-fsk-chunk-playback/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "8fbe1e1e-2344-4e02-ba9b-d1d1aa0cbd7a", "workflowType": "requirements-first", "specType": "feature"}

--- a/.kiro/specs/a8cas-fsk-chunk-playback/design.md
+++ b/.kiro/specs/a8cas-fsk-chunk-playback/design.md
@@ -1,0 +1,1002 @@
+# Design Document: A8CAS FSK Chunk Playback
+
+## Overview
+
+This design adds reproduction of A8CAS raw FSK chunks (`Chunk_Type == "fsk "`, fourth byte 0x20 SPACE) to the normal FUJI cassette playback path in `lib/device/sio/cassette.cpp` (guarded by `BUILD_ATARI`). Today `send_FUJI_tape_block` walks the chunk stream recognizing only `data` and `baud`; any other chunk (including `fsk `) is silently skipped by advancing the read offset past it. As a result, images that interleave `fsk ` records with normal `baud`/`data` records (e.g. the Chilean commercial title "Night Knight.cas") lose the signal carried by the FSK records.
+
+The change inserts `fsk ` handling into the existing chunk-walk loop of the FUJI_Playback_Path only. It honors the Inter-Record Gap carried in the chunk `aux`/`irg_length` field, then reproduces the FSK signal on the SIO Data_Line. The design is organized around three pieces:
+
+1. **A pure, hardware-independent set of step functions** (`fsk_plan`) that decode individual little-endian values, derive a logical level from index parity, split a duration into RMT-sized portions, and advance a small memory-bounded cursor over the raw FSK bytes. These functions touch no file, no RMT, no GPIO, and no FujiNet globals, so they are unit-testable on the host, and they do NOT materialize the whole waveform. The decode/parity/scale/split RULES are `static inline`, IRAM-safe arithmetic in the header so the production ISR callback can inline the exact same rules it is tested against; the cursor step (`fsk_view_step`) is a host-test-only helper that shares those same rules but is never called from the ISR.
+2. **A single pre-read step** that reads the entire clamped FSK data region into a heap buffer in ONE `fnio::fread` *before* any hardware emission begins, so the emitted waveform never depends on SD/TNFS/network latency.
+3. **An ESP RMT stateful simple encoder** whose IRAM callback (`fsk_encode_cb`) generates `rmt_symbol_word_t` entries on the fly from that single pre-read buffer during ONE continuous `rmt_transmit` transaction on the same `PIN_UART2_TX` pin that Turbo 2000 already drives with RMT, then reattaches the UART. This mirrors the existing Turbo 2000 `t2k_encode_cb` / `rmt_new_simple_encoder` precedent exactly.
+
+Each 2-byte little-endian FSK_Signal_Value is a duration in units of 1/10 ms; a logical level is assigned by index parity (even = logical 0, odd = logical 1). All reads are bounds-clamped to the file size. On the PC build (`ESP_PLATFORM` undefined) there is no GPIO/RMT capability, so the chunk is pre-read, the IRG is honored deterministically via `SYSTEM_BUS.bus_idle`, and the read offset is advanced without raw signal generation.
+
+The design makes no filename-, game-, or country-specific decisions anywhere. Detection is purely by the 4-byte Chunk_Type. The existing Turbo 2000 and QROS paths are left unchanged; QROS continues to skip `fsk ` chunks exactly as before.
+
+This design resolves the decisions the requirements explicitly deferred to Technical Design:
+
+| Deferred decision | Requirement(s) | Resolution (see section) |
+|---|---|---|
+| Signal reproduction mechanism | Req 4 | ESP RMT at 1 MHz (1 µs/tick, T2K precedent), stateful simple encoder callback, single continuous transaction, on-the-fly segment splitting — *Signal Reproduction Mechanism* |
+| Logical-to-physical level mapping | Req 2.5, 4.2, 4.6 | Index parity → logical level → HIGH=mark/logical-1 as the RMT symbol level bit — *Level Mapping* |
+| Malformed / truncated / odd-length policy | Req 1.4, 6.3–6.5 | Graceful partial reproduction, bounds-clamped; overrun terminates at real boundary via end-of-tape — *Malformed Chunk Policy* |
+| Error propagation mechanism | Req 3.4, 4.5, 5.4, 5.5 | Existing return-offset + `Debug_printf` convention; single idempotent cleanup path — *Error Propagation* |
+| PC build behavior | Req 8 | Pre-read + honor IRG deterministically via `bus_idle` + advance, no raw signal — *PC Build Behavior* |
+| Baud preservation | Req 5 | No `setBaudrate` call; RMT teardown reattaches UART TX pin, baud divisor untouched — *Baud Preservation* |
+
+---
+
+## Architecture
+
+### Where FSK handling slots in
+
+The dispatcher `sio_handle_cassette()` is unchanged:
+
+- `tape_flags.turbo2000` → `send_turbo2000_tape_block` (unchanged; never sees FSK)
+- `tape_flags.qros` → `send_QROS_tape_block` (unchanged; keeps skipping `fsk `)
+- `tape_flags.FUJI` → `send_FUJI_tape_block` (**modified** — adds `fsk ` handling)
+- else → `send_tape_block` (unchanged)
+
+Only the FUJI_Playback_Path is modified. This satisfies Req 7.2/7.3/7.4/7.6: while the active path is not the FUJI path, zero FSK reproduction operations run.
+
+Within `send_FUJI_tape_block`, the chunk-walk loop currently classifies `data` (break to emit record) and `baud` (apply baud, keep walking), and otherwise advances `offset += sizeof(hdr) + len`. The change inserts an `fsk ` branch **before** the catch-all advance. FSK is *not* a terminating record like `data`; after reproducing an FSK chunk the loop continues walking, so a `data` chunk following an FSK chunk is still reached and emitted at the current baud.
+
+### Component responsibilities
+
+- **`send_FUJI_tape_block` (modified)** — Chunk-stream walker. Detects `fsk ` in the loop and delegates the whole chunk (IRG + signal) to `play_fsk_chunk`, then continues walking. Unchanged for `baud`/`data`/other.
+- **`fsk_plan` (new, pure, cross-platform, host-buildable)** — A set of tiny pure step functions plus a small `FskChunkView` cursor. The shared pure RULES — decode a single little-endian value (`fsk_decode_le16`), derive a logical level from index parity (`fsk_level_for_index`), scale one A8CAS unit to RMT ticks (`fsk_ticks_for_value`), and split a duration one portion at a time (`fsk_next_portion`) — are `static inline`, IRAM-safe arithmetic in `fsk_plan.h`, used by BOTH the ISR callback and the host tests. Because BOTH the production ISR callback (`fsk_encode_cb`) and the host-test cursor (`fsk_view_step`) obtain each value's tick count from the same `fsk_ticks_for_value` helper, they share identical decode/parity/scale/split rules and cannot diverge on the modeled duration. The `FskChunkView` cursor advanced by `fsk_view_step` is a **host-test-only** helper in `fsk_plan.cpp` (not `static inline`, not in IRAM, not ISR-called); the production callback inlines the same static-inline RULES rather than calling it. Everything is bounded by an available-bytes count, holds O(1) state, allocates nothing, and never materializes the whole waveform. Contains no I/O and no hardware. These are the units under test for all correctness properties, and the production encoder callback calls the exact same static-inline rules.
+- **`play_fsk_chunk` (new, cross-platform)** — Owns one FSK chunk end to end: bounds-clamp, single pre-read of the data region into a heap buffer, honor IRG (with motor-line abort), reproduce the signal via the RMT stateful simple encoder driven from that buffer (ESP) or honor IRG only (PC), and return the outcome as an offset. Contains the `#ifdef ESP_PLATFORM` / `#else` split. Every exit path funnels through one idempotent cleanup routine.
+- **`fsk_encode_cb` (new, ESP-only, IRAM_ATTR)** — The RMT stateful simple-encoder callback (same 7-argument signature as Turbo 2000's `t2k_encode_cb`). It runs in ISR context (RMT ping-pong refill), so it calls ONLY ISR/cache-safe code (no allocation, no `Debug_printf`, no file I/O, no flash-dependent work), inlining the `static inline` IRAM-safe RULES from `fsk_plan.h`. It generates `rmt_symbol_word_t` entries on demand into the RMT-provided buffer from the single pre-read byte buffer plus O(1) encoder state on the `sioCassette` object, performing NO file I/O and NO heap allocation. It scales each value to `value * 100` ticks, splits it into `ceil(value * 100 / 32767)` same-level portions on the fly, sets `*done = false` at the start of every call, and sets `*done = true` only after the last value's last portion has been emitted.
+- **`fsk_signal_begin` / `fsk_signal_emit` / `fsk_signal_end` (new, ESP-only)** — RMT lifecycle for raw-signal emission, mirroring the Turbo 2000 `rmt_new_simple_encoder` init / single-`rmt_transmit` / teardown pattern on the same `PIN_UART2_TX` pin. `fsk_signal_begin` creates the simple encoder with `callback = fsk_encode_cb` and `arg = this`, returns `bool`, and fully undoes any partial setup on failure. `fsk_signal_emit` issues ONE `rmt_transmit` of the whole pre-read buffer plus `rmt_tx_wait_all_done`. `fsk_signal_end` tears down the channel + encoder and reattaches UART, idempotent.
+
+### The 1 MHz RMT grid and on-the-fly segment splitting
+
+The A8CAS FSK timebase is 1/10 ms, so the smallest non-zero duration is 100 µs. To stay portable across ESP targets WITHOUT target-specific clock-source selection, the RMT channel uses the SAME resolution Turbo 2000 already uses successfully: **1 MHz gives exactly 1 µs per tick** (`RMT_CLK_SRC_DEFAULT`, which on the classic ESP32 target is APB and cannot reliably divide down to 10 kHz). At 1 µs/tick, 1/10 ms = 100 µs = 100 ticks, so each FSK_Signal_Value of N maps to exactly `N * 100` ticks with no rounding. Each `rmt_symbol_word_t` level-duration field is 15 bits (max 32767 ticks). At 1 µs/tick that caps one symbol level at 32767 ticks (about 32.767 ms), so even a modest FSK value produces more ticks than a single 15-bit field can hold. The encoder callback therefore splits any value whose tick count exceeds 32767 into multiple consecutive same-level portions (each at most 32767 ticks) **on the fly**, carrying the remaining-ticks state across symbols and across callback invocations, so the emitted level stays continuous across the split. Because the stateful simple encoder generates portions incrementally with O(1) state (carrying `remaining_ticks` across symbols and callbacks), the larger portion counts do NOT increase the memory footprint. No full segment list is ever materialized; the splitting is a pure state transition (`fsk_next_portion`) that both the callback and the host tests share.
+
+Splitting arithmetic (see *Segment splitting for the 15-bit RMT field* in Data Models): a value of V maps to `V * 100` ticks; the portion count is 0 when V == 0, else `ceil(V * 100 / 32767)`. Each portion is at most 32767 ticks, all portions carry the same level, and they sum to `V * 100` ticks. Concrete examples: value 1 → 100 ticks (1 portion); value 256 → 25,600 ticks (1 portion); value 6818 → 681,800 ticks → `ceil(681800/32767) = 21` portions; value 65535 → 6,553,500 ticks → `ceil(6553500/32767) = 201` portions (200 portions of 32767 ticks plus a final 100-tick portion).
+
+### Flow diagram
+
+```mermaid
+flowchart TD
+    A["send_FUJI_tape_block: read chunk header at offset"] --> B{"chunk_type?"}
+    B -->|"data"| C["break -> emit data record at active baud"]
+    B -->|"baud"| D["baud = irg_length; setBaudrate(baud); continue"]
+    B -->|"fsk "| E["play_fsk_chunk(offset, chunk_length, irg_ms)"]
+    B -->|"other"| F["offset += 8 + len; continue"]
+    E --> G["offset advanced past chunk (8 + len), or 0 (EOT); continue loop"]
+    C --> H["existing data emit path"]
+```
+
+### FSK reproduction sequence
+
+```mermaid
+sequenceDiagram
+    participant Loop as send_FUJI_tape_block
+    participant FSK as play_fsk_chunk
+    participant HW as fsk_signal_* (ESP RMT)
+    participant CB as fsk_encode_cb (IRAM, on demand)
+
+    Loop->>FSK: play_fsk_chunk(offset, chunk_length, irg_ms)
+    Note over FSK: bounds-clamp; ONE fread of clamped data region into heap buffer
+    alt pre-read heap alloc fails
+        FSK-->>Loop: cleanup, log, advance safely (no emission)
+    end
+    Note over FSK: value_count = data_avail / 2 via pure helper; Honor IRG (irg_ms), gap loop identical to data path
+    alt pulldown and not motor and remaining_gap>1000
+        FSK-->>Loop: cleanup, return starting_offset (retry)
+    end
+    FSK->>HW: fsk_signal_begin() -> bool (RMT channel + simple encoder w/ callback=fsk_encode_cb, arg=this, detach UART TX)
+    alt begin() == false
+        FSK-->>Loop: cleanup (UART intact), free buffer, advance safely
+    end
+    FSK->>FSK: init encoder state (value_index=0, byte_pos=0, remaining_ticks=0, value_count)
+    FSK->>HW: fsk_signal_emit()  (ONE rmt_transmit of the whole pre-read buffer)
+    loop RMT refills ping-pong memory on demand
+        HW->>CB: fsk_encode_cb(data, size, written, free, symbols, done, this)
+        CB-->>HW: fills up to symbols_free symbols from buffer + state, sets *done at end
+    end
+    FSK->>HW: rmt_tx_wait_all_done()
+    FSK->>HW: fsk_signal_end() (teardown RMT + encoder, reattach UART TX; baud intact)
+    FSK-->>Loop: return offset + 8 + declared_len (advance, continue)
+```
+
+The waveform is one continuous, gapless RMT transaction: a single `rmt_transmit` hands the whole pre-read buffer to the simple encoder, and `fsk_encode_cb` produces symbols on demand as the RMT peripheral drains its ping-pong memory. On the PC build the `fsk_signal_*` interactions are replaced by a deterministic `SYSTEM_BUS.bus_idle` for the IRG and no signal generation; the pre-read and bounds path is identical.
+
+---
+
+## Components and Interfaces
+
+### New pure module: `fsk_plan.h` / `fsk_plan.cpp`
+
+A small, pure, hardware-independent module (placed under `lib/device/sio/`) that is free of `fnFile`, RMT, GPIO, and FujiNet globals so it links standalone on the host. It exposes tiny memory-bounded step functions and a small cursor rather than a whole-waveform builder. The static-inline rule helpers are trivial arithmetic with no allocation and are safe to inline into the IRAM encoder callback. The `fsk_view_step` cursor helper is host-test-only and is not called from the ISR.
+
+**ISR / IRAM-safety of the shared pure rules:** `fsk_encode_cb` runs in **ISR context** (the RMT peripheral calls it from its ping-pong refill interrupt). ISR-called code may use ONLY ISR/cache-safe code: **no allocation, no logging (`Debug_printf`), no file I/O, and no flash-dependent work** (any function not resident in IRAM can stall or fault if the flash cache is disabled). Therefore the tiny helpers `fsk_encode_cb` calls directly — the LE decode (`fsk_decode_le16`), the parity mapping (`fsk_level_for_index`), the tick scaling (`fsk_ticks_for_value`), and the next-portion calc (`fsk_next_portion`) — are declared **`static inline` in `fsk_plan.h`** and are pure arithmetic, so inlining them into the IRAM callback keeps the whole callback cache-safe. These same static-inline header functions are the shared pure RULES (decode, parity, scale, split) used by BOTH the ISR callback and `fsk_view_step`/the host tests, so production and tests exercise identical logic. In particular, BOTH the production ISR callback and the host-test cursor obtain each value's tick count from `fsk_ticks_for_value`, so they share identical decode/parity/timing/splitting rules and cannot diverge.
+
+**`fsk_view_step` is a host-test-only helper** defined in `fsk_plan.cpp` (NOT `static inline`, NOT called from the ISR). The production `fsk_encode_cb` implements the same per-step logic **inline** using the static-inline helpers above rather than calling `fsk_view_step`, so `fsk_view_step` need not be placed in IRAM and there is no flash-cache hazard in the ISR. (The alternative — having production call `fsk_view_step` from the ISR — would require marking it `IRAM_ATTR` with everything it calls ISR/cache-safe; this design deliberately does NOT take that route, to keep the ISR free of any flash-resident call.)
+
+The interface is:
+
+```cpp
+// fsk_plan.h — pure, host-buildable. No I/O, no hardware, no globals, no allocation.
+// The static-inline rule helpers below are trivial/inlinable arithmetic and
+// IRAM-safe so the production RMT encoder callback can use the SAME rules the tests exercise.
+// `fsk_view_step` is declared here for host tests but is implemented in fsk_plan.cpp
+// and is intentionally not called from the ISR.
+#include <cstdint>
+#include <cstddef>
+
+// The RMT 15-bit per-level tick limit (max ticks in one rmt_symbol duration field).
+static constexpr uint32_t FSK_MAX_PORTION_TICKS = 32767;
+
+// 1 us per RMT tick (1 MHz); one A8CAS unit = 1/10 ms = 100 us = 100 ticks.
+static constexpr uint32_t FSK_RMT_TICKS_PER_A8CAS_UNIT = 100;
+
+static inline uint32_t fsk_ticks_for_value(uint16_t value)
+{
+    return (uint32_t)value * FSK_RMT_TICKS_PER_A8CAS_UNIT;
+}
+
+// Decode one little-endian uint16 duration from the two bytes at p (Req 2.1).
+// The caller guarantees p and p+1 are inside the available data region.
+static inline uint16_t fsk_decode_le16(const uint8_t *p)
+{
+    return (uint16_t)p[0] | ((uint16_t)p[1] << 8);
+}
+
+// Logical level for a value by ORIGINAL A8CAS value index parity (Req 2.5/4.2):
+// even index = logical 0 (returns false), odd index = logical 1 (returns true).
+static inline bool fsk_level_for_index(size_t value_index)
+{
+    return (value_index & 1) != 0;
+}
+
+// One split step (pure state transition, NOT a materialized list). Ticks for a
+// value V are V * 100 (1/10 ms = 100 us = 100 ticks at 1 us/tick). Given the
+// ticks remaining for the current value, return the next portion to emit
+// (min(remaining, 32767)); the caller subtracts it to get the new remaining.
+// remaining==0 returns 0 (nothing to emit) (Req 4.1, 4.6).
+static inline uint32_t fsk_next_portion(uint32_t remaining_ticks)
+{
+    return remaining_ticks > FSK_MAX_PORTION_TICKS ? FSK_MAX_PORTION_TICKS
+                                                   : remaining_ticks;
+}
+
+// Number of FSK_Signal_Values available: floor(data_len_available / 2) (Req 2.3/6.4).
+static inline size_t fsk_value_count(size_t data_len_available)
+{
+    return data_len_available / 2;
+}
+
+// A small pure cursor over the pre-read byte buffer. Holds O(1) state; allocates
+// nothing; never reads outside [0, data_len_available). Host tests advance this
+// cursor with fsk_view_step. Production carries equivalent O(1) state but does not
+// call fsk_view_step; it uses the same static-inline decode/parity/scale/split rules.
+struct FskChunkView {
+    const uint8_t *data;               // pre-read data region (null iff len==0)
+    size_t   data_len_available;       // clamped bytes present (caller-bounded)
+    size_t   value_index;              // 0-based FSK_Signal_Index of current value
+    size_t   byte_pos;                 // next byte to read (== value_index*2)
+    uint32_t remaining_ticks;          // ticks left in the current value being split (value*100)
+    bool     remaining_level_high;     // level of the value currently being split
+};
+
+// Initialize a cursor at the start of the buffer.
+static inline FskChunkView fsk_view_init(const uint8_t *data, size_t data_len_available)
+{
+    return FskChunkView{ data, data_len_available, 0, 0, 0, false };
+}
+
+// Result of one cursor step.
+struct FskStep {
+    bool     produced;   // true if this step yields a portion to emit
+    bool     level_high; // level of the produced portion
+    uint32_t ticks;      // portion ticks (1..32767) when produced
+    bool     done;       // true once no more portions/values remain
+};
+
+// Advance the cursor by exactly one emitted portion. If the current value still
+// has remaining ticks, emit the next portion of it (splitting on the fly). Else
+// load the next value: skip any leading zero-duration values (they consume an
+// index and thus parity but emit nothing), then emit their first portion. Sets
+// done when all value_count values are exhausted. Reads only within
+// [0, data_len_available). HOST-TEST-ONLY: defined in fsk_plan.cpp, NOT static
+// inline, NOT called from the ISR, and NOT in IRAM. It uses the same static-
+// inline pure RULES (fsk_decode_le16 / fsk_level_for_index / fsk_ticks_for_value / fsk_next_portion)
+// that the production IRAM callback fsk_encode_cb inlines, so both share logic.
+FskStep fsk_view_step(FskChunkView &view);
+```
+
+Notes:
+
+- The cursor reads only complete 2-byte little-endian pairs from `data[0 .. data_len_available)`; any trailing odd byte is ignored (it is never inside a complete pair). It never reads at or past `data_len_available`.
+- `fsk_value_count(data_len_available)` is `data_len_available / 2` (floor). Values of duration 0 are counted in that value count and consume a parity index but produce no portion.
+- The next read offset is *not* computed here; it is left to the caller (`play_fsk_chunk`), because the offset depends on file-level state (declared length vs. EOF). This module is purely about decoding, level parity, splitting, and cursor advancement.
+- No type here holds the whole waveform: the largest state is the fixed-size `FskChunkView`. This is what keeps production memory-bounded on the no-PSRAM classic ESP32 (see *Pre-read RAM budget*).
+
+### New private members of `sioCassette` (in `cassette.h`)
+
+```cpp
+// FSK chunk playback (A8CAS "fsk " chunks) — cross-platform entry point.
+// Pre-reads the clamped data region into RAM ONCE, honors the IRG, reproduces
+// the raw FSK signal via the RMT stateful simple encoder driven directly from
+// that buffer (ESP) or safely skips (PC), and returns the next read offset.
+// Never changes the active baud. Holds NO full-waveform buffer.
+size_t play_fsk_chunk(size_t offset, uint16_t chunk_length, uint16_t irg_ms);
+
+#ifdef ESP_PLATFORM
+    // Raw FSK signal helpers built on the ESP RMT peripheral (same PIN_UART2_TX
+    // and detach/reattach approach as Turbo 2000, and the same stateful simple
+    // encoder pattern as t2k_encode_cb / rmt_new_simple_encoder).
+    bool fsk_signal_begin();   // alloc RMT channel + simple encoder (callback=fsk_encode_cb, arg=this), detach UART TX; false on failure
+    void fsk_signal_emit();    // ONE rmt_transmit of the whole pre-read buffer, then rmt_tx_wait_all_done
+    void fsk_signal_end();     // idempotent: teardown RMT + encoder, reattach UART TX
+
+    // The stateful RMT simple-encoder callback (same 7-arg signature as
+    // t2k_encode_cb). Generates rmt_symbol_word_t on demand from _fsk_buf plus
+    // the encoder state below. NO file I/O, NO heap allocation.
+    static size_t IRAM_ATTR fsk_encode_cb(const void *data, size_t data_size,
+                                          size_t symbols_written, size_t symbols_free,
+                                          rmt_symbol_word_t *symbols, bool *done, void *arg);
+
+    void       *_fsk_rmt_channel = nullptr;
+    void       *_fsk_rmt_encoder = nullptr;
+    bool        _fsk_signal_active = false;
+
+    // Preloaded source + encoder state read by fsk_encode_cb (set before
+    // rmt_transmit, read in the ISR callback). All O(1); no waveform buffer.
+    const uint8_t *_fsk_buf         = nullptr; // pre-read data region
+    size_t   _fsk_data_avail        = 0;       // clamped bytes present
+    size_t   _fsk_value_count       = 0;       // floor(_fsk_data_avail / 2); done when index reaches this
+    size_t   _fsk_value_index       = 0;       // current original FSK value index (for parity)
+    size_t   _fsk_byte_pos          = 0;       // current byte position in _fsk_buf
+    uint32_t _fsk_remaining_ticks   = 0;       // ticks left for the value being split (15-bit carry)
+    bool     _fsk_level_high        = false;   // logical level of the value being split (index parity)
+#endif
+```
+
+`play_fsk_chunk` is declared unconditionally so the FUJI loop compiles on both ESP and PC builds; the platform split lives inside its body.
+
+### Reused existing interfaces
+
+- `fnio::fseek` / `fnio::fread` — single pre-read of the clamped data region (no per-value reads).
+- `filesize` — total CAS_Image size for bounds clamping.
+- `has_pulldown()`, `motor_line()` — motor-line abort condition, identical to the data path.
+- `SYSTEM_BUS.flushOutput()` — flush pending UART bytes before detaching TX.
+- `SYSTEM_BUS.bus_idle(uint16_t ms)` — deterministic PC/NetSIO IRG idling.
+- `SYSTEM_BUS.isBoIP()` — NetSIO vs SerialSIO step sizing on non-ESP (mirrors data path).
+- `fnSystem.delay_microseconds(...)` — ESP IRG timing (gap loop, mirrors data path).
+- ESP RMT: `rmt_new_tx_channel`, `rmt_new_simple_encoder` (with `simple_cfg.callback = fsk_encode_cb` and `simple_cfg.arg = this`), `rmt_enable`, `rmt_transmit`, `rmt_tx_wait_all_done`, `rmt_disable`, `rmt_del_channel`, `rmt_del_encoder` — the same peripheral, the same stateful simple-encoder pattern, and the same lifecycle calls that Turbo 2000's `turbo2000_init_rmt` / `t2k_encode_cb` / `turbo2000_deinit_rmt` already use.
+- ESP GPIO/UART routing: `esp_rom_gpio_connect_out_signal`, `uart_periph_signal[2].pins[SOC_UART_TX_PIN_IDX].signal`, `PIN_UART2_TX` — identical detach/reattach calls to `turbo2000_init_rmt`/`turbo2000_deinit_rmt` and `qros_pilot_on`/`qros_pilot_off`.
+- `malloc` / `free` — heap allocation for the pre-read buffer, matching the T2K `all_data`/`_t2k_pending_buf` pattern (with allocation-failure handling).
+
+---
+
+## Data Models
+
+### FSK chunk layout
+
+An FSK chunk reuses the existing `struct tape_FUJI_hdr`:
+
+```cpp
+struct tape_FUJI_hdr {
+    uint8_t  chunk_type[4]; // 'f','s','k',' '  (0x66 0x73 0x6B 0x20)
+    uint16_t chunk_length;  // data byte count, LE, range 0..65535
+    uint16_t irg_length;    // aux: Inter-Record Gap in ms, LE, range 0..65535
+    uint8_t  data[];        // chunk_length bytes: sequence of LE u16 durations
+};
+```
+
+Fields are read directly from the file and are little-endian on the Atari target, consistent with all existing chunk handling. Each chunk occupies `chunk_length + 8` bytes.
+
+### FSK signal values and the tick grid
+
+- The data area is a sequence of `floor(chunk_length / 2)` FSK_Signal_Values (Req 2.3).
+- Each value is an unsigned 16-bit little-endian integer (Req 2.1) representing a duration in units of **1/10 ms** (Req 2.4).
+- The RMT grid is **1 µs per tick** (1 MHz resolution, matching the Turbo 2000 precedent). Because 1/10 ms = 100 µs = 100 ticks at 1 µs/tick, an FSK value of V maps to **exactly `V * 100` ticks** with no rounding. (Value 256 → 25.6 ms → 25,600 ticks; value 6818 → 681.8 ms → 681,800 ticks, matching Req 9.7.)
+- The IRG is `irg_length` in **milliseconds** (Req 2.2, 3.1), used directly as-is (no unit conversion).
+
+### Segment splitting for the 15-bit RMT field
+
+Each `rmt_symbol_word_t` level duration is 15 bits (max 32767 ticks). An FSK value of V maps to `V * 100` ticks at the 1 µs grid. The encoder callback emits those `V * 100` ticks on the fly as a run of consecutive same-level portions, each produced by `fsk_next_portion` (min(remaining, 32767)):
+
+- **no portion** when `V == 0` (the value still consumes a parity index, see below),
+- otherwise `ceil(V * 100 / 32767)` portions, each at most 32767 ticks, all carrying the SAME level, summing to exactly `V * 100` ticks.
+
+Because the value is scaled by 100 before splitting, even small values produce multiple portions. Concrete examples: value 1 → 100 ticks → 1 portion; value 256 → 25,600 ticks → 1 portion; value 6818 → 681,800 ticks → `ceil(681800/32767) = 21` portions; value 65535 → 6,553,500 ticks → `ceil(6553500/32767) = 201` portions (200 portions of 32767 ticks plus a final 100-tick portion). The portions of one value always carry the SAME logical level, so the emitted level stays continuous across the split, and `fsk_next_portion` is applied repeatedly against carried `remaining_ticks` state rather than building any list. Because the encoder carries `remaining_ticks` across symbols and callbacks with O(1) state, the larger portion counts do NOT increase the memory footprint.
+
+### Index-parity level assignment
+
+The A8CAS logical level of a value is determined by the parity of its zero-based FSK_Signal_Index (Req 2.5): even index → logical 0, odd index → logical 1. The logical level is a function of the ORIGINAL value index only (`fsk_level_for_index`), never of preceding durations, and never of how many portions a value was split into. A zero-duration value still consumes an index (it produces no portion but advances the parity counter, so the cursor skips it) so that the parity of every following value is preserved (Req 4.6).
+
+### Bounds derivation (in the caller, `play_fsk_chunk`)
+
+```
+remaining      = filesize - offset            // bytes from chunk header start to EOF
+if remaining < 8: treat as end-of-tape (return 0)   // Req 6.1
+declared_len   = chunk_length                  // 0..65535
+data_avail     = min(declared_len, remaining - 8)   // clamp to bytes after header
+value_count    = data_avail / 2                // floor; drops any trailing odd byte
+```
+
+The pre-read reads exactly `data_avail` bytes in one `fnio::fread`; no read may pass EOF.
+
+### Pre-read RAM budget (honest per-target analysis)
+
+`play_fsk_chunk` performs exactly ONE allocation: `data_avail` bytes (at most `chunk_length` = 65535, so about 64 KB) via `malloc`, matching the T2K `all_data` / `_t2k_pending_buf` pattern, and `free`s it on every exit path. Because emission is callback-driven directly from this buffer, **this pre-read buffer is the only large allocation** — there is NO full-waveform segment vector (see finding 2/4 and *Correctness Properties*), so the peak FSK footprint is just this one buffer plus O(1) cursor/encoder state.
+
+The RAM budget is target-dependent and must not assume PSRAM everywhere:
+
+- **Classic Atari board `fujinet-v1` (and `-4mb`/`-8mb`): plain ESP32, NO PSRAM** (`"mcu": "esp32"`, no `BOARD_HAS_PSRAM`). Internal DRAM totals only about 320 KB, and much of it is consumed at runtime by the Wi-Fi/TLS/network stack and firmware, so free heap is far below 320 KB. A ~64 KB `malloc` for a maximum-size FSK chunk **may fail** on this target.
+- **ESP32-S3 boards (`esp32-s3-wroom-1-n8r8`, `-n16r8`, `-xdrive-n4r2`): `-DBOARD_HAS_PSRAM`** (octal PSRAM), with MBs of PSRAM available; a ~64 KB pre-read is comfortable there.
+
+**Defined safe-failure behavior when the pre-read `malloc` fails:** log via `Debug_printf`, skip signal emission for that chunk (no partial waveform), still honor the IRG and the advance/EOT offset, and leave the baud/UART untouched (consistent with Req 4.5/5.5 and the safe-degradation of Req 6.x). Because the buffer is the only large allocation, this is the single point of memory pressure.
+
+**Accepted resource limitation:** on a memory-constrained no-PSRAM target, the inability to pre-read a *syntactically valid MAXIMUM-size* (~64 KB) FSK chunk is an **accepted resource limitation, not a correctness violation**. The system degrades safely (skip signal, honor advance/IRG, preserve baud) exactly as for any other allocation failure. Real-world FSK chunks are far smaller than the theoretical maximum (Night Knight's largest is a small fraction of 64 KB), so this limit is not expected to be hit in practice. A possible future mitigation is a streaming/chunked pre-read that feeds the encoder incrementally rather than allocating the whole region at once; it is **not designed here**, and the accepted limitation stands.
+
+---
+
+## Correctness Properties
+
+*A property is a characteristic or behavior that should hold true across all valid executions of a system, essentially a formal statement about what the system should do. Properties serve as the bridge between human-readable specifications and machine-verifiable correctness guarantees.*
+
+This feature uses property-based reasoning because the FSK decode, level, tick-scaling, split, and cursor-advance logic is a set of pure functions: given a byte buffer and an available-bytes count, `fsk_decode_le16`, `fsk_level_for_index`, `fsk_ticks_for_value`, `fsk_next_portion`, `fsk_value_count`, and the `FskChunkView` cursor stepped by `fsk_view_step` behave deterministically with O(1) state and no allocation. These pure rules are separable from the hardware emission (a side effect covered by integration and manual tests, not property tests), yet the production RMT callback `fsk_encode_cb` calls the exact same rules, so testing them on the host validates production behavior. The properties below quantify over those pure step functions and the cursor. They are exercised on the host with deterministic generated-input loops (see the Testing Strategy). Because nothing materializes the whole waveform, the tests never build a full segment list either; they step the cursor and check invariants per step.
+
+### Property 1: Value count is floor of clamped length over 2
+
+*For any* available-bytes count, the number of FSK_Signal_Values reported by `fsk_value_count(data_len_available)` equals `data_len_available / 2` using integer division.
+
+**Validates: Requirements 2.3, 6.4**
+
+### Property 2: Durations are the little-endian pairs scaled to 100 ticks per 1/10 ms
+
+*For any* buffer of complete 2-byte pairs, stepping the cursor over the value at each successive pair yields portions whose ticks sum to `fsk_ticks_for_value(low_byte + (high_byte << 8))` (i.e. `value * 100`), in order, where one unit of 1/10 ms equals 100 ticks at the 1 us/tick grid.
+
+**Validates: Requirements 2.1, 2.4**
+
+### Property 3: Logical level follows index parity independent of durations
+
+*For any* sequence of FSK_Signal_Values (including values of duration zero), every portion the cursor produces for the value at index `i` carries logical level 0 when `i` is even and logical level 1 when `i` is odd, regardless of the durations of any preceding values and regardless of how the value was split into portions. Equivalently, `fsk_level_for_index(i)` depends only on the parity of `i`.
+
+**Validates: Requirements 2.5, 4.2, 4.6**
+
+### Property 4: Cursor reads are bounded, no out-of-bounds access
+
+*For any* available-bytes count and any buffer, every byte the cursor reads across a full run of `fsk_view_step` calls lies within `[0, data_len_available)`; it never reads at or past `data_len_available`.
+
+**Validates: Requirements 1.4, 6.2, 6.3, 6.5, 8.3**
+
+### Property 5: Split portions preserve total duration and stay within the RMT limit
+
+*For any* FSK_Signal_Value `V` with `V >= 1`, the value maps to `fsk_ticks_for_value(V)` (i.e. `V * 100`) ticks; repeatedly applying `fsk_next_portion` and subtracting yields same-level portions whose tick counts are each at most 32767 and whose sum equals `V * 100`; a value of `V == 0` yields no portion. The portion count is `ceil(V * 100 / 32767)` for `V >= 1` (arbitrary multi-portion split, not capped at three). In particular `V == 6818` yields 21 portions, `V == 65535` yields 201 portions (200 portions of 32767 ticks plus a final 100-tick portion), and every portion carries the same level.
+
+**Validates: Requirements 2.4, 4.1, 4.6**
+
+### Property 6: Truncation is deterministic and terminating
+
+*For any* offset where fewer than 8 bytes remain, the caller reports end-of-tape (next offset 0); *for any* declared length that would pass EOF, the caller clamps the pre-read to the available bytes, the cursor steps only over fully-present values, and the caller terminates at the real boundary using the end-of-tape convention (next offset 0) rather than pointing past the image.
+
+**Validates: Requirements 1.4, 6.1, 6.3, 6.5, 8.4**
+
+### Property 7: Baud rate is invariant across FSK processing
+
+*For any* FSK chunk, the pure step functions carry no baud-change action and the caller issues no `setBaudrate`; the active baud rate after processing equals the active baud rate before.
+
+**Validates: Requirements 5.1, 5.2**
+
+### Property 8: Zero-length chunk yields an IRG-only outcome
+
+*For any* FSK chunk whose declared `chunk_length` is 0, `fsk_value_count` is 0, the cursor produces zero portions with `irg_ms` equal to the `aux` value in milliseconds, and the caller's next offset is `O + 8`.
+
+**Validates: Requirements 2.8, 4.4, 1.3**
+
+**Property reflection:** Properties were reviewed for redundancy. Property 5 (split portions) covers the RMT split boundary that Property 2 does not; the two are complementary (Property 2 fixes the total tick count per value at `V * 100`, Property 5 governs how that total is chopped into an arbitrary number of portions of at most 32767 ticks, `ceil(V * 100 / 32767)` of them), so both are kept. Property 4 (no out-of-bounds) and Property 6 (truncation determinism) overlap on bounds safety; Property 4 is retained as the pure spatial-safety invariant of the cursor while Property 6 adds the behavioral outcome (clamping plus deterministic end-of-tape termination), so both provide unique value. Property 2 (durations) and Property 3 (levels) are orthogonal (magnitude versus parity) and not combinable.
+
+---
+
+## Error Handling
+
+Error propagation uses the **existing convention** in this file: block functions return a `size_t offset`; returning `starting_offset` means "retry from here / not done," and returning `0` means end-of-tape (the dispatcher then disables the cassette; the walk loop condition is `while (offset < filesize)`). There is no separate error-reporting API; diagnostics go through `Debug_printf`. This is the concrete mechanism the requirements deferred (Req 3.4, 4.5, 5.4, 5.5).
+
+Every exit path of `play_fsk_chunk` funnels through a single idempotent cleanup routine (`fsk_signal_end` on ESP, which is a no-op if RMT was never started, plus `free` of the pre-read buffer), so the UART TX is always reattached and the pre-read buffer is always released. See *Single Cleanup Path* below.
+
+| Condition | Detection | Response | Requirement(s) |
+|---|---|---|---|
+| Motor-line abort during IRG | `has_pulldown() && !motor_line() && remaining_gap > 1000` inside the gap loop | Run cleanup (reattach UART if begun, free buffer), leave baud unchanged, return `starting_offset` (retry) — identical to the data-record path | 3.3, 3.4, 5.4 |
+| Truncated header (< 8 bytes remain) | `filesize - offset < 8` | Treat as end-of-tape: return `0`; no read past EOF | 6.1, 8.4 |
+| Truncated / overrun data (declared length would pass EOF) | `data_avail = min(chunk_length, remaining - 8)` with `offset + 8 + chunk_length > filesize` | Pre-read and reproduce only the fully-present values (`data_avail / 2`), discard any trailing unpaired byte, then terminate at the real boundary by returning `0` (end-of-tape), because the next read offset would be `>= filesize` and 0 is the established end-of-tape signal | 1.4, 6.3, 6.5 |
+| Odd `chunk_length` (well-formed, within file) | `value_count = data_avail / 2` (floor) | Reproduce complete pairs, discard the single trailing byte, no OOB, advance `offset += 8 + chunk_length` | 6.4 |
+| Pre-read heap allocation fails (only large alloc; ~64 KB may fail on no-PSRAM fujinet-v1) | `malloc(data_avail) == nullptr` | Log, skip emission (no partial waveform), run cleanup, advance `offset += 8 + chunk_length` (well-formed case) or return `0` (overrun case); IRG still honored, subsequent `data` playback uncorrupted. Accepted resource limitation for max-size chunks on no-PSRAM targets (see *Pre-read RAM budget*) | 4.5, 5.5 |
+| Raw-signal init fails (ESP): NC pin, RMT channel / simple-encoder alloc fails | `fsk_signal_begin()` returns `false` | `begin()` has already undone any partial setup; skip emission, ensure UART intact, free buffer, advance `offset += 8 + chunk_length`; subsequent `data` playback uncorrupted | 4.5, 5.5 |
+| Zero-length chunk | `chunk_length == 0` | Honor IRG, emit nothing, leave Data_Line level as-is, advance `offset += 8` | 2.8, 4.4, 1.3 |
+
+In every failure case the UART TX is guaranteed reattached (so `data` records still transmit) and the active baud rate is untouched, so subsequent normal playback is not corrupted (Req 4.5, 5.4, 5.5, 6.6). All paths are deterministic and must terminate without hangs or crashes (Req 6.6). Normal playback intentionally waits for the declared IRG and waveform duration, so this requirement is not interpreted as non-blocking execution.
+
+### Single Cleanup Path (Req 4.5, 5.4, 5.5)
+
+`play_fsk_chunk` is structured so that **every** branch reaches one teardown routine before returning. In pseudocode terms it uses a single-exit pattern: a local `size_t result` and a `goto done;` / structured wrapper (or an RAII-style guard) so that success, motor-abort mid-flow, allocation failure, `begin()` failure, and emission error all pass through the same `done:` label. At `done:`:
+
+1. `fsk_signal_end()` is called unconditionally. It is **idempotent**: if `_fsk_signal_active` is false (RMT never started) it returns immediately; otherwise it waits for any in-flight transmit, tears down the RMT channel/encoder, and reattaches UART2 TX to the pin.
+2. The pre-read heap buffer is `free`d if it was allocated (`free(nullptr)` is safe).
+3. `result` is returned.
+
+`fsk_signal_begin()` itself guarantees all-or-nothing setup: if the pin is `GPIO_NUM_NC`, or `rmt_new_tx_channel` / `rmt_new_simple_encoder` / `rmt_enable` fails, it frees whatever it already allocated, reattaches the UART TX (in case it had already detached), clears `_fsk_signal_active`, and returns `false`. Because setup is all-or-nothing and teardown is idempotent, **UART reattach and baud invariance hold on all paths**: the UART TX pin routing is restored by exactly one place (`fsk_signal_end`, reached by every branch, or by `begin()` itself on partial-setup failure), and no path ever calls `setBaudrate`.
+
+---
+
+## Concrete Design Decisions (resolving deferred items)
+
+### Signal Reproduction Mechanism (Req 4)
+
+**Decision:** Use the **ESP RMT peripheral** to emit the FSK waveform, configured at a **1 MHz resolution (1 µs per tick)** — the SAME resolution Turbo 2000 already uses successfully — driving the same `PIN_UART2_TX` pin via the detach/reattach pattern already used by Turbo 2000 and the QROS pilot. The waveform is emitted by a **stateful RMT simple encoder** (`rmt_new_simple_encoder` with `callback = fsk_encode_cb`, `arg = this`) in a **single continuous `rmt_transmit`** of the whole pre-read buffer, exactly mirroring Turbo 2000's `turbo2000_init_rmt` + `t2k_encode_cb` precedent.
+
+**Why not the earlier copy-encoder batch approach:** an earlier draft built an `rmt_symbol_word_t batch[64]` on the stack and called `rmt_transmit` repeatedly, reusing that same stack buffer across calls with only a final `rmt_tx_wait_all_done`. That is unsafe for two reasons. First, `rmt_transmit` *queues* a transaction and can return before encoding/transmission of that batch completes; the payload buffer handed to it must stay valid and unmodified until that specific transaction finishes, so overwriting a reused stack `batch` for the next transmit while a prior transmit may still be draining it is a use-after-free / data-race hazard. Second, multiple independent `rmt_transmit` transactions are **not guaranteed gapless**: the peripheral can insert timing gaps between separately queued transmits, which would corrupt an FSK waveform of contiguous alternating levels. Both problems are structural, not fixture-specific.
+
+**Replacement:** register a stateful simple encoder whose callback generates `rmt_symbol_word_t` entries on the fly from the SINGLE pre-read raw FSK buffer during ONE `rmt_transmit(channel, simple_encoder, _fsk_buf, _fsk_data_avail, &tx_cfg)` call. The whole waveform is one continuous, gapless RMT transaction, and there is no reused stack payload owned by us: the callback writes directly into the RMT-provided `symbols` memory (up to `symbols_free` per call), so there is no queued-buffer lifetime hazard. This is the identical model Turbo 2000 already uses, where the callback fills RMT ping-pong memory on demand.
+
+**Rationale for RMT at all:** a valid A8CAS `fsk ` chunk can contain many short alternating values (100 µs, 200 µs, …) that must be emitted continuously and jitter-free. GPIO bit-banging with `fnSystem.delay_microseconds` is a CPU busy-wait subject to preemption by FreeRTOS scheduler ticks, other tasks, and Wi-Fi/network interrupts; any such preemption can stretch a 100 µs level and corrupt the waveform. Turbo 2000 already establishes RMT as the precedent for jitter-free raw waveform generation on this exact pin (hardware-timed, ISR-refilled). We reuse that precedent, including its stateful encoder callback.
+
+The 1 MHz resolution is chosen deliberately for portability: the classic ESP32 FujiNet target uses APB as the default RMT clock (`RMT_CLK_SRC_DEFAULT`) and cannot reliably divide down to 10 kHz, and other ESP targets differ. Rather than select a target-specific clock source, this design reuses the exact resolution Turbo 2000 already drives successfully on this same pin: 1 MHz, 1 µs per tick, with `clk_src = RMT_CLK_SRC_DEFAULT`. A8CAS timing stays exact because 1/10 ms = 100 µs = 100 ticks at 1 µs/tick, so each value V maps to exactly `V * 100` ticks with no rounding error (`remaining_ticks = fsk_ticks_for_value(value)`, the shared helper used by both the ISR callback and the host-test cursor).
+
+**Encoder state and on-the-fly generation:** `fsk_encode_cb` is `IRAM_ATTR` and runs in **ISR context** (the RMT peripheral invokes it from its ping-pong refill interrupt). It therefore may call ONLY ISR/cache-safe code — no allocation, no logging (`Debug_printf`), no file I/O, no flash-dependent work — and it only inlines the `static inline` IRAM-safe RULES from `fsk_plan.h` (`fsk_decode_le16`, `fsk_level_for_index`, `fsk_next_portion`); it does NOT call the host-test-only `fsk_view_step` (which is not in IRAM). It has the same 7-argument signature as `t2k_encode_cb`, performs NO file I/O and NO heap allocation, and reads only from `_fsk_buf` plus the O(1) encoder state stored on the `sioCassette` object (current value index for parity, current logical level derived from index parity, remaining ticks for the current value — set to `value * 100` when a value is loaded and carried across symbols/callbacks — current byte position, and `_fsk_value_count` so it can set `*done`). One `rmt_symbol_word_t` holds two level/duration halves; the callback packs successive portions into both halves, applies `fsk_next_portion` to split each value's `value * 100` ticks into `ceil(value * 100 / 32767)` consecutive SAME-level portions (see the split math in Data Models), fills up to `symbols_free` symbols per call, and resumes from its state on the next call. Because state is O(1) and carried across callbacks, the larger portion counts do NOT increase the memory footprint.
+
+**`*done` handling (must not rely on framework state):** the callback sets `*done = false` at the START of every invocation and does NOT rely on the RMT framework to initialize or preserve the previous `*done` value. It sets `*done = true` ONLY after the last portion of the last value has been emitted — i.e. only on the two full-completion return paths (the clean-boundary "no more values" return and the "last portion of last value emitted" return). Every `return num;` path that leaves waveform pending (buffer full mid-stream) leaves `*done == false` so the framework calls the callback again. This guarantees `*done` is correctly assigned on every exit: false when more remains, true only when fully complete. A zero-duration value consumes an index/parity slot but emits no duration, so the callback advances the value index without emitting a symbol for it.
+
+**Pseudocode for `fsk_encode_cb`** (mirrors `t2k_encode_cb`'s structure):
+
+```cpp
+size_t IRAM_ATTR sioCassette::fsk_encode_cb(const void *data, size_t data_size,
+        size_t symbols_written, size_t symbols_free,
+        rmt_symbol_word_t *symbols, bool *done, void *arg)
+{
+    sioCassette *self = (sioCassette *)arg;
+    const uint8_t *buf = (const uint8_t *)data;   // == _fsk_buf, _fsk_data_avail == data_size
+    size_t num = 0;
+
+    // Do NOT rely on the RMT framework to initialize or preserve *done. Assume
+    // more waveform remains until we prove otherwise; every early return below
+    // that leaves waveform pending keeps this false, and *done is set true ONLY
+    // after the last portion of the last value has been emitted.
+    *done = false;
+
+    while (num < symbols_free)
+    {
+        // Fill both halves of one rmt_symbol_word_t.
+        uint16_t levels[2]; uint16_t durs[2]; int half = 0;
+
+        while (half < 2)
+        {
+            // Load next value if the current one is exhausted.
+            if (self->_fsk_remaining_ticks == 0)
+            {
+                // Skip zero-duration values: each consumes an index (parity) but emits nothing.
+                while (self->_fsk_value_index < self->_fsk_value_count)
+                {
+                    uint16_t v = fsk_decode_le16(buf + self->_fsk_byte_pos);
+                    bool lvl   = fsk_level_for_index(self->_fsk_value_index);
+                    self->_fsk_value_index++;
+                    self->_fsk_byte_pos += 2;
+                    // Scale to ticks: 1/10 ms = 100 us = 100 ticks at 1 us/tick.
+                    if (v != 0) { self->_fsk_remaining_ticks = fsk_ticks_for_value(v); self->_fsk_level_high = lvl; break; }
+                    // v == 0: parity index consumed, no portion emitted; keep scanning.
+                }
+                if (self->_fsk_remaining_ticks == 0)   // no more values remain
+                {
+                    if (half == 0)
+                    {
+                        // Nothing more to emit and we are on a clean symbol
+                        // boundary: this is the ONLY place the whole waveform
+                        // is complete. Mark done and return; *done stays true.
+                        *done = true;
+                        (void)symbols_written; (void)data_size;
+                        return num;
+                    }
+                    // pad the unused second half with a 0-duration same-level entry;
+                    // the value stream is exhausted, so this completes the waveform.
+                    levels[half] = levels[half-1]; durs[half] = 0; half++;
+                    break;
+                }
+            }
+            uint32_t portion = fsk_next_portion(self->_fsk_remaining_ticks);
+            self->_fsk_remaining_ticks -= portion;
+            levels[half] = self->_fsk_level_high ? 1 : 0;
+            durs[half]   = (uint16_t)portion;
+            half++;
+        }
+
+        symbols[num].level0 = levels[0]; symbols[num].duration0 = durs[0];
+        symbols[num].level1 = levels[1]; symbols[num].duration1 = durs[1];
+        num++;
+
+        // Last portion of the last value emitted -> the waveform is complete.
+        if (self->_fsk_remaining_ticks == 0 &&
+            self->_fsk_value_index >= self->_fsk_value_count)
+        {
+            *done = true;                 // set true ONLY here on full completion
+            (void)symbols_written; (void)data_size;
+            return num;
+        }
+    }
+    // Buffer full but waveform not finished: *done remains false so RMT calls
+    // this callback again to emit the remaining portions.
+    (void)symbols_written; (void)data_size;
+    return num;   // more remains; *done == false; RMT will call again
+}
+```
+
+`fsk_signal_begin` flushes pending UART output, detaches UART2 TX from the pin, allocates and enables the RMT TX channel at 1 MHz (1 µs/tick), creates the simple encoder (`rmt_new_simple_encoder`, `callback = fsk_encode_cb`, `arg = this`), and returns `true`; on any failure it undoes partial setup and returns `false`. `play_fsk_chunk` initializes the encoder state after `fsk_signal_begin()` succeeds and before `fsk_signal_emit()` starts the transaction. `fsk_signal_emit` issues one `rmt_transmit` of the whole pre-read buffer plus `rmt_tx_wait_all_done`. `fsk_signal_end` waits for the transmit to finish, tears down the channel + encoder, and reattaches UART2 TX, mirroring `turbo2000_deinit_rmt`.
+
+### Level Mapping (Req 2.5, 4.2, 4.6)
+
+**Decision:** The design assigns a logical level per FSK_Signal_Index parity: even index → logical 0, odd index → logical 1. Logical level maps to the RMT symbol **level bit** to match the SIO DATA IN mark/space convention used by the QROS pilot, which drives the pin **HIGH (level 1) as the mark**.
+
+Mapping:
+
+- **logical 1 (mark)** → RMT symbol level bit **1** (pin HIGH)
+- **logical 0 (space)** → RMT symbol level bit **0** (pin LOW)
+
+Each portion's `level_high` becomes the `level0`/`level1` bit of its `rmt_symbol_word_t`. The level comes from `fsk_level_for_index(value_index)` (`(value_index & 1) != 0`, so odd index → logical 1 → HIGH), computed once per value and reused for every portion the value is split into. This is grounded in the QROS pilot code, where sustained HIGH is the mark level on SIO DATA IN. A zero-duration value produces no portion but still advances the value index, so parity of subsequent values is preserved (Req 4.6).
+
+### Malformed Chunk Policy (Req 1.4, 6.3–6.5)
+
+**Decision:** Graceful partial reproduction with correct termination. Reproduce only the complete 2-byte FSK_Signal_Values that lie fully within the file (`floor(available_bytes / 2)` values), discard any trailing unpaired byte. For a **well-formed** chunk (`offset + 8 + chunk_length <= filesize`), advance to `offset + 8 + chunk_length`. For a **truncated/overrun** chunk (declared length would pass EOF), terminate at the real boundary by returning `0` (end-of-tape) rather than `offset + 8 + declared_length`, which would point past the image where no valid chunk exists. If fewer than 8 header bytes remain, likewise treat as end-of-tape (return 0).
+
+**Rationale:** The A8CAS FSK data area is a raw sequence of independent durations, so a prefix of complete values is meaningful on its own; there is no framing that a partial tail would corrupt. Reproducing the fully-present prefix avoids aborting an otherwise-good tape on a single damaged trailing record. For the overrun case, the next read offset `offset + 8 + declared_length` would be `>= filesize`, so the walk loop (`while (offset < filesize)`) would exit anyway; returning `0` is the established end-of-tape signal that cleanly stops playback and lets the dispatcher disable the cassette, which is the correct terminal behavior at the end of a truncated image. All reads are clamped to `min(chunk_length, filesize - data_start)`, guaranteeing no OOB read, no hang, and no crash (Req 6.2, 6.3, 6.5, 6.6). The A8CAS specification does not mandate rejection of truncated FSK chunks, so this tolerant policy is permitted by the deferral.
+
+### Error Propagation (Req 3.4, 4.5, 5.4, 5.5)
+
+**Decision:** Reuse the return-offset + `Debug_printf` convention (detailed in *Error Handling*), with a single idempotent cleanup path (detailed in *Single Cleanup Path*). Motor-line abort returns `starting_offset` after cleanup and leaving baud unchanged. `fsk_signal_begin()` failure or pre-read allocation failure logs, skips emission, runs cleanup, and advances (or returns 0 for the overrun case). No new error-reporting API is introduced, matching the established interface of `send_FUJI_tape_block`, `send_QROS_tape_block`, etc.
+
+### PC Build Behavior (Req 8)
+
+**Decision:** On non-ESP builds, pre-read the FSK chunk and compute `value_count` with full bounds checking (identical to ESP), **honor the IRG deterministically** by idling the bus via `SYSTEM_BUS.bus_idle` (with NetSIO/Serial step sizing mirroring the data path), then advance the read offset **without** raw signal generation. There is no optional behavior: the IRG is always honored on the PC build.
+
+**Rationale:** The PC build has no GPIO/RMT and cannot detach a UART TX pin; raw FSK edge generation on a host serial port is not feasible, so signal generation is unconditionally skipped. But inter-record timing *is* representable via `bus_idle`, and honoring it deterministically keeps PC playback behavior consistent and testable rather than variable. This preserves compilation (Req 8.1) and keeps subsequent `data` playback intact (Req 8.2), while the shared bounds/pre-read logic guarantees no OOB read (Req 8.3, 8.4). Truncated/overrun handling on the PC build follows the same end-of-tape termination as ESP (Req 8.4).
+
+### Baud Preservation (Req 5)
+
+**Decision:** FSK handling never calls `SYSTEM_BUS.setBaudrate`. The ESP mechanism detaches and reattaches only the UART **TX pin routing** (for the RMT channel), not the UART peripheral's baud configuration, so reattaching restores the prior baud automatically. No explicit baud save/restore is needed.
+
+**Rationale:** Because the peripheral's baud divisor is untouched during pin detach/reattach, the `Active_Baud_Rate` in effect before the FSK chunk is exactly the rate in effect after it (Req 5.1, 5.3). A `data` chunk following an FSK chunk with no intervening `baud` chunk therefore transmits at the pre-FSK baud (Req 5.2). Because reattach happens in the single cleanup routine reached by every branch, baud is likewise untouched on all failure paths (Req 5.4, 5.5).
+
+---
+
+## Low-Level Design
+
+### Modified chunk-walk loop in `send_FUJI_tape_block`
+
+The loop gains an `fsk ` branch before the catch-all advance. `p` is `hdr->chunk_type`; `len` is `hdr->chunk_length`; `hdr->irg_length` is the aux/IRG field.
+
+```cpp
+while (offset < filesize)
+{
+    fnio::fseek(_file, offset, SEEK_SET);
+    size_t got = fnio::fread(atari_sector_buffer, 1, sizeof(struct tape_FUJI_hdr), _file);
+    if (got < sizeof(struct tape_FUJI_hdr))   // Req 6.1 / 8.4: header truncated
+        return 0;                             // end-of-tape
+    len = hdr->chunk_length;
+
+    if (p[0]=='d' && p[1]=='a' && p[2]=='t' && p[3]=='a')
+    {
+        block++;
+        break;                                 // data terminates the walk (unchanged)
+    }
+    else if (p[0]=='b' && p[1]=='a' && p[2]=='u' && p[3]=='d')
+    {
+        if (tape_flags.turbo) continue;
+        baud = hdr->irg_length;
+        SYSTEM_BUS.setBaudrate(baud);          // unchanged
+    }
+    else if (p[0]=='f' && p[1]=='s' && p[2]=='k' && p[3]==' ')  // Req 1.1, 1.5
+    {
+        size_t next = play_fsk_chunk(offset, len, hdr->irg_length);
+        if (next == starting_offset)           // motor-line abort -> retry
+            return starting_offset;            // Req 3.3, 3.4
+        if (next == 0)                         // truncated/overrun or EOT
+            return 0;                          // Req 1.4, 6.1, 6.3, 6.5
+        offset = next;                         // advanced past fsk chunk; continue walk
+        continue;                              // fsk is NOT a terminating record
+    }
+    // catch-all: unrecognized chunk (Req 1.6 / 9.3)
+    offset += sizeof(struct tape_FUJI_hdr) + len;
+}
+// ... existing IRG + data-record emission for the 'data' chunk, unchanged ...
+```
+
+### `play_fsk_chunk` — cross-platform, single-exit
+
+All FSK bytes are pre-read into RAM in ONE `fnio::fread` before any emission begins. Emission is driven directly from that buffer by the RMT simple encoder (no full-waveform buffer is built), and every path funnels through one cleanup label.
+
+```cpp
+size_t sioCassette::play_fsk_chunk(size_t offset, uint16_t chunk_length, uint16_t irg_ms)
+{
+    size_t  starting_offset = offset;
+    size_t  data_start      = offset + sizeof(struct tape_FUJI_hdr); // offset + 8
+    uint8_t *buf            = nullptr;
+    size_t  result;
+
+    // ---- Bounds (Req 6.1/6.2/6.3/6.5) ----
+    if (filesize < data_start)                     // header not fully present
+        return 0;                                  // end-of-tape (no cleanup needed yet)
+
+    size_t remaining_after_hdr = filesize - data_start;
+    bool   overrun    = (chunk_length > remaining_after_hdr); // declared data passes EOF
+    size_t data_avail = overrun ? remaining_after_hdr : chunk_length;
+
+    // Next offset: well-formed advances past the chunk; overrun terminates at the
+    // real boundary via end-of-tape (Req 1.4/6.3/6.5). Zero-length advances by 8.
+    size_t next_offset = overrun ? 0 : (offset + sizeof(struct tape_FUJI_hdr) + chunk_length);
+
+    // ---- Single PRE-READ of the whole clamped data region into RAM (finding 2) ----
+    //      This is the ONLY large allocation; there is NO segment vector.
+    if (data_avail > 0)
+    {
+        buf = (uint8_t *)malloc(data_avail);       // ~64 KB max; T2K malloc pattern
+        if (buf == nullptr)                        // safe skip on alloc failure (Req 4.5/5.5)
+        {
+            // ~64 KB may fail on the no-PSRAM classic ESP32 (fujinet-v1); this is an
+            // accepted resource limitation, not a correctness violation.
+            Debug_printf("FSK: malloc(%u) failed, skipping signal\n", (unsigned)data_avail);
+            result = next_offset;
+            goto irg;                              // still honor IRG + advance/EOT, no emission
+        }
+        fnio::fseek(_file, data_start, SEEK_SET);
+        size_t r = fnio::fread(buf, 1, data_avail, _file);
+        data_avail = r;                            // trust bytes actually read; no reads past EOF
+    }
+
+    result = next_offset;                          // Req 1.2/1.3 (or 0 for overrun)
+
+irg:
+    // ---- Honor the Inter-Record Gap (Req 3.1/3.2), reusing the data-path loop ----
+    {
+        uint32_t gap = irg_ms;                     // milliseconds (Req 2.2/3.1), used as-is
+        fnLedManager.set(eLed::LED_BUS, true);
+        while (gap)
+        {
+#ifdef ESP_PLATFORM
+            gap--;
+            fnSystem.delay_microseconds(999);      // ~1 ms, matches data path
+#else
+            int step;
+            if (SYSTEM_BUS.isBoIP())
+                step = gap > 1000 ? 1000 : gap;
+            else
+                step = gap > 20 ? 20 : gap;
+            gap -= step;
+            SYSTEM_BUS.bus_idle(step);             // PC/NetSIO IRG idle (Req 8.2, deterministic)
+#endif
+            if (has_pulldown() && !motor_line() && gap > 1000)   // Req 3.3
+            {
+                fnLedManager.set(eLed::LED_BUS, false);
+                result = starting_offset;          // abort/retry (Req 3.4/5.4)
+                goto done;
+            }
+        }
+        fnLedManager.set(eLed::LED_BUS, false);
+    }
+
+    {
+        size_t value_count = fsk_value_count(data_avail);  // floor (Req 2.3/6.4)
+#ifdef ESP_PLATFORM
+        // ---- Reproduce the raw FSK signal via the RMT simple encoder (Req 4) ----
+        if (buf && value_count > 0)
+        {
+            if (!fsk_signal_begin())               // NC pin / RMT alloc failure (Req 4.5)
+            {
+                Debug_println("FSK: signal init failed, skipping signal output");
+                // begin() already undid partial setup and left UART intact.
+            }
+            else
+            {
+                // Initialize encoder state, then ONE continuous transmit driven by
+                // fsk_encode_cb reading directly from buf (no waveform buffer built).
+                _fsk_buf            = buf;
+                _fsk_data_avail     = data_avail;
+                _fsk_value_count    = value_count;
+                _fsk_value_index    = 0;
+                _fsk_byte_pos       = 0;
+                _fsk_remaining_ticks = 0;
+                _fsk_level_high     = false;
+                fsk_signal_emit();                 // single rmt_transmit + wait-done
+                // fsk_signal_end() is deferred to the single cleanup label.
+            }
+        }
+        // else: zero values -> leave Data_Line as-is, IRG already honored (Req 4.4/2.8)
+#else
+        // PC build: no raw signal generation; IRG already honored deterministically (Req 8.2).
+        Debug_printf("FSK (PC build): %u values, IRG %u ms, signal not reproduced\n",
+                     (unsigned)value_count, (unsigned)irg_ms);
+#endif
+    }
+
+done:
+    // ---- Single, idempotent cleanup reached by EVERY path (finding 8) ----
+#ifdef ESP_PLATFORM
+    fsk_signal_end();                              // no-op if RMT never started; reattaches UART
+    _fsk_buf = nullptr;                            // drop dangling pointer before buffer free
+#endif
+    if (buf) free(buf);                            // release pre-read buffer (free(nullptr) safe)
+    return result;
+}
+```
+
+The pre-read `buf` is freed only after `fsk_signal_end()` has waited for the transmit to finish (`rmt_tx_wait_all_done`), so the encoder callback never reads freed memory. The shared pure RULES `fsk_decode_le16`, `fsk_level_for_index`, `fsk_ticks_for_value`, and `fsk_next_portion` are `static inline`, IRAM-safe functions in `fsk_plan.h` (shown in *Components and Interfaces*), inlined by BOTH `fsk_encode_cb` (in the ISR) and `fsk_view_step`, so both the production ISR callback and the host-test cursor scale durations identically and cannot diverge. `fsk_view_step` itself is a **host-test-only** helper defined in `fsk_plan.cpp` (not `static inline`, not `IRAM_ATTR`, never called from the ISR); the production `fsk_encode_cb` implements the same per-step logic inline from the static-inline rules rather than calling `fsk_view_step`, so there is no flash-resident call in the ISR. `fsk_view_step` implements the on-the-fly split and zero-duration skip:
+
+```cpp
+// fsk_plan.cpp — pure, no allocation, HOST-TEST-ONLY (not static inline, not
+// IRAM_ATTR, not ISR-called). Advances the cursor by exactly one emitted portion
+// (or reports done). Reads only within [0, data_len_available). It calls the
+// same static-inline IRAM-safe RULES that fsk_encode_cb inlines in the ISR.
+FskStep fsk_view_step(FskChunkView &view)
+{
+    // Continue splitting the value currently in progress.
+    if (view.remaining_ticks == 0)
+    {
+        // Load the next value; skip zero-duration values (they consume an index
+        // and thus parity but emit no portion) (Req 4.6).
+        while (view.value_index < fsk_value_count(view.data_len_available))
+        {
+            uint16_t v = fsk_decode_le16(view.data + view.byte_pos); // in-bounds pair
+            bool     lvl = fsk_level_for_index(view.value_index);    // parity (Req 2.5)
+            view.value_index++;
+            view.byte_pos += 2;
+            if (v != 0) { view.remaining_ticks = fsk_ticks_for_value(v); view.remaining_level_high = lvl; break; }
+        }
+        if (view.remaining_ticks == 0)                 // no more values
+            return FskStep{ false, false, 0, true };
+    }
+    uint32_t portion = fsk_next_portion(view.remaining_ticks);      // <= 32767 (Req 4.1)
+    view.remaining_ticks -= portion;
+    bool more = view.remaining_ticks != 0 ||
+                view.value_index < fsk_value_count(view.data_len_available);
+    return FskStep{ true, view.remaining_level_high, portion, !more };
+}
+```
+
+### ESP-only RMT signal helpers (mirroring the Turbo 2000 RMT lifecycle)
+
+```cpp
+#ifdef ESP_PLATFORM
+#define FSK_RMT_RESOLUTION_HZ 1000000 // 1 MHz -> 1 us per tick (T2K precedent); 1/10 ms = 100 ticks
+
+bool sioCassette::fsk_signal_begin()
+{
+    if (_fsk_signal_active) return true;            // idempotent guard
+
+    if (PIN_UART2_TX == GPIO_NUM_NC)                // cannot drive signal (Req 4.5)
+        return false;
+
+    SYSTEM_BUS.flushOutput();                       // flush pending UART bytes
+
+    // Detach UART2 TX; RMT will drive the pin (same as turbo2000_init_rmt / qros_pilot_on)
+    esp_rom_gpio_connect_out_signal(PIN_UART2_TX, SIG_GPIO_OUT_IDX, false, false);
+
+    rmt_tx_channel_config_t tx_cfg = {};
+    tx_cfg.gpio_num       = (gpio_num_t)PIN_UART2_TX;
+    tx_cfg.clk_src        = RMT_CLK_SRC_DEFAULT;
+    tx_cfg.resolution_hz  = FSK_RMT_RESOLUTION_HZ;  // 1 us per tick; value V -> V*100 ticks (exact)
+    tx_cfg.mem_block_symbols = 64;
+    tx_cfg.trans_queue_depth = 4;
+
+    rmt_channel_handle_t channel = nullptr;
+    if (rmt_new_tx_channel(&tx_cfg, &channel) != ESP_OK)
+    {
+        // Undo partial setup: reattach UART before returning false.
+        esp_rom_gpio_connect_out_signal(PIN_UART2_TX,
+            uart_periph_signal[2].pins[SOC_UART_TX_PIN_IDX].signal, false, false);
+        return false;
+    }
+
+    // Stateful SIMPLE encoder (same pattern as turbo2000_init_rmt / t2k_encode_cb):
+    // the callback generates symbols on demand from the preloaded buffer + state.
+    rmt_simple_encoder_config_t simple_cfg = {};
+    simple_cfg.callback = fsk_encode_cb;            // IRAM callback, 7-arg signature
+    simple_cfg.arg      = this;                     // read encoder state off sioCassette
+    rmt_encoder_handle_t simple_enc = nullptr;
+    if (rmt_new_simple_encoder(&simple_cfg, &simple_enc) != ESP_OK ||
+        rmt_enable(channel) != ESP_OK)
+    {
+        if (simple_enc) rmt_del_encoder(simple_enc);
+        rmt_del_channel(channel);
+        esp_rom_gpio_connect_out_signal(PIN_UART2_TX,
+            uart_periph_signal[2].pins[SOC_UART_TX_PIN_IDX].signal, false, false);
+        return false;
+    }
+
+    _fsk_rmt_channel  = channel;
+    _fsk_rmt_encoder  = simple_enc;
+    _fsk_signal_active = true;
+    return true;
+}
+
+void sioCassette::fsk_signal_emit()
+{
+    if (!_fsk_signal_active || _fsk_buf == nullptr || _fsk_value_count == 0) return;
+
+    rmt_channel_handle_t channel = (rmt_channel_handle_t)_fsk_rmt_channel;
+    rmt_encoder_handle_t encoder = (rmt_encoder_handle_t)_fsk_rmt_encoder;
+
+    rmt_transmit_config_t tx_cfg = {};
+    tx_cfg.loop_count      = 0;
+    tx_cfg.flags.eot_level = 0;
+
+    // ONE continuous transaction: hand the whole preloaded buffer to the simple
+    // encoder. fsk_encode_cb fills RMT ping-pong memory on demand; there is no
+    // reused stack payload of ours and no per-batch queuing gap (finding 1/3).
+    if (rmt_transmit(channel, encoder, _fsk_buf, _fsk_data_avail, &tx_cfg) != ESP_OK)
+        Debug_println("FSK: rmt_transmit error");
+
+    rmt_tx_wait_all_done(channel, -1);              // finish before buffer/channel teardown
+}
+
+void sioCassette::fsk_signal_end()
+{
+    if (!_fsk_signal_active) return;                // idempotent: no-op if never started
+
+    rmt_channel_handle_t channel = (rmt_channel_handle_t)_fsk_rmt_channel;
+    rmt_tx_wait_all_done(channel, -1);
+    rmt_disable(channel);
+    rmt_del_channel(channel);
+    if (_fsk_rmt_encoder) rmt_del_encoder((rmt_encoder_handle_t)_fsk_rmt_encoder);
+
+    _fsk_rmt_channel  = nullptr;
+    _fsk_rmt_encoder  = nullptr;
+
+    // Reattach UART2 TX to the pin; baud divisor untouched (Req 4.3/5.3)
+    esp_rom_gpio_connect_out_signal(PIN_UART2_TX,
+        uart_periph_signal[2].pins[SOC_UART_TX_PIN_IDX].signal, false, false);
+
+    _fsk_signal_active = false;
+}
+#endif
+```
+
+Because the simple encoder writes directly into RMT-provided ping-pong memory (there is no payload buffer of ours reused across queued transmits) and the whole waveform is one `rmt_transmit`, the queued-buffer lifetime hazard and the inter-transmit gap of the old copy-encoder batch approach are both eliminated. The only buffer we own, the pre-read `buf`, stays valid for the entire single transaction and is freed only after `rmt_tx_wait_all_done` in `fsk_signal_end`. RMT is hardware-timed, so once queued the waveform is emitted without CPU busy-waiting and is immune to task/interrupt jitter. `fsk_encode_cb` (shown in *Signal Reproduction Mechanism*) does no file I/O and no allocation, reading only `_fsk_buf` plus O(1) state.
+
+---
+
+## Data Handling Summary
+
+- **Single pre-read:** the clamped data region (`min(chunk_length, filesize - data_start)` bytes) is read in ONE `fnio::fread` into a heap buffer before any emission; no file I/O occurs between emitted transitions (finding 2). This is the ONLY large allocation; no full-waveform segment vector exists.
+- **On-the-fly emission:** production derives portions from the pre-read bytes plus O(1) cursor/encoder state inside `fsk_encode_cb`; nothing materializes the whole waveform (finding 2/4).
+- **Little-endian reads:** `chunk_length`, `aux`/`irg_length`, and every FSK_Signal_Value are read as unsigned 16-bit little-endian, consistent with `struct tape_FUJI_hdr` and all existing chunk handling (Req 2.1).
+- **1/10 ms → ticks:** at the 1 µs/tick grid, 1/10 ms = 100 µs = 100 ticks, so `ticks = fsk_ticks_for_value(value) = value * 100` exactly (Req 2.4). The single shared `fsk_ticks_for_value` helper is used by BOTH the production ISR callback (`fsk_encode_cb`) and the host-test cursor (`fsk_view_step`), so they cannot model different durations.
+- **IRG units:** `irg_length` is already in milliseconds; used directly (Req 2.2).
+- **Value count:** `fsk_value_count(data_avail) = floor(min(chunk_length, bytes_available) / 2)` (Req 2.3, 6.4).
+- **Index parity level:** `fsk_level_for_index(value_index) = (value_index & 1)` (Req 2.5, 4.2, 4.6).
+- **On-the-fly split:** each value's `value * 100` ticks are split into `ceil(value * 100 / 32767)` consecutive same-level portions of at most 32767 ticks by `fsk_next_portion` (RMT 15-bit limit); e.g. value 6818 → 21 portions, value 65535 → 201 portions (200 portions of 32767 ticks plus a final 100-tick portion). O(1) carried state, so portion count does not affect memory.
+
+---
+
+## Testing Strategy
+
+This feature combines **pure, host-buildable step functions** (`fsk_decode_le16`, `fsk_level_for_index`, `fsk_ticks_for_value`, `fsk_next_portion`, `fsk_value_count`, and the `FskChunkView` cursor stepped by `fsk_view_step`, all amenable to exhaustive/generated-input testing) with a **hardware side-effect layer** (RMT emission via `fsk_encode_cb`, verified by integration/manual tests). Both are needed for comprehensive coverage: generated-input tests verify universal correctness of decode/level/bounds/splitting across the whole input space; example and integration tests verify concrete fixtures and the hardware wiring. Because the production callback calls the same pure functions the tests exercise, and because nothing builds a full waveform, the tests step the cursor and check per-step invariants rather than asserting against a materialized list.
+
+Automated tests use the repository's existing **doctest** infrastructure (`tests/` directory, `components_pc/doctest`). No property-testing library is used; each correctness property is expressed as a doctest `TEST_CASE` driven by deterministic generated loops (iterating over ranges of `chunk_length`, offsets, value patterns, and seeded pseudo-random inputs with a fixed seed for reproducibility), following the `CalendarTests.cpp` pattern (`for (z=-50000; z<50000; z+=3)`).
+
+### Test wiring (`tests/CMakeLists.txt`)
+
+Add a new standalone executable `fsk_plan_tests`, linking only the unit-under-test (`fsk_plan.cpp`) plus the doctest headers, following the `calendar_tests` / `fujibuspacket_tests` pattern:
+
+```cmake
+add_executable(fsk_plan_tests
+    FskPlanTests.cpp
+    ${CMAKE_SOURCE_DIR}/lib/device/sio/fsk_plan.cpp
+)
+
+target_include_directories(fsk_plan_tests PRIVATE
+    ${CMAKE_SOURCE_DIR}/include/
+    ${CMAKE_SOURCE_DIR}/lib/
+    ${CMAKE_SOURCE_DIR}/lib/device/sio/
+    ${CMAKE_SOURCE_DIR}/components_pc/   # doctest
+)
+
+add_test(NAME fsk_plan_tests COMMAND fsk_plan_tests)
+```
+
+`fsk_plan.cpp` links standalone because it depends only on `<cstdint>` and `<cstddef>` (no `<vector>`, no FujiNet globals, no I/O, no hardware, no allocation), which is what makes these edge cases cheap to pin down here rather than on hardware.
+
+### Synthetic in-memory fixture
+
+For CI/repo tests, a minimal synthetic A8CAS byte array is built directly in the test (Night Knight.cas is not committed — see below). It contains representative chunks in file order:
+
+- a `FUJI` header chunk,
+- two `baud` chunks (600 then 790),
+- one or more `data` chunks,
+- `fsk ` chunks whose values exercise the grid and the split path: short **value 1 (100 ticks, 1 portion)** and **value 2 (200 ticks, 1 portion)** values, a representative **value 6818 (681,800 ticks → 21 portions)**, a value **40000 (4,000,000 ticks → `ceil(4000000/32767) = 123` portions)**, and the maximum **value 65535 (6,553,500 ticks → 201 portions: 200 portions of 32767 ticks plus a final 100-tick portion)**. Tick totals are asserted as `value * 100` and portion counts as `ceil(value * 100 / 32767)`.
+
+Tests pass the known `fsk ` payload region from this synthetic byte array to the pure cursor and assert the emitted portions. The standalone `fsk_plan_tests` target validates FSK payload semantics only; it does not instantiate the full cassette subsystem or claim to exercise `send_FUJI_tape_block`. Interleaved chunk-walk behavior is covered by the PC-build integration check and the real-hardware/manual acceptance run. Because the fixture is built in the test, the tests are fully generic (Req 9.4/9.8) and derive nothing from any filename.
+
+### Unit tests (example-based, doctest)
+
+- **Req 2.7 worked example:** `chunk_length = 10`, `aux = 0x0111` (273 ms), data `00 01 10 01 80 00 20 00 80 02`. Assert `irg_ms == 273` and stepping the cursor yields five values whose tick totals are `value * 100`: value 256 → logical 0, 25,600 ticks (`ceil(25600/32767) = 1` portion); value 272 → logical 1, 27,200 ticks (1 portion); value 128 → logical 0, 12,800 ticks (1 portion); value 32 → logical 1, 3,200 ticks (1 portion); value 640 → logical 0, 64,000 ticks (`ceil(64000/32767) = 2` portions of 32767 + 31233). Each value's portions sum to `value * 100`.
+- **Zero-length chunk (Req 2.8, 4.4):** `chunk_length = 0` → `fsk_value_count == 0`, cursor produces no portion and reports done, `irg_ms == aux`; caller next offset `O + 8`.
+- **Odd length (Req 6.4):** `data_len_available = 5` → 2 values, trailing byte ignored (never inside a complete pair).
+- **Multi-portion split, value 6818 (Property 5):** value 6818 → 681,800 ticks → exactly `ceil(681800/32767) = 21` same-level portions (twenty of 32767 plus one remainder), summing to 681,800.
+- **Multi-portion split, value 40000 (Property 5):** value 40000 → 4,000,000 ticks → exactly `ceil(4000000/32767) = 123` same-level portions, summing to 4,000,000.
+- **Multi-portion split, maximum value 65535 (Property 5):** value 65535 → 6,553,500 ticks → exactly `ceil(6553500/32767) = 201` same-level portions (200 portions of 32767 ticks plus a final 100-tick portion), summing to 6,553,500.
+- **Zero-duration value preserves parity (Req 4.6):** values `[10, 0, 10]` → the value at index 2 yields a logical-0 portion, unaffected by the zero at index 1 (which yields no portion but consumes its parity index, so the cursor skips it).
+
+### Property tests (doctest, generated loops)
+
+Each property is a `TEST_CASE` with a deterministic generated loop and is tagged:
+`// Feature: a8cas-fsk-chunk-playback, Property {N}: {property_text}`
+
+- **Property 1** — loop over `data_len_available`; assert `fsk_value_count(data_len_available) == data_len_available / 2`.
+- **Property 2** — generate pair arrays (fixed-seed PRNG); step the cursor over each value and assert its portions' ticks sum to `fsk_ticks_for_value(fsk_decode_le16(pair))`.
+- **Property 3** — generate value sequences including zeros; assert every produced portion's level == `fsk_level_for_index(index)` (index parity), and check `fsk_level_for_index` directly across a range of indices.
+- **Property 4** — generate lengths/patterns; step the cursor to done and assert every byte offset it reads lies within `[0, data_len_available)` (a debug-instrumented accessor records the max index touched); assert `byte_pos <= data_len_available` at every step.
+- **Property 5** — apply `fsk_next_portion` repeatedly against carried remaining ticks for values across `[0, 65535]`; each value V maps to `V * 100` ticks; assert each yields same-level portions of at most 32767 ticks summing to `V * 100` (0 → no portion), and assert the exact portion count `ceil(V * 100 / 32767)` for `V >= 1` (e.g. 1 → 1, 256 → 1, 6818 → 21, 40000 → 123, 65535 → 201).
+- **Property 6** — exercise the caller's bounds logic on generated offsets/filesizes; assert `< 8` remaining → 0, overrun → 0, well-formed → `O + 8 + L`.
+- **Property 7** — assert the pure step functions carry no baud action for any generated chunk (structural: none of the types or functions has a baud field or a `setBaudrate` call).
+- **Property 8** — generate zero-length chunks; assert `fsk_value_count == 0`, the cursor produces zero portions, and caller next offset `O + 8`.
+
+### Night Knight.cas — manual/hardware acceptance only
+
+"Night Knight.cas" is treated as a **local/manual real-hardware acceptance fixture only** (redistribution rights unknown); it is **not committed** to the repository and is **not** used by automated CI tests. On real Atari hardware with a board where `PIN_UART2_TX` is wired (e.g. default GPIO 21):
+
+- Load Night Knight.cas and confirm it boots/loads. This validates the RMT detach/emit/reattach path and that `data` records after `fsk ` records still transmit at the correct baud (Req 5.2, 5.3).
+- Documented fixture properties for the manual check: **36,785 bytes**, **259 chunks** = **1 FUJI + 2 baud + 249 data + 7 fsk**, baud **600 → 790**, first FSK chunk's first value **6818** (681.8 ms) (Req 9.5–9.7). These are asserted by observation during the manual run, derived from the file contents only (Req 9.4/9.8).
+- **Timing tolerance** is validated here per the requirements' deferral (Req 3.1): confirm the exact `value * 100`-tick RMT durations (1 µs/tick) are within the tape decoder's tolerance for the fixture.
+- **NC-pin board:** on a board where `PIN_UART2_TX == GPIO_NUM_NC`, confirm `fsk_signal_begin()` returns false, FSK chunks are skipped with a log line, and subsequent `data` playback is unaffected (Req 4.5).
+- **Motor-line abort:** de-assert the motor line during a long IRG (> 1000 ms) and confirm the chunk aborts, cleanup reattaches UART, it retries from `starting_offset`, and baud is preserved (Req 3.3, 3.4).
+
+### PC build verification
+
+- Compile the fujinet-pc build; confirm the FSK path compiles with no GPIO/RMT calls (Req 8.1). Run `fsk_plan_tests` on the host. Confirm an image with FSK chunks honors the IRG via `bus_idle`, advances past well-formed chunks, terminates at EOT for overrun chunks, and continues `data` playback without crash or hang (Req 8.2, 8.4).
+
+---
+
+## Traceability
+
+### Requirement → design element
+
+| Requirement | Design element |
+|---|---|
+| 1.1 Detect `fsk ` | `p[0..3]=='f','s','k',' '` branch in loop |
+| 1.2 Reproduce + advance `len+8` | Well-formed: `play_fsk_chunk` returns `offset + 8 + chunk_length` |
+| 1.3 Zero-length advances 8 | `chunk_length==0` → `next_offset = offset + 8` |
+| 1.4 Payload past EOF clamped | `data_avail = min(chunk_length, remaining_after_hdr)`; overrun → return 0 (EOT) |
+| 1.5 Interleaved chunk type | `fsk ` handled in same loop as `baud`/`data`, `continue` |
+| 1.6 Unknown type advances `len+8` | Catch-all `offset += 8 + len` (unchanged) |
+| 1.7 Detect by type only | Only `chunk_type` bytes inspected; no filename logic |
+| 2.1–2.4 LE parse, 1/10 ms, IRG ms | *Data Models*, `fsk_decode_le16`, `ticks = value * 100`, `irg_ms` direct |
+| 2.5 Index parity level | `fsk_level_for_index(i) = (i & 1)` |
+| 2.6 No invented timings | Durations only from data/aux |
+| 2.7 Worked example | doctest unit test (cursor stepped) |
+| 2.8 Zero-length | `fsk_value_count == 0`, cursor produces nothing, caller returns `offset+8` |
+| 3.1/3.2 IRG honored / 0 = none | Gap loop; `gap==0` skips loop |
+| 3.3 Motor abort >1000 ms | `has_pulldown() && !motor_line() && gap>1000` → cleanup, `starting_offset` |
+| 3.4 Abort safe, baud preserved | `goto done` → `fsk_signal_end` reattaches UART, no baud change |
+| 4.1/4.2 Drive by index order/parity | Cursor value order + `fsk_level_for_index(i)`; `fsk_encode_cb` emits portions in order |
+| 4.3 Restore normal playback | `fsk_signal_end()` reattaches UART (single cleanup path) |
+| 4.4 Zero values → IRG only | `value_count == 0` branch (no `fsk_signal_emit`) |
+| 4.5 Cannot drive → safe skip | `fsk_signal_begin()` false / NC pin / RMT alloc fail / pre-read malloc fail → skip + advance |
+| 4.6 Zero-duration preserves parity | Cursor: 0 ticks → no portion, parity index still consumed (skipped) |
+| 5.1–5.3 Baud invariant | No `setBaudrate` in FSK path; RMT teardown touches pin routing only |
+| 5.4/5.5 Failure preserves baud | Single cleanup path reattaches UART on every branch; baud untouched |
+| 6.1 Header truncation | `< 8` bytes → return 0 |
+| 6.2 Bounded reads | Single clamped pre-read; cursor indexes only `[0, data_avail)` |
+| 6.3/6.5 Truncated data | Clamp + partial reproduce + terminate at real boundary (return 0 EOT) |
+| 6.4 Odd length | `value_count = data_avail / 2` floor |
+| 6.6 Deterministic termination | All branches funnel to `done:` and return an offset, non-blocking |
+| 7.1 Standard no regression | FSK branch never taken for `baud`/`data`-only images |
+| 7.2/7.3/7.4/7.6 Other paths unchanged | Only FUJI path modified; QROS keeps skipping `fsk ` |
+| 7.5 Detection unchanged | `check_for_FUJI_file` untouched |
+| 8.1 PC compiles | `play_fsk_chunk` platform split; RMT helpers ESP-only |
+| 8.2 PC safe handling | `#else` branch: pre-read + value_count + deterministic IRG idle, no signal, continue |
+| 8.3/8.4 PC bounds | Shared clamp/pre-read logic; overrun → EOT |
+| 9.1–9.3 Interleaved order | Loop walks in file order, `continue` after FSK |
+| 9.4/9.8 No filename/fixture logic | Behavior derived only from chunk bytes; synthetic fixture in tests |
+| 9.5–9.7 Night Knight assertions | Manual/hardware acceptance run (not committed) |
+
+### Deferred decision → requirement satisfaction
+
+- **Signal mechanism (Req 4):** ESP RMT at 1 MHz (1 µs/tick, T2K precedent) with a stateful simple encoder (`fsk_encode_cb`, mirroring `t2k_encode_cb`) emits each value at its index-parity level for exactly `value * 100` ticks in a single continuous `rmt_transmit`, splitting each value's `value * 100` ticks into `ceil(value * 100 / 32767)` same-level portions on the fly (e.g. 6818 → 21 portions, 65535 → 201 portions) with O(1) carried state, then reattaches UART. Satisfies 4.1/4.2/4.3 and, via NC-pin / `begin()`-failure / pre-read-alloc-failure / abort handling, 4.5/4.6. One continuous transaction is gapless and owns no reused stack payload, so it is jitter-free (hardware-timed) and free of the queued-buffer lifetime hazard, so short 100 µs alternating values are emitted correctly regardless of scheduler/interrupt activity.
+- **Level mapping (Req 2.5, 4.2, 4.6):** even→logical 0→level bit 0 (LOW), odd→logical 1→level bit 1 (HIGH, mark), matching QROS pilot HIGH=mark; zero-duration value produces no portion but preserves index parity.
+- **Malformed policy (Req 1.4, 6.3–6.5):** graceful partial reproduction with reads clamped to file size; no OOB/hang/crash; truncated header or overrun → end-of-tape (return 0), terminating at the real boundary.
+- **Error propagation (Req 3.4, 4.5, 5.4, 5.5):** existing return-offset + `Debug_printf`; `starting_offset` = retry, `0` = EOT; single idempotent cleanup path guarantees UART reattach and baud invariance on every branch.
+- **PC build (Req 8):** pre-read + value_count + deterministic IRG via `bus_idle` + advance (overrun → EOT), no raw signal — compiles and preserves subsequent `data` playback.
+- **Baud preservation (Req 5):** never calls `setBaudrate`; RMT teardown reattaches only the UART TX pin routing, so the baud divisor is untouched and baud is automatically restored on all paths.

--- a/.kiro/specs/a8cas-fsk-chunk-playback/requirements.md
+++ b/.kiro/specs/a8cas-fsk-chunk-playback/requirements.md
@@ -1,0 +1,148 @@
+# Requirements Document
+
+## Introduction
+
+FujiNet firmware plays back Atari 8-bit cassette (CAS) images through the SIO cassette subsystem (`lib/device/sio/cassette.cpp`, guarded by `BUILD_ATARI`). It currently supports standard 600 baud A8CAS playback (`data`/`baud` chunks via `send_FUJI_tape_block`), Turbo 2000 PWM (`send_turbo2000_tape_block`), and QROS turbo (`send_QROS_tape_block`). A8CAS raw FSK chunks (chunk type `"fsk "`, where the fourth byte is a SPACE) are not reproduced during normal FUJI playback; the current FUJI loop skips unrecognized chunks by advancing past them, so any signal carried by an `fsk ` chunk is silently dropped.
+
+This feature adds standards-based reproduction of A8CAS `"fsk "` chunks within the normal FUJI cassette playback path, following the authoritative A8CAS CAS format specification (https://a8cas.sourceforge.net/format-cas.html). The `"fsk "` type is treated as one chunk type among others; a single cassette image may interleave `FUJI`, `baud`, `data`, and `fsk ` chunks. The change must preserve compatibility with all existing cassette formats and must not introduce any filename-, game-, or country-specific detection. The Chilean commercial image "Night Knight.cas" is used only as a real-world interleaved-chunk acceptance example.
+
+These requirements describe behavior only. The hardware mechanism used to reproduce raw FSK signals, the concrete PC-build behavior for FSK chunks, and any acceptable hardware timing tolerances are out of scope for this document and are to be determined and justified in the Technical Design and the Test Plan.
+
+## Glossary
+
+- **CAS_Image**: An A8CAS-format Atari cassette image file, beginning with a `FUJI` header chunk and containing a sequence of chunks.
+- **Chunk**: A unit within a CAS_Image consisting of an 8-byte header (`chunk_type[4]`, `chunk_length` as uint16 little-endian, `aux`/`irg_length` as uint16 little-endian) followed by `chunk_length` bytes of data. Each Chunk occupies `chunk_length + 8` bytes. Represented in code as `struct tape_FUJI_hdr`.
+- **Chunk_Type**: The 4-byte identifier at the start of a Chunk (e.g. `data`, `baud`, `fsk ` where the fourth byte is 0x20 SPACE).
+- **FSK_Chunk**: A Chunk whose Chunk_Type equals the four bytes 0x66 0x73 0x6B 0x20 (`'f'`, `'s'`, `'k'`, `' '`). Its `aux` field carries the Inter-Record Gap length in milliseconds; its data is a sequence of alternating signal durations.
+- **FSK_Signal_Value**: One unsigned 16-bit little-endian value inside an FSK_Chunk data area, expressed in units of 1/10 millisecond. Value 0x0100 (256) equals 25.6 ms.
+- **FSK_Signal_Index**: The zero-based position of an FSK_Signal_Value within the FSK_Chunk data sequence. The A8CAS logical level of a value is determined by the parity of its index: an even index (0, 2, 4, ...) is logical 0 and an odd index (1, 3, 5, ...) is logical 1.
+- **Inter_Record_Gap (IRG)**: A silent gap preceding a record, in milliseconds, carried in the Chunk `aux`/`irg_length` field.
+- **Cassette_Subsystem**: The FujiNet Atari SIO cassette playback component (`sioCassette`) responsible for interpreting CAS_Image chunks and driving the SIO data line during playback.
+- **FUJI_Playback_Path**: The normal (non-turbo) playback routine `send_FUJI_tape_block` that walks chunks, applies `baud` changes, and emits `data` records.
+- **Standard_Playback**: Existing 600 baud A8CAS playback of `data` records through the SIO UART at the active baud rate.
+- **Turbo2000_Playback**: Existing Turbo 2000 PWM playback path (`send_turbo2000_tape_block`).
+- **QROS_Playback**: Existing QROS turbo playback path (`send_QROS_tape_block`), which explicitly skips `fsk` chunks.
+- **Active_Baud_Rate**: The SIO baud rate currently applied to the bus (set from `baud` chunks via `SYSTEM_BUS.setBaudrate`) and used for subsequent `data` records.
+- **Data_Line**: The SIO signal line driven to the Atari during cassette playback. The Cassette_Subsystem sets this line's logical level over time to convey both normal `data` records and raw FSK signals.
+- **ESP_Build**: A firmware build where `ESP_PLATFORM` is defined (target hardware capable of raw FSK signal reproduction).
+- **PC_Build**: The fujinet-pc build where `ESP_PLATFORM` is not defined and raw hardware signal generation is unavailable.
+- **Motor_Line**: The cassette motor control signal; playback honors motor de-assertion during long gaps.
+
+## Requirements
+
+### Requirement 1: Detect FSK chunks within normal FUJI playback
+
+**User Story:** As a FujiNet user playing an A8CAS cassette, I want `fsk ` chunks to be recognized during normal playback, so that images containing raw FSK records are reproduced instead of silently skipped.
+
+#### Acceptance Criteria
+
+1. WHEN the FUJI_Playback_Path encounters a Chunk whose Chunk_Type equals the bytes 0x66 0x73 0x6B 0x20, THE Cassette_Subsystem SHALL classify the Chunk as an FSK_Chunk.
+2. WHEN the FUJI_Playback_Path classifies a Chunk as an FSK_Chunk whose declared chunk_length is greater than zero and whose payload lies entirely within the CAS_Image, THE Cassette_Subsystem SHALL reproduce the FSK_Chunk payload on the Data_Line and, upon completing the payload, SHALL advance the read offset by chunk_length + 8 bytes before reading the next Chunk.
+3. WHEN the FUJI_Playback_Path classifies a Chunk as an FSK_Chunk whose declared chunk_length equals zero, THE Cassette_Subsystem SHALL advance the read offset by 8 bytes to the next Chunk without driving the Data_Line.
+4. IF the FUJI_Playback_Path classifies a Chunk as an FSK_Chunk whose declared chunk_length would extend the payload past the end of the CAS_Image, THEN THE Cassette_Subsystem SHALL bound the data read to the bytes remaining in the CAS_Image, SHALL NOT read past the end of the file, and SHALL safely terminate processing of that FSK_Chunk, where whether the fully-present FSK_Signal_Values are partially reproduced or the FSK_Chunk is rejected is deferred to Technical Design unless the A8CAS specification requires a specific behavior.
+5. THE Cassette_Subsystem SHALL treat `fsk ` as a Chunk_Type that may appear interleaved with `FUJI`, `baud`, and `data` Chunk_Types within a single CAS_Image.
+6. WHERE a Chunk_Type is not one of `data`, `baud`, or `fsk `, THE Cassette_Subsystem SHALL advance the read offset by chunk_length + 8 bytes and continue to the next Chunk.
+7. THE Cassette_Subsystem SHALL determine whether a Chunk is an FSK_Chunk solely from the 4-byte Chunk_Type and SHALL NOT use the CAS_Image filename, game identity, or country of origin as a detection input.
+
+### Requirement 2: Parse FSK chunk structure per the A8CAS specification
+
+**User Story:** As a developer maintaining cassette support, I want FSK chunks parsed exactly as the A8CAS format defines, so that reproduced signals match the recorded data without invented timings.
+
+#### Acceptance Criteria
+
+1. THE Cassette_Subsystem SHALL read the FSK_Chunk `chunk_length` and `aux` fields as unsigned 16-bit little-endian values.
+2. THE Cassette_Subsystem SHALL interpret the FSK_Chunk `aux` field as the Inter_Record_Gap length in milliseconds preceding the record.
+3. THE Cassette_Subsystem SHALL interpret the FSK_Chunk data area as a sequence of floor(`chunk_length` / 2) FSK_Signal_Values, each read as an unsigned 16-bit little-endian value.
+4. THE Cassette_Subsystem SHALL interpret each FSK_Signal_Value as a signal duration in units of 1/10 millisecond.
+5. THE Cassette_Subsystem SHALL assign each FSK_Signal_Value a logical level by its FSK_Signal_Index parity, so that the value at index 0 is logical 0, the value at index 1 is logical 1, the value at index 2 is logical 0, and so on.
+6. THE Cassette_Subsystem SHALL derive all FSK signal timings from the FSK_Chunk data and `aux` fields and SHALL NOT substitute hardcoded or invented signal timings.
+7. WHEN the FUJI_Playback_Path processes an FSK_Chunk with a `chunk_length` of 10, an `aux` of 0x0111, and a data area of 0x00 0x01 0x10 0x01 0x80 0x00 0x20 0x00 0x80 0x02, THE Cassette_Subsystem SHALL honor a 273 ms Inter_Record_Gap and reproduce five durations by FSK_Signal_Index of 25.6 ms at logical 0, 27.2 ms at logical 1, 12.8 ms at logical 0, 3.2 ms at logical 1, and 64 ms at logical 0.
+8. WHEN the FUJI_Playback_Path processes an FSK_Chunk with a `chunk_length` of 0, THE Cassette_Subsystem SHALL honor the Inter_Record_Gap specified by the `aux` field and reproduce zero FSK_Signal_Values.
+
+### Requirement 3: Honor the Inter-Record Gap before FSK signal output
+
+**User Story:** As a FujiNet user, I want the gap before each FSK record honored, so that FSK records are timed correctly relative to surrounding records.
+
+#### Acceptance Criteria
+
+1. WHEN the FUJI_Playback_Path begins reproducing an FSK_Chunk, THE Cassette_Subsystem SHALL read the Inter_Record_Gap duration in milliseconds from the FSK_Chunk `aux` field, interpreted as an unsigned value in the range 0 to 65535 ms, and SHALL delay for that duration before emitting the first FSK_Signal_Value. Any acceptable hardware timing tolerance for this delay is out of scope for these requirements and is to be justified in Technical Design and the Test Plan.
+2. IF the Inter_Record_Gap duration read from the FSK_Chunk `aux` field is 0 ms, THEN THE Cassette_Subsystem SHALL emit the first FSK_Signal_Value without applying any delay.
+3. WHILE honoring an Inter_Record_Gap that exceeds 1000 ms, IF a pulldown is present and the Motor_Line is de-asserted, THEN THE Cassette_Subsystem SHALL abort reproduction of the current FSK_Chunk, SHALL stop emitting FSK_Signal_Value output, and SHALL return the read offset to the position at which the current record began.
+4. WHEN reproduction is aborted due to a de-asserted Motor_Line during an Inter_Record_Gap, THE Cassette_Subsystem SHALL terminate reproduction of the current FSK_Chunk safely without hanging or crashing, SHALL preserve the normal playback state and the Active_Baud_Rate, and SHALL NOT corrupt subsequent normal `data` playback. The concrete mechanism, if any, for propagating that reproduction did not complete is to be determined in Technical Design after inspecting the existing cassette subsystem interfaces.
+
+### Requirement 4: Reproduce the FSK signal on the data line (ESP build)
+
+**User Story:** As a FujiNet user on target hardware, I want FSK signals emitted on the cassette data line, so that the Atari receives the raw FSK sequence recorded in the image.
+
+#### Acceptance Criteria
+
+1. WHERE the build is an ESP_Build, WHEN reproducing an FSK_Chunk, THE Cassette_Subsystem SHALL drive the Data_Line to reproduce each FSK_Signal_Value in FSK_Signal_Index order, holding each value at its A8CAS logical level for its A8CAS-specified duration.
+2. WHERE the build is an ESP_Build, WHEN reproducing an FSK_Chunk, THE Cassette_Subsystem SHALL set the Data_Line logical level for each FSK_Signal_Value from its FSK_Signal_Index parity, so that an even index is logical 0 and an odd index is logical 1, independent of the durations of any preceding FSK_Signal_Values.
+3. WHERE the build is an ESP_Build, WHEN FSK reproduction of a Chunk completes, THE Cassette_Subsystem SHALL restore normal `data` playback capability on the Data_Line before transmitting any subsequent `data` record.
+4. IF an FSK_Chunk contains zero FSK_Signal_Values, THEN THE Cassette_Subsystem SHALL leave the Data_Line at its current logical level, honor the Inter_Record_Gap for its specified duration expressed in milliseconds, and advance to the next Chunk while preserving normal `data` playback capability.
+5. WHERE the build is an ESP_Build, IF raw FSK signal reproduction cannot be performed, THEN THE Cassette_Subsystem SHALL terminate FSK reproduction of the current Chunk safely without hanging or crashing and SHALL NOT corrupt subsequent normal `data` playback. The concrete mechanism, if any, for propagating this failure is to be determined in Technical Design after inspecting the existing cassette subsystem interfaces.
+6. WHERE the build is an ESP_Build, IF an FSK_Signal_Value specifies a duration of zero, THEN THE Cassette_Subsystem SHALL continue with the next FSK_Signal_Value while preserving the FSK_Signal_Index parity of all following FSK_Signal_Values, such that a zero-duration value does not alter the logical level assigned to any subsequent FSK_Signal_Value.
+
+### Requirement 5: Preserve the active baud rate across FSK chunks
+
+**User Story:** As a FujiNet user, I want the SIO baud rate unchanged by FSK records, so that `data` records after an FSK record still transmit at the correct rate.
+
+#### Acceptance Criteria
+
+1. THE Cassette_Subsystem SHALL leave the Active_Baud_Rate value unchanged when processing an FSK_Chunk, such that the Active_Baud_Rate after the FSK_Chunk completes equals the Active_Baud_Rate immediately before the FSK_Chunk began.
+2. WHEN a `data` Chunk follows an FSK_Chunk without an intervening `baud` Chunk, THE Cassette_Subsystem SHALL transmit that `data` Chunk at the Active_Baud_Rate that was in effect immediately before the FSK_Chunk.
+3. WHEN FSK reproduction of a Chunk completes, THE Cassette_Subsystem SHALL restore the normal data-transmission capability that was in effect before the FSK_Chunk, configured to the Active_Baud_Rate that was in effect immediately before the FSK_Chunk.
+4. IF processing an FSK_Chunk fails before the FSK_Chunk completes, THEN THE Cassette_Subsystem SHALL terminate processing safely without hanging or crashing and SHALL retain the Active_Baud_Rate that was in effect immediately before the FSK_Chunk. The concrete mechanism, if any, for propagating this failure is to be determined in Technical Design after inspecting the existing cassette subsystem interfaces.
+5. IF normal data-transmission capability cannot be restored after an FSK_Chunk, THEN THE Cassette_Subsystem SHALL retain the Active_Baud_Rate that was in effect immediately before the FSK_Chunk and SHALL NOT corrupt subsequent normal `data` playback. The concrete mechanism, if any, for propagating this failure is to be determined in Technical Design after inspecting the existing cassette subsystem interfaces.
+
+### Requirement 6: Safe handling of malformed, truncated, and odd-length FSK chunks
+
+**User Story:** As a FujiNet user, I want damaged or unusual images handled without crashing, so that playback degrades safely rather than reading past the file or hanging.
+
+#### Acceptance Criteria
+
+1. IF an FSK_Chunk header cannot be fully read because fewer than the required header bytes remain before the end of the CAS_Image file, THEN THE Cassette_Subsystem SHALL stop processing the FSK_Chunk without reading past the end of the file and SHALL safely terminate processing of the FSK_Chunk without hanging or crashing.
+2. THE Cassette_Subsystem SHALL bound all FSK_Chunk data reads by the smaller of the declared `chunk_length` (valid range 0 to 65535 inclusive) and the number of bytes remaining in the CAS_Image file, SHALL perform no out-of-bounds reads, and SHALL NOT read past the end of the file.
+3. IF an FSK_Chunk header or its declared data extends beyond the CAS_Image file size, THEN THE Cassette_Subsystem SHALL safely terminate processing of that FSK_Chunk at the available data boundary without reading past the end of the file and without crashing or hanging, where whether the fully-present FSK_Signal_Values are partially reproduced or the FSK_Chunk is rejected is deferred to Technical Design unless the A8CAS specification requires a specific behavior.
+4. IF an FSK_Chunk `chunk_length` is an odd number, THEN THE Cassette_Subsystem SHALL handle the odd length with bounds checking and no out-of-bounds reads, where whether the fully-present 2-byte FSK_Signal_Values are partially reproduced or the FSK_Chunk is rejected, and how the trailing unpaired byte is treated, is deferred to Technical Design unless the A8CAS specification requires a specific behavior.
+5. IF an FSK_Chunk is truncated so that fewer than `chunk_length` data bytes are available before the end of the file, THEN THE Cassette_Subsystem SHALL handle the truncation with bounds checking and no out-of-bounds reads, SHALL NOT read past the end of the file, and SHALL safely terminate processing of that FSK_Chunk, where whether the fully-present FSK_Signal_Values are partially reproduced or the FSK_Chunk is rejected is deferred to Technical Design unless the A8CAS specification requires a specific behavior.
+6. WHEN a malformed, truncated, or odd-length FSK_Chunk is encountered, THE Cassette_Subsystem SHALL deterministically terminate processing of that FSK_Chunk and continue normal playback control flow without hanging or crashing.
+
+### Requirement 7: No regression of existing playback formats
+
+**User Story:** As an existing FujiNet user, I want standard, Turbo 2000, and QROS cassettes to keep working exactly as before, so that adding FSK support does not break current images.
+
+#### Acceptance Criteria
+
+1. WHEN a CAS_Image contains only `baud` and `data` Chunks and contains zero `fsk` Chunks, THE Cassette_Subsystem SHALL perform Standard_Playback and SHALL produce output byte-for-byte identical to the Standard_Playback output produced before FSK support was added for the same CAS_Image.
+2. WHEN a CAS_Image is detected as Turbo 2000 PWM, THE Cassette_Subsystem SHALL use Turbo2000_Playback and SHALL execute zero FSK_Chunk reproduction operations for that CAS_Image.
+3. WHEN a CAS_Image is detected as QROS, THE Cassette_Subsystem SHALL use QROS_Playback and SHALL skip every `fsk` Chunk in that CAS_Image without emitting any output for those Chunks, matching the pre-FSK-support behavior.
+4. WHILE the active playback path is not the FUJI_Playback_Path, THE Cassette_Subsystem SHALL execute zero FSK_Chunk reproduction operations.
+5. THE Cassette_Subsystem SHALL produce Turbo 2000 PWM and QROS detection outcomes that are equivalent to the pre-change behavior for any given CAS_Image, such that refactoring of the detection code is permitted only while the detection outcomes remain unchanged.
+6. IF a CAS_Image is detected as both a FUJI file and either Turbo 2000 PWM or QROS, THEN THE Cassette_Subsystem SHALL select the non-FUJI playback path (Turbo2000_Playback or QROS_Playback) and SHALL execute zero FSK_Chunk reproduction operations for that CAS_Image.
+
+### Requirement 8: Safe degradation on the PC build
+
+**User Story:** As a developer using the fujinet-pc build, I want FSK chunks handled without hardware signal generation, so that the PC build compiles and runs without attempting unavailable operations.
+
+#### Acceptance Criteria
+
+1. WHERE the build is a PC_Build, THE Cassette_Subsystem SHALL compile and operate without accessing hardware that is unsupported on the PC_Build.
+2. WHERE the build is a PC_Build, WHEN the FUJI_Playback_Path encounters an FSK_Chunk, THE Cassette_Subsystem SHALL handle the FSK_Chunk safely without invoking raw hardware Data_Line signal generation and SHALL continue processing subsequent Chunks without crashing or hanging, where the concrete PC_Build FSK playback behavior is deferred to Technical Design after inspecting platform capabilities.
+3. WHERE the build is a PC_Build, THE Cassette_Subsystem SHALL bound all FSK_Chunk reads by the number of bytes remaining in the CAS_Image, SHALL perform no out-of-bounds reads, and SHALL NOT read past the end of the file.
+4. WHERE the build is a PC_Build, IF an FSK_Chunk declares a chunk_length that would advance the read offset beyond the total byte length of the CAS_Image, or is truncated such that fewer than 8 header bytes remain, THEN THE Cassette_Subsystem SHALL safely terminate processing at the available data boundary without reading past the end of the file and without crashing or hanging.
+
+### Requirement 9: Real-world interleaved-chunk playback (acceptance example)
+
+**User Story:** As a FujiNet user with a Chilean commercial cassette image, I want an image that interleaves FSK records with normal records to play back, so that titles such as "Night Knight.cas" load correctly.
+
+#### Acceptance Criteria
+
+1. WHEN a CAS_Image interleaves `baud`, `data`, and `fsk ` Chunks, THE Cassette_Subsystem SHALL process every Chunk in ascending file order, reproducing each `fsk ` Chunk as an FSK_Chunk and transmitting each `data` Chunk at the Active_Baud_Rate, until all Chunks in the CAS_Image have been processed.
+2. WHEN the Cassette_Subsystem encounters a `baud` Chunk, THE Cassette_Subsystem SHALL set the Active_Baud_Rate to the value specified by that `baud` Chunk and apply it to every subsequent `data` Chunk until the next `baud` Chunk is encountered.
+3. IF the Cassette_Subsystem encounters a Chunk whose Chunk_Type is not `baud`, `data`, or `fsk `, THEN THE Cassette_Subsystem SHALL skip that Chunk, continue processing the next Chunk in file order, and retain the current Active_Baud_Rate and playback position.
+4. THE Cassette_Subsystem SHALL reproduce the interleaved CAS_Image without applying any filename-specific, game-specific, or country-specific logic.
+5. WHERE the "Night Knight.cas" test fixture is used, THE Cassette_Subsystem SHALL play back a 36,785-byte CAS_Image containing 259 Chunks in total, comprising 1 `FUJI` Chunk, 2 `baud` Chunks, 249 `data` Chunks, and 7 `fsk ` Chunks, processing every Chunk in ascending file order until all Chunks have been processed.
+6. WHERE the "Night Knight.cas" test fixture is used, WHEN the Cassette_Subsystem processes the fixture's `baud` Chunks in file order, THE Cassette_Subsystem SHALL begin playback at an Active_Baud_Rate of 600 baud and later switch the Active_Baud_Rate to 790 baud.
+7. WHERE the "Night Knight.cas" test fixture is used, WHEN the Cassette_Subsystem reproduces the fixture's first FSK_Chunk, THE Cassette_Subsystem SHALL treat the first FSK_Signal_Value as the raw value 6818, representing 681.8 ms.
+8. THE Cassette_Subsystem SHALL derive all playback behavior solely from the contents of the CAS_Image Chunks and SHALL NOT derive behavior from the CAS_Image filename or from the fixture Chunk counts, sizes, or values stated for the "Night Knight.cas" test fixture.

--- a/.kiro/specs/a8cas-fsk-chunk-playback/tasks.md
+++ b/.kiro/specs/a8cas-fsk-chunk-playback/tasks.md
@@ -221,7 +221,7 @@ Tasks should be completed in order. Each task includes the requirements it trace
     - On a configuration/target without a valid cassette TX pin, confirm raw signal output is skipped without breaking subsequent data playback.
     - _Requirements: 4.5, 5.5_
 
-- [ ] 10. Final review and pull-request readiness
+- [x] 10. Final review and pull-request readiness
   - [x] 10.1 Review the diff for scope discipline
     - Confirm changes are limited to generic A8CAS FSK support, tests, and required build wiring.
     - Confirm there is no Night Knight/game/country-specific code.
@@ -234,10 +234,10 @@ Tasks should be completed in order. Each task includes the requirements it trace
   - [x] 10.3 Verify working tree contents before commit
     - Ensure `Night Knight.cas` is untracked/ignored and not staged.
     - Ensure no generated binaries or temporary test artifacts are staged.
-  - [-] 10.4 Prepare implementation commits
+  - [x] 10.4 Prepare implementation commits
     - Keep commits logically grouped (pure parser/tests, cassette integration/RMT, final fixes) where practical.
     - Do not modify `master`; commit only on `feature/a8cas-fsk-playback`.
-  - [ ] 10.5 Prepare the future Pull Request description
+  - [x] 10.5 Prepare the future Pull Request description
     - Summarize the standards-based A8CAS `fsk ` support.
     - Explain the RMT 1 MHz implementation and preservation of existing formats.
     - Include automated-test/build results and manual hardware validation.

--- a/.kiro/specs/a8cas-fsk-chunk-playback/tasks.md
+++ b/.kiro/specs/a8cas-fsk-chunk-playback/tasks.md
@@ -208,7 +208,7 @@ Tasks should be completed in order. Each task includes the requirements it trace
     - Confirm the baud transition 600 → 790.
     - Confirm the first FSK value is 6818 = 681.8 ms.
     - _Requirements: 9.5-9.7_
-  - [ ] 9.3 Load `Night Knight.cas` on a physical Atari through FujiNet
+  - [x] 9.3 Load `Night Knight.cas` on a physical Atari through FujiNet
     - Confirm the title loads successfully.
     - Confirm playback proceeds through interleaved `baud`, `data`, and `fsk ` chunks.
     - Confirm data following FSK playback continues at the active baud.

--- a/.kiro/specs/a8cas-fsk-chunk-playback/tasks.md
+++ b/.kiro/specs/a8cas-fsk-chunk-playback/tasks.md
@@ -79,8 +79,8 @@ Tasks should be completed in order. Each task includes the requirements it trace
     - Keep ESP-specific declarations behind `#ifdef ESP_PLATFORM`.
     - _Requirements: 4.1-4.6, 5.1-5.5, 8.1_
 
-- [ ] 4. Implement the ESP RMT FSK encoder
-  - [ ] 4.1 Implement `fsk_encode_cb`
+- [x] 4. Implement the ESP RMT FSK encoder
+  - [x] 4.1 Implement `fsk_encode_cb`
     - Mirror the existing Turbo 2000 simple-encoder callback pattern.
     - Set `*done = false` at the beginning of every callback invocation.
     - Decode values from the already preloaded payload only.
@@ -91,7 +91,7 @@ Tasks should be completed in order. Each task includes the requirements it trace
     - Set `*done = true` only after the final portion of the final value is emitted.
     - Perform no file I/O, heap allocation, or logging from the callback.
     - _Requirements: 2.1, 2.4, 2.5, 4.1, 4.2, 4.6_
-  - [ ] 4.2 Implement `fsk_signal_begin`
+  - [x] 4.2 Implement `fsk_signal_begin`
     - Flush pending UART output before taking control of the TX pin.
     - Use `PIN_UART2_TX` and the same detach/reattach routing approach as the existing cassette RMT/QROS code.
     - Configure RMT TX at 1 MHz using `RMT_CLK_SRC_DEFAULT`.
@@ -100,12 +100,12 @@ Tasks should be completed in order. Each task includes the requirements it trace
     - Return failure cleanly for `GPIO_NUM_NC` or any RMT setup failure.
     - Fully undo partial setup on failure.
     - _Requirements: 4.1, 4.3, 4.5, 5.3-5.5_
-  - [ ] 4.3 Implement `fsk_signal_emit`
+  - [x] 4.3 Implement `fsk_signal_emit`
     - Issue exactly one `rmt_transmit` for the complete preloaded FSK payload.
     - Wait for completion before buffer teardown.
     - Do not use repeated transmit batches.
     - _Requirements: 4.1, 4.2_
-  - [ ] 4.4 Implement idempotent `fsk_signal_end`
+  - [x] 4.4 Implement idempotent `fsk_signal_end`
     - Safely wait for any in-flight transmission.
     - Disable/delete the RMT channel and encoder.
     - Reattach UART2 TX routing.

--- a/.kiro/specs/a8cas-fsk-chunk-playback/tasks.md
+++ b/.kiro/specs/a8cas-fsk-chunk-playback/tasks.md
@@ -1,0 +1,262 @@
+# Implementation Plan: A8CAS FSK Chunk Playback
+
+## Overview
+
+This task list implements the approved requirements and technical design for generic A8CAS raw `fsk ` chunk playback in the Atari FujiNet cassette subsystem.
+
+Implementation must remain generic and standards-based. Do not add filename-, game-, country-, or Night Knight-specific detection. `Night Knight.cas` is a local/manual acceptance fixture only and must not be committed to the repository.
+
+Tasks should be completed in order. Each task includes the requirements it traces to.
+
+---
+
+## Tasks
+
+- [ ] 1. Add the pure FSK parsing/timing module
+  - [ ] 1.1 Create `lib/device/sio/fsk_plan.h`
+    - Define `FSK_MAX_PORTION_TICKS = 32767`.
+    - Define `FSK_RMT_TICKS_PER_A8CAS_UNIT = 100`.
+    - Implement `static inline uint32_t fsk_ticks_for_value(uint16_t value)`.
+    - Implement `static inline uint16_t fsk_decode_le16(const uint8_t *p)`.
+    - Implement `static inline bool fsk_level_for_index(size_t value_index)`.
+    - Implement `static inline uint32_t fsk_next_portion(uint32_t remaining_ticks)`.
+    - Implement `static inline size_t fsk_value_count(size_t data_len_available)`.
+    - Define `FskChunkView`, `FskStep`, and `fsk_view_init`.
+    - Keep ISR-used helpers allocation-free, I/O-free, logging-free, and safe to inline into the RMT callback.
+    - _Requirements: 2.1, 2.3, 2.4, 2.5, 4.1, 4.2, 4.6, 6.2, 6.4_
+  - [ ] 1.2 Create `lib/device/sio/fsk_plan.cpp`
+    - Implement host-test-only `fsk_view_step(FskChunkView &view)`.
+    - Use the shared decode/parity/scale/split helpers from `fsk_plan.h`.
+    - Skip zero-duration values while preserving original value-index parity.
+    - Never read outside `data_len_available`.
+    - Never allocate or materialize the complete waveform.
+    - _Requirements: 2.1, 2.3, 2.4, 2.5, 4.6, 6.2, 6.4_
+  - [ ] 1.3 Compile the pure module independently on the host
+    - Confirm `fsk_plan.cpp` has no FujiNet hardware, filesystem, GPIO, RMT, or global-state dependency.
+    - _Requirements: 8.1_
+
+- [ ] 2. Add automated doctest coverage for the pure FSK rules
+  - [ ] 2.1 Create `tests/FskPlanTests.cpp`
+    - Add the A8CAS worked example from Requirement 2.7.
+    - Test zero-length payload behavior.
+    - Test odd-length payload handling.
+    - Test zero-duration values preserving parity.
+    - Test values 1, 256, 6818, 40000, and 65535.
+    - Verify 6818 maps to 681,800 ticks and 21 portions.
+    - Verify 65535 maps to 6,553,500 ticks and 201 portions.
+    - _Requirements: 2.7, 2.8, 4.6, 6.4_
+  - [ ] 2.2 Implement deterministic generated-loop tests for correctness properties
+    - Property 1: `fsk_value_count(len) == len / 2`.
+    - Property 2: emitted portion ticks for each value sum to `fsk_ticks_for_value(fsk_decode_le16(pair))`.
+    - Property 3: every emitted portion level follows original value-index parity.
+    - Property 4: cursor byte reads stay within the available payload.
+    - Property 5: portions are `<= 32767`, preserve total duration, and have the correct portion count.
+    - Include the full uint16 value range for split arithmetic where practical.
+    - Use deterministic/fixed-seed inputs only.
+    - _Requirements: 2.1, 2.3, 2.4, 2.5, 4.1, 4.6, 6.2, 6.4_
+  - [ ] 2.3 Add synthetic FSK payload fixtures
+    - Build test byte arrays in source; do not add copyrighted `.cas` files.
+    - Include representative short, long, zero, and odd-tail values.
+    - Keep the tests generic and independent of filenames.
+    - _Requirements: 9.4, 9.8_
+  - [ ] 2.4 Register `fsk_plan_tests` in `tests/CMakeLists.txt`
+    - Follow the existing standalone doctest executable pattern.
+    - Link only `FskPlanTests.cpp`, `fsk_plan.cpp`, and the required include paths.
+    - _Requirements: 8.1_
+
+- [ ] 3. Extend `sioCassette` declarations for FSK playback
+  - [ ] 3.1 Update `lib/device/sio/cassette.h`
+    - Include or otherwise expose the pure FSK helper declarations where needed.
+    - Add cross-platform `play_fsk_chunk(size_t offset, uint16_t chunk_length, uint16_t irg_ms)`.
+    - Under `ESP_PLATFORM`, add:
+      - `fsk_signal_begin()`
+      - `fsk_signal_emit()`
+      - `fsk_signal_end()`
+      - `IRAM_ATTR fsk_encode_cb(...)`
+      - RMT handles/state
+      - preloaded buffer pointer/state
+      - value index, byte position, remaining ticks, and logical-level state
+    - Keep ESP-specific declarations behind `#ifdef ESP_PLATFORM`.
+    - _Requirements: 4.1-4.6, 5.1-5.5, 8.1_
+
+- [ ] 4. Implement the ESP RMT FSK encoder
+  - [ ] 4.1 Implement `fsk_encode_cb`
+    - Mirror the existing Turbo 2000 simple-encoder callback pattern.
+    - Set `*done = false` at the beginning of every callback invocation.
+    - Decode values from the already preloaded payload only.
+    - Use `fsk_decode_le16`, `fsk_level_for_index`, `fsk_ticks_for_value`, and `fsk_next_portion`.
+    - Preserve value-index parity across zero-duration values.
+    - Split long durations into consecutive same-level portions of at most 32767 ticks.
+    - Emit the whole signal in original value order.
+    - Set `*done = true` only after the final portion of the final value is emitted.
+    - Perform no file I/O, heap allocation, or logging from the callback.
+    - _Requirements: 2.1, 2.4, 2.5, 4.1, 4.2, 4.6_
+  - [ ] 4.2 Implement `fsk_signal_begin`
+    - Flush pending UART output before taking control of the TX pin.
+    - Use `PIN_UART2_TX` and the same detach/reattach routing approach as the existing cassette RMT/QROS code.
+    - Configure RMT TX at 1 MHz using `RMT_CLK_SRC_DEFAULT`.
+    - Create a stateful simple encoder with `callback = fsk_encode_cb` and `arg = this`.
+    - Use the established RMT channel lifecycle pattern from Turbo 2000.
+    - Return failure cleanly for `GPIO_NUM_NC` or any RMT setup failure.
+    - Fully undo partial setup on failure.
+    - _Requirements: 4.1, 4.3, 4.5, 5.3-5.5_
+  - [ ] 4.3 Implement `fsk_signal_emit`
+    - Issue exactly one `rmt_transmit` for the complete preloaded FSK payload.
+    - Wait for completion before buffer teardown.
+    - Do not use repeated transmit batches.
+    - _Requirements: 4.1, 4.2_
+  - [ ] 4.4 Implement idempotent `fsk_signal_end`
+    - Safely wait for any in-flight transmission.
+    - Disable/delete the RMT channel and encoder.
+    - Reattach UART2 TX routing.
+    - Clear RMT handles/state.
+    - Preserve the existing UART baud divisor.
+    - _Requirements: 4.3, 4.5, 5.1, 5.3-5.5_
+
+- [ ] 5. Implement cross-platform `play_fsk_chunk`
+  - [ ] 5.1 Implement file-boundary validation
+    - Treat fewer than 8 bytes of remaining header as end-of-tape.
+    - Compute available payload bytes using the declared length clamped to EOF.
+    - Never read beyond the CAS image.
+    - For overrun/truncated payloads, reproduce only complete values present and return the established end-of-tape result afterward.
+    - For odd lengths, ignore the trailing unpaired byte.
+    - _Requirements: 1.4, 6.1-6.6, 8.3, 8.4_
+  - [ ] 5.2 Implement one-time payload pre-read
+    - Allocate only `data_avail` bytes.
+    - Read the clamped payload in one file read before waveform emission starts.
+    - Never perform file I/O between FSK transitions.
+    - On allocation failure, skip raw signal emission safely, preserve baud/UART state, and continue using the designed offset behavior.
+    - Ensure the buffer is freed on every exit path.
+    - _Requirements: 4.5, 5.4, 5.5, 6.2, 6.6_
+  - [ ] 5.3 Implement FSK IRG handling
+    - Honor `irg_ms` before raw signal emission.
+    - Preserve the existing cassette gap/motor behavior.
+    - If the pulldown is present and the motor line is de-asserted while more than 1000 ms remains, abort safely and return `starting_offset`.
+    - Ensure LED state is restored on abort and normal completion.
+    - _Requirements: 2.2, 2.8, 3.1-3.4_
+  - [ ] 5.4 Implement ESP raw signal playback inside `play_fsk_chunk`
+    - Initialize the encoder state only after `fsk_signal_begin()` succeeds.
+    - Set `_fsk_buf`, data length/value count, byte position, value index, remaining ticks, and current level.
+    - Call `fsk_signal_emit()` only when complete FSK values exist.
+    - Ensure every success/failure path reaches the common cleanup.
+    - _Requirements: 4.1-4.6, 5.1-5.5_
+  - [ ] 5.5 Implement deterministic PC-build behavior
+    - Use the same pre-read and bounds logic.
+    - Honor the IRG through `SYSTEM_BUS.bus_idle`.
+    - Do not invoke RMT, GPIO, or raw hardware signal-generation APIs.
+    - Advance to the next well-formed chunk or terminate at EOT for an overrun/truncated chunk.
+    - _Requirements: 8.1-8.4_
+  - [ ] 5.6 Preserve Active_Baud_Rate through all paths
+    - Do not call `SYSTEM_BUS.setBaudrate` from FSK processing.
+    - Confirm success, motor abort, allocation failure, and RMT setup/transmit failure leave the active baud unchanged.
+    - _Requirements: 5.1-5.5_
+
+- [ ] 6. Integrate `fsk ` chunk handling into normal FUJI playback
+  - [ ] 6.1 Update the chunk walker in `send_FUJI_tape_block`
+    - Detect exactly the four bytes `'f','s','k',' '`.
+    - Add the branch before the existing unknown-chunk catch-all.
+    - Delegate the chunk to `play_fsk_chunk`.
+    - Continue walking after a successfully handled FSK chunk rather than treating it as a terminating `data` record.
+    - Preserve the current baud until an actual `baud` chunk changes it.
+    - _Requirements: 1.1-1.7, 5.1, 9.1-9.4_
+  - [ ] 6.2 Add truncated-header protection to the FUJI chunk walk
+    - Check the number of header bytes actually read before using the header.
+    - Return end-of-tape without reading invalid header fields when fewer than 8 bytes are available.
+    - _Requirements: 6.1, 8.4_
+  - [ ] 6.3 Preserve unknown-chunk behavior
+    - Keep the existing `chunk_length + 8` skip for chunk types other than `data`, `baud`, and `fsk `.
+    - Do not add any filename/game/country-specific handling.
+    - _Requirements: 1.6, 1.7, 9.3, 9.4, 9.8_
+
+- [ ] 7. Verify no regression in existing cassette paths
+  - [ ] 7.1 Confirm dispatcher behavior is unchanged
+    - Turbo 2000 continues to use `send_turbo2000_tape_block`.
+    - QROS continues to use `send_QROS_tape_block`.
+    - Only normal FUJI playback enters the new FSK path.
+    - _Requirements: 7.2-7.6_
+  - [ ] 7.2 Confirm no FSK code executes for standard `baud`/`data`-only images
+    - Compare normal standard playback behavior before/after the feature where practical.
+    - _Requirements: 7.1_
+  - [ ] 7.3 Confirm Turbo 2000 and QROS detection outcomes remain unchanged
+    - Do not modify detection unless required for compilation; if refactoring occurs, prove equivalent outcomes.
+    - _Requirements: 7.2-7.6_
+
+- [ ] 8. Run automated and build verification
+  - [ ] 8.1 Configure and run `fsk_plan_tests`
+    - Run the new doctest executable.
+    - Confirm all example and generated-loop tests pass.
+    - _Requirements: 2.1-2.8, 4.6, 6.2, 6.4_
+  - [ ] 8.2 Build fujinet-pc
+    - Confirm the new shared code compiles without ESP-only APIs leaking into the PC build.
+    - Exercise a synthetic/interleaved CAS image where possible and verify safe FSK skipping plus IRG handling.
+    - _Requirements: 8.1-8.4_
+  - [ ] 8.3 Build at least one classic ESP32 Atari FujiNet target
+    - Verify the RMT API/configuration compiles at 1 MHz.
+    - Check for warnings around IRAM, callback signatures, pin routing, and RMT handles.
+    - _Requirements: 4.1-4.5, 7.1_
+  - [ ] 8.4 Build at least one ESP32-S3 Atari FujiNet target if supported by the normal project build matrix
+    - Confirm the implementation remains portable across the supported ESP target family.
+    - _Requirements: 4.1-4.5, 7.1_
+
+- [ ] 9. Perform local real-hardware acceptance with `Night Knight.cas`
+  - [ ] 9.1 Keep `Night Knight.cas` outside the repository
+    - Do not add the file to Git, tests, fixtures, or the PR.
+    - Use it only for local/manual acceptance unless redistribution rights are established.
+    - _Requirements: 9.4, 9.8_
+  - [ ] 9.2 Verify the known fixture structure before hardware playback
+    - Confirm locally: 36,785 bytes, 259 total chunks, 1 `FUJI`, 2 `baud`, 249 `data`, 7 `fsk `.
+    - Confirm the baud transition 600 → 790.
+    - Confirm the first FSK value is 6818 = 681.8 ms.
+    - _Requirements: 9.5-9.7_
+  - [ ] 9.3 Load `Night Knight.cas` on a physical Atari through FujiNet
+    - Confirm the title loads successfully.
+    - Confirm playback proceeds through interleaved `baud`, `data`, and `fsk ` chunks.
+    - Confirm data following FSK playback continues at the active baud.
+    - _Requirements: 5.2, 5.3, 9.1-9.8_
+  - [ ] 9.4 Verify motor-line abort and recovery
+    - During a long IRG, de-assert the motor line where practical.
+    - Confirm safe abort/retry behavior, UART restoration, and baud preservation.
+    - _Requirements: 3.3, 3.4, 5.4_
+  - [ ] 9.5 Verify FSK setup failure degrades safely where practical
+    - On a configuration/target without a valid cassette TX pin, confirm raw signal output is skipped without breaking subsequent data playback.
+    - _Requirements: 4.5, 5.5_
+
+- [ ] 10. Final review and pull-request readiness
+  - [ ] 10.1 Review the diff for scope discipline
+    - Confirm changes are limited to generic A8CAS FSK support, tests, and required build wiring.
+    - Confirm there is no Night Knight/game/country-specific code.
+    - Confirm no unrelated cassette behavior was modified.
+    - _Requirements: 1.7, 7.1-7.6, 9.4, 9.8_
+  - [ ] 10.2 Re-run tests/builds after final cleanup
+    - Run `fsk_plan_tests`.
+    - Rebuild fujinet-pc.
+    - Rebuild the selected ESP32 Atari target(s).
+  - [ ] 10.3 Verify working tree contents before commit
+    - Ensure `Night Knight.cas` is untracked/ignored and not staged.
+    - Ensure no generated binaries or temporary test artifacts are staged.
+  - [ ] 10.4 Prepare implementation commits
+    - Keep commits logically grouped (pure parser/tests, cassette integration/RMT, final fixes) where practical.
+    - Do not modify `master`; commit only on `feature/a8cas-fsk-playback`.
+  - [ ] 10.5 Prepare the future Pull Request description
+    - Summarize the standards-based A8CAS `fsk ` support.
+    - Explain the RMT 1 MHz implementation and preservation of existing formats.
+    - Include automated-test/build results and manual hardware validation.
+    - Mention `Night Knight.cas` only as a locally tested compatibility case; do not attach or redistribute it.
+
+---
+
+## Completion Criteria
+
+The implementation is ready for Pull Request only when all of the following are true:
+
+- The normal FUJI path recognizes and reproduces generic A8CAS `fsk ` chunks.
+- A8CAS value timing is derived exclusively from the file (`value × 0.1 ms`) and emitted with index-parity logical levels.
+- ESP playback uses one continuous 1 MHz RMT transaction with no file I/O during waveform emission.
+- The active baud rate survives FSK playback and failure paths unchanged.
+- Malformed, truncated, odd-length, allocation-failure, and hardware-setup cases terminate safely without out-of-bounds reads, hangs, or crashes.
+- Standard playback, Turbo 2000, and QROS behavior remain unchanged.
+- The PC build compiles and safely handles FSK chunks without unsupported hardware access.
+- `fsk_plan_tests` passes.
+- Selected ESP Atari firmware target(s) build successfully.
+- `Night Knight.cas` loads successfully on real hardware in the local acceptance test.
+- No copyrighted/commercial `.cas` fixture is committed.

--- a/.kiro/specs/a8cas-fsk-chunk-playback/tasks.md
+++ b/.kiro/specs/a8cas-fsk-chunk-playback/tasks.md
@@ -190,7 +190,7 @@ Tasks should be completed in order. Each task includes the requirements it trace
     - Confirm the new shared code compiles without ESP-only APIs leaking into the PC build.
     - Exercise a synthetic/interleaved CAS image where possible and verify safe FSK skipping plus IRG handling.
     - _Requirements: 8.1-8.4_
-  - [ ] 8.3 Build at least one classic ESP32 Atari FujiNet target
+  - [x] 8.3 Build at least one classic ESP32 Atari FujiNet target
     - Verify the RMT API/configuration compiles at 1 MHz.
     - Check for warnings around IRAM, callback signatures, pin routing, and RMT handles.
     - _Requirements: 4.1-4.5, 7.1_

--- a/.kiro/specs/a8cas-fsk-chunk-playback/tasks.md
+++ b/.kiro/specs/a8cas-fsk-chunk-playback/tasks.md
@@ -113,40 +113,40 @@ Tasks should be completed in order. Each task includes the requirements it trace
     - Preserve the existing UART baud divisor.
     - _Requirements: 4.3, 4.5, 5.1, 5.3-5.5_
 
-- [ ] 5. Implement cross-platform `play_fsk_chunk`
-  - [ ] 5.1 Implement file-boundary validation
+- [x] 5. Implement cross-platform `play_fsk_chunk`
+  - [x] 5.1 Implement file-boundary validation
     - Treat fewer than 8 bytes of remaining header as end-of-tape.
     - Compute available payload bytes using the declared length clamped to EOF.
     - Never read beyond the CAS image.
     - For overrun/truncated payloads, reproduce only complete values present and return the established end-of-tape result afterward.
     - For odd lengths, ignore the trailing unpaired byte.
     - _Requirements: 1.4, 6.1-6.6, 8.3, 8.4_
-  - [ ] 5.2 Implement one-time payload pre-read
+  - [x] 5.2 Implement one-time payload pre-read
     - Allocate only `data_avail` bytes.
     - Read the clamped payload in one file read before waveform emission starts.
     - Never perform file I/O between FSK transitions.
     - On allocation failure, skip raw signal emission safely, preserve baud/UART state, and continue using the designed offset behavior.
     - Ensure the buffer is freed on every exit path.
     - _Requirements: 4.5, 5.4, 5.5, 6.2, 6.6_
-  - [ ] 5.3 Implement FSK IRG handling
+  - [x] 5.3 Implement FSK IRG handling
     - Honor `irg_ms` before raw signal emission.
     - Preserve the existing cassette gap/motor behavior.
     - If the pulldown is present and the motor line is de-asserted while more than 1000 ms remains, abort safely and return `starting_offset`.
     - Ensure LED state is restored on abort and normal completion.
     - _Requirements: 2.2, 2.8, 3.1-3.4_
-  - [ ] 5.4 Implement ESP raw signal playback inside `play_fsk_chunk`
+  - [x] 5.4 Implement ESP raw signal playback inside `play_fsk_chunk`
     - Initialize the encoder state only after `fsk_signal_begin()` succeeds.
     - Set `_fsk_buf`, data length/value count, byte position, value index, remaining ticks, and current level.
     - Call `fsk_signal_emit()` only when complete FSK values exist.
     - Ensure every success/failure path reaches the common cleanup.
     - _Requirements: 4.1-4.6, 5.1-5.5_
-  - [ ] 5.5 Implement deterministic PC-build behavior
+  - [x] 5.5 Implement deterministic PC-build behavior
     - Use the same pre-read and bounds logic.
     - Honor the IRG through `SYSTEM_BUS.bus_idle`.
     - Do not invoke RMT, GPIO, or raw hardware signal-generation APIs.
     - Advance to the next well-formed chunk or terminate at EOT for an overrun/truncated chunk.
     - _Requirements: 8.1-8.4_
-  - [ ] 5.6 Preserve Active_Baud_Rate through all paths
+  - [x] 5.6 Preserve Active_Baud_Rate through all paths
     - Do not call `SYSTEM_BUS.setBaudrate` from FSK processing.
     - Confirm success, motor abort, allocation failure, and RMT setup/transmit failure leave the active baud unchanged.
     - _Requirements: 5.1-5.5_

--- a/.kiro/specs/a8cas-fsk-chunk-playback/tasks.md
+++ b/.kiro/specs/a8cas-fsk-chunk-playback/tasks.md
@@ -64,8 +64,8 @@ Tasks should be completed in order. Each task includes the requirements it trace
     - Link only `FskPlanTests.cpp`, `fsk_plan.cpp`, and the required include paths.
     - _Requirements: 8.1_
 
-- [ ] 3. Extend `sioCassette` declarations for FSK playback
-  - [ ] 3.1 Update `lib/device/sio/cassette.h`
+- [x] 3. Extend `sioCassette` declarations for FSK playback
+  - [x] 3.1 Update `lib/device/sio/cassette.h`
     - Include or otherwise expose the pure FSK helper declarations where needed.
     - Add cross-platform `play_fsk_chunk(size_t offset, uint16_t chunk_length, uint16_t irg_ms)`.
     - Under `ESP_PLATFORM`, add:

--- a/.kiro/specs/a8cas-fsk-chunk-playback/tasks.md
+++ b/.kiro/specs/a8cas-fsk-chunk-playback/tasks.md
@@ -151,19 +151,19 @@ Tasks should be completed in order. Each task includes the requirements it trace
     - Confirm success, motor abort, allocation failure, and RMT setup/transmit failure leave the active baud unchanged.
     - _Requirements: 5.1-5.5_
 
-- [ ] 6. Integrate `fsk ` chunk handling into normal FUJI playback
-  - [ ] 6.1 Update the chunk walker in `send_FUJI_tape_block`
+- [x] 6. Integrate `fsk ` chunk handling into normal FUJI playback
+  - [x] 6.1 Update the chunk walker in `send_FUJI_tape_block`
     - Detect exactly the four bytes `'f','s','k',' '`.
     - Add the branch before the existing unknown-chunk catch-all.
     - Delegate the chunk to `play_fsk_chunk`.
     - Continue walking after a successfully handled FSK chunk rather than treating it as a terminating `data` record.
     - Preserve the current baud until an actual `baud` chunk changes it.
     - _Requirements: 1.1-1.7, 5.1, 9.1-9.4_
-  - [ ] 6.2 Add truncated-header protection to the FUJI chunk walk
+  - [x] 6.2 Add truncated-header protection to the FUJI chunk walk
     - Check the number of header bytes actually read before using the header.
     - Return end-of-tape without reading invalid header fields when fewer than 8 bytes are available.
     - _Requirements: 6.1, 8.4_
-  - [ ] 6.3 Preserve unknown-chunk behavior
+  - [x] 6.3 Preserve unknown-chunk behavior
     - Keep the existing `chunk_length + 8` skip for chunk types other than `data`, `baud`, and `fsk `.
     - Do not add any filename/game/country-specific handling.
     - _Requirements: 1.6, 1.7, 9.3, 9.4, 9.8_

--- a/.kiro/specs/a8cas-fsk-chunk-playback/tasks.md
+++ b/.kiro/specs/a8cas-fsk-chunk-playback/tasks.md
@@ -35,8 +35,8 @@ Tasks should be completed in order. Each task includes the requirements it trace
     - Confirm `fsk_plan.cpp` has no FujiNet hardware, filesystem, GPIO, RMT, or global-state dependency.
     - _Requirements: 8.1_
 
-- [ ] 2. Add automated doctest coverage for the pure FSK rules
-  - [ ] 2.1 Create `tests/FskPlanTests.cpp`
+- [x] 2. Add automated doctest coverage for the pure FSK rules
+  - [x] 2.1 Create `tests/FskPlanTests.cpp`
     - Add the A8CAS worked example from Requirement 2.7.
     - Test zero-length payload behavior.
     - Test odd-length payload handling.
@@ -45,7 +45,7 @@ Tasks should be completed in order. Each task includes the requirements it trace
     - Verify 6818 maps to 681,800 ticks and 21 portions.
     - Verify 65535 maps to 6,553,500 ticks and 201 portions.
     - _Requirements: 2.7, 2.8, 4.6, 6.4_
-  - [ ] 2.2 Implement deterministic generated-loop tests for correctness properties
+  - [x] 2.2 Implement deterministic generated-loop tests for correctness properties
     - Property 1: `fsk_value_count(len) == len / 2`.
     - Property 2: emitted portion ticks for each value sum to `fsk_ticks_for_value(fsk_decode_le16(pair))`.
     - Property 3: every emitted portion level follows original value-index parity.
@@ -54,12 +54,12 @@ Tasks should be completed in order. Each task includes the requirements it trace
     - Include the full uint16 value range for split arithmetic where practical.
     - Use deterministic/fixed-seed inputs only.
     - _Requirements: 2.1, 2.3, 2.4, 2.5, 4.1, 4.6, 6.2, 6.4_
-  - [ ] 2.3 Add synthetic FSK payload fixtures
+  - [x] 2.3 Add synthetic FSK payload fixtures
     - Build test byte arrays in source; do not add copyrighted `.cas` files.
     - Include representative short, long, zero, and odd-tail values.
     - Keep the tests generic and independent of filenames.
     - _Requirements: 9.4, 9.8_
-  - [ ] 2.4 Register `fsk_plan_tests` in `tests/CMakeLists.txt`
+  - [x] 2.4 Register `fsk_plan_tests` in `tests/CMakeLists.txt`
     - Follow the existing standalone doctest executable pattern.
     - Link only `FskPlanTests.cpp`, `fsk_plan.cpp`, and the required include paths.
     - _Requirements: 8.1_

--- a/.kiro/specs/a8cas-fsk-chunk-playback/tasks.md
+++ b/.kiro/specs/a8cas-fsk-chunk-playback/tasks.md
@@ -198,7 +198,7 @@ Tasks should be completed in order. Each task includes the requirements it trace
     - Confirm the implementation remains portable across the supported ESP target family.
     - _Requirements: 4.1-4.5, 7.1_
 
-- [ ] 9. Perform local real-hardware acceptance with `Night Knight.cas`
+- [-] 9. Perform local real-hardware acceptance with `Night Knight.cas`
   - [x] 9.1 Keep `Night Knight.cas` outside the repository
     - Do not add the file to Git, tests, fixtures, or the PR.
     - Use it only for local/manual acceptance unless redistribution rights are established.
@@ -213,11 +213,11 @@ Tasks should be completed in order. Each task includes the requirements it trace
     - Confirm playback proceeds through interleaved `baud`, `data`, and `fsk ` chunks.
     - Confirm data following FSK playback continues at the active baud.
     - _Requirements: 5.2, 5.3, 9.1-9.8_
-  - [ ] 9.4 Verify motor-line abort and recovery
+  - [-] 9.4 Verify motor-line abort and recovery
     - During a long IRG, de-assert the motor line where practical.
     - Confirm safe abort/retry behavior, UART restoration, and baud preservation.
     - _Requirements: 3.3, 3.4, 5.4_
-  - [ ] 9.5 Verify FSK setup failure degrades safely where practical
+  - [x] 9.5 Verify FSK setup failure degrades safely where practical
     - On a configuration/target without a valid cassette TX pin, confirm raw signal output is skipped without breaking subsequent data playback.
     - _Requirements: 4.5, 5.5_
 

--- a/.kiro/specs/a8cas-fsk-chunk-playback/tasks.md
+++ b/.kiro/specs/a8cas-fsk-chunk-playback/tasks.md
@@ -182,11 +182,11 @@ Tasks should be completed in order. Each task includes the requirements it trace
     - _Requirements: 7.2-7.6_
 
 - [ ] 8. Run automated and build verification
-  - [ ] 8.1 Configure and run `fsk_plan_tests`
+  - [x] 8.1 Configure and run `fsk_plan_tests`
     - Run the new doctest executable.
     - Confirm all example and generated-loop tests pass.
     - _Requirements: 2.1-2.8, 4.6, 6.2, 6.4_
-  - [ ] 8.2 Build fujinet-pc
+  - [x] 8.2 Build fujinet-pc
     - Confirm the new shared code compiles without ESP-only APIs leaking into the PC build.
     - Exercise a synthetic/interleaved CAS image where possible and verify safe FSK skipping plus IRG handling.
     - _Requirements: 8.1-8.4_

--- a/.kiro/specs/a8cas-fsk-chunk-playback/tasks.md
+++ b/.kiro/specs/a8cas-fsk-chunk-playback/tasks.md
@@ -168,16 +168,16 @@ Tasks should be completed in order. Each task includes the requirements it trace
     - Do not add any filename/game/country-specific handling.
     - _Requirements: 1.6, 1.7, 9.3, 9.4, 9.8_
 
-- [ ] 7. Verify no regression in existing cassette paths
-  - [ ] 7.1 Confirm dispatcher behavior is unchanged
+- [x] 7. Verify no regression in existing cassette paths
+  - [x] 7.1 Confirm dispatcher behavior is unchanged
     - Turbo 2000 continues to use `send_turbo2000_tape_block`.
     - QROS continues to use `send_QROS_tape_block`.
     - Only normal FUJI playback enters the new FSK path.
     - _Requirements: 7.2-7.6_
-  - [ ] 7.2 Confirm no FSK code executes for standard `baud`/`data`-only images
+  - [x] 7.2 Confirm no FSK code executes for standard `baud`/`data`-only images
     - Compare normal standard playback behavior before/after the feature where practical.
     - _Requirements: 7.1_
-  - [ ] 7.3 Confirm Turbo 2000 and QROS detection outcomes remain unchanged
+  - [x] 7.3 Confirm Turbo 2000 and QROS detection outcomes remain unchanged
     - Do not modify detection unless required for compilation; if refactoring occurs, prove equivalent outcomes.
     - _Requirements: 7.2-7.6_
 

--- a/.kiro/specs/a8cas-fsk-chunk-playback/tasks.md
+++ b/.kiro/specs/a8cas-fsk-chunk-playback/tasks.md
@@ -181,7 +181,7 @@ Tasks should be completed in order. Each task includes the requirements it trace
     - Do not modify detection unless required for compilation; if refactoring occurs, prove equivalent outcomes.
     - _Requirements: 7.2-7.6_
 
-- [ ] 8. Run automated and build verification
+- [x] 8. Run automated and build verification
   - [x] 8.1 Configure and run `fsk_plan_tests`
     - Run the new doctest executable.
     - Confirm all example and generated-loop tests pass.
@@ -194,7 +194,7 @@ Tasks should be completed in order. Each task includes the requirements it trace
     - Verify the RMT API/configuration compiles at 1 MHz.
     - Check for warnings around IRAM, callback signatures, pin routing, and RMT handles.
     - _Requirements: 4.1-4.5, 7.1_
-  - [ ] 8.4 Build at least one ESP32-S3 Atari FujiNet target if supported by the normal project build matrix
+  - [x] 8.4 Build at least one ESP32-S3 Atari FujiNet target if supported by the normal project build matrix
     - Confirm the implementation remains portable across the supported ESP target family.
     - _Requirements: 4.1-4.5, 7.1_
 

--- a/.kiro/specs/a8cas-fsk-chunk-playback/tasks.md
+++ b/.kiro/specs/a8cas-fsk-chunk-playback/tasks.md
@@ -203,7 +203,7 @@ Tasks should be completed in order. Each task includes the requirements it trace
     - Do not add the file to Git, tests, fixtures, or the PR.
     - Use it only for local/manual acceptance unless redistribution rights are established.
     - _Requirements: 9.4, 9.8_
-  - [ ] 9.2 Verify the known fixture structure before hardware playback
+  - [x] 9.2 Verify the known fixture structure before hardware playback
     - Confirm locally: 36,785 bytes, 259 total chunks, 1 `FUJI`, 2 `baud`, 249 `data`, 7 `fsk `.
     - Confirm the baud transition 600 → 790.
     - Confirm the first FSK value is 6818 = 681.8 ms.

--- a/.kiro/specs/a8cas-fsk-chunk-playback/tasks.md
+++ b/.kiro/specs/a8cas-fsk-chunk-playback/tasks.md
@@ -199,7 +199,7 @@ Tasks should be completed in order. Each task includes the requirements it trace
     - _Requirements: 4.1-4.5, 7.1_
 
 - [ ] 9. Perform local real-hardware acceptance with `Night Knight.cas`
-  - [ ] 9.1 Keep `Night Knight.cas` outside the repository
+  - [x] 9.1 Keep `Night Knight.cas` outside the repository
     - Do not add the file to Git, tests, fixtures, or the PR.
     - Use it only for local/manual acceptance unless redistribution rights are established.
     - _Requirements: 9.4, 9.8_

--- a/.kiro/specs/a8cas-fsk-chunk-playback/tasks.md
+++ b/.kiro/specs/a8cas-fsk-chunk-playback/tasks.md
@@ -222,19 +222,19 @@ Tasks should be completed in order. Each task includes the requirements it trace
     - _Requirements: 4.5, 5.5_
 
 - [ ] 10. Final review and pull-request readiness
-  - [ ] 10.1 Review the diff for scope discipline
+  - [x] 10.1 Review the diff for scope discipline
     - Confirm changes are limited to generic A8CAS FSK support, tests, and required build wiring.
     - Confirm there is no Night Knight/game/country-specific code.
     - Confirm no unrelated cassette behavior was modified.
     - _Requirements: 1.7, 7.1-7.6, 9.4, 9.8_
-  - [ ] 10.2 Re-run tests/builds after final cleanup
+  - [x] 10.2 Re-run tests/builds after final cleanup
     - Run `fsk_plan_tests`.
     - Rebuild fujinet-pc.
     - Rebuild the selected ESP32 Atari target(s).
-  - [ ] 10.3 Verify working tree contents before commit
+  - [x] 10.3 Verify working tree contents before commit
     - Ensure `Night Knight.cas` is untracked/ignored and not staged.
     - Ensure no generated binaries or temporary test artifacts are staged.
-  - [ ] 10.4 Prepare implementation commits
+  - [-] 10.4 Prepare implementation commits
     - Keep commits logically grouped (pure parser/tests, cassette integration/RMT, final fixes) where practical.
     - Do not modify `master`; commit only on `feature/a8cas-fsk-playback`.
   - [ ] 10.5 Prepare the future Pull Request description

--- a/.kiro/specs/a8cas-fsk-chunk-playback/tasks.md
+++ b/.kiro/specs/a8cas-fsk-chunk-playback/tasks.md
@@ -12,8 +12,8 @@ Tasks should be completed in order. Each task includes the requirements it trace
 
 ## Tasks
 
-- [ ] 1. Add the pure FSK parsing/timing module
-  - [ ] 1.1 Create `lib/device/sio/fsk_plan.h`
+- [x] 1. Add the pure FSK parsing/timing module
+  - [x] 1.1 Create `lib/device/sio/fsk_plan.h`
     - Define `FSK_MAX_PORTION_TICKS = 32767`.
     - Define `FSK_RMT_TICKS_PER_A8CAS_UNIT = 100`.
     - Implement `static inline uint32_t fsk_ticks_for_value(uint16_t value)`.
@@ -24,14 +24,14 @@ Tasks should be completed in order. Each task includes the requirements it trace
     - Define `FskChunkView`, `FskStep`, and `fsk_view_init`.
     - Keep ISR-used helpers allocation-free, I/O-free, logging-free, and safe to inline into the RMT callback.
     - _Requirements: 2.1, 2.3, 2.4, 2.5, 4.1, 4.2, 4.6, 6.2, 6.4_
-  - [ ] 1.2 Create `lib/device/sio/fsk_plan.cpp`
+  - [x] 1.2 Create `lib/device/sio/fsk_plan.cpp`
     - Implement host-test-only `fsk_view_step(FskChunkView &view)`.
     - Use the shared decode/parity/scale/split helpers from `fsk_plan.h`.
     - Skip zero-duration values while preserving original value-index parity.
     - Never read outside `data_len_available`.
     - Never allocate or materialize the complete waveform.
     - _Requirements: 2.1, 2.3, 2.4, 2.5, 4.6, 6.2, 6.4_
-  - [ ] 1.3 Compile the pure module independently on the host
+  - [x] 1.3 Compile the pure module independently on the host
     - Confirm `fsk_plan.cpp` has no FujiNet hardware, filesystem, GPIO, RMT, or global-state dependency.
     - _Requirements: 8.1_
 

--- a/lib/device/sio/cassette.cpp
+++ b/lib/device/sio/cassette.cpp
@@ -82,6 +82,114 @@ size_t IRAM_ATTR t2k_encode_cb(const void *data, size_t data_size,
     *done = (symbols_written + num >= total_needed);
     return num;
 }
+
+// Simple encoder callback for A8CAS raw "fsk " chunks — generates RMT symbols
+// on the fly from the single pre-read FSK data buffer plus O(1) encoder state
+// carried on the sioCassette object. Runs in ISR context (RMT ping-pong
+// refill), so it MUST be in IRAM and may inline ONLY the static-inline pure
+// rules from fsk_plan.h: NO file I/O, NO heap allocation, NO logging.
+//
+// Each FSK value V is scaled to V*100 ticks (1/10 ms = 100 us = 100 ticks at
+// 1 us/tick) and split into consecutive same-level portions of at most
+// FSK_MAX_PORTION_TICKS (32767) ticks. The logical level of a value comes from
+// its ORIGINAL value-index parity (fsk_level_for_index); zero-duration values
+// consume an index (parity) but emit no portion. HIGH (level 1) = mark =
+// logical 1, matching the T2K/QROS mark convention. Values are emitted in
+// original order; *done is set true only after the final portion of the final
+// value has been emitted.
+size_t IRAM_ATTR sioCassette::fsk_encode_cb(const void *data, size_t data_size,
+                                            size_t symbols_written, size_t symbols_free,
+                                            rmt_symbol_word_t *symbols, bool *done, void *arg)
+{
+    sioCassette *self = (sioCassette *)arg;
+    const uint8_t *buf = (const uint8_t *)data; // == _fsk_buf, data_size == _fsk_data_avail
+    size_t num = 0;
+
+    // Do NOT rely on the RMT framework to initialize or preserve *done. Assume
+    // more waveform remains until we prove otherwise; every early return below
+    // that leaves waveform pending keeps this false, and *done is set true ONLY
+    // after the last portion of the last value has been emitted.
+    *done = false;
+
+    while (num < symbols_free)
+    {
+        // Fill both level/duration halves of one rmt_symbol_word_t.
+        uint16_t levels[2] = {0, 0};
+        uint16_t durs[2] = {0, 0};
+        int half = 0;
+
+        while (half < 2)
+        {
+            // Load the next value if the current one is exhausted.
+            if (self->_fsk_remaining_ticks == 0)
+            {
+                // Skip zero-duration values: each consumes an index (parity)
+                // but emits nothing.
+                while (self->_fsk_value_index < self->_fsk_value_count)
+                {
+                    uint16_t v = fsk_decode_le16(buf + self->_fsk_byte_pos);
+                    bool lvl = fsk_level_for_index(self->_fsk_value_index);
+                    self->_fsk_value_index++;
+                    self->_fsk_byte_pos += 2;
+                    if (v != 0)
+                    {
+                        self->_fsk_remaining_ticks = fsk_ticks_for_value(v);
+                        self->_fsk_level_high = lvl;
+                        break;
+                    }
+                    // v == 0: parity index consumed, no portion emitted; keep scanning.
+                }
+                if (self->_fsk_remaining_ticks == 0) // no more values remain
+                {
+                    if (half == 0)
+                    {
+                        // Nothing more to emit and we are on a clean symbol
+                        // boundary: the whole waveform is complete.
+                        *done = true;
+                        (void)symbols_written;
+                        (void)data_size;
+                        return num;
+                    }
+                    // The value stream is exhausted mid-symbol; pad the unused
+                    // second half with a 0-duration same-level entry, which
+                    // completes the waveform.
+                    levels[half] = levels[half - 1];
+                    durs[half] = 0;
+                    half++;
+                    break;
+                }
+            }
+
+            uint32_t portion = fsk_next_portion(self->_fsk_remaining_ticks);
+            self->_fsk_remaining_ticks -= portion;
+            levels[half] = self->_fsk_level_high ? 1 : 0;
+            durs[half] = (uint16_t)portion;
+            half++;
+        }
+
+        symbols[num].level0 = levels[0];
+        symbols[num].duration0 = durs[0];
+        symbols[num].level1 = levels[1];
+        symbols[num].duration1 = durs[1];
+        num++;
+
+        // Last portion of the last value emitted -> the waveform is complete.
+        if (self->_fsk_remaining_ticks == 0 &&
+            self->_fsk_value_index >= self->_fsk_value_count)
+        {
+            *done = true; // set true ONLY here on full completion
+            (void)symbols_written;
+            (void)data_size;
+            return num;
+        }
+    }
+
+    // Buffer full but waveform not finished: *done remains false so RMT calls
+    // this callback again to emit the remaining portions.
+    (void)symbols_written;
+    (void)data_size;
+    return num;
+}
 #endif
 
 /** thinking about state machine
@@ -1427,6 +1535,184 @@ void sioCassette::turbo2000_flush_rmt()
 void sioCassette::turbo2000_send_pilot(uint16_t count)
 {
     turbo2000_send_pulses(t2k_pilot_half, count);
+}
+
+// Allocate the RMT TX channel + stateful simple encoder for raw A8CAS "fsk "
+// signal emission, and take control of PIN_UART2_TX away from the UART.
+// Mirrors the Turbo 2000 turbo2000_init_rmt() lifecycle exactly, but uses the
+// simple encoder ONLY (no copy encoder — FSK never sends pilot pulses) and,
+// unlike T2K, returns cleanly on any failure and fully undoes partial setup so
+// the UART TX routing and RMT resources are left intact. Does NOT touch the
+// UART baud divisor (Req 5.3-5.5). Returns true on success, false on failure.
+bool sioCassette::fsk_signal_begin()
+{
+    if (_fsk_signal_active)
+        return true;
+
+    // Fail cleanly if the cassette TX pin is not connected on this target.
+    if ((gpio_num_t)PIN_UART2_TX == GPIO_NUM_NC)
+    {
+        Debug_println("FSK: PIN_UART2_TX not connected (GPIO_NUM_NC), skipping raw signal");
+        return false;
+    }
+
+    // Flush any pending UART output before detaching the TX pin.
+    SYSTEM_BUS.flushOutput();
+
+    // Detach UART2 TX from GPIO and hold the line idle HIGH (mark) before RMT
+    // takes over — identical to turbo2000_init_rmt().
+    esp_rom_gpio_connect_out_signal(PIN_UART2_TX, SIG_GPIO_OUT_IDX, false, false);
+    gpio_set_level((gpio_num_t)PIN_UART2_TX, 1);
+
+    // Configure RMT TX at 1 MHz (1 µs per tick), identical to T2K.
+    rmt_tx_channel_config_t tx_cfg = {};
+    tx_cfg.gpio_num = (gpio_num_t)PIN_UART2_TX;
+    tx_cfg.clk_src = RMT_CLK_SRC_DEFAULT;
+    tx_cfg.resolution_hz = T2K_RMT_RESOLUTION_HZ; // 1 µs per tick
+    tx_cfg.mem_block_symbols = 64 * 8; // 512 symbols for gapless ping-pong
+    tx_cfg.trans_queue_depth = 4;
+    tx_cfg.intr_priority = 0;
+    tx_cfg.flags.invert_out = false;
+    tx_cfg.flags.with_dma = false;
+    tx_cfg.flags.io_loop_back = false;
+    tx_cfg.flags.io_od_mode = false;
+    tx_cfg.flags.allow_pd = false;
+
+    rmt_channel_handle_t channel = nullptr;
+    esp_err_t err = rmt_new_tx_channel(&tx_cfg, &channel);
+    if (err != ESP_OK)
+    {
+        Debug_printf("FSK: rmt_new_tx_channel failed: %s\n", esp_err_to_name(err));
+        // Reattach UART2 TX to its normal signal; no RMT resources were created.
+        esp_rom_gpio_connect_out_signal(PIN_UART2_TX,
+            uart_periph_signal[2].pins[SOC_UART_TX_PIN_IDX].signal, false, false);
+        return false;
+    }
+
+    // Stateful simple encoder — generates rmt_symbol_word_t on the fly in the
+    // IRAM callback from the pre-read buffer plus O(1) encoder state.
+    rmt_simple_encoder_config_t simple_cfg = {};
+    simple_cfg.callback = fsk_encode_cb;
+    simple_cfg.arg = (void *)this;
+    simple_cfg.min_chunk_size = 0;
+    rmt_encoder_handle_t simple_enc = nullptr;
+    err = rmt_new_simple_encoder(&simple_cfg, &simple_enc);
+    if (err != ESP_OK)
+    {
+        Debug_printf("FSK: rmt_new_simple_encoder failed: %s\n", esp_err_to_name(err));
+        rmt_del_channel(channel);
+        esp_rom_gpio_connect_out_signal(PIN_UART2_TX,
+            uart_periph_signal[2].pins[SOC_UART_TX_PIN_IDX].signal, false, false);
+        return false;
+    }
+
+    err = rmt_enable(channel);
+    if (err != ESP_OK)
+    {
+        Debug_printf("FSK: rmt_enable failed: %s\n", esp_err_to_name(err));
+        rmt_del_encoder(simple_enc);
+        rmt_del_channel(channel);
+        esp_rom_gpio_connect_out_signal(PIN_UART2_TX,
+            uart_periph_signal[2].pins[SOC_UART_TX_PIN_IDX].signal, false, false);
+        return false;
+    }
+
+    _fsk_rmt_channel = channel;
+    _fsk_rmt_encoder = simple_enc;
+    _fsk_signal_active = true;
+    Debug_printf("FSK: RMT initialized on SIO DATA IN pin (GPIO %d) at 1 MHz\n",
+                 PIN_UART2_TX);
+    return true;
+}
+
+// Emit the whole pre-read A8CAS "fsk " payload as ONE continuous, gapless RMT
+// transaction and block until it has fully drained. A single rmt_transmit hands
+// the entire pre-read buffer (_fsk_buf / _fsk_data_avail) to the stateful simple
+// encoder; fsk_encode_cb fills the RMT ping-pong memory on demand from that
+// buffer plus O(1) encoder state, so there is no reused stack payload of ours
+// and no per-batch queuing gap (unlike the repeated-batch T2K data path). The
+// caller has already initialized the encoder state (value index, byte pos,
+// remaining ticks, level) before calling this. rmt_tx_wait_all_done blocks so
+// the pre-read buffer stays valid for the whole transaction and is only freed
+// (in fsk_signal_end / the caller's cleanup) after transmission has finished.
+void sioCassette::fsk_signal_emit()
+{
+    // Nothing to drive: no RMT channel, no buffer, or zero complete values.
+    if (!_fsk_signal_active || _fsk_buf == nullptr || _fsk_value_count == 0)
+        return;
+
+    rmt_channel_handle_t channel = (rmt_channel_handle_t)_fsk_rmt_channel;
+    rmt_encoder_handle_t encoder = (rmt_encoder_handle_t)_fsk_rmt_encoder;
+
+    rmt_transmit_config_t tx_cfg = {};
+    tx_cfg.loop_count = 0;
+    tx_cfg.flags.eot_level = 0;
+    tx_cfg.flags.queue_nonblocking = false;
+
+    // ONE continuous transaction for the complete payload — NOT repeated batches.
+    // The simple encoder writes directly into RMT-provided ping-pong memory, so
+    // the only buffer we own (_fsk_buf) must stay valid until the transaction
+    // completes; rmt_tx_wait_all_done below guarantees that before any teardown.
+    esp_err_t err = rmt_transmit(channel, encoder, _fsk_buf, _fsk_data_avail, &tx_cfg);
+    if (err != ESP_OK)
+    {
+        // Log the error but do NOT return early. The approved design requires
+        // rmt_tx_wait_all_done() to be reached after the single transmit
+        // attempt in all cases, so buffer/channel teardown is always gated on
+        // the channel being idle (a partially queued transaction may still be
+        // draining even when rmt_transmit reports an error).
+        Debug_printf("FSK: rmt_transmit error: %s\n", esp_err_to_name(err));
+    }
+
+    // Wait for the whole waveform to finish before the buffer/channel teardown.
+    // Always reached, even on transmit error.
+    rmt_tx_wait_all_done(channel, -1);
+}
+
+// Tear down the RMT raw-signal path and hand PIN_UART2_TX back to the UART so
+// normal cassette data playback resumes. Mirrors turbo2000_deinit_rmt() exactly.
+// IDEMPOTENT (Req 5.1): safe to call multiple times and safe to call even if
+// fsk_signal_begin() was never called or failed — the _fsk_signal_active guard
+// makes every call after the first a no-op. Does NOT touch the UART baud divisor
+// (no SYSTEM_BUS.setBaudrate); only the TX pin routing is reattached so the
+// existing baud rate is preserved (Req 5.3-5.5).
+void sioCassette::fsk_signal_end()
+{
+    if (!_fsk_signal_active)
+        return;
+
+    rmt_channel_handle_t channel = (rmt_channel_handle_t)_fsk_rmt_channel;
+
+    // Safely wait for any in-flight transmission to finish before teardown, so
+    // the pre-read buffer is not reclaimed while the peripheral is still draining
+    // it (Req 4.3). channel may be null only if state is inconsistent; guard it.
+    if (channel)
+        rmt_tx_wait_all_done(channel, -1);
+
+    // Disable and delete the RMT channel, then delete the simple encoder.
+    if (channel)
+    {
+        rmt_disable(channel);
+        rmt_del_channel(channel);
+    }
+    if (_fsk_rmt_encoder)
+        rmt_del_encoder((rmt_encoder_handle_t)_fsk_rmt_encoder);
+
+    // Clear RMT handles so a subsequent call is a no-op.
+    _fsk_rmt_channel = nullptr;
+    _fsk_rmt_encoder = nullptr;
+
+    // Reattach UART2 TX to its normal signal on PIN_UART2_TX. This restores
+    // normal data playback routing WITHOUT altering the baud divisor.
+    // UART2 TX signal index = uart_periph_signal[2].pins[SOC_UART_TX_PIN_IDX].signal
+    esp_rom_gpio_connect_out_signal(PIN_UART2_TX,
+        uart_periph_signal[2].pins[SOC_UART_TX_PIN_IDX].signal, false, false);
+
+    // Per approved design, remain active until UART2 TX has actually been
+    // reattached; only now is teardown fully complete.
+    _fsk_signal_active = false;
+
+    Debug_println("FSK: UART restored on SIO DATA IN pin");
 }
 
 void sioCassette::turbo2000_send_byte(uint8_t byte)

--- a/lib/device/sio/cassette.cpp
+++ b/lib/device/sio/cassette.cpp
@@ -721,7 +721,16 @@ size_t sioCassette::send_FUJI_tape_block(size_t offset)
         // looking for a data header while handling baud changes along the way
         Debug_printf("Offset: %u\r\n", offset);
         fnio::fseek(_file, offset, SEEK_SET);
-        fnio::fread(atari_sector_buffer, 1, sizeof(struct tape_FUJI_hdr), _file);
+        size_t hdr_read = fnio::fread(atari_sector_buffer, 1, sizeof(struct tape_FUJI_hdr), _file);
+        if (hdr_read < sizeof(struct tape_FUJI_hdr))
+        {
+            // Truncated header: fewer than the 8 required header bytes remain
+            // before the end of the CAS image. Do NOT use any header fields
+            // (chunk_type, chunk_length, irg_length) that were not fully read.
+            // Treat this as end-of-tape following the same convention used
+            // elsewhere in this walk (return 0). (Req 6.1, 8.4)
+            return 0;
+        }
         len = hdr->chunk_length;
 
         if (p[0] == 'd' && //is a data header?
@@ -741,6 +750,42 @@ size_t sioCassette::send_FUJI_tape_block(size_t offset)
                 continue;
             baud = hdr->irg_length;
             SYSTEM_BUS.setBaudrate(baud);
+        }
+        else if (p[0] == 'f' && //is a raw A8CAS FSK header? ('f','s','k',' ')
+                 p[1] == 's' &&
+                 p[2] == 'k' &&
+                 p[3] == ' ')
+        {
+            // Delegate the whole FSK chunk (IRG + raw signal) to play_fsk_chunk.
+            // FSK is NOT a terminating "data" record: after reproducing the
+            // chunk the walk continues so a following "data"/"baud" chunk is
+            // still reached and emitted at the current baud. The active baud is
+            // preserved here (no setBaudrate) until an actual "baud" chunk
+            // changes it (Req 1.1-1.5, 5.1, 9.1-9.4).
+            size_t next = play_fsk_chunk(offset, hdr->chunk_length, hdr->irg_length);
+            if (next == offset)
+            {
+                // MOTOR-line abort during the IRG: play_fsk_chunk returns the
+                // offset it was called with (the current FSK chunk start) to
+                // request a retry, NOT a successful advance. Compare against the
+                // CURRENT offset (the walker may already have advanced through
+                // preceding baud/other chunks). Continuing with the same offset
+                // would reprocess this same chunk while MOTOR stays de-asserted.
+                // Return the OUTER starting_offset so the walker retries this
+                // record, matching the existing data-record motor-abort path.
+                return starting_offset;
+            }
+            if (next == 0)
+            {
+                // End-of-tape result from play_fsk_chunk (truncated header or
+                // overrun/truncated chunk). Follow the existing FUJI-path
+                // convention for reaching the end of the tape: return 0 so the
+                // dispatcher disables the cassette.
+                return 0;
+            }
+            // Successfully handled: advance past the chunk and keep walking.
+            offset = next;
+            continue;
         }
         offset += sizeof(struct tape_FUJI_hdr) + len;
     }

--- a/lib/device/sio/cassette.cpp
+++ b/lib/device/sio/cassette.cpp
@@ -3,6 +3,7 @@
 #include "cassette.h"
 
 #include <cstring>
+#include <cstdlib>
 
 #include "../../include/debug.h"
 
@@ -1778,6 +1779,274 @@ void sioCassette::turbo2000_send_bytes(const uint8_t *data, size_t length)
 }
 
 #endif // ESP_PLATFORM
+
+// Reproduce a single A8CAS "fsk " chunk end to end. Cross-platform entry point
+// called from the FUJI chunk walker (wired up in task 6). `offset` points at the
+// chunk header start; `chunk_length` and `irg_ms` are the already-decoded header
+// fields. Returns the read offset the walker should continue from: the advance
+// past a well-formed chunk, or the end-of-tape result (0) for a malformed /
+// truncated / overrun chunk (matching the surrounding "return 0 == EOT"
+// convention). Never changes the active baud.
+//
+// TASK 5.1 SCOPE: file-boundary / bounds validation only. Pre-read (5.2), IRG
+// handling (5.3), ESP raw RMT playback (5.4), PC-build behavior (5.5), and baud
+// preservation verification (5.6) are added by later tasks; their insertion
+// points are marked with TODO below. The bounds logic here is fully
+// cross-platform and compiles on both ESP_PLATFORM and PC builds.
+size_t sioCassette::play_fsk_chunk(size_t offset, uint16_t chunk_length, uint16_t irg_ms)
+{
+    // Bounds derivation (design: "Bounds derivation (in the caller,
+    // play_fsk_chunk)"). All arithmetic is done in size_t so nothing underflows
+    // or reads past the CAS image.
+
+    // Bytes from the chunk header start to EOF.
+    // Req 6.1 / 8.4: fewer than 8 header bytes remaining => treat as end-of-tape
+    // and never touch the (incomplete) header fields.
+    if (offset >= filesize || (filesize - offset) < sizeof(struct tape_FUJI_hdr))
+    {
+        Debug_printf("FSK: truncated header at offset %u (filesize %u) - end of tape\r\n",
+                     (unsigned)offset, (unsigned)filesize);
+        return 0; // established end-of-tape result
+    }
+
+    size_t remaining = filesize - offset;
+
+    // Declared payload length from the header (0..65535).
+    uint16_t declared_len = chunk_length;
+
+    // Bytes actually available after the 8-byte header, clamped to EOF. This is
+    // the number of payload bytes we may ever read (Req 6.2 / 6.3 / 8.3): never
+    // beyond filesize.
+    size_t bytes_after_header = remaining - sizeof(struct tape_FUJI_hdr);
+    size_t data_avail = (size_t)declared_len < bytes_after_header
+                            ? (size_t)declared_len
+                            : bytes_after_header;
+
+    // A truncated / overrun chunk is one whose declared length runs past the
+    // bytes actually present after the header (Req 1.4 / 6.3 / 6.5). Only the
+    // complete FSK values present may be reproduced, and afterward the chunk
+    // terminates at the real data boundary via the end-of-tape result.
+    bool truncated = (size_t)declared_len > bytes_after_header;
+
+    // Number of complete little-endian FSK_Signal_Values available. floor(/2)
+    // via the pure helper drops any trailing unpaired byte for an odd data_avail
+    // (Req 6.4). value_count feeds the pre-read / emission tasks below.
+    size_t value_count = fsk_value_count(data_avail);
+    (void)value_count; // consumed by tasks 5.3-5.4 (emission)
+
+    Debug_printf("FSK: offset %u declared_len %u irg %u ms | remaining %u data_avail %u value_count %u%s\r\n",
+                 (unsigned)offset, (unsigned)declared_len, (unsigned)irg_ms,
+                 (unsigned)remaining, (unsigned)data_avail, (unsigned)value_count,
+                 truncated ? " (TRUNCATED)" : "");
+
+    // TASK 5.2: one-time payload pre-read.
+    // Read the entire clamped data region into a heap buffer in ONE fnio::fread
+    // BEFORE any waveform emission begins, so the emitted signal never depends
+    // on SD/TNFS/network latency and no file I/O ever happens between FSK
+    // transitions (Req 4.5 / 5.4 / 5.5 / 6.2 / 6.6). Mirrors the Turbo 2000
+    // all_data / _t2k_pending_buf malloc/free precedent in this same file.
+    //
+    // Kept as a LOCAL buffer for now: tasks 5.3/5.4/5.5 consume it for IRG and
+    // emission, and on ESP task 5.4 explicitly assigns it to _fsk_buf and sets
+    // up the encoder state (_fsk_data_avail, _fsk_value_count, byte pos, value
+    // index, remaining ticks, level). Until then this task only guarantees the
+    // single pre-read and that the buffer is freed on every exit path.
+    uint8_t *fsk_buf = nullptr;
+    if (data_avail > 0)
+    {
+        fsk_buf = (uint8_t *)malloc(data_avail);
+        if (fsk_buf == nullptr)
+        {
+            // Accepted resource limitation (design: "Pre-read RAM budget"): a
+            // max-size (~64 KB) chunk can fail to allocate on a no-PSRAM target.
+            // Degrade safely: skip raw signal emission (a null buffer means "no
+            // emission" for tasks 5.3-5.5), leave the baud/UART state untouched
+            // (do NOT call SYSTEM_BUS.setBaudrate), and still return the designed
+            // advance/EOT offset below (Req 4.5 / 5.5 / 6.6).
+            Debug_printf("FSK: malloc(%u) failed - skipping signal emission, preserving baud/UART\r\n",
+                         (unsigned)data_avail);
+        }
+        else
+        {
+            // ONE seek + ONE read of the clamped payload region. data_avail is
+            // already clamped to EOF by the bounds derivation above, so this
+            // read never passes the end of the CAS image (Req 6.2).
+            fnio::fseek(_file, offset + sizeof(struct tape_FUJI_hdr), SEEK_SET);
+            size_t got = fnio::fread(fsk_buf, 1, data_avail, _file);
+            if (got != data_avail)
+            {
+                // Short read (unexpected given the EOF clamp): treat as "no
+                // emission" and free the partial buffer. Baud/UART untouched.
+                Debug_printf("FSK: pre-read short (%u of %u bytes) - skipping emission\r\n",
+                             (unsigned)got, (unsigned)data_avail);
+                free(fsk_buf);
+                fsk_buf = nullptr;
+            }
+        }
+    }
+
+    // TASK 5.3: honor irg_ms before raw signal emission.
+    // The current record began at `offset`; the motor-line abort path returns
+    // this so the walker retries the same record (Req 3.3).
+    size_t starting_offset = offset;
+
+    // Mirror the existing data-path gap loop (send_FUJI_tape_block) exactly, but
+    // drive it from irg_ms interpreted as milliseconds (Req 2.2 / 3.1). Use a
+    // local countdown so irg_ms itself is left intact for any later use. When
+    // irg_ms is 0 the `while (gap)` guard skips the body entirely, so no delay
+    // is applied (Req 3.2 / 2.8).
+    uint16_t gap = irg_ms;
+    fnLedManager.set(eLed::LED_BUS, true);
+    while (gap)
+    {
+#ifdef ESP_PLATFORM
+        gap--;
+        fnSystem.delay_microseconds(999); // shave off a usec for the MOTOR pin check
+#else
+        int step;
+        // SYSTEM_BUS is fnSioCom
+        if (SYSTEM_BUS.isBoIP())
+            step = gap > 1000 ? 1000 : gap; // step is 1000 ms (NetSIO)
+        else
+            step = gap > 20 ? 20 : gap; // step is 20 ms (SerialSIO)
+        gap -= step;
+        SYSTEM_BUS.bus_idle(step); // idle bus (i.e. delay for SerialSIO, BUS_IDLE message for NetSIO)
+#endif
+        // While more than 1000 ms of gap remains, a de-asserted motor line (with
+        // pulldown present) aborts this record safely: restore the LED, free the
+        // pre-read buffer, and return the record start so the walker retries.
+        // Baud/UART state is left untouched (no setBaudrate) (Req 3.3 / 3.4).
+        if (has_pulldown() && !motor_line() && gap > 1000)
+        {
+            Debug_printf("FSK: motor line de-asserted during IRG (%u ms left) - aborting, returning to record start %u\r\n",
+                         (unsigned)gap, (unsigned)starting_offset);
+            fnLedManager.set(eLed::LED_BUS, false);
+            free(fsk_buf); // safe on nullptr; do not leak the pre-read buffer
+            return starting_offset;
+        }
+    }
+    fnLedManager.set(eLed::LED_BUS, false);
+
+#ifdef ESP_PLATFORM
+    // TASK 5.4: ESP raw FSK signal playback.
+    //
+    // Only reproduce a signal when there is a valid pre-read buffer AND at least
+    // one complete little-endian FSK_Signal_Value present. A null buffer means
+    // "no emission" — the pre-read either had nothing to read (data_avail == 0),
+    // failed to allocate, or short-read (all handled in task 5.2). In every such
+    // case we fall straight through to the common cleanup/return paths below
+    // with the baud/UART left untouched (Req 4.5 / 5.4 / 5.5 / 6.6). value_count
+    // == 0 (e.g. a single trailing odd byte) likewise emits nothing (Req 6.4).
+    if (fsk_buf != nullptr && value_count > 0)
+    {
+        // Bring up the RMT raw-signal path FIRST. fsk_signal_begin() flushes and
+        // detaches UART2 TX, allocates the RMT channel + stateful simple encoder
+        // (callback = fsk_encode_cb, arg = this), and fully undoes any partial
+        // setup on failure (Req 4.3 / 4.5 / 5.3-5.5). It does NOT touch the baud
+        // divisor. Only if it succeeds do we publish the encoder state that the
+        // IRAM callback reads.
+        if (fsk_signal_begin())
+        {
+            // Initialize the encoder state consumed by fsk_encode_cb ONLY after
+            // begin() succeeded, so the ISR callback never observes state that
+            // points at a half-configured channel. The member _fsk_buf aliases
+            // the LOCAL fsk_buf; the buffer stays owned by fsk_buf for the free
+            // on the common cleanup paths below (Req 4.1 / 4.2 / 4.6).
+            _fsk_buf = fsk_buf;              // pre-read data region (source of truth for the ISR)
+            _fsk_data_avail = data_avail;    // clamped bytes present
+            _fsk_value_count = value_count;  // floor(data_avail / 2); done when index reaches this
+            _fsk_value_index = 0;            // start at FSK_Signal_Index 0 (parity anchor)
+            _fsk_byte_pos = 0;               // first byte of the first value
+            _fsk_remaining_ticks = 0;        // no value being split yet
+            _fsk_level_high = false;         // index-0 parity is logical 0 (updated per value)
+
+            // Emit the whole payload as ONE continuous, gapless RMT transaction.
+            // fsk_signal_emit() also guards internally (active + buffer + count),
+            // but we gate here too so the caller's intent is explicit. It blocks
+            // on rmt_tx_wait_all_done, so the pre-read buffer stays valid for the
+            // entire transaction (Req 4.1 / 4.2).
+            fsk_signal_emit();
+
+            // Tear down the RMT path and hand PIN_UART2_TX back to the UART so
+            // normal data playback resumes at the unchanged baud (idempotent,
+            // preserves the baud divisor). fsk_signal_end() also waits for any
+            // in-flight transmission, guaranteeing the peripheral is fully done
+            // reading the pre-read buffer BEFORE the local free() below (Req 4.3
+            // / 5.1 / 5.3-5.5).
+            fsk_signal_end();
+
+            // Defensive: drop the member alias now that the transaction has
+            // completed and the channel is torn down. The LOCAL fsk_buf still
+            // holds the pointer for the free() on the common cleanup paths, so
+            // this leaves no dangling member pointer without double-freeing.
+            _fsk_buf = nullptr;
+        }
+        else
+        {
+            // RMT/UART setup failed (e.g. GPIO_NUM_NC or an RMT alloc error).
+            // fsk_signal_begin() already undid any partial setup and left the
+            // UART TX routing and baud divisor intact. Degrade safely: no
+            // emission, fall through to the common cleanup below (Req 4.5 / 5.5).
+            Debug_printf("FSK: signal setup failed - skipping emission, preserving baud/UART\r\n");
+        }
+    }
+#else
+    // TASK 5.5: deterministic PC-build behavior (Req 8.1-8.4).
+    //
+    // On the PC build (ESP_PLATFORM not defined) raw hardware Data_Line signal
+    // generation is unavailable, so the PC build intentionally performs NO raw
+    // signal emission: none of the ESP-only RMT/GPIO paths (fsk_signal_begin /
+    // fsk_signal_emit / fsk_signal_end, rmt_*, or PIN_UART2_TX routing) exist
+    // outside the #ifdef ESP_PLATFORM guard above, and none are called here
+    // (Req 8.1: compile/operate without unsupported hardware; Req 8.2: no raw
+    // Data_Line signal generation).
+    //
+    // The full deterministic PC behavior is already produced by the shared,
+    // cross-platform code surrounding this block, so this branch adds no logic:
+    //   * Bounds + pre-read (tasks 5.1/5.2, above the IRG loop) clamp every read
+    //     to `data_avail` (declared_len clamped to EOF) using only fnio::* and
+    //     malloc/free, never reading past the CAS image (Req 8.3).
+    //   * The IRG has ALREADY been honored deterministically before this block:
+    //     the gap loop above takes its non-ESP branch, stepping via
+    //     SYSTEM_BUS.isBoIP() sizing and idling the bus with SYSTEM_BUS.bus_idle
+    //     (a PC-only member), so the IRG is always honored on the PC build. It
+    //     is NOT duplicated here (Req 8.2).
+    //   * The common cleanup/return paths below the #endif free the pre-read
+    //     buffer and either advance past a well-formed chunk (offset + header +
+    //     declared_len) or return 0 (end-of-tape) for a truncated/overrun chunk,
+    //     letting the walker continue with subsequent chunks without crashing or
+    //     hanging (Req 8.4). No path calls SYSTEM_BUS.setBaudrate, so the active
+    //     baud is preserved.
+    //
+    // The pre-read buffer is unused for emission on PC; keep it referenced so an
+    // -Werror=unused-variable build stays clean while it is still freed exactly
+    // once below.
+    (void)fsk_buf;
+    (void)value_count;
+#endif // ESP_PLATFORM
+
+    // Common cleanup / return paths. Every success and failure path above funnels
+    // through exactly one of the two free()+return statements below, so the
+    // pre-read buffer is freed exactly once and no path double-frees. No path
+    // here calls SYSTEM_BUS.setBaudrate, so the active baud is preserved (Req
+    // 5.1-5.5). On ESP, fsk_signal_end() has already completed (blocking on the
+    // channel) before we reach the free(), so the buffer is never reclaimed
+    // while the RMT peripheral is still reading it.
+    if (truncated)
+    {
+        // Overrun / truncated payload: after reproducing the complete values
+        // present (added by later tasks), terminate at the real boundary
+        // (Req 1.4 / 6.3). Signal end-of-tape to the walker.
+        free(fsk_buf); // safe on nullptr; freed on every exit path
+        return 0;
+    }
+
+    // Well-formed chunk: advance past the full declared chunk (8-byte header +
+    // declared_len payload) so the walker continues with the next chunk
+    // (Req 1.2). Payload emission is added by tasks 5.3-5.5.
+    free(fsk_buf); // safe on nullptr; freed on every exit path
+    return offset + sizeof(struct tape_FUJI_hdr) + (size_t)declared_len;
+}
 
 size_t sioCassette::send_turbo2000_tape_block(size_t offset)
 {

--- a/lib/device/sio/cassette.h
+++ b/lib/device/sio/cassette.h
@@ -5,11 +5,16 @@
 
 #ifdef ESP_PLATFORM
 #include <driver/rmt_types.h>
+#include <esp_attr.h> // IRAM_ATTR for the FSK RMT encoder callback declaration
 #endif
 
 #include "bus.h"
 #include "fnSystem.h"
 #include "fnio.h"
+
+// Pure, host-buildable A8CAS FSK parsing/timing rules (decode/parity/scale/split).
+// Shared by the cross-platform play_fsk_chunk and the ESP RMT encoder callback.
+#include "fsk_plan.h"
 
 #define CASSETTE_BAUDRATE 600
 #define BLOCK_LEN 128
@@ -192,6 +197,43 @@ private:
     rmt_symbol_word_t _t2k_sync_syms[16];
     size_t _t2k_sync_count = 0;
     size_t _t2k_pilot_pending = 0; // pilot symbols to generate before sync+data
+#endif
+
+    // FSK chunk playback (A8CAS "fsk " chunks) — cross-platform entry point.
+    // Pre-reads the clamped data region into RAM ONCE, honors the IRG, reproduces
+    // the raw FSK signal via the RMT stateful simple encoder driven directly from
+    // that buffer (ESP) or safely skips (PC), and returns the next read offset.
+    // Never changes the active baud. Holds NO full-waveform buffer.
+    size_t play_fsk_chunk(size_t offset, uint16_t chunk_length, uint16_t irg_ms);
+
+#ifdef ESP_PLATFORM
+    // Raw FSK signal helpers built on the ESP RMT peripheral (same PIN_UART2_TX
+    // and detach/reattach approach as Turbo 2000, and the same stateful simple
+    // encoder pattern as t2k_encode_cb / rmt_new_simple_encoder).
+    bool fsk_signal_begin();   // alloc RMT channel + simple encoder (callback=fsk_encode_cb, arg=this), detach UART TX; false on failure
+    void fsk_signal_emit();    // ONE rmt_transmit of the whole pre-read buffer, then rmt_tx_wait_all_done
+    void fsk_signal_end();     // idempotent: teardown RMT + encoder, reattach UART TX
+
+    // The stateful RMT simple-encoder callback (same 7-arg signature as
+    // t2k_encode_cb). Generates rmt_symbol_word_t on demand from _fsk_buf plus
+    // the encoder state below. NO file I/O, NO heap allocation.
+    static size_t IRAM_ATTR fsk_encode_cb(const void *data, size_t data_size,
+                                          size_t symbols_written, size_t symbols_free,
+                                          rmt_symbol_word_t *symbols, bool *done, void *arg);
+
+    void       *_fsk_rmt_channel = nullptr;
+    void       *_fsk_rmt_encoder = nullptr;
+    bool        _fsk_signal_active = false;
+
+    // Preloaded source + encoder state read by fsk_encode_cb (set before
+    // rmt_transmit, read in the ISR callback). All O(1); no waveform buffer.
+    const uint8_t *_fsk_buf         = nullptr; // pre-read data region
+    size_t   _fsk_data_avail        = 0;       // clamped bytes present
+    size_t   _fsk_value_count       = 0;       // floor(_fsk_data_avail / 2); done when index reaches this
+    size_t   _fsk_value_index       = 0;       // current original FSK value index (for parity)
+    size_t   _fsk_byte_pos          = 0;       // current byte position in _fsk_buf
+    uint32_t _fsk_remaining_ticks   = 0;       // ticks left for the value being split (15-bit carry)
+    bool     _fsk_level_high        = false;   // logical level of the value being split (index parity)
 #endif
 };
 

--- a/lib/device/sio/fsk_plan.cpp
+++ b/lib/device/sio/fsk_plan.cpp
@@ -20,7 +20,13 @@ FskStep fsk_view_step(FskChunkView &view)
     {
         uint32_t portion = fsk_next_portion(view.remaining_ticks);
         view.remaining_ticks -= portion;
-        return FskStep{ true, view.remaining_level_high, portion, false };
+
+        // Approved contract: the LAST emitted portion carries done=true in the
+        // SAME call. More work remains iff this value still has ticks left or
+        // another value is still to be loaded.
+        bool more = view.remaining_ticks != 0 ||
+                    view.value_index < fsk_value_count(view.data_len_available);
+        return FskStep{ true, view.remaining_level_high, portion, !more };
     }
 
     // Case 2: load the next value. Skip leading zero-duration values, which
@@ -53,7 +59,14 @@ FskStep fsk_view_step(FskChunkView &view)
 
         uint32_t portion = fsk_next_portion(view.remaining_ticks);
         view.remaining_ticks -= portion;
-        return FskStep{ true, level, portion, false };
+
+        // Approved contract: this may be the LAST emitted portion (single-portion
+        // final value), in which case done=true is returned in the SAME call.
+        // More work remains iff this value still has ticks left or another value
+        // is still to be loaded (value_index already advanced past this one).
+        bool more = view.remaining_ticks != 0 ||
+                    view.value_index < value_count;
+        return FskStep{ true, level, portion, !more };
     }
 
     // Case 3: all values exhausted and nothing left to split.

--- a/lib/device/sio/fsk_plan.cpp
+++ b/lib/device/sio/fsk_plan.cpp
@@ -1,0 +1,61 @@
+// fsk_plan.cpp — host-test-only cursor step for the pure A8CAS FSK module.
+//
+// This file implements ONLY fsk_view_step. It is host-buildable and carries no
+// FujiNet, ESP-IDF, GPIO, RMT, filesystem, or global-state dependency. It does
+// not allocate, perform I/O, or log, and it performs only O(1) state
+// transitions on the FskChunkView cursor (it never materializes the full
+// waveform). It reads strictly within [0, data_len_available).
+//
+// fsk_view_step shares the SAME pure rule helpers (fsk_decode_le16,
+// fsk_level_for_index, fsk_ticks_for_value, fsk_next_portion, fsk_value_count)
+// declared in fsk_plan.h that the production IRAM RMT callback (fsk_encode_cb)
+// inlines, so host tests and production cannot diverge on the modeled duration.
+
+#include "fsk_plan.h"
+
+FskStep fsk_view_step(FskChunkView &view)
+{
+    // Case 1: the current value is still being split. Emit its next portion.
+    if (view.remaining_ticks > 0)
+    {
+        uint32_t portion = fsk_next_portion(view.remaining_ticks);
+        view.remaining_ticks -= portion;
+        return FskStep{ true, view.remaining_level_high, portion, false };
+    }
+
+    // Case 2: load the next value. Skip leading zero-duration values, which
+    // still consume a value index (advancing parity) and byte position but
+    // produce no portion. Keep advancing until a non-zero value is found or
+    // the values are exhausted.
+    const size_t value_count = fsk_value_count(view.data_len_available);
+
+    while (view.value_index < value_count)
+    {
+        // byte_pos == value_index * 2, and value_index < floor(len/2), so both
+        // byte_pos and byte_pos+1 are strictly within [0, data_len_available).
+        uint16_t decoded = fsk_decode_le16(&view.data[view.byte_pos]);
+        bool     level   = fsk_level_for_index(view.value_index);
+        uint32_t ticks   = fsk_ticks_for_value(decoded);
+
+        // Consume this value's index/parity slot and byte position.
+        view.value_index += 1;
+        view.byte_pos    += 2;
+
+        if (ticks == 0)
+        {
+            // Zero-duration value: consumed a parity slot, emits nothing.
+            continue;
+        }
+
+        // Non-zero value: begin splitting it and emit its first portion.
+        view.remaining_ticks      = ticks;
+        view.remaining_level_high = level;
+
+        uint32_t portion = fsk_next_portion(view.remaining_ticks);
+        view.remaining_ticks -= portion;
+        return FskStep{ true, level, portion, false };
+    }
+
+    // Case 3: all values exhausted and nothing left to split.
+    return FskStep{ false, false, 0, true };
+}

--- a/lib/device/sio/fsk_plan.h
+++ b/lib/device/sio/fsk_plan.h
@@ -1,0 +1,116 @@
+#ifndef FSK_PLAN_H
+#define FSK_PLAN_H
+
+// fsk_plan.h — pure, host-buildable A8CAS FSK parsing/timing rules.
+//
+// No I/O, no hardware, no FujiNet globals, no allocation, no logging.
+// The static-inline rule helpers below are trivial/inlinable arithmetic and
+// IRAM-safe so the production RMT encoder callback (fsk_encode_cb) can inline
+// the SAME rules the host tests exercise, keeping production and tests from
+// diverging on the modeled duration.
+//
+// `fsk_view_step` is declared here for host tests but is implemented in
+// fsk_plan.cpp; it is intentionally NOT static inline and NOT called from the
+// ISR.
+
+#include <cstdint>
+#include <cstddef>
+
+// Force-inline the pure rule helpers that the production IRAM RMT callback
+// (fsk_encode_cb) may call. Plain `static inline` is only a hint; the compiler
+// may still emit an out-of-line, flash-resident copy, which is unsafe to call
+// from an IRAM/ISR context. `always_inline` guarantees the body is inlined at
+// each call site so nothing flash-resident is invoked from the ISR path. Stays
+// host-buildable: no ESP-IDF dependency and no IRAM_ATTR in this pure module.
+#if defined(__GNUC__) || defined(__clang__)
+#define FSK_FORCE_INLINE static inline __attribute__((always_inline))
+#else
+#define FSK_FORCE_INLINE static inline
+#endif
+
+// The RMT 15-bit per-level tick limit (max ticks in one rmt_symbol duration field).
+static constexpr uint32_t FSK_MAX_PORTION_TICKS = 32767;
+
+// 1 us per RMT tick (1 MHz); one A8CAS unit = 1/10 ms = 100 us = 100 ticks.
+static constexpr uint32_t FSK_RMT_TICKS_PER_A8CAS_UNIT = 100;
+
+// Scale one A8CAS value (in 1/10 ms units) to RMT ticks at the 1 us grid.
+FSK_FORCE_INLINE uint32_t fsk_ticks_for_value(uint16_t value)
+{
+    return (uint32_t)value * FSK_RMT_TICKS_PER_A8CAS_UNIT;
+}
+
+// Decode one little-endian uint16 duration from the two bytes at p (Req 2.1).
+// The caller guarantees p and p+1 are inside the available data region.
+FSK_FORCE_INLINE uint16_t fsk_decode_le16(const uint8_t *p)
+{
+    return (uint16_t)p[0] | ((uint16_t)p[1] << 8);
+}
+
+// Logical level for a value by ORIGINAL A8CAS value index parity (Req 2.5/4.2):
+// even index = logical 0 (returns false), odd index = logical 1 (returns true).
+FSK_FORCE_INLINE bool fsk_level_for_index(size_t value_index)
+{
+    return (value_index & 1) != 0;
+}
+
+// One split step (pure state transition, NOT a materialized list). Ticks for a
+// value V are V * 100 (1/10 ms = 100 us = 100 ticks at 1 us/tick). Given the
+// ticks remaining for the current value, return the next portion to emit
+// (min(remaining, 32767)); the caller subtracts it to get the new remaining.
+// remaining==0 returns 0 (nothing to emit) (Req 4.1, 4.6).
+FSK_FORCE_INLINE uint32_t fsk_next_portion(uint32_t remaining_ticks)
+{
+    return remaining_ticks > FSK_MAX_PORTION_TICKS ? FSK_MAX_PORTION_TICKS
+                                                   : remaining_ticks;
+}
+
+// Number of FSK_Signal_Values available: floor(data_len_available / 2) (Req 2.3/6.4).
+FSK_FORCE_INLINE size_t fsk_value_count(size_t data_len_available)
+{
+    return data_len_available / 2;
+}
+
+// A small pure cursor over the pre-read byte buffer. Holds O(1) state; allocates
+// nothing; never reads outside [0, data_len_available). Host tests advance this
+// cursor with fsk_view_step. Production carries equivalent O(1) state but does
+// not call fsk_view_step; it uses the same static-inline decode/parity/scale/
+// split rules.
+struct FskChunkView
+{
+    const uint8_t *data;               // pre-read data region (null iff len==0)
+    size_t   data_len_available;       // clamped bytes present (caller-bounded)
+    size_t   value_index;              // 0-based FSK_Signal_Index of current value
+    size_t   byte_pos;                 // next byte to read (== value_index*2)
+    uint32_t remaining_ticks;          // ticks left in the current value being split (value*100)
+    bool     remaining_level_high;     // level of the value currently being split
+};
+
+// Initialize a cursor at the start of the buffer.
+FSK_FORCE_INLINE FskChunkView fsk_view_init(const uint8_t *data, size_t data_len_available)
+{
+    return FskChunkView{ data, data_len_available, 0, 0, 0, false };
+}
+
+// Result of one cursor step.
+struct FskStep
+{
+    bool     produced;   // true if this step yields a portion to emit
+    bool     level_high; // level of the produced portion
+    uint32_t ticks;      // portion ticks (1..32767) when produced
+    bool     done;       // true once no more portions/values remain
+};
+
+// Advance the cursor by exactly one emitted portion. If the current value still
+// has remaining ticks, emit the next portion of it (splitting on the fly). Else
+// load the next value: skip any leading zero-duration values (they consume an
+// index and thus parity but emit nothing), then emit their first portion. Sets
+// done when all value_count values are exhausted. Reads only within
+// [0, data_len_available). HOST-TEST-ONLY: defined in fsk_plan.cpp, NOT static
+// inline, NOT called from the ISR, and NOT in IRAM. It uses the same static-
+// inline pure RULES (fsk_decode_le16 / fsk_level_for_index / fsk_ticks_for_value /
+// fsk_next_portion) that the production IRAM callback fsk_encode_cb inlines, so
+// both share logic.
+FskStep fsk_view_step(FskChunkView &view);
+
+#endif // FSK_PLAN_H

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -38,6 +38,24 @@ target_include_directories(calendar_tests PRIVATE
 add_test(NAME calendar_tests COMMAND calendar_tests)
 
 # ------------------------------------------------------------------------------
+# A8CAS FSK chunk playback rules. fsk_plan is a pure, host-buildable module: it
+# models the FSK decode/parity/scale/split contract with no hardware, I/O, or
+# FujiNet globals, so it links on its own - which is what lets these decode and
+# split edge cases be pinned down here instead of on device.
+# ------------------------------------------------------------------------------
+add_executable(fsk_plan_tests
+    FskPlanTests.cpp
+    ${CMAKE_SOURCE_DIR}/lib/device/sio/fsk_plan.cpp
+)
+
+target_include_directories(fsk_plan_tests PRIVATE
+    ${CMAKE_SOURCE_DIR}/lib/device/      # for "sio/fsk_plan.h"
+    ${CMAKE_SOURCE_DIR}/components_pc/   # doctest
+)
+
+add_test(NAME fsk_plan_tests COMMAND fsk_plan_tests)
+
+# ------------------------------------------------------------------------------
 # Mail draft parsing and RFC822 assembly (compose / reply). mail_draft depends
 # only on the standard library, so the EOL and threading edge cases are pinned
 # here rather than on hardware.

--- a/tests/FskPlanTests.cpp
+++ b/tests/FskPlanTests.cpp
@@ -1,0 +1,1029 @@
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include <doctest/doctest.h>
+
+#include "sio/fsk_plan.h"
+
+#include <array>
+#include <cstdint>
+#include <cstddef>
+#include <vector>
+
+// FskPlanTests.cpp — doctest coverage for the pure A8CAS FSK rules in
+// lib/device/sio/fsk_plan.{h,cpp}. These tests exercise the pure decode/parity/
+// scale/split helpers and drive the host-only fsk_view_step cursor. They touch
+// no hardware, I/O, or globals.
+//
+// Requirements traced here: 2.7 (worked example), 2.8 (empty payload),
+// 4.6 (zero-duration parity + split), 6.4 (odd-length / floor pairing).
+//
+// NOTE: This file is registered into the build under task 2.4. Later tasks
+// (2.2 generated-loop property tests, 2.3 synthetic fixtures) add more sections
+// to this same file, so the TEST_CASE blocks below are kept self-contained.
+
+namespace
+{
+// Build a little-endian 2-byte buffer for a single uint16 value.
+inline std::array<uint8_t, 2> le16_buf(uint16_t value)
+{
+    return { (uint8_t)(value & 0xFF), (uint8_t)((value >> 8) & 0xFF) };
+}
+
+// Result of running a FskChunkView to exhaustion.
+struct DrainResult
+{
+    size_t   portion_count;   // number of produced portions
+    uint64_t total_ticks;     // sum of all produced portion ticks
+    bool     all_same_level;  // every produced portion carried the same level
+    bool     first_level;     // level of the first produced portion (if any)
+    uint32_t max_portion;     // largest produced portion (0 if none produced)
+};
+
+// Drive a cursor over `data`/`len` until fsk_view_step reports done, collecting
+// aggregate statistics. Per the approved contract, the LAST emitted portion may
+// carry produced=true AND done=true in the SAME call, so a produced portion is
+// always accounted for before honoring done.
+DrainResult drain(const uint8_t *data, size_t len)
+{
+    FskChunkView view = fsk_view_init(data, len);
+
+    DrainResult r{ 0, 0, true, false, 0 };
+    bool have_first = false;
+
+    for (;;)
+    {
+        FskStep step = fsk_view_step(view);
+
+        // Account for a produced portion first — the terminal step may both
+        // produce the final portion and report done in one call.
+        if (step.produced)
+        {
+            if (!have_first)
+            {
+                r.first_level = step.level_high;
+                have_first    = true;
+            }
+            else if (step.level_high != r.first_level)
+            {
+                r.all_same_level = false;
+            }
+
+            r.portion_count += 1;
+            r.total_ticks   += step.ticks;
+            if (step.ticks > r.max_portion)
+                r.max_portion = step.ticks;
+        }
+
+        if (step.done)
+            break;
+    }
+
+    return r;
+}
+
+// Convenience: drain a single uint16 value laid out as one LE pair.
+DrainResult drain_value(uint16_t value)
+{
+    std::array<uint8_t, 2> buf = le16_buf(value);
+    return drain(buf.data(), buf.size());
+}
+} // namespace
+
+// ─── Requirement 2.7: A8CAS worked example ─────────────────────────────────────
+
+TEST_CASE("Req 2.7 worked example: 10 data bytes decode to 5 FSK values")
+{
+    // Data area bytes for the worked example. 10 bytes => 5 LE uint16 values.
+    const uint8_t data[] = {
+        0x00, 0x01, // index 0: 0x0100 = 256  -> 25.6 ms -> logical 0 (even)
+        0x10, 0x01, // index 1: 0x0110 = 272  -> 27.2 ms -> logical 1 (odd)
+        0x80, 0x00, // index 2: 0x0080 = 128  -> 12.8 ms -> logical 0
+        0x20, 0x00, // index 3: 0x0020 = 32   ->  3.2 ms -> logical 1
+        0x80, 0x02  // index 4: 0x0280 = 640  -> 64.0 ms -> logical 0
+    };
+    const size_t len = sizeof(data);
+
+    // Ten bytes yield exactly five values (floor of len/2).
+    CHECK(fsk_value_count(len) == 5);
+
+    SUBCASE("fsk_decode_le16 recovers each value")
+    {
+        CHECK(fsk_decode_le16(&data[0]) == 256);
+        CHECK(fsk_decode_le16(&data[2]) == 272);
+        CHECK(fsk_decode_le16(&data[4]) == 128);
+        CHECK(fsk_decode_le16(&data[6]) == 32);
+        CHECK(fsk_decode_le16(&data[8]) == 640);
+    }
+
+    SUBCASE("fsk_level_for_index follows index parity")
+    {
+        CHECK(fsk_level_for_index(0) == false); // logical 0
+        CHECK(fsk_level_for_index(1) == true);  // logical 1
+        CHECK(fsk_level_for_index(2) == false); // logical 0
+        CHECK(fsk_level_for_index(3) == true);  // logical 1
+        CHECK(fsk_level_for_index(4) == false); // logical 0
+    }
+
+    SUBCASE("fsk_ticks_for_value scales by 100 ticks per unit")
+    {
+        CHECK(fsk_ticks_for_value(256) == 25600);
+        CHECK(fsk_ticks_for_value(272) == 27200);
+        CHECK(fsk_ticks_for_value(128) == 12800);
+        CHECK(fsk_ticks_for_value(32) == 3200);
+        CHECK(fsk_ticks_for_value(640) == 64000);
+    }
+
+    SUBCASE("fsk_view_step reproduces every value in order at parity level")
+    {
+        // Each value maps to `value * 100` ticks. The first four fit in a single
+        // portion (<= 32767 ticks), but index 4 (640 -> 64,000 ticks) exceeds
+        // FSK_MAX_PORTION_TICKS and is split across two same-level portions
+        // (32767 + 31233 = 64000). Drive the whole buffer, grouping portions by
+        // value, and confirm each value's total ticks and level.
+        struct Expect { bool level_high; uint32_t total_ticks; };
+        const Expect expected[] = {
+            { false, 25600 }, // index 0: 256 -> one portion
+            { true,  27200 }, // index 1: 272 -> one portion
+            { false, 12800 }, // index 2: 128 -> one portion
+            { true,   3200 }, // index 3: 32  -> one portion
+            { false, 64000 }, // index 4: 640 -> split into two portions
+        };
+
+        FskChunkView view = fsk_view_init(data, len);
+
+        const size_t last = (sizeof(expected) / sizeof(expected[0])) - 1;
+        bool saw_done = false;
+
+        for (size_t i = 0; i < sizeof(expected) / sizeof(expected[0]); ++i)
+        {
+            const Expect &e = expected[i];
+
+            // Consume all portions that belong to this value: the value's ticks
+            // remain "in flight" (view.remaining_ticks) until fully emitted.
+            uint32_t accumulated = 0;
+            do
+            {
+                FskStep step = fsk_view_step(view);
+                REQUIRE(step.produced);
+                CHECK(step.level_high == e.level_high);
+                CHECK(step.ticks <= FSK_MAX_PORTION_TICKS);
+                accumulated += step.ticks;
+
+                // Approved contract: done becomes true on the LAST emitted
+                // portion (last portion of the last value) in the SAME call.
+                // Every earlier produced portion has more work remaining.
+                if (step.done)
+                {
+                    saw_done = true;
+                }
+                else
+                {
+                    // Not-done is only valid mid-value or before the last value.
+                    bool more_work_expected = (view.remaining_ticks > 0) || (i < last);
+                    CHECK(more_work_expected);
+                }
+            } while (view.remaining_ticks > 0);
+
+            CHECK(accumulated == e.total_ticks);
+        }
+
+        // The final emitted portion already carried done=true; no extra
+        // non-producing terminal call is required.
+        CHECK(saw_done);
+    }
+}
+
+// ─── Requirement 2.8: zero-length payload ───────────────────────────────────────
+
+TEST_CASE("Req 2.8 empty payload produces nothing and is immediately done")
+{
+    CHECK(fsk_value_count(0) == 0);
+
+    FskChunkView view = fsk_view_init(nullptr, 0);
+    FskStep step = fsk_view_step(view);
+    CHECK_FALSE(step.produced);
+    CHECK(step.done);
+}
+
+// ─── Requirement 6.4: odd-length payload handling ───────────────────────────────
+
+TEST_CASE("Req 6.4 odd-length payload ignores the trailing unpaired byte")
+{
+    // Five bytes: two complete LE pairs plus one dangling byte that must never
+    // be read. If the trailing byte were read, the sentinel 0xEE below would
+    // corrupt a decoded value; the test proves it is ignored.
+    const uint8_t data[] = {
+        0x0A, 0x00, // index 0: 10  -> logical 0
+        0x14, 0x00, // index 1: 20  -> logical 1
+        0xEE        // trailing unpaired byte — must be ignored
+    };
+    const size_t len = sizeof(data);
+
+    // Floor pairing: 5 bytes -> 2 values.
+    CHECK(fsk_value_count(len) == 2);
+
+    FskChunkView view = fsk_view_init(data, len);
+
+    FskStep s0 = fsk_view_step(view);
+    REQUIRE(s0.produced);
+    CHECK_FALSE(s0.done);               // a second value still remains
+    CHECK(s0.level_high == false);      // index 0 even -> logical 0
+    CHECK(s0.ticks == fsk_ticks_for_value(10)); // 1000
+
+    // The second (last) value's single portion carries done=true in the SAME
+    // call per the approved contract; no extra non-producing terminal call.
+    FskStep s1 = fsk_view_step(view);
+    REQUIRE(s1.produced);
+    CHECK(s1.done);                     // last portion of the last value
+    CHECK(s1.level_high == true);       // index 1 odd -> logical 1
+    CHECK(s1.ticks == fsk_ticks_for_value(20)); // 2000
+
+    // The cursor stopped after two values, before the trailing byte: the
+    // unpaired byte at index 4 (0xEE) was never read.
+    CHECK(view.byte_pos == 4);
+    CHECK(view.byte_pos < len);
+
+    // A further step past exhaustion is a non-producing done.
+    FskStep past_end = fsk_view_step(view);
+    CHECK_FALSE(past_end.produced);
+    CHECK(past_end.done);
+}
+
+// ─── Requirement 4.6: zero-duration values preserve parity ──────────────────────
+
+TEST_CASE("Req 4.6 zero-duration values consume a parity slot without emitting")
+{
+    SUBCASE("a middle zero is skipped but keeps later parity aligned")
+    {
+        // Values [100, 0, 200]. The zero at index 1 emits nothing, but the
+        // value at index 2 must still be logical 0 (even), proving the zero
+        // consumed a parity slot rather than shifting parity onto the next
+        // value.
+        const uint8_t data[] = {
+            0x64, 0x00, // index 0: 100 -> logical 0
+            0x00, 0x00, // index 1: 0   -> skipped, still consumes parity slot
+            0xC8, 0x00  // index 2: 200 -> logical 0 (even)
+        };
+        const size_t len = sizeof(data);
+
+        CHECK(fsk_value_count(len) == 3);
+
+        FskChunkView view = fsk_view_init(data, len);
+
+        FskStep first = fsk_view_step(view);
+        REQUIRE(first.produced);
+        CHECK_FALSE(first.done);                          // value 200 still remains
+        CHECK(first.level_high == false);                 // index 0 even
+        CHECK(first.ticks == fsk_ticks_for_value(100));   // 10000
+
+        // The zero at index 1 is skipped internally; the next produced portion
+        // is value 200 at index 2, which must remain logical 0 (even parity).
+        // It is the last value, so its single portion carries done=true in the
+        // SAME call per the approved contract.
+        FskStep second = fsk_view_step(view);
+        REQUIRE(second.produced);
+        CHECK(second.done);                               // last portion of last value
+        CHECK(second.level_high == false);                // index 2 even, NOT odd
+        CHECK(second.ticks == fsk_ticks_for_value(200));  // 20000
+
+        // A further step past exhaustion is a non-producing done.
+        FskStep past_end = fsk_view_step(view);
+        CHECK_FALSE(past_end.produced);
+        CHECK(past_end.done);
+    }
+
+    SUBCASE("a leading zero keeps the next value at logical 1")
+    {
+        // Values [0, 300]. Index 0 is zero (skipped, consumes parity), so the
+        // first produced portion is index 1 -> logical 1.
+        const uint8_t data[] = {
+            0x00, 0x00, // index 0: 0   -> skipped
+            0x2C, 0x01  // index 1: 300 -> logical 1 (odd)
+        };
+        const size_t len = sizeof(data);
+
+        CHECK(fsk_value_count(len) == 2);
+
+        FskChunkView view = fsk_view_init(data, len);
+
+        // Index 1 (value 300) is the only and last value emitted, so its
+        // single portion carries done=true in the SAME call.
+        FskStep first = fsk_view_step(view);
+        REQUIRE(first.produced);
+        CHECK(first.done);                                // last portion of last value
+        CHECK(first.level_high == true);                  // index 1 odd
+        CHECK(first.ticks == fsk_ticks_for_value(300));   // 30000
+
+        // A further step past exhaustion is a non-producing done.
+        FskStep past_end = fsk_view_step(view);
+        CHECK_FALSE(past_end.produced);
+        CHECK(past_end.done);
+    }
+}
+
+// ─── Requirements 2.4 / 4.6 / 6.4: value scaling and split portion counts ───────
+
+TEST_CASE("value scaling and split portion counts across the range")
+{
+    struct ValueCase
+    {
+        uint16_t value;
+        uint32_t expected_ticks;
+        size_t   expected_portions;
+    };
+
+    // Portion count = ceil(ticks / 32767); the final portion carries the
+    // remainder. All portions except possibly the last are exactly 32767.
+    const ValueCase cases[] = {
+        { 1,        100, 1 },     // 1 -> 100 ticks -> 1 portion
+        { 256,    25600, 1 },     // 256 -> 25,600 ticks -> 1 portion
+        { 6818,  681800, 21 },    // 6818 -> 681,800 ticks -> 21 portions
+        { 40000, 4000000, 123 },  // 40000 -> 4,000,000 ticks -> 123 portions
+        { 65535, 6553500, 201 },  // 65535 -> 6,553,500 ticks -> 201 portions
+    };
+
+    for (const ValueCase &c : cases)
+    {
+        CAPTURE(c.value);
+
+        // Pure scaling helper.
+        CHECK(fsk_ticks_for_value(c.value) == c.expected_ticks);
+
+        // Drive the cursor over a single-value buffer and count portions.
+        DrainResult r = drain_value(c.value);
+
+        CHECK(r.portion_count == c.expected_portions);
+        CHECK(r.total_ticks == c.expected_ticks);   // duration preserved
+        CHECK(r.max_portion <= FSK_MAX_PORTION_TICKS);
+        CHECK(r.all_same_level);                     // one value -> one level
+        CHECK(r.first_level == false);               // index 0 even -> logical 0
+    }
+
+    SUBCASE("6818 explicitly maps to 681,800 ticks over 21 portions")
+    {
+        DrainResult r = drain_value(6818);
+        CHECK(r.total_ticks == 681800);
+        CHECK(r.portion_count == 21);
+        CHECK(r.max_portion == FSK_MAX_PORTION_TICKS); // at least one full portion
+    }
+
+    SUBCASE("65535 explicitly maps to 6,553,500 ticks over 201 portions")
+    {
+        // 200 portions of 32767 (= 6,553,400) plus a final 100-tick portion.
+        DrainResult r = drain_value(65535);
+        CHECK(r.total_ticks == 6553500);
+        CHECK(r.portion_count == 201);
+        CHECK(r.max_portion == FSK_MAX_PORTION_TICKS);
+        CHECK(200u * FSK_MAX_PORTION_TICKS + 100u == 6553500u); // arithmetic sanity
+    }
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// Task 2.2 — Deterministic generated-loop tests for the correctness properties.
+//
+// These are deterministic (loop/enumeration driven — NO randomness): every input
+// is either fully enumerated over the uint16 range or drawn from a fixed set.
+// They reuse the anonymous-namespace helpers above (le16_buf, DrainResult, drain,
+// drain_value) and add a few small local helpers where a per-portion view is
+// needed that the aggregate `drain` cannot provide.
+//
+// Properties (traced to Requirements 2.1, 2.3, 2.4, 2.5, 4.1, 4.6, 6.2, 6.4):
+//   P1  fsk_value_count(len) == len / 2
+//   P2  summed emitted portion ticks == fsk_ticks_for_value(decoded value)
+//   P3  every emitted portion level follows original value-index parity
+//   P4  cursor byte reads stay within the available payload
+//   P5  portions <= FSK_MAX_PORTION_TICKS, preserve total duration, correct count
+// ════════════════════════════════════════════════════════════════════════════
+
+namespace
+{
+// Expected portion count for a single value V using pure integer arithmetic:
+// 0 portions when V == 0, else ceil(V * 100 / 32767). Computed independently of
+// the module under test so the test is a real cross-check, not a tautology.
+inline size_t expected_portion_count(uint16_t value)
+{
+    uint32_t ticks = (uint32_t)value * FSK_RMT_TICKS_PER_A8CAS_UNIT; // V * 100
+    if (ticks == 0)
+        return 0;
+    return (size_t)((ticks + (FSK_MAX_PORTION_TICKS - 1)) / FSK_MAX_PORTION_TICKS);
+}
+
+// One emitted portion recorded while draining, with the ORIGINAL value index it
+// belongs to. Used by Property 3 to check per-portion parity, and by Property 4
+// to observe byte_pos monotonicity/bounds at every step.
+struct PortionRecord
+{
+    size_t   value_index; // original FSK_Signal_Index the portion came from
+    bool     level_high;  // emitted level of the portion
+    uint32_t ticks;       // portion ticks
+    size_t   byte_pos;    // view.byte_pos observed immediately after the step
+};
+
+// Drain a payload, recording one PortionRecord per emitted portion and grouping
+// portions under the original value index they belong to. A value's index is the
+// cursor value_index minus one after the value has been loaded (the cursor
+// advances value_index when it loads a value; every portion of that value shares
+// the same "just-loaded" index). We reconstruct the owning index by tracking the
+// low-water value_index for each contiguous run of same-remaining portions.
+//
+// The reconstruction rule mirrors the cursor contract exactly:
+//  - When a step begins a NEW value, view.value_index has already advanced past
+//    it, so the owning index is (value_index - 1).
+//  - When a step continues splitting the SAME value (the previous step left
+//    remaining_ticks > 0), the owning index is unchanged from the previous step.
+// We detect "new value" by observing that the previous step left no remainder.
+std::vector<PortionRecord> drain_portions(const uint8_t *data, size_t len,
+                                           size_t &final_byte_pos, bool &saw_done)
+{
+    FskChunkView view = fsk_view_init(data, len);
+
+    std::vector<PortionRecord> out;
+    saw_done = false;
+
+    bool   prev_left_remainder = false; // did the previous produced step leave ticks?
+    size_t current_owner_index = 0;
+
+    for (;;)
+    {
+        FskStep step = fsk_view_step(view);
+
+        if (step.produced)
+        {
+            if (!prev_left_remainder)
+            {
+                // This portion begins a freshly-loaded value; the cursor already
+                // advanced value_index past it, so the owner is value_index - 1.
+                current_owner_index = view.value_index - 1;
+            }
+            // else: continuation of the same value; owner index unchanged.
+
+            out.push_back(PortionRecord{
+                current_owner_index, step.level_high, step.ticks, view.byte_pos });
+
+            prev_left_remainder = (view.remaining_ticks != 0);
+        }
+
+        if (step.done)
+        {
+            saw_done = true;
+            break;
+        }
+    }
+
+    final_byte_pos = view.byte_pos;
+    return out;
+}
+} // namespace
+
+// ─── Property 1: fsk_value_count(len) == len / 2 ────────────────────────────────
+
+TEST_CASE("P1 fsk_value_count(len) == len/2 for a deterministic length set")
+{
+    // Small exhaustive prefix (0..512) catches every odd/even boundary, then a
+    // deterministic stride sample up to a few thousand bytes.
+    for (size_t len = 0; len <= 512; ++len)
+    {
+        CAPTURE(len);
+        CHECK(fsk_value_count(len) == len / 2);
+    }
+
+    for (size_t len = 513; len <= 4096; len += 7)
+    {
+        CAPTURE(len);
+        CHECK(fsk_value_count(len) == len / 2);
+    }
+
+    // Explicit boundary cases named in the task.
+    CHECK(fsk_value_count(0) == 0);
+    CHECK(fsk_value_count(1) == 0);
+    CHECK(fsk_value_count(2) == 1);
+    CHECK(fsk_value_count(3) == 1);
+}
+
+// ─── Property 5: pure split arithmetic across the FULL uint16 range ─────────────
+
+TEST_CASE("P5 pure split arithmetic holds for every uint16 value 0..65535")
+{
+    // The split arithmetic (tick scaling + portion count) is cheap, so enumerate
+    // the ENTIRE uint16 range here as the task requests ("full uint16 value range
+    // for split arithmetic where practical"). This validates fsk_ticks_for_value
+    // and the ceil-based portion count without draining a cursor per value.
+    for (uint32_t v = 0; v <= 0xFFFF; ++v)
+    {
+        uint16_t value = (uint16_t)v;
+        uint32_t ticks = fsk_ticks_for_value(value);
+
+        // Tick scaling is exactly V * 100.
+        REQUIRE(ticks == (uint32_t)value * 100u);
+
+        // Portion count matches the independent ceil computation.
+        size_t expected = expected_portion_count(value);
+
+        // Reconstruct the per-portion sequence purely from fsk_next_portion to
+        // confirm: each portion <= max, all portions sum to `ticks`, and the
+        // count equals `expected`. This mirrors the production split loop.
+        size_t   portions = 0;
+        uint32_t remaining = ticks;
+        uint64_t summed = 0;
+        while (remaining > 0)
+        {
+            uint32_t portion = fsk_next_portion(remaining);
+            REQUIRE(portion > 0);
+            REQUIRE(portion <= FSK_MAX_PORTION_TICKS);
+            summed    += portion;
+            remaining -= portion;
+            ++portions;
+        }
+
+        REQUIRE(portions == expected);
+        REQUIRE(summed == ticks);
+    }
+
+    // Explicit boundary/tick-edge values called out by the task.
+    CHECK(expected_portion_count(0) == 0);
+    CHECK(expected_portion_count(1) == 1);      // 100 ticks
+    CHECK(expected_portion_count(327) == 1);    // 32,700 <= 32767 -> 1 portion
+    CHECK(expected_portion_count(328) == 2);    // 32,800 > 32767  -> 2 portions
+    CHECK(expected_portion_count(6818) == 21);  // 681,800 -> 21 portions
+    CHECK(expected_portion_count(65535) == 201);// 6,553,500 -> 201 portions
+}
+
+// ─── Property 2 + Property 5 (cursor): per-value drain over a dense value set ───
+
+TEST_CASE("P2/P5 single-value drain preserves duration and portion count")
+{
+    // Draining a cursor per value is more expensive than the pure arithmetic
+    // above, so use a dense-but-bounded deterministic set rather than all 65536:
+    //  - every value 0..1024 (covers the 327/328 tick boundary and small counts)
+    //  - a fixed stride across the rest of the range
+    //  - the explicit boundary values named in the task.
+    std::vector<uint32_t> values;
+    for (uint32_t v = 0; v <= 1024; ++v)
+        values.push_back(v);
+    for (uint32_t v = 1025; v <= 0xFFFF; v += 337) // deterministic stride
+        values.push_back(v);
+    for (uint32_t v : { 327u, 328u, 6818u, 32767u, 40000u, 65535u })
+        values.push_back(v);
+
+    for (uint32_t v : values)
+    {
+        uint16_t value = (uint16_t)v;
+        CAPTURE(value);
+
+        std::array<uint8_t, 2> buf = le16_buf(value);
+
+        // Sanity: decode round-trips through the LE pair.
+        REQUIRE(fsk_decode_le16(buf.data()) == value);
+
+        DrainResult r = drain(buf.data(), buf.size());
+
+        // P2: summed emitted portion ticks == fsk_ticks_for_value(decoded).
+        CHECK(r.total_ticks == fsk_ticks_for_value(value));
+
+        // P5: every portion within the 15-bit cap, and the portion count matches
+        // the independent ceil computation (0 for a zero-duration value).
+        CHECK(r.max_portion <= FSK_MAX_PORTION_TICKS);
+        CHECK(r.portion_count == expected_portion_count(value));
+
+        // A single value yields a single logical level.
+        CHECK(r.all_same_level);
+
+        // Index 0 is even -> logical 0. (Zero-duration values produce no portion,
+        // so first_level stays at its default false, which also matches.)
+        CHECK(r.first_level == false);
+    }
+}
+
+// ─── Property 3: per-portion level follows ORIGINAL value-index parity ──────────
+
+TEST_CASE("P3 every emitted portion level follows original value-index parity")
+{
+    // A deterministic multi-value payload with zeros interspersed. Zero-duration
+    // values emit nothing but MUST still consume a parity slot, so the parity of
+    // every following value stays aligned to its original index. Values are
+    // chosen so several of them split into multiple portions (all portions of a
+    // value must share that value's index parity).
+    const uint16_t values[] = {
+        100,   // index 0 even -> logical 0, 1 portion
+        0,     // index 1 odd  -> zero: emits nothing, still consumes parity
+        400,   // index 2 even -> logical 0, 2 portions (40000 ticks)
+        6818,  // index 3 odd  -> logical 1, 21 portions
+        0,     // index 4 even -> zero: emits nothing, still consumes parity
+        0,     // index 5 odd  -> zero: emits nothing, still consumes parity
+        500,   // index 6 even -> logical 0, 2 portions (50000 ticks)
+        1,     // index 7 odd  -> logical 1, 1 portion
+        65535, // index 8 even -> logical 0, 201 portions
+    };
+    const size_t n = sizeof(values) / sizeof(values[0]);
+
+    // Build the LE payload deterministically.
+    std::vector<uint8_t> data;
+    data.reserve(n * 2);
+    for (size_t i = 0; i < n; ++i)
+    {
+        std::array<uint8_t, 2> pair = le16_buf(values[i]);
+        data.push_back(pair[0]);
+        data.push_back(pair[1]);
+    }
+
+    CHECK(fsk_value_count(data.size()) == n);
+
+    size_t final_byte_pos = 0;
+    bool   saw_done = false;
+    std::vector<PortionRecord> portions =
+        drain_portions(data.data(), data.size(), final_byte_pos, saw_done);
+
+    CHECK(saw_done);
+
+    // Every portion's level equals the parity of the ORIGINAL value index it came
+    // from, and each portion is attributed to a non-zero-duration value.
+    for (const PortionRecord &p : portions)
+    {
+        CAPTURE(p.value_index);
+        REQUIRE(p.value_index < n);
+        CHECK(values[p.value_index] != 0);                       // zeros emit nothing
+        CHECK(p.level_high == fsk_level_for_index(p.value_index));
+    }
+
+    // Group ticks per original index and confirm each non-zero value's total
+    // ticks and portion count, proving zeros neither emit nor shift parity.
+    for (size_t vi = 0; vi < n; ++vi)
+    {
+        uint64_t ticks_for_vi = 0;
+        size_t   count_for_vi = 0;
+        for (const PortionRecord &p : portions)
+        {
+            if (p.value_index == vi)
+            {
+                ticks_for_vi += p.ticks;
+                ++count_for_vi;
+            }
+        }
+        CAPTURE(vi);
+        CHECK(ticks_for_vi == fsk_ticks_for_value(values[vi]));
+        CHECK(count_for_vi == expected_portion_count(values[vi]));
+    }
+
+    // Spot-check the parity expectation directly against the payload layout:
+    // even original index -> logical 0, odd -> logical 1, regardless of splits
+    // or interspersed zeros.
+    bool saw_index_2 = false, saw_index_3 = false, saw_index_8 = false;
+    for (const PortionRecord &p : portions)
+    {
+        if (p.value_index == 2) { saw_index_2 = true; CHECK(p.level_high == false); }
+        if (p.value_index == 3) { saw_index_3 = true; CHECK(p.level_high == true);  }
+        if (p.value_index == 8) { saw_index_8 = true; CHECK(p.level_high == false); }
+    }
+    CHECK(saw_index_2);
+    CHECK(saw_index_3);
+    CHECK(saw_index_8);
+}
+
+// ─── Property 4: cursor byte reads stay within the available payload ────────────
+
+TEST_CASE("P4 cursor byte_pos stays in bounds and ends at value_count*2")
+{
+    // Exercise a deterministic set of payload lengths, including odd tails, zero,
+    // and single-byte cases. For each, build a repeatable byte pattern, drain it,
+    // and assert byte_pos never exceeds the available length at any step and lands
+    // exactly on value_count*2 at the end (the trailing odd byte is never read).
+    const size_t lengths[] = { 0, 1, 2, 3, 4, 5, 8, 9, 16, 17, 31, 64, 65, 100, 101, 256, 257, 400 };
+
+    for (size_t len : lengths)
+    {
+        CAPTURE(len);
+
+        // Deterministic, non-zero-biased byte pattern so most values are non-zero
+        // (a purely zero payload would emit no portions and still be valid, but we
+        // want portions to actually flow to exercise the split path too).
+        std::vector<uint8_t> data(len);
+        for (size_t i = 0; i < len; ++i)
+            data[i] = (uint8_t)((i * 37 + 1) & 0xFF);
+
+        const size_t value_count = fsk_value_count(len);
+
+        // Step the cursor manually so byte_pos can be observed after EVERY step,
+        // proving no internal read ever addressed a byte at or beyond `len`.
+        FskChunkView view = fsk_view_init(len ? data.data() : nullptr, len);
+
+        size_t guard = 0;
+        const size_t guard_max = value_count * 210 + 16; // generous upper bound
+        for (;;)
+        {
+            // Precondition for a legal 2-byte read on this step: byte_pos+1 < len.
+            // The cursor must never leave byte_pos in a state where it would read
+            // out of bounds on the next value load.
+            CHECK(view.byte_pos <= len);
+            CHECK(view.byte_pos <= value_count * 2);
+
+            FskStep step = fsk_view_step(view);
+
+            // After any step, byte_pos must remain within the payload and on an
+            // even, value-aligned boundary.
+            CHECK(view.byte_pos <= len);
+            CHECK(view.byte_pos % 2 == 0);
+            CHECK(view.byte_pos <= value_count * 2);
+
+            if (step.done)
+                break;
+
+            REQUIRE(++guard < guard_max); // deterministic runaway guard
+        }
+
+        // The cursor consumed exactly the complete-pair region; any trailing odd
+        // byte was never read.
+        CHECK(view.byte_pos == value_count * 2);
+        CHECK(view.byte_pos <= len);
+    }
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// Task 2.3 — Synthetic FSK payload fixtures.
+//
+// Reusable, named, in-source byte-array fixtures for the categories the task
+// calls out: SHORT, LONG, ZERO, and ODD-TAIL. They are built entirely in source
+// as raw generic FSK data areas — NO copyrighted `.cas` files, NO filenames, NO
+// game/country/title-specific bytes. Per Requirements 9.4 and 9.8, every check
+// below derives behavior ONLY from the generic chunk contents (the decoded
+// values and their index parity), never from a fixture's name or identity: the
+// fixture names are test-local labels, and the assertions would hold for ANY
+// payload with the same bytes regardless of what it is called.
+//
+// These fixtures reuse the anonymous-namespace helpers defined at the top of the
+// file (le16_buf, DrainResult, drain, drain_value) rather than re-implementing
+// them, and the pure fsk_plan.h rules for their expectations. They neither
+// weaken nor duplicate the 2.1 example tests or the 2.2 property tests; they add
+// a distinct, category-oriented fixture layer with one consuming TEST_CASE per
+// category driven through the cursor.
+// ════════════════════════════════════════════════════════════════════════════
+
+namespace fsk_fixtures
+{
+// Append one FSK_Signal_Value as a little-endian pair onto a byte vector.
+inline void push_le16(std::vector<uint8_t> &out, uint16_t value)
+{
+    std::array<uint8_t, 2> pair = le16_buf(value);
+    out.push_back(pair[0]);
+    out.push_back(pair[1]);
+}
+
+// Build a generic FSK data area from an ordered list of values. This is the
+// only "builder" the fixtures need; the payload is exactly the concatenation of
+// LE pairs, matching how an A8CAS `fsk ` chunk data area is laid out.
+inline std::vector<uint8_t> build_payload(std::initializer_list<uint16_t> values)
+{
+    std::vector<uint8_t> out;
+    out.reserve(values.size() * 2);
+    for (uint16_t v : values)
+        push_le16(out, v);
+    return out;
+}
+
+// ── SHORT fixture ───────────────────────────────────────────────────────────
+// A small handful of ordinary, single-portion values. Chosen so each value's
+// ticks (value * 100) stay well under FSK_MAX_PORTION_TICKS, so every value maps
+// to exactly one portion. Generic durations, no special meaning.
+inline std::vector<uint8_t> short_payload()
+{
+    // 4 values -> 8 bytes, all single-portion (<= 327 keeps ticks <= 32700).
+    return build_payload({ 10, 25, 100, 200 });
+}
+
+// ── LONG fixture ──────────────────────────────────────────────────────────────
+// Contains at least one value that splits into MANY same-level portions. 65535
+// -> 6,553,500 ticks -> 201 portions. Surrounded by a couple of ordinary values
+// so the long value sits at a known index (parity) inside a multi-value payload.
+inline std::vector<uint8_t> long_payload()
+{
+    // index 0: 50    (1 portion, logical 0)
+    // index 1: 65535 (201 portions, logical 1)  <- the long/splitting value
+    // index 2: 300   (1 portion, logical 0)
+    return build_payload({ 50, 65535, 300 });
+}
+
+// ── ZERO fixtures ─────────────────────────────────────────────────────────────
+// Two distinct "zero" shapes the task calls out:
+//   (a) an EMPTY payload (no bytes at all), and
+//   (b) a payload CONTAINING zero-duration values interspersed with real ones.
+// The empty payload is simply an empty byte vector.
+inline std::vector<uint8_t> empty_payload()
+{
+    return std::vector<uint8_t>{};
+}
+
+// Zero-duration values at various indices. The zeros emit nothing but each still
+// consumes a parity slot, so the non-zero values keep their original-index
+// parity. Layout:
+//   index 0: 0   (zero, logical 0 slot, emits nothing)
+//   index 1: 150 (logical 1)
+//   index 2: 0   (zero, logical 0 slot, emits nothing)
+//   index 3: 0   (zero, logical 1 slot, emits nothing)
+//   index 4: 250 (logical 0)
+inline std::vector<uint8_t> zero_duration_payload()
+{
+    return build_payload({ 0, 150, 0, 0, 250 });
+}
+
+// ── ODD-TAIL fixture ────────────────────────────────────────────────────────
+// A payload whose byte length is ODD, so the final unpaired byte must be ignored
+// (floor pairing). Two complete values plus one trailing sentinel byte that must
+// never be read. The sentinel is a distinctive value so that, if it were ever
+// paired/decoded, the resulting value would be far outside the two real values.
+inline std::vector<uint8_t> odd_tail_payload()
+{
+    std::vector<uint8_t> out = build_payload({ 40, 80 }); // 2 values -> 4 bytes
+    out.push_back(0xEE);                                  // trailing unpaired byte
+    return out;                                           // total length 5 (odd)
+}
+} // namespace fsk_fixtures
+
+// ─── Req 9.4/9.8: SHORT fixture is a valid generic payload ──────────────────────
+
+TEST_CASE("Fixture(short): a small handful of single-portion values drains cleanly")
+{
+    std::vector<uint8_t> data = fsk_fixtures::short_payload();
+
+    // Behavior comes only from the bytes: 4 values, each one portion.
+    REQUIRE(fsk_value_count(data.size()) == 4);
+
+    const uint16_t values[] = { 10, 25, 100, 200 };
+
+    DrainResult r = drain(data.data(), data.size());
+
+    // Every value is single-portion, so portion_count == value_count and total
+    // ticks == sum of per-value ticks derived purely from the values.
+    uint64_t expected_ticks = 0;
+    for (uint16_t v : values)
+        expected_ticks += fsk_ticks_for_value(v);
+
+    CHECK(r.portion_count == 4);
+    CHECK(r.total_ticks == expected_ticks);
+    CHECK(r.max_portion <= FSK_MAX_PORTION_TICKS);
+    CHECK(r.first_level == false); // index 0 even -> logical 0
+
+    // Per-value confirmation through a fresh cursor: value/level/ticks all from
+    // the payload contents and index parity, never from the fixture's name.
+    FskChunkView view = fsk_view_init(data.data(), data.size());
+    for (size_t i = 0; i < 4; ++i)
+    {
+        CAPTURE(i);
+        FskStep step = fsk_view_step(view);
+        REQUIRE(step.produced);
+        CHECK(step.level_high == fsk_level_for_index(i));
+        CHECK(step.ticks == fsk_ticks_for_value(values[i]));
+        // done is true only on the final value's single portion.
+        CHECK(step.done == (i == 3));
+    }
+}
+
+// ─── Req 9.4/9.8: LONG fixture splits its big value into many portions ──────────
+
+TEST_CASE("Fixture(long): a value that splits into many same-level portions")
+{
+    std::vector<uint8_t> data = fsk_fixtures::long_payload();
+
+    REQUIRE(fsk_value_count(data.size()) == 3);
+
+    // 65535 -> 6,553,500 ticks -> 201 portions; the two neighbors are 1 portion
+    // each. Total portions = 1 + 201 + 1 = 203.
+    DrainResult r = drain(data.data(), data.size());
+    CHECK(r.portion_count == 203);
+    CHECK(r.max_portion == FSK_MAX_PORTION_TICKS); // the long value hits the cap
+    CHECK(r.total_ticks ==
+          fsk_ticks_for_value(50) + fsk_ticks_for_value(65535) + fsk_ticks_for_value(300));
+
+    // Walk the cursor and confirm the long value (index 1, odd -> logical 1)
+    // emits exactly 201 same-level portions summing to its full duration, while
+    // its neighbors emit one portion each. All expectations come from the bytes.
+    FskChunkView view = fsk_view_init(data.data(), data.size());
+
+    // index 0: value 50, single portion, logical 0.
+    FskStep s0 = fsk_view_step(view);
+    REQUIRE(s0.produced);
+    CHECK(s0.level_high == false);
+    CHECK(s0.ticks == fsk_ticks_for_value(50));
+    CHECK_FALSE(s0.done);
+
+    // index 1: value 65535, 201 portions, all logical 1, capped at max except
+    // the final remainder portion.
+    size_t   long_portions = 0;
+    uint64_t long_ticks    = 0;
+    for (;;)
+    {
+        FskStep s = fsk_view_step(view);
+        REQUIRE(s.produced);
+        CHECK(s.level_high == true); // index 1 odd -> logical 1 for every portion
+        CHECK(s.ticks <= FSK_MAX_PORTION_TICKS);
+        ++long_portions;
+        long_ticks += s.ticks;
+        CHECK_FALSE(s.done); // index 2 still remains after the long value
+        if (view.remaining_ticks == 0)
+            break;
+    }
+    CHECK(long_portions == 201);
+    CHECK(long_ticks == fsk_ticks_for_value(65535));
+
+    // index 2: value 300, single portion, logical 0, and it is the last value so
+    // its single portion carries done in the same call.
+    FskStep s2 = fsk_view_step(view);
+    REQUIRE(s2.produced);
+    CHECK(s2.level_high == false);
+    CHECK(s2.ticks == fsk_ticks_for_value(300));
+    CHECK(s2.done);
+}
+
+// ─── Req 9.4/9.8: ZERO fixtures — empty payload and zero-duration values ────────
+
+TEST_CASE("Fixture(zero): empty payload and interspersed zero-duration values")
+{
+    SUBCASE("empty payload produces nothing and is immediately done")
+    {
+        std::vector<uint8_t> data = fsk_fixtures::empty_payload();
+        CHECK(data.empty());
+        CHECK(fsk_value_count(data.size()) == 0);
+
+        DrainResult r = drain(data.empty() ? nullptr : data.data(), data.size());
+        CHECK(r.portion_count == 0);
+        CHECK(r.total_ticks == 0);
+    }
+
+    SUBCASE("zero-duration values emit nothing but keep later parity aligned")
+    {
+        std::vector<uint8_t> data = fsk_fixtures::zero_duration_payload();
+
+        // 5 values: [0, 150, 0, 0, 250]. Only indices 1 and 4 emit.
+        REQUIRE(fsk_value_count(data.size()) == 5);
+
+        DrainResult r = drain(data.data(), data.size());
+
+        // Only the two non-zero values emit a (single) portion each.
+        CHECK(r.portion_count == 2);
+        CHECK(r.total_ticks == fsk_ticks_for_value(150) + fsk_ticks_for_value(250));
+
+        // The first emitted portion is value 150 at index 1 -> logical 1.
+        CHECK(r.first_level == true);
+
+        // Confirm the parity of each emitted value derives from its ORIGINAL
+        // index (1 odd -> logical 1, 4 even -> logical 0), proving the zeros
+        // consumed parity slots without shifting the survivors.
+        FskChunkView view = fsk_view_init(data.data(), data.size());
+
+        FskStep first = fsk_view_step(view);
+        REQUIRE(first.produced);
+        CHECK(first.level_high == fsk_level_for_index(1)); // true
+        CHECK(first.ticks == fsk_ticks_for_value(150));
+        CHECK_FALSE(first.done); // value 250 still remains
+
+        FskStep second = fsk_view_step(view);
+        REQUIRE(second.produced);
+        CHECK(second.level_high == fsk_level_for_index(4)); // false
+        CHECK(second.ticks == fsk_ticks_for_value(250));
+        CHECK(second.done); // last emitting value
+
+        // A further step past exhaustion is a non-producing done.
+        FskStep past_end = fsk_view_step(view);
+        CHECK_FALSE(past_end.produced);
+        CHECK(past_end.done);
+    }
+}
+
+// ─── Req 9.4/9.8: ODD-TAIL fixture ignores the trailing unpaired byte ───────────
+
+TEST_CASE("Fixture(odd-tail): odd-length payload ignores the trailing unpaired byte")
+{
+    std::vector<uint8_t> data = fsk_fixtures::odd_tail_payload();
+
+    // Length is odd; floor pairing yields 2 complete values.
+    CHECK(data.size() % 2 == 1);
+    REQUIRE(fsk_value_count(data.size()) == 2);
+
+    const uint16_t values[] = { 40, 80 };
+
+    // Drain: exactly two single portions, and the cursor stops before the tail.
+    DrainResult r = drain(data.data(), data.size());
+    CHECK(r.portion_count == 2);
+    CHECK(r.total_ticks == fsk_ticks_for_value(40) + fsk_ticks_for_value(80));
+
+    FskChunkView view = fsk_view_init(data.data(), data.size());
+
+    FskStep s0 = fsk_view_step(view);
+    REQUIRE(s0.produced);
+    CHECK(s0.level_high == fsk_level_for_index(0)); // false
+    CHECK(s0.ticks == fsk_ticks_for_value(values[0]));
+    CHECK_FALSE(s0.done);
+
+    FskStep s1 = fsk_view_step(view);
+    REQUIRE(s1.produced);
+    CHECK(s1.level_high == fsk_level_for_index(1)); // true
+    CHECK(s1.ticks == fsk_ticks_for_value(values[1]));
+    CHECK(s1.done);
+
+    // The cursor consumed exactly the two complete pairs (4 bytes); the trailing
+    // unpaired byte at index 4 was never read.
+    CHECK(view.byte_pos == 4);
+    CHECK(view.byte_pos < data.size());
+
+    // A further step past exhaustion is a non-producing done.
+    FskStep past_end = fsk_view_step(view);
+    CHECK_FALSE(past_end.produced);
+    CHECK(past_end.done);
+}


### PR DESCRIPTION
## Summary

Adds standards-based reproduction of A8CAS raw FSK chunks (`Chunk_Type == "fsk "`,
fourth byte `0x20`) to the normal FUJI cassette playback path in the Atari SIO
cassette subsystem (`lib/device/sio/cassette.cpp`, guarded by `BUILD_ATARI`).

Previously, `send_FUJI_tape_block` recognized only `data` and `baud` chunks; any
other chunk, including `fsk `, was silently skipped by advancing past it, so any
signal carried by an `fsk ` record was dropped. This change reproduces `fsk `
chunks per the A8CAS CAS format specification, treating `fsk ` as one chunk
type that may be interleaved with `FUJI`, `baud`, and `data` in a single image.

The implementation is deliberately **generic and standards-based**. Detection is
purely by the 4-byte chunk type. There is no filename-, game-, country-, or
title-specific logic anywhere in the change.

## What changed

- **New pure module `lib/device/sio/fsk_plan.{h,cpp}`** — hardware-independent,
  allocation-free, I/O-free step functions plus a small O(1) cursor. Handles:
  - `fsk ` chunk parsing with **little-endian** decoding of `chunk_length`, the
    `aux`/IRG field, and each 16-bit FSK signal value.
  - Duration decoding in A8CAS units of **1/10 ms**, converted to **1 MHz RMT
    ticks** (`value × 100`, exact — no rounding).
  - Logical level from **original signal-index parity** (even → logical 0, odd →
    logical 1), independent of preceding durations.
  - **Zero-duration values** consume a parity index but emit no portion, so the
    logical level of every following value is preserved.
  - Splitting long durations into consecutive same-level **portions of at most
    32767 ticks** (the RMT 15-bit field limit) on the fly, with O(1) carried
    state and no materialized waveform.
- **`play_fsk_chunk` (cross-platform)** — owns one FSK chunk end to end:
  bounds-clamping, a **single pre-read** of the clamped payload into a heap
  buffer *before* any signal emission (no file I/O during emission), IRG
  handling, signal reproduction (ESP) or safe skip (PC), and a single idempotent
  cleanup path. Never calls `setBaudrate`.
- **ESP32 RMT raw signal output** — a stateful RMT simple encoder
  (`fsk_encode_cb`, `IRAM_ATTR`) drives `PIN_UART2_TX` at 1 MHz in one continuous
  `rmt_transmit`, mirroring the existing Turbo 2000 encoder precedent. On
  teardown it reattaches UART2 TX routing, leaving the **active baud divisor
  untouched** so `data` records after an FSK record transmit at the correct rate.
- **Safe PC-build behavior** — where `ESP_PLATFORM` is undefined, no RMT/GPIO is
  used; the IRG is honored deterministically via `SYSTEM_BUS.bus_idle`, bounds
  and pre-read logic are identical, and playback continues without raw signal
  generation.
- **Malformed / truncated / odd-length handling** — all reads are bounded by the
  smaller of the declared length and bytes remaining in the image; no
  out-of-bounds reads. Odd lengths ignore the trailing unpaired byte; truncated
  headers and overruns terminate safely at the real boundary (end-of-tape).
- **Chunk-walk integration** — `send_FUJI_tape_block` gains an `fsk ` branch
  before the unknown-chunk catch-all and continues walking after a handled FSK
  chunk (FSK is not a terminating record). Turbo 2000 and QROS paths are
  unchanged; QROS continues to skip `fsk ` exactly as before.
- **Tests** — new host-buildable `fsk_plan_tests` (doctest), registered in
  `tests/CMakeLists.txt`, covering the A8CAS worked example plus generated-loop
  property checks over the value/length space.

Existing formats are preserved: a `baud`/`data`-only image plays back exactly as
before, and only the FUJI path is modified.

## Verification

Automated and build verification:

- **`fsk_plan_tests`: pass** — 14/14 test cases, ~13.77M assertions, exit 0.
- **fujinet-pc build: pass** — shared FSK code compiles and links cleanly with no
  ESP-only RMT/GPIO APIs leaking into the PC build.
- **Full `fujinet-atari-v1` ESP32 firmware build: pass** — built via the official
  `build.sh` in the configured PlatformIO environment; `firmware.elf` linked and
  `firmware.bin` image generated successfully.

Manual real-hardware acceptance:

- A real-world CAS image, `Night Knight.cas`, was used **only as a local
  manual hardware-compatibility example**. It loaded and played back correctly
  through interleaved `baud`, `data`, and `fsk ` chunks, with `data` after FSK
  continuing at the active baud (including the 600 → 790 baud transition).
  **This file is NOT included in this repository** — it is not committed, not
  added as a test fixture, and not redistributed. All behavior is derived solely
  from chunk contents, never from the filename or any fixture-specific value.
- FSK IRG behavior was hardware-tested using a **local synthetic modified
  fixture** (not committed) to exercise inter-record gap timing.

## Known limitation

The live **motor-line de-assertion abort during an FSK IRG longer than 1000 ms**
has **not** been physically exercised on hardware. The abort/recovery code path
(safe abort, UART restoration, baud preservation, retry from the record's
starting offset) was verified by **code inspection only**, which passed. This PR
does **not** claim full hardware verification of that specific abort trigger.

## Test plan

- [x] `fsk_plan_tests` passes on the host.
- [x] fujinet-pc builds cleanly.
- [x] Full `fujinet-atari-v1` ESP32 firmware builds (ELF + BIN generated).
- [x] Manual: `Night Knight.cas` loads and plays on real Atari + FujiNet hardware
      (local only; file not committed).
- [x] Manual: FSK IRG timing exercised with a local synthetic modified fixture.
- [ ] Motor-line abort during a >1000 ms FSK IRG — not physically exercised;
      code-inspection-reviewed only.