### PR TITLE
New DaisyChain class to centralize device chain management across buses

### DIFF
--- a/build_version_pc.py
+++ b/build_version_pc.py
@@ -57,6 +57,7 @@ class Version:
         describe = vc.get_commit_version()
         version, *_rest = vc.parse_describe(describe, ver_major, ver_minor)
         if vc.get_modified_files():
+            version = version[:13]
             version += "*"
         return version
 

--- a/debug_version.py
+++ b/debug_version.py
@@ -113,6 +113,7 @@ def main():
       ver_patch = macros['FN_VERSION_PATCH'] = parsed_patch
 
   if modified and not args.set_version:
+    version = version[:13]
     version += "*"
   macros['FN_VERSION_FULL'] = version
   macros['FN_VERSION_DATE'] = datetime.fromtimestamp(mtime).strftime("%Y-%m-%d %H:%M:%S")

--- a/fujinet_pc.cmake
+++ b/fujinet_pc.cmake
@@ -302,6 +302,7 @@ set(SOURCES src/main.cpp
     lib/fuji/fujiHost.h lib/fuji/fujiHost.cpp
     lib/fuji/fujiDisk.h lib/fuji/fujiDisk.cpp
     lib/bus/bus.h lib/bus/bus.cpp
+    lib/bus/DaisyChain.h lib/bus/DaisyChain.cpp
     lib/device/device.h
     lib/device/disk.h
     lib/device/printer.h
@@ -373,6 +374,7 @@ if(FUJINET_TARGET STREQUAL "APPLE")
     lib/bus/iwm/connector.h
     lib/bus/iwm/iwm.h lib/bus/iwm/iwm.cpp
     lib/bus/iwm/FujiIWMPacket.h lib/bus/iwm/FujiIWMPacket.cpp
+    lib/bus/iwm/IWMBusIDMap.h lib/bus/iwm/IWMBusIDMap.cpp
 
     lib/devrelay/util.h lib/devrelay/util.cpp
     lib/devrelay/types/Request.h lib/devrelay/types/Request.cpp

--- a/lib/bus/DaisyChain.cpp
+++ b/lib/bus/DaisyChain.cpp
@@ -1,0 +1,49 @@
+#include "DaisyChain.h"
+#include <algorithm>
+
+DaisyChain::Entry *DaisyChain::entryForDevice(virtualDevice *device)
+{
+    auto it = std::find_if(_daisyChain.begin(), _daisyChain.end(),
+                           [device](const DaisyChain::Entry &entry) {
+                               return entry.device == device;
+                           });
+
+    return it != _daisyChain.end() ? &*it : nullptr;
+}
+
+DaisyChain::Entry *DaisyChain::entryForFujiID(fujiDeviceID_t fujiID)
+{
+    auto it = std::find_if(_daisyChain.begin(), _daisyChain.end(),
+                           [fujiID](const DaisyChain::Entry &entry) {
+                               return entry.fujiID == fujiID;
+                           });
+
+    return it != _daisyChain.end() ? &*it : nullptr;
+}
+
+virtualDevice *DaisyChain::deviceWithFujiID(fujiDeviceID_t fujiID)
+{
+    auto entry = entryForFujiID(fujiID);
+    return entry ? entry->device : nullptr;
+}
+
+std::optional<fujiDeviceID_t> DaisyChain::fujiIDForDevice(virtualDevice *device)
+{
+    auto entry = entryForDevice(device);
+    return entry ? std::optional<fujiDeviceID_t>(entry->fujiID) : std::nullopt;
+}
+
+void DaisyChain::addDevice(virtualDevice *newDev, fujiDeviceID_t devID)
+{
+    _daisyChain.push_front({newDev, devID});
+    return;
+}
+
+void DaisyChain::assignFujiIDToDevice(virtualDevice *device, fujiDeviceID_t fujiID)
+{
+    auto entry = entryForDevice(device);
+
+    if (entry)
+        entry->fujiID = fujiID;
+    return;
+}

--- a/lib/bus/DaisyChain.h
+++ b/lib/bus/DaisyChain.h
@@ -1,0 +1,103 @@
+#ifndef DAISYCHAIN_H
+#define DAISYCHAIN_H
+
+#include "fujiDeviceID.h"
+
+#include <optional>
+#include <forward_list>
+#include <vector>
+
+class virtualDevice;
+
+class DaisyChain
+{
+protected:
+    struct Entry {
+        virtualDevice *device;
+        fujiDeviceID_t fujiID;
+    };
+
+    using Container = std::forward_list<DaisyChain::Entry>;
+    Container _daisyChain;
+
+    DaisyChain::Entry *entryForDevice(virtualDevice *device);
+    DaisyChain::Entry *entryForFujiID(fujiDeviceID_t fujiID);
+
+public:
+    virtualDevice *deviceWithFujiID(fujiDeviceID_t fujiID);
+    std::optional<fujiDeviceID_t> fujiIDForDevice(virtualDevice *device);
+
+    void addDevice(virtualDevice *newDev, fujiDeviceID_t fujiID);
+    void assignFujiIDToDevice(virtualDevice *device, fujiDeviceID_t fujiID);
+
+    class iterator {
+        friend class DaisyChain;
+
+        using InternalIterator = Container::iterator;
+
+        InternalIterator _it;
+        iterator(InternalIterator it) : _it(it) {}
+
+    public:
+        virtualDevice *operator*() const {
+            return _it->device;
+        }
+
+        iterator &operator++() {
+            ++_it;
+            return *this;
+        }
+
+        bool operator!=(const iterator &other) const {
+            return _it != other._it;
+        }
+    };
+
+    iterator begin() {
+        return iterator(_daisyChain.begin());
+    }
+
+    iterator end() {
+        return iterator(_daisyChain.end());
+    }
+
+    // Rotate the specified devices by the given index offset.
+    // Positive values increase each device's index; negative values decrease it.
+    // Indices wrap around within the supplied device sequence.
+    template <typename T>
+    requires std::derived_from<T, virtualDevice>
+    void rotateDevices(const std::vector<T *> &devices, int amount) {
+        size_t idx, len;
+
+        if (devices.size() < 2 || amount == 0)
+            return;
+
+        std::vector<DaisyChain::Entry *> entries;
+
+        for (auto *device : devices)
+        {
+            if (auto *entry = entryForDevice(device))
+                entries.push_back(entry);
+        }
+
+        len = entries.size();
+        if (len != devices.size())
+            return;
+
+        amount %= len;
+
+        if (amount < 0)
+            amount += len;
+
+        std::vector<virtualDevice *> rotated(len);
+        for (idx = 0; idx < len; idx++)
+            rotated[(idx + amount) % len] = entries[idx]->device;
+
+        for (idx = 0; idx < len; idx++)
+            entries[idx]->device = rotated[idx];
+
+        return;
+    }
+};
+
+#endif /* DAISYCHAIN_H */

--- a/lib/bus/adamnet/adamnet.cpp
+++ b/lib/bus/adamnet/adamnet.cpp
@@ -224,9 +224,14 @@ bool systemBus::writeBusPacket(const FujiAdamPacket &packet)
     return true;
 }
 
+fujiDeviceID_t virtualDevice::id()
+{
+    return SYSTEM_BUS.fujiIDForDevice(this);
+}
+
 void virtualDevice::reset()
 {
-    Debug_printf("No Reset implemented for device %u\n", _devnum);
+    Debug_printf("No Reset implemented for device %u\n", id());
 }
 
 void virtualDevice::adamnet_control_ready()
@@ -293,15 +298,14 @@ void systemBus::_adamnet_process_cmd()
     _stall_silent = false;
 
     auto tmpPacket = FujiAdamPacket(_port->read());
-    auto it = _daisyChain.find(tmpPacket.device());
-    if (it != _daisyChain.end() && it->second->device_active == true)
+    _activeDev = _daisyChain.deviceWithFujiID(tmpPacket.device());
+    if (_activeDev && _activeDev->device_active == true)
     {
         busPhase.begin(tmpPacket);
 
         // turn on AdamNet Indicator LED
         fnLedManager.set(eLed::LED_BUS, true);
 
-        _activeDev = it->second;
         _activePacket = &tmpPacket;
 
         if (tmpPacket.type() == APT::MN_SEND)
@@ -411,8 +415,9 @@ void systemBus::_adamnet_process_queue()
         switch (msg.message_id)
         {
         case ADAMNETMSG_DISKSWAP:
-            if (_fujiDev != nullptr)
-                _fujiDev->fujicmd_image_rotate();
+            auto fujiDev = dynamic_cast<adamFuji *>(_daisyChain.deviceWithFujiID(FUJI_DEVICEID::FUJINET));
+            if (fujiDev != nullptr)
+                fujiDev->fujicmd_image_rotate();
             break;
         }
     }
