### PR TITLE
Tolerate SD cards that reject CMD59 (CRC_ON_OFF) on the SPI path

### DIFF
--- a/lib/FileSystem/fnFsSD.cpp
+++ b/lib/FileSystem/fnFsSD.cpp
@@ -620,6 +620,46 @@ const char * FileSystemSDFAT::partition_type()
 }
 
 #ifdef ESP_PLATFORM
+/*
+  Some SD cards answer CMD59 (CRC_ON_OFF) with the R1 illegal-command bit set, which the
+  sdspi layer reports as ESP_ERR_NOT_SUPPORTED (0x106). ESP-IDF runs that step
+  (sdmmc_init_spi_crc) unconditionally for every card brought up over SPI and treats a
+  failure as fatal, so sdmmc_card_init() aborts and the card never mounts:
+
+    E (xxxx) sdmmc_sd: sdmmc_init_spi_crc: sdmmc_send_cmd_crc_on_off returned 0x106
+    E (xxxx) vfs_fat_sdmmc: sdmmc_card_init failed (0x106).
+
+  CRC16 of data transfers is optional in SPI mode per the SD Physical Layer spec (it is only
+  mandatory in SD/native mode), which is why these cards work under the Arduino SD library -
+  its SPI diskio never sends CMD59 at all. IDF offers no Kconfig option or sdmmc_host_t flag
+  to skip the step, so it is redirected here with "-Wl,--wrap=sdmmc_init_spi_crc" (see the
+  build_flags in platformio-ini-files/platformio.common.ini) and made non-fatal: cards that
+  accept CMD59 keep CRC on, cards that reject it mount with CRC off instead of failing.
+
+  Only the SPI path reaches this step - in SD/4-bit mode CRC is mandatory and handled by the
+  hardware - so the SDMMC branch of start() below is unaffected.
+
+  See https://github.com/FujiNetWIFI/fujinet-firmware/issues/1625
+*/
+extern "C"
+{
+    // Exported by the sdmmc component, declared in its private header
+    // esp_private/sdmmc_common.h - declared here so we don't have to reach into that header.
+    esp_err_t sdmmc_send_cmd_crc_on_off(sdmmc_card_t *card, bool crc_enable);
+
+    esp_err_t __wrap_sdmmc_init_spi_crc(sdmmc_card_t *card)
+    {
+        // CMD59 is attempted directly rather than through __real_sdmmc_init_spi_crc(), which
+        // remains linked, because that one does an ESP_LOGE on failure - printing the alarming
+        // "returned 0x106" line on every boot with an affected card.
+        esp_err_t e = sdmmc_send_cmd_crc_on_off(card, true);
+        if(e != ESP_OK)
+            Debug_printf("SD card rejected CMD59/CRC_ON_OFF (%s), continuing with SPI CRC off\r\n", esp_err_to_name(e));
+
+        return ESP_OK; // never fatal
+    }
+}
+
 success_is_true FileSystemSDFAT::start()
 {
     if(_started)

--- a/platformio-ini-files/platformio.common.ini
+++ b/platformio-ini-files/platformio.common.ini
@@ -52,6 +52,9 @@ build_flags =
     -D ${fujinet.flash_filesystem}
     -D CMAKE_EXPORT_COMPILE_COMMANDS=ON
     -D DEBUG_SPEED=${env.monitor_speed}
+    ; Make the SPI SD CRC-enable step (CMD59) non-fatal - see __wrap_sdmmc_init_spi_crc()
+    ; in lib/FileSystem/fnFsSD.cpp
+    -Wl,--wrap=sdmmc_init_spi_crc
 
 # [fujinet] section allowed values.
 # copy one of the build_board values to your platformio.local.ini under [fujinet], or read the build-sh.md docs.

--- a/platformio-sample.ini
+++ b/platformio-sample.ini
@@ -133,6 +133,9 @@ build_flags =
     -D ${fujinet.flash_filesystem}
     -D CMAKE_EXPORT_COMPILE_COMMANDS=ON
     -D DEBUG_SPEED=${env.monitor_speed}
+    ; Make the SPI SD CRC-enable step (CMD59) non-fatal - see __wrap_sdmmc_init_spi_crc()
+    ; in lib/FileSystem/fnFsSD.cpp
+    -Wl,--wrap=sdmmc_init_spi_crc
     ;-D LEAK_DEBUG           ; Show low heap usage every service loop.
     ;-D NO_BUTTONS          ; if your hardware has no physical buttons
     ;-D JTAG                ; enable use with JTAG debugger


### PR DESCRIPTION
Fixes #1625.

## Problem

Some microSD cards answer **CMD59 (CRC_ON_OFF)** with the R1 illegal-command bit set. The sdspi transaction layer maps that to `ESP_ERR_NOT_SUPPORTED` (0x106), ESP-IDF's `sdmmc_init_spi_crc()` step treats it as fatal, and `sdmmc_card_init()` aborts the whole mount:

```
E (xxxx) sdmmc_sd: sdmmc_init_spi_crc: sdmmc_send_cmd_crc_on_off returned 0x106
E (xxxx) vfs_fat_sdmmc: sdmmc_card_init failed (0x106).
```

The cards aren't defective — CRC16 of data transfers is *optional* in SPI mode per the SD Physical Layer spec (mandatory only in SD/native mode), and the same cards mount fine under the Arduino `SD` library, whose SPI diskio never sends CMD59 at all.

## Fix

IDF exposes no Kconfig option or `sdmmc_host_t` flag to skip that init step, so it is redirected with a linker wrap — no IDF sources patched:

- `-Wl,--wrap=sdmmc_init_spi_crc` added to the shared `[env] build_flags` in `platformio-ini-files/platformio.common.ini` (and `platformio-sample.ini` for the VS Code users), so every board picks it up through `${env.build_flags}`.
- `__wrap_sdmmc_init_spi_crc()` next to the mount code in `lib/FileSystem/fnFsSD.cpp`: it attempts CMD59, and if the card rejects it, logs one `Debug_printf` line and continues with CRC off. Cards that accept CMD59 keep CRC on. It never returns an error, so the mount proceeds either way.

It calls `sdmmc_send_cmd_crc_on_off()` directly rather than `__real_sdmmc_init_spi_crc()` because the real step does an `ESP_LOGE` on failure, which would print the alarming "returned 0x106" line on every boot with an affected card.

Only the SPI path runs this step — in SD/4-bit mode CRC is mandatory and handled in hardware — so the `SDMMC_HOST_WIDTH` branch of `FileSystemSDFAT::start()` is unaffected. The wrapper is defined unconditionally on ESP builds so the link is correct regardless of which branch a board uses, and it is inside `#ifdef ESP_PLATFORM`, so FujiNet-PC builds are untouched.

## Verification

Built `fujinet-v1-8mb` (Atari, SPI SD, IDF 5.5) and checked the linked ELF:

- `__wrap_sdmmc_init_spi_crc` is present and the IDF init-step table points at it; the real `sdmmc_init_spi_crc` is gone from the image entirely, i.e. its only reference was redirected.
- Disassembly of the wrapper is exactly `sdmmc_send_cmd_crc_on_off(card, true)` → on error `Debug_printf(...)` → `return 0`.

Not tested against physical hardware here — the reporter has the affected cards. Original analysis and the approach come from @deltecent in #1625.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K6tJLB5ci4VRQfSrwwAJSu