### PR TITLE
Fix crash on STATUS after closing a DriveWire network channel

### DIFF
--- a/lib/device/drivewire/network.cpp
+++ b/lib/device/drivewire/network.cpp
@@ -359,6 +359,8 @@ fujiError_t drivewireNetwork::write_channel(unsigned short num_bytes)
  */
 void drivewireNetwork::status(uint8_t mode)
 {
+    SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
+
     if (protocol == nullptr)
         status_local(mode);
     else
@@ -438,8 +440,6 @@ void drivewireNetwork::status_channel()
 #ifdef TOO_MUCH_DEBUG
     Debug_printf("drivewireNetwork::status_channel(%u)\n", channelMode);
 #endif /* TOO_MUCH_DEBUG */
-
-    SYSTEM_BUS.transaction_accept(TRANS_STATE::NO_GET);
 
     switch (channelMode)
     {


### PR DESCRIPTION
status() dispatches to status_local() or status_channel(), but only status_channel() called transaction_accept(). A STATUS with no protocol bound therefore reached transaction_send() while the transaction was still INVALID and tripped its NO_GET assertion, aborting the firmware.

close() resets the protocol, so the first STATUS after a *successful* close took that path: any CoCo client that wrote to a network channel and then asked for status brought FujiNet down. On ESP that is a panic and reboot, since the CoCo sdkconfigs build with assertions enabled, leaving the client waiting for a response that never arrives.

Hoist the accept into status(), ahead of the branch, matching sioNetwork::sio_status().

NOTE: This fixes a firmware crash when adding/editing a GCAL entry.