### PR TITLE
[all] report largest free internal block in heap telemetry

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -597,16 +597,18 @@ void fn_service_loop(void *param)
 #endif
 
 #if defined(ESP_PLATFORM) && defined(DEBUG)
-        // Internal DRAM every 10s: flat is a fixed cost, falling is a leak. The loop has
-        // no delay, so anything per-iteration is unreadable at bus rates.
+        // Internal DRAM every 10s: flat is a fixed cost, falling is a leak. Flat free
+        // with a decaying largest block is fragmentation. The loop has no delay, so
+        // anything per-iteration is unreadable at bus rates.
         {
             static unsigned long last_heap_report = 0;
             unsigned long now = fnSystem.millis();
             if (now - last_heap_report >= 10000)
             {
                 last_heap_report = now;
-                Debug_printv("Low Heap: %lu Heap: %lu",
-                             esp_get_free_internal_heap_size(), esp_get_free_heap_size());
+                Debug_printv("Low Heap: %lu Heap: %lu MaxIntBlk: %u",
+                             esp_get_free_internal_heap_size(), esp_get_free_heap_size(),
+                             (unsigned)heap_caps_get_largest_free_block(MALLOC_CAP_INTERNAL));
             }
         }
 #endif


### PR DESCRIPTION
Follow-up to #1608. Free-size alone cannot distinguish a leak from fragmentation, and internal-DRAM exhaustion has now shown up twice with PSRAM sitting idle. This adds `heap_caps_get_largest_free_block(MALLOC_CAP_INTERNAL)` to the existing 10-second DEBUG heap report.

Reading the telemetry:
- **falling free** = a leak
- **flat free, decaying MaxIntBlk** = fragmentation (mixed-size churn checkerboarding the internal heap)

First PR of a 5-part series from a codebase-wide heap-depletion audit (unchecked allocation-backed creation, error-path leaks, structural internal-DRAM pressure). Stacked on #1608; the later PRs use this signal for verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014RVdfsiC2b8Cc24j45qbCh