@@ -512,101 +517,16 @@ void systemBus::shutdown()
 
     for (auto devicep : _daisyChain)
     {
-        Debug_printf("Shutting down device %02x\n", devicep.second->id());
-        devicep.second->shutdown();
+        Debug_printf("Shutting down device %02x\n", devicep->id());
+        devicep->shutdown();
     }
     Debug_printf("All devices shut down.\n");
-}
-
-void systemBus::addDevice(virtualDevice *pDevice, fujiDeviceID_t device_id)
-{
-    Debug_printf("Adding device: %02X\n", device_id);
-    pDevice->_devnum = device_id;
-    _daisyChain[device_id] = pDevice;
-
-    switch (device_id)
-    {
-    case FUJI_DEVICEID::FUJINET:
-        _fujiDev = dynamic_cast<adamFuji*>(pDevice);
-        break;
-    default:
-        break;
-    }
-}
-
-bool systemBus::deviceExists(uint8_t device_id)
-{
-    return _daisyChain.find(device_id) != _daisyChain.end();
-}
-
-bool systemBus::deviceEnabled(uint8_t device_id)
-{
-    if (deviceExists(device_id))
-        return _daisyChain[device_id]->device_active;
-    else
-        return false;
-}
-
-void systemBus::remDevice(virtualDevice *pDevice)
-{
-}
-
-void systemBus::remDevice(uint8_t device_id)
-{
-    if (deviceExists(device_id))
-    {
-        _daisyChain.erase(device_id);
-    }
-}
-
-int systemBus::numDevices()
-{
-    return _daisyChain.size();
-}
-
-void systemBus::changeDeviceId(virtualDevice *p, fujiDeviceID_t device_id)
-{
-    for (auto it = _daisyChain.begin(); it != _daisyChain.end(); ++it)
-    {
-        if (it->second == p)
-        {
-            _daisyChain.erase(it);
-            break;
-        }
-    }
-    p->_devnum = device_id;
-    _daisyChain[device_id] = p;
-}
-
-virtualDevice *systemBus::deviceById(uint8_t device_id)
-{
-    for (auto devicep : _daisyChain)
-    {
-        if (devicep.second->_devnum == device_id)
-            return devicep.second;
-    }
-    return nullptr;
 }
 
 void systemBus::reset()
 {
     for (auto devicep : _daisyChain)
-        devicep.second->reset();
+        devicep->reset();
 }
 
-void systemBus::enableDevice(uint8_t device_id)
-{
-    Debug_printf("Enabling AdamNet Device %d\n",device_id);
-
-    if (_daisyChain.find(device_id) != _daisyChain.end())
-        _daisyChain[device_id]->device_active = true;
-}
-
-void systemBus::disableDevice(uint8_t device_id)
-{
-    Debug_printf("Disabling AdamNet Device %d\n",device_id);
-
-    if (_daisyChain.find(device_id) != _daisyChain.end())
-        _daisyChain[device_id]->device_active = false;
-}
 #endif /* BUILD_ADAM */

--- a/lib/bus/adamnet/adamnet.h
+++ b/lib/bus/adamnet/adamnet.h
@@ -100,11 +100,6 @@ protected:
 
     virtual AdamNetStatus deviceStatus() = 0;
 
-    /**
-     * @brief Device Number: 0-15
-     */
-    fujiDeviceID_t _devnum;
-
     // PC/BoIP: bypass the 300us response window (a slow host can blow it). Only
     // for re-polled block devices; single-shot devices keep it.
     bool _pc_no_response_deadline = false;
@@ -132,9 +127,7 @@ public:
      * @brief return the device number (0-15) of this device
      * @return the device # (0-15) of this device
      */
-    fujiDeviceID_t id() { return _devnum; }
-
-
+    fujiDeviceID_t id();
 };
 
 /**
@@ -143,10 +136,8 @@ public:
 class systemBus : public SystemBusBase
 {
 private:
-    std::map<uint8_t, virtualDevice *> _daisyChain;
     virtualDevice *_activeDev = nullptr;
     const FujiAdamPacket *_activePacket;
-    adamFuji *_fujiDev = nullptr;
 
     // _port = UART on hardware, or a TCP socket to an emulator on PC (Bus over IP).
     UARTChannel _serial;
@@ -214,16 +205,16 @@ public:
         busPhase.didIgnore();
     }
 
-    int numDevices();
-    void addDevice(virtualDevice *pDevice, fujiDeviceID_t device_id);
-    void remDevice(virtualDevice *pDevice);
-    void remDevice(uint8_t device_id);
-    bool deviceExists(uint8_t device_id);
-    void enableDevice(uint8_t device_id);
-    void disableDevice(uint8_t device_id);
-    virtualDevice *deviceById(uint8_t device_id);
-    void changeDeviceId(virtualDevice *pDevice, fujiDeviceID_t device_id);
-    bool deviceEnabled(uint8_t device_id);
+    bool deviceExists(fujiDeviceID_t device_id) {
+        return _daisyChain.deviceWithFujiID(device_id) != nullptr;
+    }
+    bool deviceEnabled(fujiDeviceID_t device_id) {
+        auto device = _daisyChain.deviceWithFujiID(device_id);
+        if (device)
+            return device->device_active;
+        return false;
+    }
+
 #ifdef ESP_PLATFORM
     QueueHandle_t qAdamNetMessages = nullptr;
 #endif /* ESP_PLATFORM */

--- a/lib/bus/bus.cpp
+++ b/lib/bus/bus.cpp
@@ -1,32 +1,8 @@
 #include "bus.h"
 
-// Temporary migration wrappers. Remove after all buses have been
-// converted to inherit from SystemBusBase.
-#ifdef NEED_VDEV_MIGRATION
-
-void VDevMigrationWrapper::transaction_begin(transState_t expectMoreData)
+void SystemBusBase::setDeviceEnabled(fujiDeviceID_t device_id, bool enabled)
 {
-    SYSTEM_BUS.transaction_accept(expectMoreData);
+    virtualDevice *device = _daisyChain.deviceWithFujiID(device_id);
+    if (device)
+        device->device_active = enabled;
 }
-
-void VDevMigrationWrapper::transaction_complete()
-{
-    SYSTEM_BUS.transaction_success();
-}
-
-void VDevMigrationWrapper::transaction_error()
-{
-    SYSTEM_BUS.transaction_error();
-}
-
-success_is_true VDevMigrationWrapper::transaction_get(void *data, size_t len)
-{
-    return SYSTEM_BUS.transaction_get(data, len);
-}
-
-void VDevMigrationWrapper::transaction_put(const void *data, size_t len, bool is_error)
-{
-    SYSTEM_BUS.transaction_send(data, len, is_error);
-}
-
-#endif

--- a/lib/bus/bus.h
+++ b/lib/bus/bus.h
@@ -1,6 +1,7 @@
 #ifndef BUS_H
 #define BUS_H
 
+#include "DaisyChain.h"
 #include "global_types.h"
 
 #include <string>
