### PR TITLE
Enable FN_LABEL and FN_DEVICE_NAME on all platforms

### DIFF
--- a/lib/config/fnConfig.h
+++ b/lib/config/fnConfig.h
@@ -108,9 +108,7 @@ public:
 
     // GENERAL
     std::string get_general_devicename() { return _general.devicename; };
-#ifndef ESP_PLATFORM
     std::string get_general_label();
-#endif
     int get_general_hsioindex() { return _general.hsio_index; };
     std::string get_general_timezone() { return _general.timezone.empty() ? "UTC" : _general.timezone; };
     bool get_general_rotation_sounds() { return _general.rotation_sounds; };

--- a/lib/config/fnc_general.cpp
+++ b/lib/config/fnc_general.cpp
@@ -1,9 +1,7 @@
 #include "fnConfig.h"
 #include <cstring>
 #include "utils.h"
-#ifndef ESP_PLATFORM
 #include "fnSystem.h"
-#endif
 
 #include "../../include/debug.h"
 
@@ -134,6 +132,7 @@ std::string fnConfig::get_general_label()
     return _general.devicename;
 }
 
+#ifndef ESP_PLATFORM
 void fnConfig::store_general_interface_url(const char *url)
 {
     if (_general.interface_url.compare(url) == 0)

--- a/lib/config/fnc_general.cpp
+++ b/lib/config/fnc_general.cpp
@@ -126,13 +126,12 @@ void fnConfig::store_general_fnconfig_spifs(bool fnconfig_spifs)
     _dirty = true;
 }
 
-#ifndef ESP_PLATFORM
 std::string fnConfig::get_general_label()
 {
     // TODO html escape - label goes into <title>
     if (_general.devicename.empty())
         return fnSystem.Net.get_hostname();
-    return _general.devicename; 
+    return _general.devicename;
 }
 
 void fnConfig::store_general_interface_url(const char *url)

--- a/lib/http/httpServiceParser.cpp
+++ b/lib/http/httpServiceParser.cpp
@@ -26,10 +26,8 @@ const string fnHttpServiceParser::substitute_tag(const string &tag)
     enum tagids
     {
         FN_HOSTNAME = 0,
-#ifndef ESP_PLATFORM
         FN_DEVICE_NAME,
         FN_LABEL,
-#endif
         FN_VERSION,
         FN_IPADDRESS,
         FN_IPMASK,
@@ -155,10 +153,8 @@ const string fnHttpServiceParser::substitute_tag(const string &tag)
     const char *tagids[FN_LASTTAG] =
     {
         "FN_HOSTNAME",
-#ifndef ESP_PLATFORM
         "FN_DEVICE_NAME",
         "FN_LABEL",
-#endif
         "FN_VERSION",
         "FN_IPADDRESS",
         "FN_IPMASK",

--- a/lib/http/httpServiceParser.cpp
+++ b/lib/http/httpServiceParser.cpp
@@ -305,7 +305,6 @@ const string fnHttpServiceParser::substitute_tag(const string &tag)
     case FN_HOSTNAME:
         resultstream << fnSystem.Net.get_hostname();
         break;
-#ifndef ESP_PLATFORM
     case FN_DEVICE_NAME:
         resultstream << Config.get_general_devicename();
         break;
@@ -313,7 +312,6 @@ const string fnHttpServiceParser::substitute_tag(const string &tag)
         // TODO html escape
         resultstream << Config.get_general_label();
         break;
-#endif
     case FN_VERSION:
         resultstream << fnSystem.get_fujinet_version();
         break;


### PR DESCRIPTION
## Summary
Enable FN_LABEL (custom device label with hostname fallback) and FN_DEVICE_NAME template variables on hardware and PC builds, not just PC-only.

The underlying dependencies (devicename config field and fnSystem.Net.get_hostname()) are available on all platforms. This allows the webui to use a unified label source across all platforms instead of platform-specific conditionals in templates.

## Changes
- `lib/config/fnc_general.cpp`: Moved `#ifndef ESP_PLATFORM` guard to wrap only PC-specific helper functions, leaving `get_general_label()` available on all platforms
- `lib/http/httpServiceParser.cpp`: Removed platform guards from FN_DEVICE_NAME and FN_LABEL template variable handlers
