### PR TITLE
[cicd] Add Ubuntu 24.04 ARM64 and ARMv7 (armhf) builds for FujiNet-PC

### DIFF
--- a/.github/workflows/build-fujinet-pc.yml
+++ b/.github/workflows/build-fujinet-pc.yml
@@ -59,6 +59,24 @@ jobs:
             runner: ubuntu-24.04
             target: ubuntu-24.04-amd64
             default-shell: bash
+          - name: Ubuntu 24.04 ARM64
+            runner: ubuntu-24.04-arm
+            target: ubuntu-24.04-arm64
+            default-shell: bash
+          # 32-bit ARM (armhf) cross-build on the arm64 runner; its cores still
+          # execute AArch32, so the unit tests run natively under ctest
+          - name: Ubuntu 24.04 ARMv7
+            runner: ubuntu-24.04-arm
+            target: ubuntu-24.04-armhf
+            default-shell: bash
+            cmake-args: >-
+              -DCMAKE_C_COMPILER=arm-linux-gnueabihf-gcc
+              -DCMAKE_CXX_COMPILER=arm-linux-gnueabihf-g++
+              -DMBEDTLS_INCLUDE_DIR=/usr/include
+              -DMBEDTLS_LIBRARY_DIR=/usr/lib/arm-linux-gnueabihf
+              -DOPENSSL_INCLUDE_DIR=/usr/include
+              -DOPENSSL_CRYPTO_LIBRARY=/usr/lib/arm-linux-gnueabihf/libcrypto.so
+              -DOPENSSL_SSL_LIBRARY=/usr/lib/arm-linux-gnueabihf/libssl.so
           - name: macOS 15 ARM
             target: macos-15-arm64
             runner: macos-15
@@ -126,10 +144,19 @@ jobs:
         brew link --force --overwrite mbedtls@3
 
     - name: '[Ubuntu] Install MbedTLS'
-      if: ${{ startsWith(matrix.os.target, 'ubuntu') }}
+      if: ${{ startsWith(matrix.os.target, 'ubuntu') && !endsWith(matrix.os.target, 'armhf') }}
       run: |
         sudo apt-get update
         sudo apt-get install -y libmbedtls-dev
+
+    - name: '[Ubuntu armhf] Install cross toolchain and MbedTLS'
+      if: ${{ endsWith(matrix.os.target, 'armhf') }}
+      run: |
+        sudo dpkg --add-architecture armhf
+        sudo apt-get update
+        sudo apt-get install -y crossbuild-essential-armhf \
+          libmbedtls-dev:armhf libssl-dev:armhf libexpat1-dev:armhf zlib1g-dev:armhf \
+          libstdc++6:armhf
 
     - name: About ${{ matrix.os.name }}
       run: |
@@ -171,7 +198,7 @@ jobs:
     - name: '[regular OS] 🚧 Build FujiNet-PC (matrix.fujinet_target)'
       if: ${{ !startsWith(matrix.os.target, 'windows') }}
       run: |
-        ./build.sh -p ${{ matrix.fujinet_target }}
+        ./build.sh -p ${{ matrix.fujinet_target }} -- ${{ matrix.os.cmake-args }}
 
     # For MSYS tune PATH variable for PYTHON:
     # add 'C:\hostedtoolcache\windows\Python\3.10.11\x64' as '/c/hostedtoolcache/windows/Python/3.10.11/x64'


### PR DESCRIPTION
Adds two build matrix entries on the free `ubuntu-24.04-arm` runner to `build-fujinet-pc.yml`:

- **Ubuntu 24.04 ARM64** (`ubuntu-24.04-arm64`) — native aarch64 build for 64-bit ARM systems (Raspberry Pi 4/5, etc.)
- **Ubuntu 24.04 ARMv7** (`ubuntu-24.04-armhf`) — 32-bit ARM build for devices like the Intellivision Sprint

The ARMv7 build cross-compiles with `arm-linux-gnueabihf-gcc` via `build.sh`'s existing `--` cmake passthrough. The arm64 runner's cores still execute AArch32, so the unit tests run natively under ctest — no qemu, no test skipping.

Details worth knowing:

- The Linux build silently depends on runner-preinstalled packages: libssh's crypto backend is **OpenSSL** (`WITH_MBEDTLS` defaults to OFF) and it requires zlib. The armhf job installs `libssl-dev:armhf` and `zlib1g-dev:armhf` explicitly, alongside mbedtls/expat.
- `FindOpenSSL` takes hints from host pkg-config, which points at the aarch64 tree and outranks the armhf multiarch path, so the OpenSSL paths are pre-seeded (`-DOPENSSL_INCLUDE_DIR`/`-DOPENSSL_CRYPTO_LIBRARY`/`-DOPENSSL_SSL_LIBRARY`), same approach as the existing mbedtls variables.
- The trailing `-- ${{ matrix.os.cmake-args }}` on the shared build step is a no-op for every existing platform (empty passthrough after `--`).
- Release/nightly packaging picks up the new artifacts via the existing `*ubuntu*` glob; no other workflow changes needed.

All 12 new jobs are green across all six fujinet targets: https://github.com/FujiNetWIFI/fujinet-firmware/actions/runs/33808098864

Runtime note for 32-bit deployments: the armhf binaries link against Ubuntu 24.04's glibc 2.39 and dynamically link armhf `libssl3`, `libz1`, `libexpat1`, `libstdc++6` — target devices need those (or the job can be converted to build in an older armhf container if needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AEPPezKxxCgLGVKYMmq9jz