@@ -30,8 +31,29 @@ class SystemBusBase
 {
 protected:
     transState_t _transaction_state = TRANS_STATE::INVALID;
+    DaisyChain _daisyChain;
 
 public:
+    virtual void addDevice(virtualDevice *device, fujiDeviceID_t deviceType) {
+        _daisyChain.addDevice(device, deviceType);
+    }
+    fujiDeviceID_t fujiIDForDevice(virtualDevice *device) {
+        return _daisyChain.fujiIDForDevice(device).value_or((fujiDeviceID_t) 0);
+    }
+    virtual void assignFujiIDToDevice(virtualDevice *device, fujiDeviceID_t fujiID) {
+        _daisyChain.assignFujiIDToDevice(device, fujiID);
+    }
+    void setDeviceEnabled(fujiDeviceID_t device_id, bool enabled);
+
+    // Rotate the specified devices by the given index offset.
+    // Positive values increase each device's index; negative values decrease it.
+    // Indices wrap around within the supplied device sequence.
+    template <typename T>
+    requires std::derived_from<T, virtualDevice>
+    void rotateDevices(const std::vector<T *> &devices, int amount) {
+        _daisyChain.rotateDevices(devices, amount);
+    }
+
     // Accept the current transaction and perform any protocol-specific setup
     // required before data transfer.
     virtual void transaction_accept(transState_t expectMoreData) = 0;

--- a/lib/bus/comlynx/comlynx.cpp
+++ b/lib/bus/comlynx/comlynx.cpp
@@ -22,7 +22,12 @@
 
 void virtualDevice::reset()
 {
-    Debug_printf("No Reset implemented for device %u\n", _devnum);
+    Debug_printf("No Reset implemented for device %u\n", id());
+}
+
+fujiDeviceID_t virtualDevice::id()
+{
+    return SYSTEM_BUS.fujiIDForDevice(this);
 }
 
 bool systemBus::wait_for_idle()
@@ -103,7 +108,7 @@ void systemBus::_comlynx_process_cmd()
 
     for (auto devicep : _daisyChain)
     {
-        if (tmpPacket->device() == devicep->_devnum)
+        if (tmpPacket->device() == devicep->id())
         {
             _activeDev = devicep;
             _activePacket = tmpPacket.get();
@@ -188,77 +193,17 @@ void systemBus::addDevice(virtualDevice *pDevice, fujiDeviceID_t device_id)
 {
     Debug_printf("Adding device: %02X\n", device_id);
 
-    if (device_id == FUJI_DEVICEID::FUJINET)
-    {
-        _fujiDev = (lynxFuji *)pDevice;
-    }
-    else if (device_id >= FUJI_DEVICEID::NETWORK && device_id <= FUJI_DEVICEID::NETWORK_LAST)
-    {
-        _netDev[device_id - FUJI_DEVICEID::NETWORK] = (lynxNetwork*)pDevice;
-    }
-    else if (device_id == FUJI_DEVICEID::PRINTER)
-    {
-        _printerDev = (lynxPrinter *)pDevice;
-    }
-    else if (device_id == FUJI_DEVICEID::MIDI)
+    if (device_id == FUJI_DEVICEID::MIDI)
     {
         _streamDev = (lynxNetStream *)pDevice;
     }
-
-    pDevice->_devnum = device_id;
-    _daisyChain.push_front(pDevice);
-}
-
-void systemBus::remDevice(virtualDevice *pDevice)
-{
-    _daisyChain.remove(pDevice);
-}
-
-void systemBus::remDevice(fujiDeviceID_t device_id)
-{
-}
-
-int systemBus::numDevices()
-{
-      int i = 0;
-    //__BEGIN_IGNORE_UNUSEDVARS
-    for (auto devicep : _daisyChain)
-        i++;
-    return i;
-    //__END_IGNORE_UNUSEDVARS
-}
-
-void systemBus::changeDeviceId(virtualDevice *p, int device_id)
-{
-    for (auto devicep : _daisyChain)
-    {
-        if (devicep == p)
-            devicep->_devnum = (fujiDeviceID_t) device_id;
-    }
-}
-
-virtualDevice *systemBus::deviceById(fujiDeviceID_t device_id)
-{
-    for (auto devicep : _daisyChain)
-    {
-        if (devicep->_devnum == device_id)
-            return devicep;
-    }
-    return nullptr;
+    _daisyChain.addDevice(pDevice, device_id);
 }
 
 void systemBus::reset()
 {
     for (auto devicep : _daisyChain)
         devicep->reset();
-}
-
-void systemBus::enableDevice(fujiDeviceID_t device_id)
-{
-}
-
-void systemBus::disableDevice(fujiDeviceID_t device_id)
-{
 }
 
 void systemBus::setStreamHost(const char *hostname, int port)

--- a/lib/bus/comlynx/comlynx.h
+++ b/lib/bus/comlynx/comlynx.h
@@ -46,11 +46,6 @@ protected:
     virtual void shutdown() {}
     virtual void comlynx_process(const FujiLynxPacket &packet);
 
-    /**
-     * @brief Device Number: 0-15
-     */
-    fujiDeviceID_t _devnum;
-
 public:
 
     /**
@@ -67,7 +62,7 @@ public:
      * @brief return the device number (0-15) of this device
      * @return the device # (0-15) of this device
      */
-    fujiDeviceID_t id() { return _devnum; }
+    fujiDeviceID_t id();
 };
 
 /**
@@ -76,12 +71,8 @@ public:
 class systemBus : public SystemBusBase
 {
 private:
-    std::forward_list<virtualDevice *> _daisyChain;
     virtualDevice *_activeDev = nullptr;
     const FujiLynxPacket *_activePacket;
-    lynxFuji *_fujiDev = nullptr;
-    lynxPrinter *_printerDev = nullptr;
-    lynxNetwork *_netDev[8] = {nullptr};
     lynxNetStream *_streamDev = nullptr;
 
     IOChannel *_port;
@@ -105,16 +96,8 @@ public:
     bool wait_for_idle();
     bool netstreamActive() const;
 
-    int numDevices();
-    void addDevice(virtualDevice *pDevice, fujiDeviceID_t device_id);
-    void remDevice(virtualDevice *pDevice);
-    void remDevice(fujiDeviceID_t device_id);
-    bool deviceExists(fujiDeviceID_t device_id);
-    void enableDevice(fujiDeviceID_t device_id);
-    void disableDevice(fujiDeviceID_t device_id);
-    virtualDevice *deviceById(fujiDeviceID_t device_id);
-    void changeDeviceId(virtualDevice *pDevice, int device_id);
-    bool deviceEnabled(fujiDeviceID_t device_id);
+    void addDevice(virtualDevice *pDevice, fujiDeviceID_t device_id) override;
+
     void setStreamHost(const char *newhost, int port);
     void setStreamHostWithOptions(const char *newhost, int port, int mode, bool register_enabled, bool redeye_enabled);
 

--- a/lib/bus/drivewire/drivewire.h
+++ b/lib/bus/drivewire/drivewire.h
@@ -77,6 +77,7 @@ class drivewireNetStream; // declare here so can reference it, but define in net
 class drivewireCassette;  // Cassette forward-declaration.
 class drivewireCPM;       // CPM device.
 class drivewirePrinter;   // Printer device
+class drivewireDisk;      // See if you can guess what kind of device it is
 class fujiDevice;
 
 class drivewireDevice
@@ -310,7 +311,7 @@ public:
     }
 
     // For compatibility with fujiDevice.cpp
-    void changeDeviceId(void *pDevice, int device_id) {};
+    void rotateDevices(const std::vector<drivewireDisk *> &disks, int amount) {}
 };
 
 extern systemBus SYSTEM_BUS;

--- a/lib/bus/iec/iec.h
+++ b/lib/bus/iec/iec.h
@@ -97,6 +97,8 @@ public:
         return val;
     }
 
+    void rotateDevices(const std::vector<iecDrive *> &devices, int amount) {}
+
  private:
     /**
      * @brief is device shutting down?

--- a/lib/bus/iwm/FujiIWMPacket.cpp
+++ b/lib/bus/iwm/FujiIWMPacket.cpp
@@ -80,4 +80,16 @@ const std::optional<ByteBuffer>& FujiIWMPacket::data() const
   return _data;
 }
 
+uint8_t FujiIWMPacket::unit() const
+{
+  if ((frame.sp_command == SP_CMD_STATUS || frame.sp_command == SP_CMD_CONTROL)
+      && frame.param_count == 4)
+    return frame.control_status.fuji.network_unit;
+  if ((frame.sp_command == SP_CMD_READ || frame.sp_command == SP_CMD_WRITE)
+      && frame.param_count == 5)
+    return frame.char_rw.fuji.network_unit;
+
+  return 0;
+}
+
 #endif /* BUILD_APPLE */

--- a/lib/bus/iwm/FujiIWMPacket.h
+++ b/lib/bus/iwm/FujiIWMPacket.h
@@ -69,6 +69,8 @@ public:
   uint8_t device() const { return frame.sp_dev_id; }
   fujiCommandID_t command() const { return frame.control_status.fuji.command; }
 
+  uint8_t unit() const;
+
   ParamProxy param(size_t index) const { return ParamProxy{ index, this }; }
 
   const std::optional<ByteBuffer>& data() const;

--- a/lib/bus/iwm/IWMBusIDMap.cpp
+++ b/lib/bus/iwm/IWMBusIDMap.cpp
@@ -1,0 +1,71 @@
+#include "IWMBusIDMap.h"
+
+void IWMBusIDMap::addFujiID(fujiDeviceID_t fujiID, bool participatesInBusIDAssignment)
+{
+  _entries[fujiID] = {std::nullopt, participatesInBusIDAssignment, };
+  return;
+}
+
+std::optional<fujiDeviceID_t> IWMBusIDMap::fujiIDForBusID(busDeviceID_t busID)
+{
+  for (const auto &[fujiID, entry] : _entries)
+  {
+    if (entry.busID && *entry.busID == busID)
+      return fujiID;
+  }
+
+  return std::nullopt;
+}
+
+std::optional<IWMBusIDMap::busDeviceID_t> IWMBusIDMap::busIDForFujiID(fujiDeviceID_t fujiID)
+{
+  auto it = _entries.find(fujiID);
+
+  if (it == _entries.end())
+    return std::nullopt;
+
+  return it->second.busID;
+}
+
+void IWMBusIDMap::resetAllBusIDs()
+{
+  for (auto &[fujiID, entry] : _entries)
+    entry.busID.reset();
+  return;
+}
+
+void IWMBusIDMap::assignBusIDToFujiID(busDeviceID_t busID, fujiDeviceID_t fujiID)
+{
+  auto it = _entries.find(fujiID);
+
+  if (it == _entries.end())
+    return;
+
+  it->second.busID = busID;
+  return;
+}
+
+bool IWMBusIDMap::participatesInBusIDAssignment(fujiDeviceID_t fujiID)
+{
+  auto it = _entries.find(fujiID);
+
+  if (it == _entries.end())
+    return false;
+
+  return it->second.participatesInBusIDAssignment;
+}
+
+void IWMBusIDMap::changeFujiID(fujiDeviceID_t oldFujiID, fujiDeviceID_t newFujiID)
+{
+  if (oldFujiID == newFujiID)
+    return;
+
+  auto it = _entries.find(oldFujiID);
+
+  if (it == _entries.end())
+    return;
+
+  auto entry = it->second;
+  _entries.erase(it);
+  _entries[newFujiID] = entry;
+}

--- a/lib/bus/iwm/IWMBusIDMap.h
+++ b/lib/bus/iwm/IWMBusIDMap.h
@@ -1,0 +1,32 @@
+#ifndef BUSIDMAP_H
+#define BUSIDMAP_H
+
+#include "fujiDeviceID.h"
+
+#include <optional>
+#include <map>
+
+class IWMBusIDMap
+{
+public:
+    using busDeviceID_t = unsigned;
+
+private:
+  struct Entry {
+    std::optional<busDeviceID_t> busID;
+    bool participatesInBusIDAssignment;
+  };
+
+  std::map<fujiDeviceID_t, Entry> _entries;
+
+public:
+  void addFujiID(fujiDeviceID_t fujiID, bool participatesInBusIDAssignment);
+  std::optional<fujiDeviceID_t> fujiIDForBusID(busDeviceID_t busID);
+  std::optional<busDeviceID_t> busIDForFujiID(fujiDeviceID_t fujiID);
+  void resetAllBusIDs();
+  void assignBusIDToFujiID(busDeviceID_t busID, fujiDeviceID_t fujiID);
+  bool participatesInBusIDAssignment(fujiDeviceID_t fujiID);
+  void changeFujiID(fujiDeviceID_t oldFujiID, fujiDeviceID_t newFujiID);
+};
+
+#endif /* BUSIDMAP_H */

--- a/lib/bus/iwm/iwm.cpp
+++ b/lib/bus/iwm/iwm.cpp
@@ -319,6 +319,11 @@ void systemBus::send_status_dib_reply_packet()
                   &dib_packet, sizeof(dib_packet));
 }
 
