### PR TITLE
[config][rs232] Add default fnconfig.ini with SD and TNFS hosts

### DIFF
--- a/data/webui/device_specific/BUILD_RS232/fnconfig.ini
+++ b/data/webui/device_specific/BUILD_RS232/fnconfig.ini
@@ -1,0 +1,17 @@
+[General]
+devicename=FujiNet
+
+[Network]
+sntpserver=pool.ntp.org
+
+[Host1]
+type=SD
+name=SD
+
+[Host2]
+type=TNFS
+name=tnfs.fujinet.online
+
+[Host3]
+type=TNFS
+name=apps.irata.online


### PR DESCRIPTION
This supplies the standard 3-host block: SD, tnfs.fujinet.online, and apps.irata.online, matching APPLE/LYNX/MAC defaults.

Fixes issue https://github.com/FujiNetWIFI/fujinet-config/issues/203