### PR TITLE
Don't blindly try to strip N: prefix from URL that doesn't have it

### DIFF
--- a/lib/device/adamnet/network.cpp
+++ b/lib/device/adamnet/network.cpp
@@ -633,8 +633,7 @@ void adamNetwork::create_devicespec(string d, bool is_dir)
  */
 void adamNetwork::create_url_parser()
 {
-    std::string url = deviceSpec.substr(deviceSpec.find(":") + 1);
-    urlParser = PeoplesUrlParser::parseURL(url);
+    urlParser = PeoplesUrlParser::parseURL(deviceSpec);
 }
 
 void adamNetwork::parse_and_instantiate_protocol(string d, bool is_dir)

--- a/lib/device/comlynx/network.cpp
+++ b/lib/device/comlynx/network.cpp
@@ -642,8 +642,7 @@ void lynxNetwork::create_devicespec(string d, bool is_dir)
 */
 void lynxNetwork::create_url_parser()
 {
-    std::string url = deviceSpec.substr(deviceSpec.find(":") + 1);
-    urlParser = PeoplesUrlParser::parseURL(url);
+    urlParser = PeoplesUrlParser::parseURL(deviceSpec);
 }
 
 void lynxNetwork::parse_and_instantiate_protocol(string d, bool is_dir)

--- a/lib/device/drivewire/network.cpp
+++ b/lib/device/drivewire/network.cpp
@@ -687,8 +687,7 @@ void drivewireNetwork::create_devicespec(bool is_dir)
 */
 void drivewireNetwork::create_url_parser()
 {
-    std::string url = deviceSpec.substr(deviceSpec.find(":") + 1);
-    urlParser = PeoplesUrlParser::parseURL(url);
+    urlParser = PeoplesUrlParser::parseURL(deviceSpec);
 }
 
 void drivewireNetwork::parse_and_instantiate_protocol(bool is_dir)

--- a/lib/device/iwm/network.cpp
+++ b/lib/device/iwm/network.cpp
@@ -725,8 +725,7 @@ void iwmNetwork::create_devicespec(string d, bool is_dir)
 void iwmNetwork::create_url_parser()
 {
     auto& current_network_data = network_data_map[current_network_unit];
-    std::string url = current_network_data.deviceSpec.substr(current_network_data.deviceSpec.find(":") + 1);
-    current_network_data.urlParser = std::move(PeoplesUrlParser::parseURL(url));
+    current_network_data.urlParser = std::move(PeoplesUrlParser::parseURL(current_network_data.deviceSpec));
 }
 
 error_is_true iwmNetwork::parse_and_instantiate_protocol(string d, bool is_dir)

--- a/lib/device/rs232/network.cpp
+++ b/lib/device/rs232/network.cpp
@@ -961,8 +961,7 @@ void rs232Network::create_devicespec(fileAccessMode_t access)
 */
 void rs232Network::create_url_parser()
 {
-    std::string url = deviceSpec.substr(deviceSpec.find(":") + 1);
-    urlParser = PeoplesUrlParser::parseURL(url);
+    urlParser = PeoplesUrlParser::parseURL(deviceSpec);
 }
 
 void rs232Network::parse_and_instantiate_protocol(fileAccessMode_t access)

--- a/lib/device/sio/network.cpp
+++ b/lib/device/sio/network.cpp
@@ -1029,8 +1029,7 @@ void sioNetwork::create_devicespec(bool is_dir)
 */
 void sioNetwork::create_url_parser()
 {
-    std::string url = deviceSpec.substr(deviceSpec.find(":") + 1);
-    urlParser = PeoplesUrlParser::parseURL(url);
+    urlParser = PeoplesUrlParser::parseURL(deviceSpec);
 }
 
 void sioNetwork::parse_and_instantiate_protocol(bool is_dir)

--- a/lib/utils/utils.cpp
+++ b/lib/utils/utils.cpp
@@ -880,6 +880,35 @@ void clean_transform_petscii_to_ascii(std::string& data) {
     data = mstr::toUTF8(data);
 }
 
+static bool util_has_N_prefix(const std::string &url)
+{
+    std::string unit = url.substr(0, url.find_first_of(":") + 1);
+
+    // Must start with 'N' and end with ':'
+    if (unit.size() < 2 || (unit.front() != 'N' && unit.front() != 'n') || unit.back() != ':')
+        return false;
+
+    // If it's exactly "N:", it's a valid match
+    if (unit.size() == 2)
+        return true;
+
+    // For "N[0-9]+:", ensure all middle characters are digits
+    for (size_t idx = 1; idx < unit.size() - 1; idx++)
+    {
+        if (!std::isdigit(static_cast<unsigned char>(unit[idx])))
+            return false;
+    }
+
+    return true;
+}
+
+std::string util_remove_n_prefix(std::string url)
+{
+    if (util_has_N_prefix(url))
+        url = url.substr(url.find_first_of(":") + 1);
+    return url;
+}
+
 // Non-mutating
 std::string util_devicespec_fix_for_parsing(std::string deviceSpec, std::string prefix, bool is_directory_read, bool process_fs_dot)
 {
@@ -888,11 +917,13 @@ std::string util_devicespec_fix_for_parsing(std::string deviceSpec, std::string 
         return "";
     }
 
-    string unit = deviceSpec.substr(0, deviceSpec.find_first_of(":") + 1);
-    string path = deviceSpec.substr(unit.length());
+    // Delete the N: prefix if it is still there, the N: device unit
+    // number has already been determined
+    deviceSpec = util_remove_n_prefix(deviceSpec);
 
+    // FIXME - prefix should go between the host part and the path part
     // if prefix is empty, the concatenation is still valid
-    deviceSpec = unit + prefix + path;
+    deviceSpec = prefix + deviceSpec;
 
 #ifdef VERBOSE_PROTOCOL
     Debug_printf("util_devicespec_fix_for_parsing, spec: >%s<, prefix: >%s<, dir_read?: %s, fs_dot?: %s)\n", deviceSpec.c_str(), prefix.c_str(), is_directory_read ? "true" : "false", process_fs_dot ? "true" : "false");

--- a/lib/utils/utils.h
+++ b/lib/utils/utils.h
@@ -83,6 +83,7 @@ std::string util_remove_spaces(const std::string &s);
 
 void util_strip_nonascii(std::string &s);
 void util_devicespec_fix_9b(uint8_t* buf, unsigned short len);
+std::string util_remove_n_prefix(std::string url);
 std::string util_devicespec_fix_for_parsing(std::string deviceSpec, std::string prefix, bool is_directory_read, bool process_fs_dot);
 
 void clean_transform_petscii_to_ascii(std::string& data);


### PR DESCRIPTION
By the time a URL is being handled by the N: device, the unit number has already been determined. There's no need for a URL to be sent with the N: prefix. Don't blindly look for the first ':' and assume that it is the N: prefix.