+IWMBusIDMap::busDeviceID_t virtualDevice::id()
+{
+  return SYSTEM_BUS.busIDForDevice(this).value_or(0);
+}
+
 void virtualDevice::iwm_return_badcmd(const iwm_decoded_cmd_t &cmd)
 {
   //Handle possible data packet to avoid crash extended and non-extended
@@ -546,8 +551,7 @@ bool IRAM_ATTR systemBus::serviceSmartPort()
     Debug_printf("\r\nReset");
 
     // clear all the device addresses
-    for (auto devicep : _daisyChain)
-      devicep->_devnum = 0;
+    resetAllBusIDs();
 
 #ifndef DEV_RELAY_SLIP
     while (iwm_phases() == iwm_phases_t::reset)
@@ -601,31 +605,24 @@ bool IRAM_ATTR systemBus::serviceSmartPort()
     }
     else
     {
-      for (auto devicep : _daisyChain)
+      command.decode(command_packet.data);
+      auto devID = remapDeviceAddress(command_packet.dest, command);
+      _activeDev = _daisyChain.deviceWithFujiID(devID);
+      if (_activeDev)
       {
-        // This could be a map of _devnum to devicep, then wouldn't have to loop.
-        if (command_packet.dest == devicep->_devnum)
+        if (iwm_req_deassert_timeout(50000))
         {
-          // wait for REQ to go low
-          if (iwm_req_deassert_timeout(50000))
-          {
-            Debug_printf("\nREQ timeout in command processing");
-            iwm_ack_deassert(); // go hi-Z
-            return true;
-          }
-#ifndef DEV_RELAY_SLIP
-          // need to take time here to service other ESP processes so they can catch up
-          taskYIELD(); // Allow other tasks to run
-#endif
-          // Debug_printf("\r\nCommand Packet:");
-          // print_packet(command_packet.data);
-
-          _activeDev = devicep;
-          // handle command
-          command.decode(command_packet.data);
-          iwm_process(command);
-          break; // we don't need to needlessly keep looping once we find it
+          Debug_printf("\nREQ timeout in command processing");
+          iwm_ack_deassert(); // go hi-Z
+          return true;
         }
+
+#ifndef DEV_RELAY_SLIP
+        // need to take time here to service other ESP processes so they can catch up
+        taskYIELD(); // Allow other tasks to run
+#endif
+
+        iwm_process(command);
       }
     }
 
@@ -636,6 +633,24 @@ bool IRAM_ATTR systemBus::serviceSmartPort()
   }                     // switch (phasestate)
 
   return true;
+}
+
+fujiDeviceID_t systemBus::remapDeviceAddress(uint8_t address, iwm_decoded_cmd_t &cmd)
+{
+  virtualDevice *devicep = deviceWithBusID(address);
+  fujiDeviceID_t devID = _daisyChain.fujiIDForDevice(devicep).value_or((fujiDeviceID_t) 0);
+
+#ifdef UNUSED
+  if (devID >= FUJI_DEVICEID::NETWORK && devID <= FUJI_DEVICEID::NETWORK_LAST)
+  {
+    unsigned unit = cmd.unit();
+    if (!unit)
+      unit = _defaultNetworkUnit;
+    devID = (fujiDeviceID_t) (((unsigned) FUJI_DEVICEID::NETWORK) + unit - 1);
+  }
+#endif /* UNUSED */
+
+  return devID;
 }
 
 #ifndef DEV_RELAY_SLIP
@@ -837,36 +852,22 @@ void systemBus::handle_init()
 
   // iwm_rddata_clr();
 
-  // to do - get the next device in the daisy chain and assign ID
-  for (auto it = _daisyChain.begin(); it != _daisyChain.end(); ++it)
-  {
-    // assign dev numbers
-    pDevice = (*it);
+  pDevice = firstDeviceWithNoBusID();
+  if (pDevice) {
     pDevice->switched = false; //reset switched condition on init
-    if (pDevice->id() == 0)
-    {
-      _activeDev = pDevice;
-      _activeDev->_devnum = command_packet.dest; // assign address
-      if (++it == _daisyChain.end())
-        err = SP_ERR::ENDOFCHAIN; // end of the line, so status=non zero - to do: check GPIO for another device in the physical daisy chain
-      Debug_printf("\r\nSending INIT Response Packet...");
-      send_init_reply_packet(command_packet.dest, err);
-
-      // smartport.iwm_send_packet_spi((uint8_t *)_activeDev->packet_buffer); // timeout error return is not handled here (yet?)
-
-      // print_packet ((uint8_t*) packet_buffer,get_packet_length());
-
-      Debug_printf("\r\nDrive: %02x\r\n", _activeDev->id());
-      fnLedManager.set(LED_BUS, false);
-      return;
-    }
+    fujiDeviceID_t fujiID = _daisyChain.fujiIDForDevice(pDevice).value();
+    _busMap.assignBusIDToFujiID(command_packet.dest, fujiID);
+    if (firstDeviceWithNoBusID() == nullptr)
+      err = SP_ERR::ENDOFCHAIN;
+    send_init_reply_packet(command_packet.dest, err);
+    Debug_printf("\r\nDrive: %02x\r\n", pDevice->id());
   }
 
   fnLedManager.set(LED_BUS, false);
 }
 
-// Add device to SIO bus
-void systemBus::addDevice(virtualDevice *pDevice, iwm_fujinet_type_t deviceType)
+// Add device to IWM bus
+void systemBus::addDevice(virtualDevice *pDevice, fujiDeviceID_t deviceType)
 {
   // SmartPort interface assigns device numbers to the devices in the daisy chain one at a time
   // as opposed to using standard or fixed device ID's like Atari SIO. Therefore, an emulated
@@ -898,70 +899,62 @@ void systemBus::addDevice(virtualDevice *pDevice, iwm_fujinet_type_t deviceType)
   // assign dedicated pointers to certain devices
   switch (deviceType)
   {
-  case iwm_fujinet_type_t::CPM:
+  case FUJI_DEVICEID::CPM:
     if ( !Config.get_cpm_enabled() )
       return;
-    break;
-  case iwm_fujinet_type_t::Printer:
-    _printerdev = (iwmPrinter *)pDevice;
     break;
   default:
       break;
   }
 
-  pDevice->_devnum = 0;
+  _daisyChain.addDevice(pDevice, deviceType);
+  _busMap.addFujiID(deviceType, true);
+
   pDevice->_initialized = false;
-
-  _daisyChain.push_front(pDevice);
 }
 
-// Removes device from the SIO bus.
-// Note that the destructor is called on the device!
-void systemBus::remDevice(virtualDevice *p)
+std::optional<IWMBusIDMap::busDeviceID_t> systemBus::busIDForDevice(virtualDevice *device)
 {
-  _daisyChain.remove(p);
+  auto fujiID = _daisyChain.fujiIDForDevice(device);
+
+  if (fujiID.has_value())
+    return _busMap.busIDForFujiID(fujiID.value());
+  return std::nullopt;
 }
 
-// Should avoid using this as it requires counting through the list
-int systemBus::numDevices()
+virtualDevice *systemBus::deviceWithBusID(IWMBusIDMap::busDeviceID_t busID)
 {
-  int i = 0;
-  __BEGIN_IGNORE_UNUSEDVARS
-  for (auto devicep : _daisyChain)
-    i++;
-  return i;
-  __END_IGNORE_UNUSEDVARS
-}
+  auto fujiID = _busMap.fujiIDForBusID(busID);
 
-void systemBus::changeDeviceId(virtualDevice *p, int device_id)
-{
-  for (auto devicep : _daisyChain)
-  {
-    if (devicep == p)
-      devicep->_devnum = device_id;
-  }
-}
-
-virtualDevice *systemBus::deviceById(int device_id)
-{
-  for (auto devicep : _daisyChain)
-  {
-    if (devicep->_devnum == device_id)
-      return devicep;
-  }
+  if (fujiID.has_value())
+    return _daisyChain.deviceWithFujiID(fujiID.value());
   return nullptr;
 }
 
-void systemBus::enableDevice(uint8_t device_id)
+virtualDevice *systemBus::firstDeviceWithNoBusID()
 {
-  virtualDevice *p = deviceById(device_id);
-  p->device_active = true;
+  for (auto devicep : _daisyChain)
+  {
+    auto fujiID = _daisyChain.fujiIDForDevice(devicep);
+    if (fujiID.has_value()
+        && _busMap.participatesInBusIDAssignment(fujiID.value())
+        && !_busMap.busIDForFujiID(fujiID.value()).has_value())
+      return devicep;
+  }
+
+  return nullptr;
 }
 
-void systemBus::disableDevice(uint8_t device_id)
+void systemBus::assignFujiIDToDevice(virtualDevice *device, fujiDeviceID_t fujiID)
 {
-  virtualDevice *p = deviceById(device_id);
-  p->device_active = false;
+  auto oldID = _daisyChain.fujiIDForDevice(device);
+  SystemBusBase::assignFujiIDToDevice(device, fujiID);
+  _busMap.changeFujiID(oldID.value(), fujiID);
+}
+
+iwmPrinter *systemBus::getPrinter()
+{
+  return dynamic_cast<iwmPrinter*>(_daisyChain.deviceWithFujiID(FUJI_DEVICEID::PRINTER));
 }
 
 // Give devices an opportunity to clean up before a reboot

--- a/lib/bus/iwm/iwm.h
+++ b/lib/bus/iwm/iwm.h
@@ -4,7 +4,8 @@
 
 #include "bus.h"
 #include "FujiIWMPacket.h"
-#include "../../include/debug.h"
+#include "IWMBusIDMap.h"
+#include "debug.h"
 
 // for ESP IWM-SLIP build, DEV_RELAY_SLIP should be defined in platformio.ini
 // for PC IWM-SLIP build DEV_RELAY_SLIP should be defined in fujinet_pc.cmake
@@ -105,25 +106,6 @@ class fujiDevice;
 #define BLOCK_DATA_LEN      512
 #define MAX_DATA_LEN        767
 
-enum class iwm_smartport_type_t
-{
-  Block_Device,
-  Character_Device
-};
-
-enum class iwm_fujinet_type_t
-{
-  BlockDisk,
-  FujiNet,
-  Modem,
-  Network,
-  CPM,
-  Printer,
-  Voice,
-  Clock,
-  Other
-};
-
 enum class iwm_enable_state_t
 {
   off,
@@ -159,9 +141,6 @@ class virtualDevice
 
 protected:
   // set these things in constructor or initializer?
-  iwm_smartport_type_t device_type;
-  iwm_fujinet_type_t internal_type;
-  uint8_t _devnum; // assigned by Apple II during INIT
   bool _initialized;
 
   virtual void shutdown() = 0;
@@ -192,8 +171,7 @@ public:
    * @brief get the IWM device Number (1-255)
    * @return The device number registered for this device
    */
-  void set_id(uint8_t dn) { _devnum=dn; };
-  int id() { return _devnum; };
+  IWMBusIDMap::busDeviceID_t id();
 };
 
 class systemBus : public SystemBusBase
@@ -201,8 +179,6 @@ class systemBus : public SystemBusBase
 private:
   virtualDevice *_activeDev = nullptr;
   ByteBuffer _transaction_response;
-
-  iwmPrinter *_printerdev = nullptr;
 
   #ifndef DEV_RELAY_SLIP
   bool iwm_phase_val(uint8_t p);
@@ -244,7 +220,7 @@ private:
   int new_track = -1;
 
 public:
-  std::forward_list<virtualDevice *> _daisyChain;
+  IWMBusIDMap _busMap;
 
   cmdPacket_t command_packet;
   bool iwm_decode_data_packet(uint8_t *a, int &n);
@@ -267,15 +243,20 @@ public:
   using SystemBusBase::transaction_send;
   void transaction_send(const void *data, size_t len, bool is_error=false) override;
 
-  int numDevices();
-  void addDevice(virtualDevice *pDevice, iwm_fujinet_type_t deviceType); // todo: probably get called by handle_init()
-  void remDevice(virtualDevice *pDevice);
-  virtualDevice *deviceById(int device_id);
-  virtualDevice *firstDev() {return _daisyChain.front();}
-  void enableDevice(uint8_t device_id);
-  void disableDevice(uint8_t device_id);
-  void changeDeviceId(virtualDevice *p, int device_id);
-  iwmPrinter *getPrinter() { return _printerdev; }
+  void setDeviceEnabled(fujiDeviceID_t device_id, bool enabled) {
+    virtualDevice *device = _daisyChain.deviceWithFujiID(device_id);
+    if (device)
+      device->device_active = enabled;
+  }
+  fujiDeviceID_t remapDeviceAddress(uint8_t address, iwm_decoded_cmd_t &cmd);
+  void addDevice(virtualDevice *device, fujiDeviceID_t deviceType) override;
+  void assignFujiIDToDevice(virtualDevice *device, fujiDeviceID_t fujiID) override;
+  std::optional<IWMBusIDMap::busDeviceID_t> busIDForDevice(virtualDevice *device);
+  virtualDevice *deviceWithBusID(IWMBusIDMap::busDeviceID_t busID);
+  virtualDevice *firstDeviceWithNoBusID();
+  void resetAllBusIDs() { _busMap.resetAllBusIDs(); }
+  iwmPrinter *getPrinter();
+
   bool shuttingDown = false;                                  // TRUE if we are in shutdown process
   bool getShuttingDown() { return shuttingDown; };
   bool en35Host = false; // TRUE if we are connected to a host that supports the /EN35 signal

--- a/lib/bus/iwm/iwm_ll.cpp
+++ b/lib/bus/iwm/iwm_ll.cpp
@@ -71,33 +71,31 @@ void IRAM_ATTR phi_isr_handler(void *arg)
         }
         else
         {
-          for (auto devicep : SYSTEM_BUS._daisyChain)
+          auto devicep = SYSTEM_BUS.deviceWithBusID(SYSTEM_BUS.command_packet.dest);
+          if (devicep != nullptr)
           {
-            if (SYSTEM_BUS.command_packet.dest == devicep->id())
-            {
-              smartport.iwm_ack_clr();
-              // look for CTRL command
-              //  Debug_printf("\nhello from ISR - looking for control command!");
+            smartport.iwm_ack_clr();
+            // look for CTRL command
+            //  Debug_printf("\nhello from ISR - looking for control command!");
 
-              if ((c == SP_CMD_WRITEBLOCK) ||
-                  (c == SP_CMD_CONTROL) ||
-                  (c == SP_CMD_WRITE))
+            if ((c == SP_CMD_WRITEBLOCK) ||
+                (c == SP_CMD_CONTROL) ||
+                (c == SP_CMD_WRITE))
+            {
+              // Debug_printf("\nhello from ISR - control command!");
+              if (smartport.req_wait_for_falling_timeout(5500))
               {
-                // Debug_printf("\nhello from ISR - control command!");
-                if (smartport.req_wait_for_falling_timeout(5500))
-                {
-                  Debug_printf("\nWRITE/CTRL received\nREQ timeout in ISR");
-                  return;
-                }
-                memset(smartport.packet_buffer, 0, sizeof(smartport.packet_buffer));
-                smartport.iwm_ack_set();
-                sp_command_mode = sp_cmd_state_t::rxdata;
-                // Debug_printf("\nWRITE/CTRL received\nACK set in ISR!");
+                Debug_printf("\nWRITE/CTRL received\nREQ timeout in ISR");
+                return;
               }
-              else
-              {
-                sp_command_mode = sp_cmd_state_t::command;
-              }
+              memset(smartport.packet_buffer, 0, sizeof(smartport.packet_buffer));
+              smartport.iwm_ack_set();
+              sp_command_mode = sp_cmd_state_t::rxdata;
+              // Debug_printf("\nWRITE/CTRL received\nACK set in ISR!");
+            }
+            else
+            {
+              sp_command_mode = sp_cmd_state_t::command;
             }
           }
         }

--- a/lib/bus/rs232/rs232.cpp
+++ b/lib/bus/rs232/rs232.cpp
@@ -53,13 +53,13 @@ void systemBus::transaction_accept(transState_t expectMoreData)
 void systemBus::transaction_success()
 {
     assert(_transaction_state == TRANS_STATE::NO_GET || _transaction_state == TRANS_STATE::DID_GET);
-    sendReplyPacket(_activeDev->_devnum, true, nullptr, 0);
+    sendReplyPacket(_activeDev->id(), true, nullptr, 0);
     _transaction_state = TRANS_STATE::INVALID;
 }
 
 void systemBus::transaction_error()
 {
-    sendReplyPacket(_activeDev->_devnum, false, nullptr, 0);
+    sendReplyPacket(_activeDev->id(), false, nullptr, 0);
     _transaction_state = TRANS_STATE::INVALID;
 }
 
@@ -87,7 +87,7 @@ success_is_true systemBus::transaction_get(void *data, size_t len)
 void systemBus::transaction_send(const void *data, size_t len, bool is_error)
 {
     assert(_transaction_state == TRANS_STATE::NO_GET);
-    sendReplyPacket(_activeDev->_devnum, !is_error, data, len);
+    sendReplyPacket(_activeDev->id(), !is_error, data, len);
     _transaction_state = TRANS_STATE::INVALID;
 }
 
@@ -95,14 +95,6 @@ void systemBus::transaction_send(const void *data, size_t len, bool is_error)
 void systemBus::_rs232_process_cmd()
 {
     Debug_printf("rs232_process_cmd()\n");
-#ifdef OBSOLETE
-    if (_modemDev != nullptr && _modemDev->modemActive && Config.get_modem_enabled())
-    {
-        _modemDev->modemActive = false;
-        Debug_println("Modem was active - resetting RS232 baud");
-        _serial.setBaudrate(_rs232Baud);
-    }
-#endif /* OBSOLETE */
 
     ByteBuffer packet;
     int val, count;
@@ -135,19 +127,7 @@ void systemBus::_rs232_process_cmd()
 
 
     _activePacket = tempFrame.get();
-    _activeDev = nullptr;
-
-    // find device, ack and pass control
-    // or go back to WAIT
-    for (auto devicep : _daisyChain)
-    {
-        if (tempFrame->device() == devicep->_devnum)
-        {
-            _activeDev = devicep;
-            break;
-        }
-    }
-
+    _activeDev = _daisyChain.deviceWithFujiID(tempFrame->device());
     if (_activeDev != nullptr)
         _activeDev->rs232_process(*tempFrame);
 
@@ -277,46 +257,7 @@ void systemBus::addDevice(virtualDevice *pDevice, fujiDeviceID_t device_id)
         _printerdev = (rs232Printer *)pDevice;
     }
 
-    pDevice->_devnum = device_id;
-
-    _daisyChain.push_front(pDevice);
-}
-
-// Removes device from the RS232 bus.
-// Note that the destructor is called on the device!
-void systemBus::remDevice(virtualDevice *p)
-{
-    _daisyChain.remove(p);
-}
-
-// Should avoid using this as it requires counting through the list
-int systemBus::numDevices()
-{
-    int i = 0;
-    __BEGIN_IGNORE_UNUSEDVARS
-    for (auto devicep : _daisyChain)
-        i++;
-    return i;
-    __END_IGNORE_UNUSEDVARS
-}
-
-void systemBus::changeDeviceId(virtualDevice *p, int device_id)
-{
-    for (auto devicep : _daisyChain)
-    {
-        if (devicep == p)
-            devicep->_devnum = (fujiDeviceID_t) device_id;
-    }
-}
-
-virtualDevice *systemBus::deviceById(fujiDeviceID_t device_id)
-{
-    for (auto devicep : _daisyChain)
-    {
-        if (devicep->_devnum == device_id)
-            return devicep;
-    }
-    return nullptr;
+    _daisyChain.addDevice(pDevice, device_id);
 }
 
 // Give devices an opportunity to clean up before a reboot
@@ -395,7 +336,7 @@ void systemBus::writeBusPacket(FujiBusPacket &packet)
 void systemBus::sendReplyPacket(fujiDeviceID_t source, bool ack, const void *data, size_t length)
 {
     // FIXME - check to make sure this wasn't through a bus call
-    if (source == _modemDev->_devnum)
+    if (source == _modemDev->id())
     {
         _port->write(data, length);
         return;
@@ -412,6 +353,11 @@ void systemBus::sendReplyPacket(fujiDeviceID_t source, bool ack, const void *dat
     FujiBusPacket packet(source, ack ? CMD::FUJI_ACK : CMD::FUJI_NAK, bb);
     writeBusPacket(packet);
     return;
+}
+
+fujiDeviceID_t virtualDevice::id()
+{
+    return SYSTEM_BUS.fujiIDForDevice(this);
 }
 
 #endif /* BUILD_RS232 */

--- a/lib/bus/rs232/rs232.h
+++ b/lib/bus/rs232/rs232.h
@@ -57,8 +57,6 @@ class virtualDevice
     friend fujiDevice;
 
 protected:
-    fujiDeviceID_t _devnum;
-
     bool listen_to_type3_polls = false;
 
     /**
@@ -81,7 +79,7 @@ public:
      * @brief get the RS232 device Number (1-255)
      * @return The device number registered for this device
      */
-    fujiDeviceID_t id() { return _devnum; };
+    fujiDeviceID_t id();
 
     /**
      * @brief Is this virtualDevice holding the virtual disk drive used to boot CONFIG?
@@ -119,8 +117,6 @@ private:
     FujiBusPacket *_activePacket;
     size_t _activePacketDataPosition;
 
-    std::forward_list<virtualDevice *> _daisyChain;
-
     int _command_frame_counter = 0;
 
     virtualDevice *_activeDev = nullptr;
@@ -150,11 +146,7 @@ public:
     void service();
     void shutdown();
 
-    int numDevices();
-    void addDevice(virtualDevice *pDevice, fujiDeviceID_t device_id);
-    void remDevice(virtualDevice *pDevice);
-    virtualDevice *deviceById(fujiDeviceID_t device_id);
-    void changeDeviceId(virtualDevice *pDevice, int device_id);
+    void addDevice(virtualDevice *pDevice, fujiDeviceID_t device_id) override;
 
     int getBaudrate();                                          // Gets current RS232 baud rate setting
     void setBaudrate(int baud);                                 // Sets RS232 to specific baud rate

--- a/lib/bus/sio/sio.cpp
+++ b/lib/bus/sio/sio.cpp
@@ -34,6 +34,11 @@ uint8_t sio_checksum(uint8_t *buf, unsigned short len)
     return chk;
 }
 
+fujiDeviceID_t virtualDevice::id()
+{
+    return SYSTEM_BUS.fujiIDForDevice(this);
+}
+
 // SIO NAK
 void systemBus::_sio_nak()
 {
@@ -284,7 +289,7 @@ void systemBus::_sio_process_cmd()
                 {
                     if (devicep->listen_to_type3_polls)
                     {
-                        Debug_printf("Sending TYPE3 poll to dev %x\n", devicep->_devnum);
+                        Debug_printf("Sending TYPE3 poll to dev %x\n", devicep->id());
                         _activeDev = devicep;
                         // handle command
                         _activeDev->sio_process(tmpFrame);
@@ -295,15 +300,9 @@ void systemBus::_sio_process_cmd()
             {
                 // find device, ack and pass control
                 // or go back to WAIT
-                for (auto devicep : _daisyChain)
-                {
-                    if (tmpFrame.device() == devicep->_devnum)
-                    {
-                        _activeDev = devicep;
-                        // handle command
-                        _activeDev->sio_process(tmpFrame);
-                    }
-                }
+                _activeDev = _daisyChain.deviceWithFujiID(tmpFrame.device());
+                if (_activeDev)
+                    _activeDev->sio_process(tmpFrame);
             }
         }
     } // valid checksum
@@ -577,49 +576,10 @@ void systemBus::addDevice(virtualDevice *pDevice, fujiDeviceID_t device_id)
     }
     else if (device_id == FUJI_DEVICEID::PRINTER)
     {
-        _printerdev = (sioPrinter *)pDevice;
+        _printerDev = (sioPrinter *)pDevice;
     }
 
-    pDevice->_devnum = device_id;
-
-    _daisyChain.push_front(pDevice);
-}
-
-// Removes device from the SIO bus.
-// Note that the destructor is called on the device!
-void systemBus::remDevice(virtualDevice *p)
-{
-    _daisyChain.remove(p);
-}
-
-// Should avoid using this as it requires counting through the list
-int systemBus::numDevices()
-{
-    int i = 0;
-    __BEGIN_IGNORE_UNUSEDVARS
-    for (auto devicep : _daisyChain)
-        i++;
-    return i;
-    __END_IGNORE_UNUSEDVARS
-}
-
-void systemBus::changeDeviceId(virtualDevice *p, int device_id)
-{
-    for (auto devicep : _daisyChain)
-    {
-        if (devicep == p)
-            devicep->_devnum = (fujiDeviceID_t) device_id;
-    }
-}
-
-virtualDevice *systemBus::deviceById(fujiDeviceID_t device_id)
-{
-    for (auto devicep : _daisyChain)
-    {
-        if (devicep->_devnum == device_id)
-            return devicep;
-    }
-    return nullptr;
+    SystemBusBase::addDevice(pDevice, device_id);
 }
 
 // Give devices an opportunity to clean up before a reboot

--- a/lib/bus/sio/sio.h
+++ b/lib/bus/sio/sio.h
@@ -89,7 +89,6 @@ class virtualDevice
     friend fujiDevice;
 
 protected:
-    fujiDeviceID_t _devnum;
     bool listen_to_type3_polls = false;
 
     /**
@@ -112,7 +111,7 @@ public:
      * @brief get the SIO device Number (1-255)
      * @return The device number registered for this device
      */
-    fujiDeviceID_t id() { return _devnum; };
+    fujiDeviceID_t id();
 
     /**
      * @brief Command 0x3F '?' intended to return a single byte to the atari via bus_to_computer(), which
@@ -157,8 +156,6 @@ class systemBus : public SystemBusBase
     friend FujiSIOPacket;
 
 private:
-    std::forward_list<virtualDevice *> _daisyChain;
-
     int _command_frame_counter = 0;
 
     virtualDevice *_activeDev = nullptr;
@@ -169,7 +166,7 @@ private:
     sioNetStream *_streamDev = nullptr;
     sioCassette *_cassetteDev = nullptr;
     sioCPM *_cpmDev = nullptr;
-    sioPrinter *_printerdev = nullptr;
+    sioPrinter *_printerDev = nullptr;
 
     sioSpeedMode_t _sioBaud = SIO_SPEED::STANDARD;
     int _sioHighSpeedIndex = SIO_HISPEED_INDEX;
@@ -238,11 +235,7 @@ public:
     void service();
     void shutdown();
 
-    int numDevices();
-    void addDevice(virtualDevice *pDevice, fujiDeviceID_t device_id);
-    void remDevice(virtualDevice *pDevice);
-    virtualDevice *deviceById(fujiDeviceID_t device_id);
-    void changeDeviceId(virtualDevice *pDevice, int device_id);
+    void addDevice(virtualDevice *pDevice, fujiDeviceID_t device_id) override;
 
     int getBaudrate();                                          // Gets current SIO baud rate setting
     int getCurrentBaudrate();                                   // Gets current I/O channel baud rate
@@ -271,11 +264,9 @@ public:
     bool getShuttingDown() { return shuttingDown; };
 
     sioCassette *getCassette() { return _cassetteDev; }
-    sioPrinter *getPrinter() { return _printerdev; }
+    sioPrinter *getPrinter() { return _printerDev; }
     sioCPM *getCPM() { return _cpmDev; }
 
-    // I wish this codebase would make up its mind to use camel or snake casing.
-    modem *get_modem() { return _modemDev; }
     bool commandAsserted();
 
 #ifdef ESP_PLATFORM

--- a/lib/device/adamnet/adamFuji.cpp
+++ b/lib/device/adamnet/adamFuji.cpp
@@ -178,7 +178,7 @@ void adamFuji::adamnet_enable_device(const FujiAdamPacket &packet)
 
     Config.save();
 
-    SYSTEM_BUS.enableDevice(d);
+    SYSTEM_BUS.setDeviceEnabled(d, true);
     SYSTEM_BUS.transaction_success();
 }
 
@@ -213,7 +213,7 @@ void adamFuji::adamnet_disable_device(const FujiAdamPacket &packet)
 
     Config.save();
 
-    SYSTEM_BUS.disableDevice(d);
+    SYSTEM_BUS.setDeviceEnabled(d, false);
     SYSTEM_BUS.transaction_success();
 }
 
@@ -283,7 +283,7 @@ void adamFuji::adamnet_get_time()
 
 void adamFuji::adamnet_device_enable_status(const FujiAdamPacket &packet)
 {
-    uint8_t d = packet.param(0);
+    fujiDeviceID_t d = (fujiDeviceID_t) packet.param8(0);
 
     SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
 

--- a/lib/device/adamnet/network.cpp
+++ b/lib/device/adamnet/network.cpp
@@ -746,7 +746,7 @@ void adamNetwork::process_tcp(const FujiAdamPacket &packet)
 
         {
             cmd_err = tcp->accept_connection();
-            Debug_printf("ACCEPT %x CHANMODE %d ERR: %d\n", _devnum, channelMode, cmd_err);
+            Debug_printf("ACCEPT %x CHANMODE %d ERR: %d\n", id(), channelMode, cmd_err);
 
             // Because we're not handling Adam bus very well, sometimes it
             // retries and we've already accepted which will return an

--- a/lib/device/comlynx/network.cpp
+++ b/lib/device/comlynx/network.cpp
@@ -760,7 +760,7 @@ void lynxNetwork::process_tcp(const FujiLynxPacket &packet)
             if (!status.connected)
             {
                 cmd_err = tcp->accept_connection();
-                Debug_printf("ACCEPT %x CHANMODE %d ERR: %d\n", _devnum, channelMode, (int)cmd_err);
+                Debug_printf("ACCEPT %x CHANMODE %d ERR: %d\n", id(), channelMode, (int)cmd_err);
             }
         }
         break;

--- a/lib/device/drivewire/network.cpp
+++ b/lib/device/drivewire/network.cpp
@@ -482,6 +482,7 @@ void drivewireNetwork::get_prefix()
     Debug_printf("drivewireNetwork::get_prefix(%s)\n",prefix.c_str());
     memset(out,0,sizeof(out));
     strcpy(out,prefix.c_str());
+    SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
     SYSTEM_BUS.transaction_send(out, sizeof(out));
 }
 

--- a/lib/device/fujiDevice/fujiDevice.cpp
+++ b/lib/device/fujiDevice/fujiDevice.cpp
@@ -345,35 +345,23 @@ void fujiDevice::fujicmd_image_rotate()
 {
     Debug_println("Fuji cmd: IMAGE ROTATE");
 
-    int count = 0;
-    while (count < (int)_totalDiskDevices && _fnDisks[count].fileh != nullptr)
-        count++;
-
-    if (count > 1)
+    std::vector<DISK_DEVICE *> mounted;
+    for (size_t idx = 0; idx < _totalDiskDevices; idx++)
     {
-        count--;
+        if (_fnDisks[idx].fileh != nullptr)
+            mounted.push_back(get_disk_dev(idx));
+    }
 
-        // Save the device ID of the disk in the last slot
-        fujiDeviceID_t last_id = (fujiDeviceID_t)get_disk_dev(count)->id();
+    // The first slot gets the device ID of the last slot
+    SYSTEM_BUS.rotateDevices(mounted, -1);
 
-        for (int n = count; n > 0; n--)
-        {
-            fujiDeviceID_t swap = (fujiDeviceID_t)get_disk_dev(n - 1)->id();
-            Debug_printf("setting slot %d to ID %hx\n", n, swap);
-            SYSTEM_BUS.changeDeviceId(get_disk_dev(n), swap);
-        }
-
-        // The first slot gets the device ID of the last slot
-        SYSTEM_BUS.changeDeviceId(get_disk_dev(0), last_id);
-
-        // Blink out which slot is now drive 1, then let the platform announce it
-        int rotate_slot = get_rotate_slot();
-        if (rotate_slot >= 0)
-        {
-            _active_rotate_slot = rotate_slot;
-            fnLedManager.blink(LED_BUS, rotate_slot + 1);
-            announce_rotation(rotate_slot);
-        }
+    // Blink out which slot is now drive 1, then let the platform announce it
+    int rotate_slot = get_rotate_slot();
+    if (rotate_slot >= 0)
+    {
+        _active_rotate_slot = rotate_slot;
+        fnLedManager.blink(LED_BUS, rotate_slot + 1);
+        announce_rotation(rotate_slot);
     }
 }
 

--- a/lib/device/iwm/disk.cpp
+++ b/lib/device/iwm/disk.cpp
@@ -125,7 +125,7 @@ void iwmDisk::iwm_ctrl(const iwm_decoded_cmd_t &cmd)
     Debug_printf("Handling Eject command\r\n");
     unmount();
     switched = false; //force switched = false when ejected from host.
-    platformFuji.handle_ctl_eject(_devnum);
+    platformFuji.handle_ctl_eject(id());
     break;
   default:
     SYSTEM_BUS.transaction_error(SP_ERR::BADCTL);

--- a/lib/device/iwm/iwmFuji.cpp
+++ b/lib/device/iwm/iwmFuji.cpp
@@ -143,61 +143,62 @@ void iwmFuji::iwm_ctrl_new_disk(const iwm_decoded_cmd_t &cmd)
 
 void iwmFuji::iwm_ctrl_enable_device(const iwm_decoded_cmd_t &cmd)
 {
-        unsigned char d = cmd.param(0);
+  fujiDeviceID_t d = (fujiDeviceID_t) cmd.param8(0);
 
-        Debug_printf("\nFuji cmd: ENABLE DEVICE");
-        SYSTEM_BUS.enableDevice(d);
+  Debug_printf("\nFuji cmd: ENABLE DEVICE");
+  SYSTEM_BUS.setDeviceEnabled(d, true);
 }
 
 void iwmFuji::iwm_ctrl_disable_device(const iwm_decoded_cmd_t &cmd)
 {
-        unsigned char d = cmd.param(0);
+  fujiDeviceID_t d = (fujiDeviceID_t) cmd.param8(0);
 
-        Debug_printf("\nFuji cmd: DISABLE DEVICE");
-        SYSTEM_BUS.disableDevice(d);
+  Debug_printf("\nFuji cmd: DISABLE DEVICE");
+  SYSTEM_BUS.setDeviceEnabled(d, false);
 }
 
 // Initializes base settings and adds our devices to the SIO bus
 void iwmFuji::setup()
 {
-        populate_slots_from_config();
+  populate_slots_from_config();
 
-        // Disable booting from CONFIG if our settings say to turn it off
-        boot_config = Config.get_general_config_enabled();
+  // Disable booting from CONFIG if our settings say to turn it off
+  boot_config = Config.get_general_config_enabled();
 
-        // Build the device topology once, to avoid duplicating the daisy chain
-        // and leaking the devices when setup() re-runs on an in-process restart.
-        if (theNetwork == nullptr)
-        {
-                // add ourselves as a device
-                SYSTEM_BUS.addDevice(this, iwm_fujinet_type_t::FujiNet);
+  // Build the device topology once, to avoid duplicating the daisy chain
+  // and leaking the devices when setup() re-runs on an in-process restart.
+  if (theNetwork == nullptr)
+  {
+    // add ourselves as a device
+    SYSTEM_BUS.addDevice(this, FUJI_DEVICEID::FUJINET);
 
-                theNetwork = new iwmNetwork();
-                SYSTEM_BUS.addDevice(theNetwork, iwm_fujinet_type_t::Network);
+    theNetwork = new iwmNetwork();
+    SYSTEM_BUS.addDevice(theNetwork, FUJI_DEVICEID::NETWORK);
 
-                SYSTEM_BUS.addDevice(&platformClock, iwm_fujinet_type_t::Clock);
+    SYSTEM_BUS.addDevice(&platformClock, FUJI_DEVICEID::CLOCK);
 
-                theCPM = new iwmCPM();
-                SYSTEM_BUS.addDevice(theCPM, iwm_fujinet_type_t::CPM);
+    theCPM = new iwmCPM();
+    SYSTEM_BUS.addDevice(theCPM, FUJI_DEVICEID::CPM);
 
-                for (int i = MAX_SPDISK_DEVICES - 1; i >= 0; i--)
-                {
-                        DISK_DEVICE *disk_dev = get_disk_dev(i);
-                        disk_dev->set_disk_number('0' + i);
-                        SYSTEM_BUS.addDevice(disk_dev, iwm_fujinet_type_t::BlockDisk);
-                }
-        }
+    for (int idx = MAX_SPDISK_DEVICES - 1; idx >= 0; idx--)
+    {
+      DISK_DEVICE *disk_dev = get_disk_dev(idx);
+      disk_dev->set_disk_number('0' + idx);
+      SYSTEM_BUS.addDevice(disk_dev,
+                           (fujiDeviceID_t) (((unsigned) FUJI_DEVICEID::DISK) + idx));
+    }
+  }
 
-        if (boot_config)
-        {
-            Debug_printf("\nConfig General Boot Mode: %u\n", Config.get_general_boot_mode());
-            insert_boot_device(Config.get_general_boot_mode(), MEDIATYPE_PO, get_disk_dev(0));
-        }
-        else if (!Config.get_config_filename().empty())
-        {
-            Debug_printf("\nInsert Alternate Config Disk: %s\n", Config.get_config_filename().c_str());
-            insert_boot_device(Config.get_config_filename(), MEDIATYPE_PO, get_disk_dev(0));
-        }
+  if (boot_config)
+  {
+    Debug_printf("\nConfig General Boot Mode: %u\n", Config.get_general_boot_mode());
+    insert_boot_device(Config.get_general_boot_mode(), MEDIATYPE_PO, get_disk_dev(0));
+  }
+  else if (!Config.get_config_filename().empty())
+  {
+    Debug_printf("\nInsert Alternate Config Disk: %s\n", Config.get_config_filename().c_str());
+    insert_boot_device(Config.get_config_filename(), MEDIATYPE_PO, get_disk_dev(0));
+  }
 }
 
 iwm_device_status_block_t iwmFuji::create_status_reply_packet()

--- a/lib/device/rs232/modem.cpp
+++ b/lib/device/rs232/modem.cpp
@@ -1578,7 +1578,7 @@ void rs232Modem::tx(ByteBuffer data)
 
 void rs232Modem::rx(const void *buffer, size_t length)
 {
-    SYSTEM_BUS.sendReplyPacket(_devnum, true, buffer, length);
+    SYSTEM_BUS.sendReplyPacket(id(), true, buffer, length);
 }
 
 void rs232Modem::rx(ByteBuffer data)

--- a/lib/device/sio/network.cpp
+++ b/lib/device/sio/network.cpp
@@ -559,7 +559,7 @@ void sioNetwork::sio_set_prefix()
     uint8_t prefixSpec[256];
     string prefixSpec_str;
 
-    SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
+    SYSTEM_BUS.transaction_accept(TRANS_STATE::WILL_GET);
 
     memset(prefixSpec, 0, sizeof(prefixSpec));
 

--- a/lib/http/httpServiceConfigurator.cpp
+++ b/lib/http/httpServiceConfigurator.cpp
@@ -494,8 +494,8 @@ void fnHttpServiceConfigurator::config_printer_port(std::string printernumber, s
     fnPrinters.set_port(0, port);
 #ifdef BUILD_ATARI
     // Tell the SIO daisy chain to change the device ID for this printer
-    SYSTEM_BUS.changeDeviceId(fnPrinters.get_ptr(0),
-                              (fujiDeviceID_t) (FUJI_DEVICEID::PRINTER + port));
+    SYSTEM_BUS.assignFujiIDToDevice(fnPrinters.get_ptr(0),
+                                    (fujiDeviceID_t) (FUJI_DEVICEID::PRINTER + port));
 #endif
 
     Config.save();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -396,11 +396,7 @@ void main_setup(int argc, char *argv[])
     adamPrinter *ptr = new adamPrinter(ptrfs, printer);
     fnPrinters.set_entry(0, ptr, printer, 0);
     SYSTEM_BUS.addDevice(ptr, FUJI_DEVICEID::PRINTER);
-
-    if (Config.get_printer_enabled())
-        SYSTEM_BUS.enableDevice(FUJI_DEVICEID::PRINTER);
-    else
-        SYSTEM_BUS.disableDevice(FUJI_DEVICEID::PRINTER);
+    SYSTEM_BUS.setDeviceEnabled(FUJI_DEVICEID::PRINTER, Config.get_printer_enabled());
 
     if (Config.get_apetime_enabled() == true)
         SYSTEM_BUS.addDevice(&platformClock, FUJI_DEVICEID::CLOCK); // APETime compatible, extended for additional return types
@@ -430,11 +426,11 @@ void main_setup(int argc, char *argv[])
     iwmModem *sioR;
     FileSystem *ptrfs = fnSDFAT.running() ? (FileSystem *)&fnSDFAT : (FileSystem *)&fsFlash;
     sioR = new iwmModem(ptrfs, Config.get_modem_sniffer_enabled());
-    SYSTEM_BUS.addDevice(sioR,iwm_fujinet_type_t::Modem);
+    SYSTEM_BUS.addDevice(sioR, FUJI_DEVICEID::SERIAL);
     iwmPrinter::printer_type ptype = Config.get_printer_type(0);
     iwmPrinter *ptr = new iwmPrinter(ptrfs, ptype);
     fnPrinters.set_entry(0, ptr, ptype, Config.get_printer_port(0));
-    SYSTEM_BUS.addDevice(ptr, iwm_fujinet_type_t::Printer);
+    SYSTEM_BUS.addDevice(ptr, FUJI_DEVICEID::PRINTER);
 
     theFuji->setup();
     SYSTEM_BUS.setup(); // save device unit SP address somewhere and restore it after reboot?


### PR DESCRIPTION
Move the common device chain handling out of the individual bus implementations and into new DaisyChain class. This eliminates the duplicated device ordering, ID management, swapping, rotation, and lookup logic that each bus previously maintained independently, while leaving bus-specific behavior in the bus implementations.